### PR TITLE
feat(analytics): report connector state from the mover's own account of every sync

### DIFF
--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -89,6 +89,18 @@ path = "docs/components/backend/analytics/specs/ai-cost/DECOMPOSITION.md"
 name = "AI Development Cost Decomposition"
 traceability = "DOCS-ONLY"
 
+[[systems.artifacts]]
+kind = "PRD"
+path = "docs/components/backend/analytics/specs/connector-health/PRD.md"
+name = "Connector Health PRD"
+traceability = "DOCS-ONLY"
+
+[[systems.artifacts]]
+kind = "DESIGN"
+path = "docs/components/backend/analytics/specs/connector-health/DESIGN.md"
+name = "Connector Health Design"
+traceability = "DOCS-ONLY"
+
 [[systems]]
 name = "Identity Service"
 slug = "identity-svc"
@@ -209,15 +221,3 @@ name = "ADR-0003: Operator identity corrections as append-only persons observati
 kind = "FEATURE"
 path = "docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md"
 name = "Feature: Manual Identity Resolution"
-
-[[systems.artifacts]]
-kind = "PRD"
-path = "docs/components/backend/analytics/specs/connector-health/PRD.md"
-name = "Connector Health PRD"
-traceability = "DOCS-ONLY"
-
-[[systems.artifacts]]
-kind = "DESIGN"
-path = "docs/components/backend/analytics/specs/connector-health/DESIGN.md"
-name = "Connector Health Design"
-traceability = "DOCS-ONLY"

--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -209,3 +209,15 @@ name = "ADR-0003: Operator identity corrections as append-only persons observati
 kind = "FEATURE"
 path = "docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md"
 name = "Feature: Manual Identity Resolution"
+
+[[systems.artifacts]]
+kind = "PRD"
+path = "docs/components/backend/analytics/specs/connector-health/PRD.md"
+name = "Connector Health PRD"
+traceability = "DOCS-ONLY"
+
+[[systems.artifacts]]
+kind = "DESIGN"
+path = "docs/components/backend/analytics/specs/connector-health/DESIGN.md"
+name = "Connector Health Design"
+traceability = "DOCS-ONLY"

--- a/.github/trufflehog-allowlist.txt
+++ b/.github/trufflehog-allowlist.txt
@@ -130,6 +130,7 @@ bb3a7fbda6080765  Lob                src/ingestion/connectors/git/github/tests/t
 6975843dfd4f4686  Lob                src/ingestion/connectors/git/gitlab/tests/test_windowing.py  # test function name; `test_` + 35 chars is also the Lob key shape
 bb96cc56962de929  Lob                src/ingestion/connectors/hr-directory/bamboohr/tests/test_client.py  # test function name; `test_` + 35 chars is also the Lob key shape
 c92f1ad78ae8322c  Lob                src/ingestion/connectors/hr-directory/bamboohr/tests/test_fields_discovery.py  # test function name; `test_` + 35 chars is also the Lob key shape
+67d774383c91b87e  Lob                src/ingestion/reconcile-connectors/tests/test_sweep_plan.py  # test function name; `test_` + 35 chars is also the Lob key shape
 e0ecc3df5888177a  Lob                src/ingestion/scripts/tests/test_reconcile_against_clickhouse.py  # test function name; `test_` + 35 chars is also the Lob key shape
 ac6b1f5e17b6f4fb  Lob                src/ingestion/scripts/tests/test_reconcile_bronze_schema.py  # test function name; `test_` + 35 chars is also the Lob key shape
 2fd74bf6cecacdff  Lob                src/ingestion/tests/e2e/api/test_metric_thresholds.py  # test function name; `test_` + 35 chars is also the Lob key shape

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -194,6 +194,73 @@
           }
         ]
       },
+      "ConnectorHealth": {
+        "properties": {
+          "configured": {
+            "description": "Present in the newest sealed snapshot of the set the controller manages.",
+            "type": "boolean"
+          },
+          "connector": {
+            "type": "string"
+          },
+          "last_sync": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SyncFact",
+                "description": "Absent for a configured connector that has never synced."
+              }
+            ]
+          }
+        },
+        "required": [
+          "connector",
+          "configured"
+        ],
+        "type": "object"
+      },
+      "ConnectorHealthResponse": {
+        "properties": {
+          "as_of": {
+            "description": "When this answer was computed. Dates the answer; `checked_at` dates the\nfacts in it.",
+            "type": "string"
+          },
+          "checked_at": {
+            "description": "When the mover was last read. Absent before the first sweep sealed.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "connectors": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorHealth"
+            },
+            "type": "array"
+          },
+          "history_available": {
+            "description": "False when nothing has been recorded at all, so the page can say so\ninstead of implying health.",
+            "type": "boolean"
+          },
+          "typical_read_interval_ms": {
+            "description": "The median gap between the recent sealed ticks. Measured, not\nconfigured — nothing on this path knows what cadence was intended.\nAbsent where too few ticks are recorded to establish one.",
+            "format": "int64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "as_of",
+          "history_available",
+          "connectors"
+        ],
+        "type": "object"
+      },
       "ContextEntryResponse": {
         "properties": {
           "body": {
@@ -2276,6 +2343,74 @@
         ],
         "type": "object"
       },
+      "SyncFact": {
+        "properties": {
+          "duration_ms": {
+            "description": "Absent for a job still in flight, and for one the mover gave no usable\npair of stamps for. Never zero to mean absent.",
+            "format": "int64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "job_id": {
+            "description": "The mover's own job identity.",
+            "type": "string"
+          },
+          "records_reported": {
+            "description": "What the mover states it moved. Absent where it reported no count at\nall, which is a different answer from a reported zero.",
+            "format": "int64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "started_at": {
+            "description": "Absent for a job the mover had not started.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "description": "The mover's own word for how the sync ended, or `unknown` where the\nrecorded word was outside its documented vocabulary.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "job_id",
+          "status"
+        ],
+        "type": "object"
+      },
+      "SyncHistoryResponse": {
+        "properties": {
+          "connector": {
+            "type": "string"
+          },
+          "syncs": {
+            "description": "A bounded window, newest first — not the full retained history.",
+            "items": {
+              "$ref": "#/components/schemas/SyncFact"
+            },
+            "type": "array"
+          },
+          "window": {
+            "description": "How many rows this window holds at most, so the page can say the list\nis a window rather than everything.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "connector",
+          "syncs",
+          "window"
+        ],
+        "type": "object"
+      },
       "TelemetryRecord": {
         "properties": {
           "context_app_name": {
@@ -3834,6 +3969,203 @@
           }
         ],
         "summary": "Replace this tenant's system prompt"
+      }
+    },
+    "/v1/connector-health": {
+      "get": {
+        "operationId": "analytics_api.connector_health.summary",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectorHealthResponse"
+                }
+              }
+            },
+            "description": "One row per connector, ordered by what needs acting on"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Recorded sync state of every connector"
+      }
+    },
+    "/v1/connector-health/{connector}/syncs": {
+      "get": {
+        "operationId": "analytics_api.connector_health.syncs",
+        "parameters": [
+          {
+            "description": "Connector name, as the descriptors spell it",
+            "in": "path",
+            "name": "connector",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncHistoryResponse"
+                }
+              }
+            },
+            "description": "A bounded window of recorded syncs"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Recent syncs of one connector, newest first"
       }
     },
     "/v1/feedback": {

--- a/docs/components/backend/analytics/specs/connector-health/DESIGN.md
+++ b/docs/components/backend/analytics/specs/connector-health/DESIGN.md
@@ -1,0 +1,487 @@
+# DESIGN — Connector Health
+
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+  - [3.8 Deployment Topology](#38-deployment-topology)
+- [4. Additional context](#4-additional-context)
+  - [4.1 What was deliberately not built](#41-what-was-deliberately-not-built)
+
+<!-- /toc -->
+
+Realises [PRD.md](PRD.md). Scoped addition to the
+[Analytics service design](../../DESIGN.md) on the read side and to the reconcile loop on the
+write side. Everything the parent design already specifies — the admin gate, error taxonomy,
+OpenAPI registration — applies unchanged; this document adds one table, one writer, two
+endpoints, and one portal pane.
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+The page must answer from facts that were recorded when they were true, not gathered when the
+operator asks. Two routes were rejected for that reason.
+
+**Reading the mover on the request path** couples the page's availability to the mover's, and
+its listing is orders of magnitude slower than a warehouse read. An operator opening the page
+during an incident is exactly when the mover is least likely to answer.
+
+**Reading storage metadata on the request path** cannot be done by a reader that holds no
+data access: row visibility in the warehouse's parts metadata follows real access, so a
+metadata-only grant is not a reachable permission state. Widening the read-only query-path
+role to see bronze is not acceptable for a page that reports on it.
+
+What remains is a ledger: the reconcile loop reads the mover's job history on its own cadence
+and records what it found. The request path then touches one relation and nothing else, and
+the page stays up when everything above it is down.
+
+The ledger buys a second thing the mover cannot: **history that outlives its source.** Delete
+a connection in the mover and its job history goes with it; the ledger keeps six months.
+
+### 1.2 Architecture Drivers
+
+#### Functional Drivers
+
+- Every sync in the mover's history is recorded, whatever started it (FR-1) — drives the
+  sweep and its job coverage.
+- History is bounded and survives the mover (FR-2) — drives retention and the decision to
+  copy rather than proxy.
+- The configured set is recorded (FR-4) — drives the sealed per-tick snapshot.
+- Facts, not verdicts (FR-7) — drives a wire shape that ships observations and no state enum.
+- The read path depends on nothing external (FR-11) — drives the single-relation read.
+
+#### NFR Allocation
+
+- **NFR-1 interactive read** — one relation, bounded reads, no measurement while the operator
+  waits.
+- **NFR-2 recording never breaks reconciliation** — every sweep path returns success to its
+  caller; the tick around it cannot abort because observability broke.
+- **NFR-3 idempotent sweep** — coverage is keyed on the mover's own job identity, so
+  re-reading the same history adds nothing.
+- **NFR-4 bounded storage** — its own database, outside anything customer-facing, with a TTL.
+
+### 1.3 Architecture Layers
+
+| Layer | This change adds |
+|---|---|
+| Ingestion control | the sweep inside the reconcile tick |
+| Warehouse | `ingestion_runs.pipeline_events` and one grant |
+| Analytics service | a domain read module and two admin routes |
+| Portal | the Connector health pane, replacing Data health |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### The seam is a table, not an API
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-principle-seam-is-a-table`
+
+The writer and the reader never meet. The reconcile loop knows nothing about the analytics
+service; the analytics service knows nothing about the mover. Either side can change, fail,
+or be replaced without the other noticing, and the page answers from the table while
+everything above the seam is down (FR-11).
+
+#### Recording is subordinate to the recorded
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-principle-recording-subordinate`
+
+A sweep failure is logged and swallowed, never propagated: no reconcile tick aborts because
+observability broke (NFR-2). The cost of that choice is that a tick can leave a gap. The next
+tick repairs it, because the mover's history is still there to re-read — which is the reason
+the sweep reads a source it does not own rather than recording as it goes.
+
+#### The page reports the mover's account as the mover's account
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-principle-account-not-verdict`
+
+Every fact on this page comes from one source that reports on itself. Nothing corroborates
+it, so nothing on the page may read as corroborated: a successful sync is shown as a
+successful sync, and the record count is labelled as reported. The page never says a
+connector is delivering, because it does not know (FR-7).
+
+#### Absence is representable
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-principle-absence-representable`
+
+Every column whose value can genuinely be missing is nullable, so "nobody measured this" and
+"this was zero" are different values in the table rather than a distinction reconstructed at
+read time. A job the mover has not started has no start time and no duration; storing the
+epoch or a zero there would make the page state something nobody recorded.
+
+### 2.2 Constraints
+
+#### Instance-wide, operator-gated
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-constraint-instance-wide`
+
+Bronze schemas are not tenant-partitioned, so the surface cannot be scoped by tenant. It is
+gated on the operator role and reports the whole install (FR-9). The refusal names the
+surface the caller was refused, so an operator who followed a link knows what to ask for.
+
+#### Append-only, no updates
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-constraint-append-only`
+
+No writer updates or deletes ledger rows. A job seen mid-flight and later seen finished
+yields two rows; reads take the newest per job identity. This is what makes NFR-3 hold by
+construction — a repeated sweep can only add rows that resolve to the same answer.
+
+#### The reader holds no bronze access
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-constraint-no-bronze-grant`
+
+The read-only query-path role gains exactly one thing: `SELECT` on the ledger database. It is
+not a read-only role in general — other databases are create/insert-only for it, which that
+role's own test pins — but on the ledger it reads and nothing more, and a static test over
+the migration fails the moment that changes.
+
+#### No compose-stand behaviour beyond degradation
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-constraint-no-compose`
+
+Compose stands run no mover, so nothing records and the ledger stays empty. The surface is
+required only to degrade honestly there (FR-10). Stand tests that need recorded syncs carry
+the ingestion capability and skip with a reason rather than passing over an empty list.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+One table holds three kinds of row, told apart by `event`.
+
+| Event | Written when | Carries |
+|---|---|---|
+| `sync.completed` | the sweep sees a job in the mover's history | job identity, connector, outcome, timestamps, duration, reported records |
+| `connector.configured` | each tick, one row per managed connector | connector, tick identity |
+| `sweep.completed` | each tick, last | tick identity — the marker that seals the snapshot |
+
+**Resolution.** The summary takes, per connector, the newest `sync.completed` by the mover's
+job creation time; the configured set is the membership of the newest *sealed* tick. Sealing
+matters: without keying on the marker, a snapshot still being written would read as the whole
+set, and a connector removed a moment ago would come back for one tick.
+
+**Status vocabulary.** `ok`, `failed`, `cancelled`, `running`, `unknown`. The mover's own
+words are mapped onto this closed set at the boundary; a word outside the mover's documented
+vocabulary is stored as `unknown` rather than passed through, so nothing downstream holds a
+value it cannot read. `unknown` is not a failure and not a reason to sort a connector as
+quiet — the page shows it as a state it cannot read.
+
+**Two timestamps, kept apart.** `started_at` is when the mover says the sync began, and is
+absent for a job it has not started. `job_created_at` is when the job was created, which is
+the field the mover's listing is ordered and filtered by — and therefore the axis the sweep's
+own frontier moves along. Substituting one for the other would report a start that never
+happened and still leave the cursor on the wrong axis.
+
+### 3.2 Component Model
+
+#### Job Sweep
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-component-job-sweep`
+
+##### Why this component exists
+
+The mover is the only account of what synced, its history is bounded, and it disappears with
+a deleted connection. Something has to copy that account somewhere durable, on a cadence, and
+the reconcile loop already authenticates to the mover and ticks.
+
+##### Responsibility scope
+
+Each tick: resolve the frontier from the ledger, page the mover's job listing forward from
+it, map each job's connection to a connector, plan one row per job the ledger does not
+already hold with a terminal outcome, plan the configured-set snapshot, write the rows, then
+write the seal.
+
+The planning is a pure function over values — the shell gathers, the planner decides, and the
+planner is what the tests exercise. Its rules are the change's densest logic: which jobs to
+cover, which recorded rows already close a job, which jobs cannot be placed in time at all.
+
+##### Responsibility boundaries
+
+Records; never reads back for the page. Cannot abort the reconcile tick around it: every path
+returns success to its caller, and a failure to read any input means the tick records nothing
+rather than sealing a partial picture.
+
+##### Related components (by ID)
+
+- Writes the table read by `cpt-insightspec-connhealth-component-read-model`.
+
+#### Health Read Model
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-component-read-model`
+
+##### Why this component exists
+
+The page needs one merged answer from several statements over the ledger — newest sync per
+connector, the sealed configured set, a connector's recent syncs — which is domain logic that
+belongs in one tested module, not in a handler.
+
+##### Responsibility scope
+
+A handful of reads per request, all over the ledger alone. Pure functions merge them into
+connector summaries, resolve the quiet states from the configured set, order rows by
+attention (FR-8), and mark unknowns explicitly (FR-7). Serves the bounded sync history for
+the expansion (FR-6).
+
+##### Responsibility boundaries
+
+Holds no bronze access; never calls the mover; never classifies freshness; ships no verdict
+enum — the attention order is used for sorting and is not serialised. A missing ledger table
+leaves nothing to serve: the endpoint answers an empty list rather than erroring (FR-10).
+
+##### Related components (by ID)
+
+- Serves `cpt-insightspec-connhealth-component-health-pane`.
+
+#### Connector Health Pane
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-component-health-pane`
+
+##### Why this component exists
+
+The Manage zone needs one place that answers "is ingestion working", replacing a pane that
+answered a different question.
+
+##### Responsibility scope
+
+One row per connector with the fields of FR-5; a row expands to that connector's recent
+syncs. Decides the displayed state from the served facts in one documented function, so the
+precedence lives in one place rather than scattered across cells. Every state carries words
+as well as a tone, so colour is never the only signal.
+
+##### Responsibility boundaries
+
+Renders; computes no cadence and asserts no freshness. Where a served value is absent it
+prints unknown rather than a zero.
+
+##### Related components (by ID)
+
+- Reads `cpt-insightspec-connhealth-component-read-model`.
+
+### 3.3 API Contracts
+
+Realises `cpt-insightspec-connhealth-interface-read-surface`, and consumes
+`cpt-insightspec-connhealth-contract-mover-history` on the write side.
+
+Two admin routes on the analytics service, registered like every other route in the parent
+design.
+
+`GET /v1/connector-health` — the whole install:
+
+```json
+{
+  "as_of": "2026-01-15T09:12:00Z",
+  "checked_at": "2026-01-15T09:06:00Z",
+  "history_available": true,
+  "connectors": [
+    {
+      "connector": "example-tracker",
+      "configured": true,
+      "last_sync": {
+        "job_id": "8412",
+        "status": "ok",
+        "started_at": "2026-01-15T09:00:00Z",
+        "duration_ms": 142000,
+        "records_reported": 12400
+      }
+    }
+  ]
+}
+```
+
+`GET /v1/connector-health/{connector}/syncs` — one connector's recent syncs, newest first,
+bounded:
+
+```json
+{
+  "connector": "example-tracker",
+  "syncs": [
+    {
+      "job_id": "8412",
+      "status": "ok",
+      "started_at": "2026-01-15T09:00:00Z",
+      "duration_ms": 142000,
+      "records_reported": 12400
+    }
+  ]
+}
+```
+
+Shape rules that the generated contract enforces:
+
+- **Nullable fields are required and nullable**, never optional. The service always emits the
+  key; a client written to the contract must handle `null` rather than a missing key.
+- `last_sync` is null for a configured connector that has never synced.
+- `checked_at` is the newest sealed tick's own stamp, never the response's clock — serving
+  the reader's clock there would read as "just now" however long ago the controller last ran.
+- `history_available` is false when nothing has been recorded at all, so the page can say so
+  instead of implying health.
+
+### 3.4 Internal Dependencies
+
+- The analytics service's existing warehouse client, admin-role gate, and OpenAPI
+  registration — the summary and the per-connector history are two more routes.
+- The portal's Manage-zone navigation: the `data-health` item is replaced by this pane; the
+  admin-gate wrapper is reused as-is.
+- The reconcile loop's existing mover authentication and tick scheduling.
+- The deployed-stand suite's endpoint coverage gate: contract tests accompany the routes, and
+  the ones needing recorded syncs carry the ingestion capability rather than passing over an
+  empty list.
+
+### 3.5 External Dependencies
+
+#### Data mover job listing
+
+The sweep consumes the mover's stable public job listing: per job, its identity, connection,
+outcome, creation and start timestamps, duration, and reported record count. Richer per-job
+detail exists but is not contract-stable across mover upgrades, so nothing here depends on
+it. Unavailable ⇒ the sweep records nothing this tick and the page serves the last recorded
+facts.
+
+#### Warehouse
+
+Holds the ledger. Unavailable ⇒ the sweep skips the tick and the read surface fails like any
+other warehouse-backed read.
+
+### 3.6 Interactions & Sequences
+
+#### Sweep tick
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-seq-sweep-tick`
+
+```mermaid
+sequenceDiagram
+    participant R as Reconcile tick
+    participant M as Data mover
+    participant L as Run ledger
+
+    R->>L: newest job-creation time already covered
+    L-->>R: frontier (empty ⇒ backfill everything)
+    R->>M: list jobs created since frontier, oldest first, paged
+    M-->>R: jobs with outcome, timestamps, reported records
+    R->>R: plan rows for jobs not already closed
+    R->>L: insert planned sync rows
+    R->>L: insert configured-set rows
+    R->>L: insert the seal
+```
+
+The frontier moves along job creation time because that is what the listing is ordered and
+filtered by. Reading oldest-first makes a truncated read resumable: what is cut is newer than
+everything collected, so the next tick continues at the edge rather than leaving a gap behind
+the cursor. The seal is written last, so a snapshot read never names a tick whose rows are
+still arriving.
+
+#### Page read
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-seq-page-read`
+
+```mermaid
+sequenceDiagram
+    participant P as Portal
+    participant A as Analytics
+    participant L as Run ledger
+
+    P->>A: GET /v1/connector-health
+    A->>L: newest sealed tick
+    A->>L: newest sync per connector
+    A->>L: configured set at that tick
+    A-->>P: one row per connector, ordered by attention
+    P->>A: GET /v1/connector-health/{connector}/syncs
+    A->>L: that connector's recent syncs
+    A-->>P: bounded window, newest first
+```
+
+The sealed tick is resolved once and bound into the snapshot reads. Resolving it per statement
+would let a sweep landing between two of them answer with the newer configured set beside the
+older facts — a state that never existed on any tick.
+
+### 3.7 Database schemas & tables
+
+#### `ingestion_runs.pipeline_events`
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-dbtable-pipeline-events`
+
+Its own database, deliberately: the presentation database is swept by metric exports and
+customer extracts, which must never carry service rows.
+
+| Column | Type | Notes |
+|---|---|---|
+| `event_id` | `UUID DEFAULT generateUUIDv4()` | makes the sort key unique; nothing reads it |
+| `ts` | `DateTime64(3, 'UTC') DEFAULT now64(3)` | insert time |
+| `tick_id` | `String` | the sweep tick that wrote the row; what a sealed snapshot is keyed on |
+| `job_id` | `String` | the mover's job identity; empty on snapshot rows |
+| `connector` | `LowCardinality(String)` | hyphenated connector name |
+| `event` | `LowCardinality(String)` | `sync.completed` \| `connector.configured` \| `sweep.completed` |
+| `status` | `LowCardinality(String)` | `ok` \| `failed` \| `cancelled` \| `running` \| `unknown` — the closed set |
+| `started_at` | `Nullable(DateTime64(3, 'UTC'))` | when the mover says the sync began; NULL for a job it has not started |
+| `job_created_at` | `Nullable(DateTime64(3, 'UTC'))` | when the job was created — the axis the frontier moves along |
+| `duration_ms` | `Nullable(UInt64)` | elapsed time as reported; NULL where the mover reported none, which a zero could not express |
+| `records_reported` | `Nullable(UInt64)` | the mover's own count; NULL where it reported none |
+
+`ENGINE = MergeTree`, `PARTITION BY toYYYYMM(ts)`, `ORDER BY (connector, ts, event_id)`,
+`TTL toDateTime(ts) + INTERVAL 6 MONTH`.
+
+The migration is idempotent and re-runs on every deploy: this channel keeps no ledger of
+applied files, so every statement in it is written to be safe to repeat.
+
+#### Grants
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-dbtable-grants`
+
+| Role | Grant | Why |
+|---|---|---|
+| read-only query-path role | `SELECT ON ingestion_runs.*` | everything the read surface needs |
+
+The writer takes no grant here: the reconcile loop authenticates as the ingestion user, which
+owns the database already. The query-path role must not be given anything that writes, and a
+static test over the migration asserts exactly that.
+
+### 3.8 Deployment Topology
+
+| Change | Where it lands |
+|---|---|
+| ledger table and grant | ClickHouse migration, applied by the post-upgrade hook |
+| sweep | the reconcile loop's existing image and CronWorkflow |
+| horizon-free configuration | none — the sweep needs no new chart value |
+| two routes | analytics service |
+| pane | portal bundle |
+
+Nothing here adds a deployable unit. The sweep runs inside a controller that already exists,
+and the read surface is two more routes on a service that already serves the portal.
+
+## 4. Additional context
+
+### 4.1 What was deliberately not built
+
+- **Verifying that a sync's data reached storage.** It needs a measurement taken at sync
+  time, inside the ingestion pipeline, against a window that has passed by the time a sweep
+  runs. That puts recording code on the critical ingestion path, where a recorder appended
+  after the work it records becomes the only task its DAG's phase is read from — and one
+  succeeding after a failure would mask that failure. The capability is worth having; it is
+  not worth carrying that hazard for a first iteration.
+- **Transform outcome.** Same reason: only the pipeline knows it.
+- **How a sync was started.** The mover's listing does not say, and inferring it means
+  correlating against the workflow layer's own records — a second uncertain source, with a
+  trust horizon of its own, to answer a question the page cannot act on without the transform
+  outcome anyway.
+- **Per-stream volume.** Reading it means either granting the reader bronze access, which the
+  constraint above forbids, or recording it per tick, which grows the table with streams
+  rather than with syncs.
+- **Freshness verdicts** — the declared thresholds have no runtime source. The page shows
+  when the last sync started and a bounded window of recent ones, which lets an operator
+  judge cadence without the product asserting one.

--- a/docs/components/backend/analytics/specs/connector-health/DESIGN.md
+++ b/docs/components/backend/analytics/specs/connector-health/DESIGN.md
@@ -61,14 +61,18 @@ a connection in the mover and its job history goes with it; the ledger keeps six
   sweep and its job coverage.
 - History is bounded and survives the mover (FR-2) — drives retention and the decision to
   copy rather than proxy.
+- First sweep backfills retained history (FR-3) — drives the frontier, whose empty state is
+  what makes the first sweep read the mover's whole retained window.
 - The configured set is recorded (FR-4) — drives the sealed per-tick snapshot.
 - Facts, not verdicts (FR-7) — drives a wire shape that ships observations and no state enum.
 - The read path depends on nothing external (FR-11) — drives the single-relation read.
+- A stopped recorder is visible (FR-12) — drives serving the age of the last read beside the
+  facts it produced.
 
 #### NFR Allocation
 
-- **NFR-1 interactive read** — one relation, bounded reads, no measurement while the operator
-  waits.
+- **NFR-1 interactive read** — one relation, a sort key whose leading column every read
+  filters on, and no measurement taken while the operator waits.
 - **NFR-2 recording never breaks reconciliation** — every sweep path returns success to its
   caller; the tick around it cannot abort because observability broke.
 - **NFR-3 idempotent sweep** — coverage is keyed on the mover's own job identity, so
@@ -80,7 +84,7 @@ a connection in the mover and its job history goes with it; the ledger keeps six
 | Layer | This change adds |
 |---|---|
 | Ingestion control | the sweep inside the reconcile tick |
-| Warehouse | `ingestion_runs.pipeline_events` and one grant |
+| Warehouse | `ingestion_history.sync_events` and one grant |
 | Analytics service | a domain read module and two admin routes |
 | Portal | the Connector health pane, replacing Data health |
 
@@ -171,6 +175,25 @@ One table holds three kinds of row, told apart by `event`.
 | `connector.configured` | each tick, one row per managed connector | connector, tick identity |
 | `sweep.completed` | each tick, last | tick identity — the marker that seals the snapshot |
 
+**What each event writes.** One table serving three row classes means every column needs a
+defined value on every one of them. A column left to the implementation's judgement is a
+column the reader and the writer will disagree about.
+
+| Column | `sync.completed` | `connector.configured` | `sweep.completed` |
+|---|---|---|---|
+| `tick_id` | the tick that recorded it | the tick | the tick |
+| `job_id` | the mover's job identity | empty | empty |
+| `connector` | the synced connector | the member connector | empty |
+| `status` | the mapped outcome | empty | empty |
+| `started_at` | as reported; NULL if not started | NULL | NULL |
+| `job_created_at` | always present | NULL | NULL |
+| `duration_ms` | as reported; NULL if none | NULL | NULL |
+| `records_reported` | as reported; NULL if none | NULL | NULL |
+
+Empty rather than NULL where a column is inapplicable to a row class: those columns are
+`LowCardinality(String)`, and every read filters by `event` before touching them, so an
+absent-value type would buy nothing and cost a nullable read on the hot path.
+
 **Resolution.** The summary takes, per connector, the newest `sync.completed` by the mover's
 job creation time; the configured set is the membership of the newest *sealed* tick. Sealing
 matters: without keying on the marker, a snapshot still being written would read as the whole
@@ -187,6 +210,16 @@ absent for a job it has not started. `job_created_at` is when the job was create
 the field the mover's listing is ordered and filtered by — and therefore the axis the sweep's
 own frontier moves along. Substituting one for the other would report a start that never
 happened and still leave the cursor on the wrong axis.
+
+**`job_created_at` is never NULL on a sync row.** The listing is ordered and filtered by it,
+so a job the mover returns always carries one; the column is nullable only because snapshot
+and seal rows are not about a job at all. The invariant is load-bearing rather than tidy: the
+summary resolves the newest sync per connector with `argMax` over this column, and `argMax`
+ignores rows whose value argument is NULL. A sync row missing it would not merely lose that
+comparison — it would drop out of the summary entirely, taking with it a connector whose only
+recorded sync it was, and rendering as absence rather than as unknown. So a job the mover
+returns without a creation time is one the planner cannot place in time, and it is skipped
+and logged rather than written with a NULL.
 
 ### 3.2 Component Model
 
@@ -236,13 +269,15 @@ belongs in one tested module, not in a handler.
 A handful of reads per request, all over the ledger alone. Pure functions merge them into
 connector summaries, resolve the quiet states from the configured set, order rows by
 attention (FR-8), and mark unknowns explicitly (FR-7). Serves the bounded sync history for
-the expansion (FR-6).
+the expansion (FR-6), and measures the interval between the recent sealed ticks so the pane
+can date the picture it is showing (FR-12).
 
 ##### Responsibility boundaries
 
 Holds no bronze access; never calls the mover; never classifies freshness; ships no verdict
-enum — the attention order is used for sorting and is not serialised. A missing ledger table
-leaves nothing to serve: the endpoint answers an empty list rather than erroring (FR-10).
+enum — the attention order sorts the rows and is not serialised, and neither is the judgement
+that recording has stopped. A missing ledger table leaves nothing to serve: the endpoint
+answers an empty list rather than erroring (FR-10).
 
 ##### Related components (by ID)
 
@@ -262,7 +297,8 @@ answered a different question.
 One row per connector with the fields of FR-5; a row expands to that connector's recent
 syncs. Decides the displayed state from the served facts in one documented function, so the
 precedence lives in one place rather than scattered across cells. Every state carries words
-as well as a tone, so colour is never the only signal.
+as well as a tone, so colour is never the only signal. Dates the whole page by when the mover
+was last read, and says so when that read stands out against the ones before it (FR-12).
 
 ##### Responsibility boundaries
 
@@ -287,6 +323,7 @@ design.
 {
   "as_of": "2026-01-15T09:12:00Z",
   "checked_at": "2026-01-15T09:06:00Z",
+  "typical_read_interval_ms": 900000,
   "history_available": true,
   "connectors": [
     {
@@ -322,13 +359,29 @@ bounded:
 }
 ```
 
+The examples above are illustrative. The authority is the generated contract in
+[`openapi.json`](../../openapi.json), which these routes join like every other; where the two
+disagree, the generated one is right.
+
 Shape rules that the generated contract enforces:
 
 - **Nullable fields are required and nullable**, never optional. The service always emits the
   key; a client written to the contract must handle `null` rather than a missing key.
 - `last_sync` is null for a configured connector that has never synced.
-- `checked_at` is the newest sealed tick's own stamp, never the response's clock — serving
-  the reader's clock there would read as "just now" however long ago the controller last ran.
+- **`as_of` and `checked_at` are different clocks and both are needed.** `as_of` is when the
+  service computed the answer; `checked_at` is the newest sealed tick's own stamp — when the
+  mover was last read. `as_of` dates the answer, `checked_at` dates the facts in it, and the
+  gap between them is the age of the recording, which is what the page prints and what FR-12
+  reads. Serving the reader's clock as `checked_at` would make every answer read as "just
+  now" however long ago the controller last ran.
+- `typical_read_interval_ms` is the median gap between the recent sealed ticks, or null where
+  too few are recorded to establish one. It is measured, not configured: nothing on this path
+  knows what cadence was intended, and reading one from chart values would assert a schedule
+  the surface cannot verify.
+- **No field says recording has stopped.** The service ships the two clocks and the interval;
+  the pane words the conclusion. Same rule as the attention order, which sorts the rows and is
+  never serialised — a verdict on the wire is a verdict some other client will read
+  differently (FR-7).
 - `history_available` is false when nothing has been recorded at all, so the page can say so
   instead of implying health.
 
@@ -368,7 +421,7 @@ other warehouse-backed read.
 sequenceDiagram
     participant R as Reconcile tick
     participant M as Data mover
-    participant L as Run ledger
+    participant L as Sync ledger
 
     R->>L: newest job-creation time already covered
     L-->>R: frontier (empty ⇒ backfill everything)
@@ -394,10 +447,10 @@ still arriving.
 sequenceDiagram
     participant P as Portal
     participant A as Analytics
-    participant L as Run ledger
+    participant L as Sync ledger
 
     P->>A: GET /v1/connector-health
-    A->>L: newest sealed tick
+    A->>L: newest sealed tick, and the gaps between the recent ones
     A->>L: newest sync per connector
     A->>L: configured set at that tick
     A-->>P: one row per connector, ordered by attention
@@ -412,9 +465,9 @@ older facts — a state that never existed on any tick.
 
 ### 3.7 Database schemas & tables
 
-#### `ingestion_runs.pipeline_events`
+#### `ingestion_history.sync_events`
 
-- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-dbtable-pipeline-events`
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-dbtable-sync-events`
 
 Its own database, deliberately: the presentation database is swept by metric exports and
 customer extracts, which must never carry service rows.
@@ -424,17 +477,39 @@ customer extracts, which must never carry service rows.
 | `event_id` | `UUID DEFAULT generateUUIDv4()` | makes the sort key unique; nothing reads it |
 | `ts` | `DateTime64(3, 'UTC') DEFAULT now64(3)` | insert time |
 | `tick_id` | `String` | the sweep tick that wrote the row; what a sealed snapshot is keyed on |
-| `job_id` | `String` | the mover's job identity; empty on snapshot rows |
-| `connector` | `LowCardinality(String)` | hyphenated connector name |
+| `job_id` | `String` | the mover's job identity; empty on rows that are not about a job |
+| `connector` | `LowCardinality(String)` | hyphenated connector name; empty on the seal row |
 | `event` | `LowCardinality(String)` | `sync.completed` \| `connector.configured` \| `sweep.completed` |
-| `status` | `LowCardinality(String)` | `ok` \| `failed` \| `cancelled` \| `running` \| `unknown` — the closed set |
+| `status` | `LowCardinality(String)` | on a sync row, the closed set `ok` \| `failed` \| `cancelled` \| `running` \| `unknown`; empty elsewhere |
 | `started_at` | `Nullable(DateTime64(3, 'UTC'))` | when the mover says the sync began; NULL for a job it has not started |
-| `job_created_at` | `Nullable(DateTime64(3, 'UTC'))` | when the job was created — the axis the frontier moves along |
+| `job_created_at` | `Nullable(DateTime64(3, 'UTC'))` | when the job was created — the axis the frontier moves along; never NULL on a sync row |
 | `duration_ms` | `Nullable(UInt64)` | elapsed time as reported; NULL where the mover reported none, which a zero could not express |
 | `records_reported` | `Nullable(UInt64)` | the mover's own count; NULL where it reported none |
 
-`ENGINE = MergeTree`, `PARTITION BY toYYYYMM(ts)`, `ORDER BY (connector, ts, event_id)`,
-`TTL toDateTime(ts) + INTERVAL 6 MONTH`.
+`ENGINE = MergeTree`, `PARTITION BY toYYYYMM(ts)`,
+`ORDER BY (event, connector, ts, event_id)`, `TTL toDateTime(ts) + INTERVAL 6 MONTH`.
+
+`event` leads the sort key because every read filters on it first and the three row classes
+have nothing to say to each other:
+
+| Read | Narrowed by |
+|---|---|
+| the newest sealed tick | `event` |
+| the newest sync per connector | `event`, grouped along `connector` |
+| one connector's recent syncs | `event`, `connector` |
+| the configured set of a given tick | `event`; `tick_id` is filtered, not indexed |
+
+Only the last falls back to a filter. Leading with `tick_id` instead would narrow it at the
+cost of the per-connector expansion — the one read an operator actually waits on — so the
+filter stays, bounded by the size below rather than by the key.
+
+**Size.** Sync rows arrive at one or two per sync: one when a job is first seen in flight,
+one when it ends. They grow with sync activity, not with time. Snapshot rows arrive at one
+per configured connector per tick plus one seal, so at the chart's default reconcile cadence
+of every fifteen minutes that is 96 × (connectors + 1) rows a day, against roughly 17,500
+ticks inside a six-month retention. The snapshot class therefore dominates the table and is
+what retention is sized against. If it ever stops being negligible, writing the snapshot only
+when the managed set changes removes the class without changing what any read resolves.
 
 The migration is idempotent and re-runs on every deploy: this channel keeps no ledger of
 applied files, so every statement in it is written to be safe to repeat.
@@ -445,7 +520,7 @@ applied files, so every statement in it is written to be safe to repeat.
 
 | Role | Grant | Why |
 |---|---|---|
-| read-only query-path role | `SELECT ON ingestion_runs.*` | everything the read surface needs |
+| read-only query-path role | `SELECT ON ingestion_history.*` | everything the read surface needs |
 
 The writer takes no grant here: the reconcile loop authenticates as the ingestion user, which
 owns the database already. The query-path role must not be given anything that writes, and a

--- a/docs/components/backend/analytics/specs/connector-health/DESIGN.md
+++ b/docs/components/backend/analytics/specs/connector-health/DESIGN.md
@@ -61,7 +61,7 @@ a connection in the mover and its job history goes with it; the ledger keeps six
   sweep and its job coverage.
 - History is bounded and survives the mover (FR-2) — drives retention and the decision to
   copy rather than proxy.
-- First sweep backfills retained history (FR-3) — drives the frontier, whose empty state is
+- First sweep backfills retained history (FR-3) — drives the watermark, whose empty state is
   what makes the first sweep read the mover's whole retained window.
 - The configured set is recorded (FR-4) — drives the sealed per-tick snapshot.
 - Facts, not verdicts (FR-7) — drives a wire shape that ships observations and no state enum.
@@ -72,9 +72,11 @@ a connection in the mover and its job history goes with it; the ledger keeps six
 #### NFR Allocation
 
 - **NFR-1 interactive read** — one relation, a sort key whose leading column every read
-  filters on, and no measurement taken while the operator waits.
-- **NFR-2 recording never breaks reconciliation** — every sweep path returns success to its
-  caller; the tick around it cannot abort because observability broke.
+  filters on, aggregates rather than sorts, and no measurement taken while the operator waits.
+  Measured at 42 ms and 5 MiB over two million recorded syncs.
+- **NFR-2 recording never breaks reconciliation** — the sweep's own entry point reports a
+  failed or partial tick, and the shell that calls it swallows that deliberately, so the tick
+  around it cannot abort because observability broke.
 - **NFR-3 idempotent sweep** — coverage is keyed on the mover's own job identity, so
   re-reading the same history adds nothing.
 - **NFR-4 bounded storage** — its own database, outside anything customer-facing, with a TTL.
@@ -152,16 +154,16 @@ construction — a repeated sweep can only add rows that resolve to the same ans
 
 The read-only query-path role gains exactly one thing: `SELECT` on the ledger database. It is
 not a read-only role in general — other databases are create/insert-only for it, which that
-role's own test pins — but on the ledger it reads and nothing more, and a static test over
-the migration fails the moment that changes.
+role's own test pins — but on the ledger it reads and nothing more, and a static test over the
+role definition fails the moment that changes.
 
 #### No compose-stand behaviour beyond degradation
 
 - [ ] `p2` - **ID**: `cpt-insightspec-connhealth-constraint-no-compose`
 
 Compose stands run no mover, so nothing records and the ledger stays empty. The surface is
-required only to degrade honestly there (FR-10). Stand tests that need recorded syncs carry
-the ingestion capability and skip with a reason rather than passing over an empty list.
+required only to degrade honestly there (FR-10), and the stand tests assert that degradation
+rather than any recorded figure.
 
 ## 3. Technical Architecture
 
@@ -190,9 +192,15 @@ column the reader and the writer will disagree about.
 | `duration_ms` | between the mover's own two stamps; NULL until terminal | NULL | NULL |
 | `records_reported` | the last attempt's count; NULL if it reported none | NULL | NULL |
 
-Empty rather than NULL where a column is inapplicable to a row class: those columns are
-`LowCardinality(String)`, and every read filters by `event` before touching them, so an
-absent-value type would buy nothing and cost a nullable read on the hot path.
+Empty rather than NULL where a column is inapplicable to a row class. Those columns are
+`String` and `LowCardinality(String)`, and every read filters by `event` before touching
+them, so an absent-value type would buy nothing and cost a nullable read on the hot path.
+
+**Every value is range-checked before it is written.** ClickHouse does not reject an
+out-of-range one — it clamps a `DateTime64` and wraps a `UInt64`. A year-1000 stamp lands as
+1900 and a count above 2^64 lands as a different number, and the page would label both as
+what the mover reported. A stamp or a count the column cannot hold is therefore treated as
+absent, and a job whose creation stamp is unusable is not recorded at all.
 
 **Resolution.** The summary takes, per connector, the newest `sync.completed` by the mover's
 job creation time; the configured set is the membership of the newest *sealed* tick. Sealing
@@ -213,7 +221,7 @@ a status the sweep could not read is one it keeps re-reading until it becomes on
 **Two timestamps, kept apart.** `started_at` is when the mover says the sync began, and is
 absent for a job it has not started. `job_created_at` is when the job was created, which is
 the field the mover's listing is ordered and filtered by — and therefore the axis the sweep's
-own frontier moves along. Substituting one for the other would report a start that never
+own watermark moves along. Substituting one for the other would report a start that never
 happened and still leave the cursor on the wrong axis.
 
 **`job_created_at` is never NULL on a sync row.** The listing is ordered by it, so a job the
@@ -221,16 +229,33 @@ mover returns always carries one; the column is nullable only because snapshot a
 are not about a job at all. A job the mover returns without a creation time is one the planner
 cannot place in time, so it is skipped and logged rather than written with a NULL.
 
-**The resolution is two `LIMIT 1 BY` steps, not `argMax`.** The inner step takes the newest
-ROW per job and the outer step the newest JOB per connector, and the split is load-bearing in
-both directions.
+**The resolution is one aggregate over an ordering tuple.** Per connector the newest row wins
+by `argMax` over
+`(coalesce(job_created_at, ts), toUInt64OrZero(job_id), status IN (terminal), ts)`.
 
-A job seen mid-flight and later seen finished leaves two rows that share one creation time, so
-resolving straight to the newest job would tie between them — and could answer `running` for a
-sync that ended. And `argMax` ignores rows whose value argument is NULL, so a sync row that
-somehow carried no creation time would not merely lose the comparison but take its whole
-connector out of the answer, rendering as absence rather than as unknown. `LIMIT 1 BY` still
-returns a row when every candidate is NULL, which is the failure mode worth preferring.
+Every component earns its place, and each closes a wrong answer that was measured first:
+
+- **`coalesce(job_created_at, ts)`** — NULLs sort last in ClickHouse in BOTH directions, so a
+  job the mover gave no creation stamp for does not merely lose the comparison: a different,
+  older job wins it, and the page presents a stale success as the current state. Falling back
+  to when the row was recorded places the job by a real recorded moment instead.
+- **`toUInt64OrZero(job_id)`** — the mover's ids are numbers stored as text, so comparing them
+  as text makes `"9"` newer than `"10"`.
+- **the terminal flag** — within one job a final row outranks a provisional one whatever the
+  clocks say. Two rows of one job can share a millisecond, and without this the answer is
+  decided by physical row order.
+- **`ts`** — the last resort, newest recorded wins.
+
+**One tuple, not one `argMax` per column.** `argMax` ignores rows whose value argument is
+NULL, so six independent calls answer from six independently-chosen rows: one column from the
+newest job beside another from an older one whose value happened not to be NULL, producing a
+row that never existed. The tuple is never NULL, so one row wins all six.
+
+**An aggregate rather than a sort, for a measured reason.** Ordering the relation by a column
+outside its sort key reads and sorts the whole retention window to answer with one row per
+connector. At two million rows that was 259 MiB and 541 ms against 5 MiB and 42 ms for the
+aggregate — and the service caps its own query memory, so the page whose reason for existing
+is answering during an incident would be the thing that fails first.
 
 ### 3.2 Component Model
 
@@ -246,7 +271,7 @@ the reconcile loop already authenticates to the mover and ticks.
 
 ##### Responsibility scope
 
-Each tick: resolve the frontier from the ledger, page the mover's job listing forward from
+Each tick: resolve the watermark from the ledger, page the mover's job listing forward from
 it, map each job's connection to a connector, plan one row per job the ledger does not
 already hold with a terminal outcome, plan the configured-set snapshot, write the rows, then
 write the seal.
@@ -257,9 +282,10 @@ cover, which recorded rows already close a job, which jobs cannot be placed in t
 
 ##### Responsibility boundaries
 
-Records; never reads back for the page. Cannot abort the reconcile tick around it: every path
-returns success to its caller, and a failure to read any input means the tick records nothing
-rather than sealing a partial picture.
+Records; never reads back for the page. Cannot abort the reconcile tick around it: the shell
+that calls it returns 0 on every path, and a failure to read any input means the tick records
+nothing rather than sealing a partial picture. The sweep itself reports the failure, so the
+swallow is visible at the call site rather than hidden in the worker.
 
 ##### Related components (by ID)
 
@@ -408,16 +434,17 @@ Shape rules that the generated contract enforces:
 - The portal's Manage-zone navigation: the `data-health` item is replaced by this pane; the
   admin-gate wrapper is reused as-is.
 - The reconcile loop's existing mover authentication and tick scheduling.
-- The deployed-stand suite's endpoint coverage gate: contract tests accompany the routes, and
-  the ones needing recorded syncs carry the ingestion capability rather than passing over an
-  empty list.
+- The deployed-stand suite's endpoint coverage gate: contract tests accompany the routes. They
+  assert the shape, the gate and the two honesty properties, and no figure — a compose stand
+  runs no mover, so the ledger is legitimately empty there and a count would pin the suite to
+  a stand that happened to have been seeded.
 
 ### 3.5 External Dependencies
 
 #### Data mover job listing
 
-The sweep reads the mover's public job listing, paged, with four query parameters: the job
-type, ascending creation order, the page, and a creation-time floor. Per entry it takes the
+The sweep reads the mover's public job listing, paged, with five query parameters: the job
+type, ascending creation order, the page's size and offset, and a creation-time floor. Per entry it takes the
 job's identity, its connection, its status, its creation and start stamps, its duration and
 its reported record count — all flat on the entry, all as the listing spells them.
 
@@ -453,8 +480,9 @@ sequenceDiagram
     participant M as Data mover
     participant L as Sync ledger
 
-    R->>L: oldest job still open, else the newest recorded
+    R->>L: oldest job still open (floored), or the newest recorded
     L-->>R: watermark (empty ⇒ backfill everything)
+    R->>L: jobs already closed at or after the watermark
     R->>M: list sync jobs from the watermark, oldest first, paged
     M-->>R: jobs with status, stamps, duration, reported records
     R->>R: map each job's connection to a connector
@@ -474,7 +502,35 @@ runs. No assumption about how many jobs the mover runs at once is needed for tha
 A job the ledger already holds with a terminal status is planned away rather than re-recorded,
 so the re-read costs rows only for jobs that are genuinely still open.
 
-The seal is written last, so a snapshot read never names a tick whose rows are still arriving.
+**The watermark is floored a bounded distance behind the newest recorded job.** Without a
+floor one job that can never close pins the read start for ever, and three inputs produce one:
+a connection deleted while a job was running, so the mover drops the job and its last recorded
+word stays provisional; a status word a later mover release adds, stored as `unknown`, which
+is deliberately non-terminal; and a creation stamp the column cannot hold. Once the start is
+pinned and more jobs than one tick may read sit above it, the newest syncs stop being read at
+all and the page freezes on stale data with only a log line to say so.
+
+**The floor's cost is paid explicitly.** A job open longer than the floor will never be asked
+about again, so its last provisional word would stand as the page's answer indefinitely — the
+page reporting a sync as running long after it stopped being visible. Each tick therefore
+names the jobs that have fallen below its own read start and records their state as `unknown`:
+not a failure, not a success, a state that can no longer be read. That marker also takes the
+job out of the search, so it is written once rather than once a tick.
+
+**The read is bounded in time as well as in pages.** The page cap alone bounds nothing in
+wall-clock: enough slow pages outlive the tick's own deadline, and a tick killed part-way
+never reaches its summary — so the run reads as aborted and the next one is skipped by the
+concurrency policy. Returning success from every sweep path does not protect a tick from a
+sweep that simply takes too long.
+
+**A tick that did not read the mover does not seal.** The seal is what dates the page, so
+sealing anyway would keep an install whose mover is unreachable reporting that it was just
+checked — and the page could then never say recording had stopped (FR-12). The configured-set
+snapshot goes unwritten with it: an unsealed snapshot is unreadable by construction, so
+writing one would be recording nothing anybody reads.
+
+Otherwise the seal is written last, so a snapshot read never names a tick whose rows are still
+arriving.
 
 #### Page read
 
@@ -487,7 +543,8 @@ sequenceDiagram
     participant L as Sync ledger
 
     P->>A: GET /v1/connector-health
-    A->>L: newest sealed tick, and the gaps between the recent ones
+    A->>L: newest sealed tick
+    A->>L: gaps between the recent sealed ticks
     A->>L: newest sync per connector
     A->>L: configured set at that tick
     A-->>P: one row per connector, ordered by attention
@@ -496,9 +553,13 @@ sequenceDiagram
     A-->>P: bounded window, newest first
 ```
 
-The sealed tick is resolved once and bound into the snapshot reads. Resolving it per statement
-would let a sweep landing between two of them answer with the newer configured set beside the
-older facts — a state that never existed on any tick.
+The sealed tick is resolved first and bound into the configured-set read. Resolving it per
+statement would let a sweep landing between two of them answer with the newer configured set
+beside the older facts — a state that never existed on any tick.
+
+The remaining three run concurrently once the tick is known. The gap measurement is bound to
+nothing, which is correct: it describes the recorder's own cadence rather than any tick's
+facts.
 
 ### 3.7 Database schemas & tables
 
@@ -519,7 +580,7 @@ customer extracts, which must never carry service rows.
 | `event` | `LowCardinality(String)` | `sync.completed` \| `connector.configured` \| `sweep.completed` |
 | `status` | `LowCardinality(String)` | on a sync row, the mover's own word or `unknown`; empty elsewhere |
 | `started_at` | `Nullable(DateTime64(3, 'UTC'))` | when the mover says the sync began; NULL for a job it has not started |
-| `job_created_at` | `Nullable(DateTime64(3, 'UTC'))` | when the job was created — the axis the frontier moves along; never NULL on a sync row |
+| `job_created_at` | `Nullable(DateTime64(3, 'UTC'))` | when the job was created — the axis the watermark moves along; never NULL on a sync row |
 | `duration_ms` | `Nullable(UInt64)` | between the mover's own start and end stamps; NULL while a job is in flight and where either stamp is missing, which a zero could not express |
 | `records_reported` | `Nullable(UInt64)` | the mover's own count; NULL where it reported none |
 
@@ -531,8 +592,9 @@ have nothing to say to each other:
 
 | Read | Narrowed by |
 |---|---|
-| the newest sealed tick | `event` |
-| the newest sync per connector | `event`, grouped along `connector` |
+| the newest sealed tick | `event`, then one row off the top |
+| the gaps between the recent sealed ticks | `event`, then twenty rows off the top |
+| the newest sync per connector | `event`, then aggregated by `connector` |
 | one connector's recent syncs | `event`, `connector` |
 | the configured set of a given tick | `event`; `tick_id` is filtered, not indexed |
 
@@ -540,11 +602,16 @@ Only the last falls back to a filter. Leading with `tick_id` instead would narro
 cost of the per-connector expansion — the one read an operator actually waits on — so the
 filter stays, bounded by the size below rather than by the key.
 
-**Size.** Sync rows arrive at one or two per sync: one when a job is first seen in flight,
-one when it ends. They grow with sync activity, not with time. Snapshot rows arrive at one
-per configured connector per tick plus one seal, so at the chart's default reconcile cadence
-of every fifteen minutes that is 96 × (connectors + 1) rows a day, against roughly 17,500
-ticks inside a six-month retention. The snapshot class therefore dominates the table and is
+**Size.** Two row classes, and neither grows without a bound.
+
+Sync rows arrive at one or two per sync — one when a job is first seen in flight, one when it
+ends — plus one per tick for as long as a job stays open. A job that never closes would
+therefore accrue a row per tick indefinitely, which is what the sweep's read floor exists to
+bound rather than the table.
+
+Snapshot rows arrive at one per configured connector per tick plus one seal, so at the chart's
+default reconcile cadence of every fifteen minutes that is 96 × (connectors + 1) rows a day,
+against roughly 17,500 ticks inside a six-month retention. The snapshot class dominates and is
 what retention is sized against. If it ever stops being negligible, writing the snapshot only
 when the managed set changes removes the class without changing what any read resolves.
 
@@ -572,9 +639,10 @@ user and checks that `SELECT` is allowed while `INSERT`, `CREATE`, `DROP`, `TRUN
 
 | Change | Where it lands |
 |---|---|
-| ledger table and grant | ClickHouse migration, applied by the post-upgrade hook |
+| ledger table | ClickHouse migration, applied by the post-upgrade hook |
+| ledger grant | the query-path role's definition, applied by the same hook before the migrations |
 | sweep | the reconcile loop's existing image and CronWorkflow |
-| horizon-free configuration | none — the sweep needs no new chart value |
+| configuration | none — the sweep reuses the credentials the reconcile loop already holds |
 | two routes | analytics service |
 | pane | portal bundle |
 
@@ -593,9 +661,9 @@ and the read surface is two more routes on a service that already serves the por
   not worth carrying that hazard for a first iteration.
 - **Transform outcome.** Same reason: only the pipeline knows it.
 - **How a sync was started.** The mover's listing does not say, and inferring it means
-  correlating against the workflow layer's own records — a second uncertain source, with a
-  trust horizon of its own, to answer a question the page cannot act on without the transform
-  outcome anyway.
+  correlating against the workflow layer's own records — a second uncertain source, needing its
+  own rules about how far back an absence counts as evidence, to answer a question the page
+  cannot act on without the transform outcome anyway.
 - **Per-stream volume.** Reading it means either granting the reader bronze access, which the
   constraint above forbids, or recording it per tick, which grows the table with streams
   rather than with syncs.

--- a/docs/components/backend/analytics/specs/connector-health/DESIGN.md
+++ b/docs/components/backend/analytics/specs/connector-health/DESIGN.md
@@ -426,6 +426,10 @@ Shape rules that the generated contract enforces:
   instead of implying health.
 - `window` is the largest number of rows the per-connector list can hold, so the page can say
   the list is a window rather than the whole retained history (FR-6).
+- **The summary carries a row cap too.** The set is bounded by the build's descriptor list in
+  practice, so an install cannot reach the cap by configuring connectors — only by accumulating
+  names in the ledger that no build has. It is a backstop rather than a page, and the read logs
+  when it truncates, because reaching it should be visible rather than silent.
 
 ### 3.4 Internal Dependencies
 

--- a/docs/components/backend/analytics/specs/connector-health/DESIGN.md
+++ b/docs/components/backend/analytics/specs/connector-health/DESIGN.md
@@ -185,10 +185,10 @@ column the reader and the writer will disagree about.
 | `job_id` | the mover's job identity | empty | empty |
 | `connector` | the synced connector | the member connector | empty |
 | `status` | the mapped outcome | empty | empty |
-| `started_at` | as reported; NULL if not started | NULL | NULL |
+| `started_at` | the job's own start, else its first attempt's; NULL if not started | NULL | NULL |
 | `job_created_at` | always present | NULL | NULL |
-| `duration_ms` | as reported; NULL if none | NULL | NULL |
-| `records_reported` | as reported; NULL if none | NULL | NULL |
+| `duration_ms` | between the mover's own two stamps; NULL until terminal | NULL | NULL |
+| `records_reported` | the last attempt's count; NULL if it reported none | NULL | NULL |
 
 Empty rather than NULL where a column is inapplicable to a row class: those columns are
 `LowCardinality(String)`, and every read filters by `event` before touching them, so an
@@ -199,11 +199,16 @@ job creation time; the configured set is the membership of the newest *sealed* t
 matters: without keying on the marker, a snapshot still being written would read as the whole
 set, and a connector removed a moment ago would come back for one tick.
 
-**Status vocabulary.** `ok`, `failed`, `cancelled`, `running`, `unknown`. The mover's own
-words are mapped onto this closed set at the boundary; a word outside the mover's documented
-vocabulary is stored as `unknown` rather than passed through, so nothing downstream holds a
-value it cannot read. `unknown` is not a failure and not a reason to sort a connector as
-quiet — the page shows it as a state it cannot read.
+**Status vocabulary.** The mover's own six words, stored verbatim: `pending`, `running`,
+`incomplete`, `succeeded`, `failed`, `cancelled` — plus `unknown` for a word outside that set.
+Nothing is translated on the way in. A surface reporting someone else's account should not
+paraphrase it, and a translation table is one more place for a meaning to be lost: rewriting
+`succeeded` as `ok` would be this service asserting something the mover did not say. What the
+boundary does instead is close the set, so nothing downstream holds a value it cannot read.
+
+`unknown` is neither a failure nor a success, and it does not sort a connector as quiet — the
+page shows it as a state it could not read. It is also not terminal: coverage fails closed, so
+a status the sweep could not read is one it keeps re-reading until it becomes one it can.
 
 **Two timestamps, kept apart.** `started_at` is when the mover says the sync began, and is
 absent for a job it has not started. `job_created_at` is when the job was created, which is
@@ -211,15 +216,21 @@ the field the mover's listing is ordered and filtered by — and therefore the a
 own frontier moves along. Substituting one for the other would report a start that never
 happened and still leave the cursor on the wrong axis.
 
-**`job_created_at` is never NULL on a sync row.** The listing is ordered and filtered by it,
-so a job the mover returns always carries one; the column is nullable only because snapshot
-and seal rows are not about a job at all. The invariant is load-bearing rather than tidy: the
-summary resolves the newest sync per connector with `argMax` over this column, and `argMax`
-ignores rows whose value argument is NULL. A sync row missing it would not merely lose that
-comparison — it would drop out of the summary entirely, taking with it a connector whose only
-recorded sync it was, and rendering as absence rather than as unknown. So a job the mover
-returns without a creation time is one the planner cannot place in time, and it is skipped
-and logged rather than written with a NULL.
+**`job_created_at` is never NULL on a sync row.** The listing is ordered by it, so a job the
+mover returns always carries one; the column is nullable only because snapshot and seal rows
+are not about a job at all. A job the mover returns without a creation time is one the planner
+cannot place in time, so it is skipped and logged rather than written with a NULL.
+
+**The resolution is two `LIMIT 1 BY` steps, not `argMax`.** The inner step takes the newest
+ROW per job and the outer step the newest JOB per connector, and the split is load-bearing in
+both directions.
+
+A job seen mid-flight and later seen finished leaves two rows that share one creation time, so
+resolving straight to the newest job would tie between them — and could answer `running` for a
+sync that ended. And `argMax` ignores rows whose value argument is NULL, so a sync row that
+somehow carried no creation time would not merely lose the comparison but take its whole
+connector out of the answer, rendering as absence rather than as unknown. `LIMIT 1 BY` still
+returns a row when every candidate is NULL, which is the failure mode worth preferring.
 
 ### 3.2 Component Model
 
@@ -331,7 +342,7 @@ design.
       "configured": true,
       "last_sync": {
         "job_id": "8412",
-        "status": "ok",
+        "status": "succeeded",
         "started_at": "2026-01-15T09:00:00Z",
         "duration_ms": 142000,
         "records_reported": 12400
@@ -347,10 +358,11 @@ bounded:
 ```json
 {
   "connector": "example-tracker",
+  "window": 50,
   "syncs": [
     {
       "job_id": "8412",
-      "status": "ok",
+      "status": "succeeded",
       "started_at": "2026-01-15T09:00:00Z",
       "duration_ms": 142000,
       "records_reported": 12400
@@ -365,8 +377,10 @@ disagree, the generated one is right.
 
 Shape rules that the generated contract enforces:
 
-- **Nullable fields are required and nullable**, never optional. The service always emits the
-  key; a client written to the contract must handle `null` rather than a missing key.
+- **Nullable fields are always emitted.** No field is skipped when absent, so a client sees
+  `null` rather than a missing key. The generated contract still marks them optional, which is
+  what every other DTO on this service does — a lone shape with its own nullability convention
+  would cost more than the looser contract does, since handling `null` handles both.
 - `last_sync` is null for a configured connector that has never synced.
 - **`as_of` and `checked_at` are different clocks and both are needed.** `as_of` is when the
   service computed the answer; `checked_at` is the newest sealed tick's own stamp — when the
@@ -384,6 +398,8 @@ Shape rules that the generated contract enforces:
   differently (FR-7).
 - `history_available` is false when nothing has been recorded at all, so the page can say so
   instead of implying health.
+- `window` is the largest number of rows the per-connector list can hold, so the page can say
+  the list is a window rather than the whole retained history (FR-6).
 
 ### 3.4 Internal Dependencies
 
@@ -400,10 +416,24 @@ Shape rules that the generated contract enforces:
 
 #### Data mover job listing
 
-The sweep consumes the mover's stable public job listing: per job, its identity, connection,
-outcome, creation and start timestamps, duration, and reported record count. Richer per-job
-detail exists but is not contract-stable across mover upgrades, so nothing here depends on
-it. Unavailable ⇒ the sweep records nothing this tick and the page serves the last recorded
+The sweep reads the mover's public job listing, paged, with four query parameters: the job
+type, ascending creation order, the page, and a creation-time floor. Per entry it takes the
+job's identity, its connection, its status, its creation and start stamps, its duration and
+its reported record count — all flat on the entry, all as the listing spells them.
+
+Two of those parameters carry the correctness of the whole read. **Ascending order** is what
+makes a capped pass safe: whatever the cap leaves unread is newer than everything collected,
+so the next tick resumes at that edge rather than the watermark stepping over a gap. **The
+creation-time floor** is what keeps a steady tick from re-reading the whole retained history
+to find the handful of jobs it has not seen.
+
+The floor is sent in the listing's own stamp format, which differs from the ledger's by a
+separator. Sending the ledger's form is silent rather than loud — the listing does not filter
+on it — so the conversion lives in one named function rather than at the call site.
+
+Nothing richer is read. Per-job detail exists and is not contract-stable across mover
+upgrades; the value of this ledger is that it keeps saying what a changing source said.
+Unavailable ⇒ the sweep records nothing this tick and the page serves the last recorded
 facts.
 
 #### Warehouse
@@ -423,21 +453,28 @@ sequenceDiagram
     participant M as Data mover
     participant L as Sync ledger
 
-    R->>L: newest job-creation time already covered
-    L-->>R: frontier (empty ⇒ backfill everything)
-    R->>M: list jobs created since frontier, oldest first, paged
-    M-->>R: jobs with outcome, timestamps, reported records
+    R->>L: oldest job still open, else the newest recorded
+    L-->>R: watermark (empty ⇒ backfill everything)
+    R->>M: list sync jobs from the watermark, oldest first, paged
+    M-->>R: jobs with status, stamps, duration, reported records
+    R->>R: map each job's connection to a connector
     R->>R: plan rows for jobs not already closed
     R->>L: insert planned sync rows
     R->>L: insert configured-set rows
     R->>L: insert the seal
 ```
 
-The frontier moves along job creation time because that is what the listing is ordered and
-filtered by. Reading oldest-first makes a truncated read resumable: what is cut is newer than
-everything collected, so the next tick continues at the edge rather than leaving a gap behind
-the cursor. The seal is written last, so a snapshot read never names a tick whose rows are
-still arriving.
+**The watermark is the oldest job still open, and only the newest job recorded when nothing
+is open.** The newest recorded job is the one most likely still running, so a watermark
+standing on it would never let a later tick see how that job ended — the page would show a
+sync running for ever. Standing on the oldest open job leaves every unfinished job at or above
+the line, to be re-read until it closes, at the cost of one duplicate row per tick while it
+runs. No assumption about how many jobs the mover runs at once is needed for that to hold.
+
+A job the ledger already holds with a terminal status is planned away rather than re-recorded,
+so the re-read costs rows only for jobs that are genuinely still open.
+
+The seal is written last, so a snapshot read never names a tick whose rows are still arriving.
 
 #### Page read
 
@@ -480,10 +517,10 @@ customer extracts, which must never carry service rows.
 | `job_id` | `String` | the mover's job identity; empty on rows that are not about a job |
 | `connector` | `LowCardinality(String)` | hyphenated connector name; empty on the seal row |
 | `event` | `LowCardinality(String)` | `sync.completed` \| `connector.configured` \| `sweep.completed` |
-| `status` | `LowCardinality(String)` | on a sync row, the closed set `ok` \| `failed` \| `cancelled` \| `running` \| `unknown`; empty elsewhere |
+| `status` | `LowCardinality(String)` | on a sync row, the mover's own word or `unknown`; empty elsewhere |
 | `started_at` | `Nullable(DateTime64(3, 'UTC'))` | when the mover says the sync began; NULL for a job it has not started |
 | `job_created_at` | `Nullable(DateTime64(3, 'UTC'))` | when the job was created — the axis the frontier moves along; never NULL on a sync row |
-| `duration_ms` | `Nullable(UInt64)` | elapsed time as reported; NULL where the mover reported none, which a zero could not express |
+| `duration_ms` | `Nullable(UInt64)` | between the mover's own start and end stamps; NULL while a job is in flight and where either stamp is missing, which a zero could not express |
 | `records_reported` | `Nullable(UInt64)` | the mover's own count; NULL where it reported none |
 
 `ENGINE = MergeTree`, `PARTITION BY toYYYYMM(ts)`,
@@ -522,9 +559,14 @@ applied files, so every statement in it is written to be safe to repeat.
 |---|---|---|
 | read-only query-path role | `SELECT ON ingestion_history.*` | everything the read surface needs |
 
+The grant lives with the role definition rather than in the migration, beside every other
+grant the query path holds, and re-applies on each deploy along with them.
+
 The writer takes no grant here: the reconcile loop authenticates as the ingestion user, which
-owns the database already. The query-path role must not be given anything that writes, and a
-static test over the migration asserts exactly that.
+owns the database already. The query-path role must not be given anything that writes, and an
+opt-in test against a real server asserts exactly that — it assigns the role to a throwaway
+user and checks that `SELECT` is allowed while `INSERT`, `CREATE`, `DROP`, `TRUNCATE` and
+`ALTER` are all refused.
 
 ### 3.8 Deployment Topology
 

--- a/docs/components/backend/analytics/specs/connector-health/PRD.md
+++ b/docs/components/backend/analytics/specs/connector-health/PRD.md
@@ -415,10 +415,14 @@ the product computes no cadence and claims no intended schedule.
 - [ ] `p2` - **ID**: `cpt-insightspec-connhealth-usecase-fresh-install`
 
 On a new install the operator configures a subset of connectors. The page lists configured
-connectors with their first recorded syncs, and shows the rest — schemas with no
-configuration record and no syncs — as never configured at the bottom, not as failures
-(FR-4). Before the first controller cadence completes, the page says nothing has been read
-from the mover yet rather than implying anything.
+connectors with their first recorded syncs, and sorts a connector that has dropped out of
+configuration — one holding sync history but absent from the newest snapshot — to the bottom
+rather than reporting it as a failure (FR-4). Before the first controller cadence completes,
+the page says nothing has been read from the mover yet rather than implying anything.
+
+A connector that was never configured and has never synced is not listed at all. FR-11 gives
+the read surface one relation and nothing else, and such a connector has left no record in
+it; listing it would mean reading storage the reader deliberately holds no access to.
 
 ## 9. Acceptance Criteria
 
@@ -461,10 +465,10 @@ from the mover yet rather than implying anything.
 - The mover retains job history long enough for a useful backfill window; retention shorter
   than ledger retention limits backfill, not steady-state operation. Its listing is paged, so
   the window is the mover's retention rather than one page of it.
-- A connector name carries no underscore, which keeps the mapping between a connector name
-  and its bronze schema reversible. Nothing enforces this today, and a name that breaks it
-  would attribute syncs to the wrong connector; extending the connector wiring guard is the
-  cheapest way to turn the assumption into a fact.
+- A connector name carries no underscore, so the name the read surface parses out of a URL
+  path is the name the descriptor declares. Enforced by the connector wiring guard rather
+  than assumed: a name that breaks it would leave that connector's history unreachable
+  behind a row the page had already drawn.
 
 ## 12. Open Decisions
 

--- a/docs/components/backend/analytics/specs/connector-health/PRD.md
+++ b/docs/components/backend/analytics/specs/connector-health/PRD.md
@@ -1,0 +1,471 @@
+# PRD — Connector Health
+
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Module-Specific Environment Constraints](#31-module-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 Recording Syncs](#51-recording-syncs)
+  - [5.2 Presenting State](#52-presenting-state)
+  - [5.3 Degradation](#53-degradation)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 NFR Inclusions](#61-nfr-inclusions)
+  - [6.2 NFR Exclusions](#62-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+  - [UC-1 — A failing connector is triaged from the product](#uc-1--a-failing-connector-is-triaged-from-the-product)
+  - [UC-2 — A silent stop is noticed](#uc-2--a-silent-stop-is-noticed)
+  - [UC-3 — A fresh install is read correctly](#uc-3--a-fresh-install-is-read-correctly)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Open Decisions](#12-open-decisions)
+- [13. Risks](#13-risks)
+
+<!-- /toc -->
+
+Scoped addition to the [Analytics service](../../DESIGN.md) and the reconcile loop: what an
+instance operator must be able to learn about the state of every connector, and what the
+product may and may not claim about it. Realised by [DESIGN.md](DESIGN.md). Supersedes the
+current Data health pane and the sketch in
+[PR #2713](https://github.com/constructorfabric/insight/pull/2713), which is not merged.
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Give the instance operator one admin surface that answers, per connector: is it configured,
+when did its last sync run, how did that sync end, and how often has it been failing. The
+surface reports recorded facts about syncs; it never infers a verdict it cannot back.
+
+### 1.2 Background / Problem Statement
+
+The product today has no surface that reports connector state. The pane named *Data health*
+counts schema-check statuses of metric definitions — a fact about the metric catalogue, not
+about whether data arrives — and each of its counters overstates (custom metrics carry no
+schema status by design, disabled definitions count as health, a schema-broken definition
+with no observation counts twice).
+
+The consequence is operational: a connector that quietly stops delivering looks identical to
+one that was never configured, and the customer notices empty dashboards before the operator
+notices the connector. Related backlog items describe the same pain from the alerting side
+([#744](https://github.com/constructorfabric/insight/issues/744),
+[#723](https://github.com/constructorfabric/insight/issues/723)); this PRD covers the
+observation surface, not notifications.
+
+Two failure classes are invisible today even to a diligent operator reading dashboards:
+
+| Failure | Why it is invisible |
+|---|---|
+| Sync fails repeatedly | old data still renders; nothing states that ingestion is failing |
+| A connector is removed or never configured | its schema still exists, so absence looks like emptiness |
+
+### 1.3 Goals (Business Outcomes)
+
+- The operator learns that a connector's syncs are failing from the product, the same day
+  they start failing — not from a user reporting an empty dashboard.
+- Every sync the mover ran leaves a durable, queryable record that outlives the mover's own
+  job retention.
+- The page distinguishes *failing*, *running*, *never ran*, and *no longer configured* —
+  states that are conflated today.
+- No verdict is presented that the recorded facts cannot back; absence of knowledge renders
+  as *unknown*, never as *healthy*.
+
+### 1.4 Glossary
+
+| Term | Meaning |
+|---|---|
+| **Connector** | one ingestion source type configured on the install; its raw data lands in a per-connector bronze schema |
+| **Sync** | one execution of the data mover for one connector's connection |
+| **Run ledger** | the append-only record of sync outcomes this PRD introduces |
+| **Sweep** | the periodic reconciliation that copies sync outcomes from the mover's job history into the ledger |
+| **Configured connector** | a connector present in the reconcile controller's latest recorded snapshot of the set it manages; absence from the latest snapshot means no longer configured |
+| **Honest unknown** | a value the system does not know rendered as unknown, never as zero or as healthy |
+| **Reported records** | the record count the mover states for a sync. It describes what the mover sent, not what storage kept |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Instance operator
+
+**ID**: `cpt-insightspec-connhealth-actor-operator`
+
+**Role**: administers one Insight install; configures connectors and is accountable for data
+arriving.
+**Needs**: to see which connectors are configured, when each last synced, how that sync
+ended, and whether a quiet connector is failing, stopped, or was never configured. The
+operator is the only human actor permitted to read this surface.
+
+### 2.2 System Actors
+
+#### Reconcile loop
+
+**ID**: `cpt-insightspec-connhealth-actor-reconcile`
+
+**Role**: the periodic controller that provisions connections from connector configuration.
+Sole writer of the run ledger: each tick it sweeps the mover's job history and records sync
+outcomes, plus a snapshot of the connector set it manages.
+
+#### Data mover
+
+**ID**: `cpt-insightspec-connhealth-actor-mover`
+
+**Role**: executes syncs and keeps a bounded job history with per-job outcome, timestamps and
+a reported record count. Source the sweep reads; never read on the page's request path.
+
+#### Warehouse
+
+**ID**: `cpt-insightspec-connhealth-actor-warehouse`
+
+**Role**: stores the run ledger and serves it to the read surface.
+
+#### Analytics service
+
+**ID**: `cpt-insightspec-connhealth-actor-analytics`
+
+**Role**: serves the read surface to the portal from the ledger alone.
+
+#### Portal
+
+**ID**: `cpt-insightspec-connhealth-actor-portal`
+
+**Role**: renders the admin page: one summary row per connector, expandable to that
+connector's recent syncs.
+
+## 3. Operational Concept & Environment
+
+Facts flow one way. On a fixed cadence the reconcile loop reads the mover's job history and
+records each sync's outcome into the run ledger, alongside a snapshot of the connectors it
+manages. At read time the analytics service answers from the ledger alone — no call leaves
+the warehouse on the request path, and nothing the page shows depends on the mover being
+reachable.
+
+### 3.1 Module-Specific Environment Constraints
+
+- **Bronze schemas are not tenant-partitioned**, so this read is instance-wide and gated on
+  the operator role rather than scoped by tenant.
+- **Bronze schemas exist for every connector the build knows**, configured or not; storage
+  presence alone cannot distinguish *never configured* from *configured and broken*. The
+  recorded configured set provides that distinction.
+- **Sync schedules live in the cluster's workflow layer**, not in the mover; the mover cannot
+  say when the next sync is due, only what its past jobs did.
+- **Freshness thresholds are declared per connector in transform-layer source definitions
+  and have no runtime-readable form.** Until they do, the surface reports facts without
+  fresh/stale verdicts.
+- **Development compose stands run no mover.** The surface is not supported there beyond not
+  breaking: it renders its degraded state (see FR-9).
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- The run ledger: an append-only record of sync outcomes, written by the sweep.
+- Sweep coverage of every sync in the mover's job history, and one-time backfill of the
+  ledger from that history.
+- Recording of the currently configured connector set, so *never configured* is
+  distinguishable from *configured and never ran*.
+- The read surface: two admin endpoints and one portal page — per-connector summary and
+  per-connector sync history.
+- Replacing the current Data health pane with this page.
+
+### 4.2 Out of Scope
+
+- **Whether a sync's data reached storage.** The page reports what the mover states it moved
+  and does not verify it against storage. Pairing a self-report with an independent count
+  requires measuring at sync time inside the ingestion pipeline, which this iteration does
+  not do.
+- **Transform outcome.** Whether downstream layers rebuilt after a sync is not recorded, so
+  "sync succeeded, transform failed" is not a state this surface can show.
+- **How a sync was started.** The mover's job history does not say who triggered a job, and
+  nothing here infers it.
+- **Per-stream volume** — stream counts, stored rows and size are not recorded.
+- **Alerting and notifications** — this PRD makes state observable;
+  [#723](https://github.com/constructorfabric/insight/issues/723) owns pushing it.
+- **Expectation and alerting on the connector set** — this surface records and shows what
+  *is* configured (FR-4); deciding what *should* be configured for a given customer, and
+  alerting on the gap, belongs to
+  [#744](https://github.com/constructorfabric/insight/issues/744).
+- **Freshness verdicts** (fresh / warn / stale) — deferred until declared thresholds have a
+  runtime source.
+- **Compose-stand support** beyond graceful degradation.
+- **Fleet-level views across installs**
+  ([#1816](https://github.com/constructorfabric/insight/issues/1816)).
+
+## 5. Functional Requirements
+
+### 5.1 Recording Syncs
+
+#### FR-1 — Every sync in the mover's history is recorded
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-fr-all-syncs-recorded`
+
+Sync outcome, start time, duration and the mover's reported record count are recorded for
+every job in the mover's history, whatever started it. Each record carries the mover's job
+identity, so re-reading the same history changes nothing. A sync appears in the ledger no
+later than one sweep interval after the mover reports it.
+
+A job the mover has not finished is recorded with the outcome it has, and re-recorded on a
+later tick once it ends: a provisional state never closes a job.
+
+#### FR-2 — History is bounded and survives the mover
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-fr-bounded-history`
+
+Ledger rows are retained for a bounded period long enough to answer "when did this break"
+and "how often does it fail". Retained history outlives connection deletion in the mover,
+where a removed connection takes its job history with it.
+
+#### FR-3 — First sweep backfills retained history
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-fr-backfill`
+
+On an install whose ledger is empty, the first sweep ingests the mover's whole retained job
+history rather than only what happened since. The page therefore has depth on day one. The
+listing is paged and read oldest-first, so a truncated read resumes at its own edge rather
+than leaving a gap behind it.
+
+#### FR-4 — The configured set is recorded
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-fr-configured-set`
+
+Each tick records which connectors the controller manages, as a complete snapshot sealed once
+it is written. A connector present in the newest sealed snapshot is configured; one absent
+from it, but holding sync history, is no longer configured. A tick that cannot read its
+inputs records nothing rather than sealing an empty snapshot, because an empty set is
+indistinguishable from "everything was removed".
+
+### 5.2 Presenting State
+
+#### FR-5 — One summary row per connector
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-fr-summary-row`
+
+Each connector occupies one row carrying: its name, whether it is configured now, when its
+last sync started, how long that sync took, how it ended, and the record count the mover
+reported for it. Values the ledger does not hold render as unknown.
+
+#### FR-6 — A row expands to its recent syncs
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-fr-sync-history`
+
+Expanding a row lists that connector's recent syncs newest first — each with its start time,
+duration, outcome and reported record count — so a one-off failure is distinguishable from a
+repeating one, and a shrinking record count is visible. The list is a bounded window and the
+page says so; it is not the full retained history.
+
+#### FR-7 — Facts, not verdicts
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-fr-facts-not-verdicts`
+
+The surface asserts only what the ledger records. No fresh/stale verdict appears anywhere. A
+successful sync is reported as a successful sync, never as delivery: the ledger holds the
+mover's own account and nothing that corroborates it. Where a fact is missing the page says
+unknown; it never substitutes zero, and never lets an unreadable value read as healthy.
+
+#### FR-8 — Attention orders the page
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-fr-attention-order`
+
+Rows sort by what needs acting on: failing syncs first, then states the page cannot read,
+then everything quiet, with never-ran and never-configured connectors last. Within a band the
+most recent activity comes first.
+
+#### FR-9 — Operator-only, instance-wide
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-fr-operator-only`
+
+The surface is available only to the instance operator role and reports the whole install.
+A caller without that role is refused, and the refusal names the surface it was refused.
+
+### 5.3 Degradation
+
+#### FR-10 — The page works with an empty ledger
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-fr-empty-ledger`
+
+Before the first controller cadence, or on stands where nothing records, the page states
+plainly that nothing has been read from the mover yet, and says when the first read is due.
+It does not error and does not imply health.
+
+#### FR-11 — The read path depends on nothing external
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-fr-no-external-reads`
+
+Serving the page requires only the recorded facts. No mover, cluster API, or other external
+call is made on the request path, and the reader holds no access to raw connector data in any
+form; unavailability upstream cannot degrade the page beyond the staleness of the last
+recorded facts.
+
+## 6. Non-Functional Requirements
+
+### 6.1 NFR Inclusions
+
+#### NFR-1 — Reading is interactive
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-nfr-interactive-read`
+
+Opening the page completes within an interactive budget on large installs, because the read
+path touches only recorded facts — never raw connector data, and never a measurement taken
+while the operator waits.
+
+#### NFR-2 — Recording never breaks reconciliation
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-nfr-recording-harmless`
+
+A failure anywhere in the sweep must not disturb connector reconciliation around it: no tick
+aborts because observability broke. Observability is subordinate to the thing observed.
+
+#### NFR-3 — The sweep is idempotent
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-nfr-idempotent-sweep`
+
+Re-sweeping the same job history — after a crash, a restart, or overlap — does not change
+what the page reports. Duplicate discovery is harmless.
+
+#### NFR-4 — Storage is bounded
+
+- [ ] `p3` - **ID**: `cpt-insightspec-connhealth-nfr-bounded-storage`
+
+The ledger grows with syncs and with controller ticks, and is bounded by retention; it stays
+a small service table and never enters customer-facing exports or metric relations.
+
+### 6.2 NFR Exclusions
+
+- **No real-time guarantee** — a sync becomes visible within one sweep interval, not
+  instantly; an in-flight sync may be reported as running with sweep-interval staleness.
+- **No alerting SLA** — see Out of Scope.
+- **No completeness guarantee for pre-ledger history** — backfill reaches only as far as the
+  mover's retained job history.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### Connector health read surface
+
+**ID**: `cpt-insightspec-connhealth-interface-read-surface`
+
+One operator-gated read surface on the analytics service returning the per-connector summary
+and the recent-sync history described in §5.2. Contract, shape, and transport are specified
+in [DESIGN.md](DESIGN.md).
+
+### 7.2 External Integration Contracts
+
+#### Mover job history
+
+**ID**: `cpt-insightspec-connhealth-contract-mover-history`
+
+The sweep consumes the mover's job listing: per job, its identity, connection, outcome,
+creation and start timestamps, duration, and reported record count. This is a background
+integration owned by the reconcile loop; the read surface never depends on it.
+
+## 8. Use Cases
+
+### UC-1 — A failing connector is triaged from the product
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-usecase-broken-sync`
+
+A connector's scheduled sync fails. The operator opens the page, sees the connector sorted to
+the top with its last sync failed, and expands the row to the recent syncs — enough to tell a
+one-off from a repeating failure, and to see whether the record count had been shrinking
+before it stopped. The window is bounded and the page says so; dating the first failure of a
+long series is out of scope for this surface.
+
+### UC-2 — A silent stop is noticed
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-usecase-silent-stop`
+
+A connector's schedule disappears (a suspended or deleted workflow). No new syncs are
+recorded. The page shows how long ago the connector's last sync started, and the expansion
+lists the start times of the recent ones. The operator reads the gap from those timestamps;
+the product computes no cadence and claims no intended schedule.
+
+### UC-3 — A fresh install is read correctly
+
+- [ ] `p2` - **ID**: `cpt-insightspec-connhealth-usecase-fresh-install`
+
+On a new install the operator configures a subset of connectors. The page lists configured
+connectors with their first recorded syncs, and shows the rest — schemas with no
+configuration record and no syncs — as never configured at the bottom, not as failures
+(FR-4). Before the first controller cadence completes, the page says nothing has been read
+from the mover yet rather than implying anything.
+
+## 9. Acceptance Criteria
+
+- [ ] Every job in the mover's history appears in the ledger within one sweep interval, with
+      outcome, timestamps, duration and reported record count (FR-1).
+- [ ] A job still running is recorded provisionally and re-recorded with its outcome once it
+      ends (FR-1).
+- [ ] A connector with a schema, no snapshot membership, and no syncs renders as never
+      configured; present in the snapshot with no syncs, as configured and never ran; removed
+      from configuration, it stops rendering configured within one controller cadence (FR-4).
+- [ ] A tick whose inputs are unreadable records nothing rather than sealing an empty
+      configured set (FR-4).
+- [ ] Deleting a connection in the mover does not remove already-recorded history (FR-2).
+- [ ] On a ledger-less install the first sweep populates history from the mover's retained
+      jobs (FR-3).
+- [ ] The page renders one row per connector with the fields of FR-5, expandable per FR-6.
+- [ ] No fresh/stale verdict appears anywhere, no successful sync is described as delivery,
+      and unknown states render as unknown (FR-7).
+- [ ] A non-operator caller is refused; the response is instance-wide for the operator
+      (FR-9).
+- [ ] With the mover unreachable, the page still serves the last recorded facts and the
+      reader holds no access to raw connector data (FR-11).
+- [ ] A sweep failure does not abort connector reconciliation (NFR-2); a repeated sweep does
+      not change reported state (NFR-3).
+
+## 10. Dependencies
+
+- The reconcile loop, which already authenticates to the mover and runs on a periodic tick;
+  the sweep extends it.
+- The warehouse, which stores the ledger.
+- Replacement target: the Manage-zone Data health pane in the portal.
+
+## 11. Assumptions
+
+- The mover's job listing is the complete account of syncs for a connection: a sync that ran
+  appears there whatever started it.
+- The mover retains job history long enough for a useful backfill window; retention shorter
+  than ledger retention limits backfill, not steady-state operation. Its listing is paged, so
+  the window is the mover's retention rather than one page of it.
+- A connector name carries no underscore, which keeps the bronze schema naming reversible.
+  Enforced by the connector wiring guard rather than assumed.
+
+## 12. Open Decisions
+
+- ~~Ledger retention length~~ — settled at six months.
+- ~~Per-stream moved-record counters from the mover's job detail~~ — deferred: the sweep
+  consumes the public listing only, so nothing depends on an API that is not
+  contract-stable across mover upgrades.
+- ~~Naming of the replacement pane~~ — settled as Connector health.
+- Whether the sync history needs paging beyond its bounded window. UC-1 is served by the
+  window; dating the first failure of a long series is not, and would need a cursor on the
+  read surface.
+
+## 13. Risks
+
+- **The sweep reads the mover's API across versions.** Mitigation: consume only its stable
+  public listing for outcomes; treat any richer detail as optional enrichment that may
+  degrade without degrading the page (FR-11 keeps the read path independent).
+- **The mover's account is uncorroborated.** A sync it calls successful may have delivered
+  nothing to storage, and this surface cannot tell. Mitigation is honesty rather than
+  detection: the page reports the count as reported, and no state on it says "delivering".
+  Closing the gap needs measurement at sync time and is out of scope here.
+- **A tick can record a partial picture.** Mitigation: the configured-set snapshot is sealed
+  by a marker written last, and reads key on the newest sealed marker, so a half-written tick
+  is never read as a complete one.

--- a/docs/components/backend/analytics/specs/connector-health/PRD.md
+++ b/docs/components/backend/analytics/specs/connector-health/PRD.md
@@ -49,8 +49,9 @@ current Data health pane and the sketch in
 ### 1.1 Purpose
 
 Give the instance operator one admin surface that answers, per connector: is it configured,
-when did its last sync run, how did that sync end, and how often has it been failing. The
-surface reports recorded facts about syncs; it never infers a verdict it cannot back.
+when did its last sync run, and how did that sync end — and, on expanding the row, how often
+it has been failing. The surface reports recorded facts about syncs; it never infers a verdict
+it cannot back.
 
 ### 1.2 Background / Problem Statement
 
@@ -93,9 +94,8 @@ Two failure classes are invisible today even to a diligent operator reading dash
 | **Connector** | one ingestion source type configured on the install; its raw data lands in a per-connector bronze schema |
 | **Sync** | one execution of the data mover for one connector's connection |
 | **Sync ledger** | the append-only record of sync outcomes this PRD introduces |
-| **Sweep** | the periodic reconciliation that copies sync outcomes from the mover's job history into the ledger |
-| **Configured connector** | a connector present in the reconcile controller's latest recorded snapshot of the set it manages; absence from the latest snapshot means no longer configured |
-| **Honest unknown** | a value the system does not know rendered as unknown, never as zero or as healthy |
+| **Sweep** | the periodic reconciliation that copies sync outcomes from the mover's job history into the ledger, and records which connectors it manages |
+| **Configured connector** | a connector present in the controller's newest COMPLETE snapshot of the set it manages; absence from that snapshot means no longer configured. A snapshot still being written is not one |
 | **Reported records** | the record count the mover states for a sync. It describes what the mover sent, not what storage kept |
 
 ## 2. Actors
@@ -216,9 +216,10 @@ reachable.
 - [ ] `p1` - **ID**: `cpt-insightspec-connhealth-fr-all-syncs-recorded`
 
 Sync outcome, start time, duration and the mover's reported record count are recorded for
-every job in the mover's history, whatever started it. Each record carries the mover's job
-identity, so re-reading the same history changes nothing. A sync appears in the ledger no
-later than one sweep interval after the mover reports it.
+every sync job in the mover's history, whatever started it. Each record carries the mover's
+job identity, so re-reading the same history changes nothing. In steady state a sync appears
+in the ledger no later than one sweep interval after the mover reports it; while a backfill is
+still catching up it appears within the passes that backfill takes (FR-3).
 
 A job the mover has not finished is recorded with the outcome it has, and re-recorded on a
 later tick once it ends: a provisional state never closes a job.
@@ -324,7 +325,8 @@ stopped and the connector states shown may no longer be current.
 
 Both the age and the interval are recorded facts, so the page asserts nothing about a
 schedule it cannot see. Where too few reads are recorded to establish an interval, the page
-shows the age alone.
+shows the age and says the cadence is unmeasured — it does not conclude that recording
+stopped, because with no cadence recorded there is nothing for the age to be late against.
 
 ## 6. Non-Functional Requirements
 
@@ -448,6 +450,13 @@ it; listing it would mean reading storage the reader deliberately holds no acces
 - [ ] The page dates itself by when the mover was last read; with recording stopped long
       enough to stand out against the preceding reads, it says so rather than presenting the
       last picture as current (FR-12).
+- [ ] Rows sort worst-first: failing, then unreadable, then quiet, with never-ran and
+      no-longer-configured last, and most recent activity first inside a band (FR-8).
+- [ ] Before any tick has sealed, the page states that nothing has been read rather than
+      rendering an empty install as healthy (FR-10).
+- [ ] The summary answers within its budget with a full retention window recorded (NFR-1).
+- [ ] Ledger growth is bounded by retention, and no connector's history can grow it without
+      bound (NFR-4).
 - [ ] A sweep failure does not abort connector reconciliation (NFR-2); a repeated sweep does
       not change reported state (NFR-3).
 

--- a/docs/components/backend/analytics/specs/connector-health/PRD.md
+++ b/docs/components/backend/analytics/specs/connector-health/PRD.md
@@ -432,9 +432,10 @@ it; listing it would mean reading storage the reader deliberately holds no acces
       outcome, timestamps, duration and reported record count (FR-1).
 - [ ] A job still running is recorded provisionally and re-recorded with its outcome once it
       ends (FR-1).
-- [ ] A connector with a schema, no snapshot membership, and no syncs renders as never
-      configured; present in the snapshot with no syncs, as configured and never ran; removed
-      from configuration, it stops rendering configured within one controller cadence (FR-4).
+- [ ] A connector present in the snapshot with no syncs renders as configured and never ran;
+      removed from configuration, it stops rendering configured within one controller cadence;
+      one that has left no record at all is not listed, because the reader holds one relation
+      and nothing else (FR-4, FR-11).
 - [ ] A tick whose inputs are unreadable records nothing rather than recording an empty
       configured set (FR-4).
 - [ ] Deleting a connection in the mover does not remove already-recorded history (FR-2).

--- a/docs/components/backend/analytics/specs/connector-health/PRD.md
+++ b/docs/components/backend/analytics/specs/connector-health/PRD.md
@@ -56,9 +56,10 @@ surface reports recorded facts about syncs; it never infers a verdict it cannot 
 
 The product today has no surface that reports connector state. The pane named *Data health*
 counts schema-check statuses of metric definitions — a fact about the metric catalogue, not
-about whether data arrives — and each of its counters overstates (custom metrics carry no
-schema status by design, disabled definitions count as health, a schema-broken definition
-with no observation counts twice).
+about whether data arrives — and three of its four counters overstate. Custom metrics carry
+no schema status by design, so they inflate both *unchecked* and *no data yet*; disabled
+definitions count as health. A schema-broken definition that has never produced a row is
+counted twice, under two different counters.
 
 The consequence is operational: a connector that quietly stops delivering looks identical to
 one that was never configured, and the customer notices empty dashboards before the operator
@@ -91,7 +92,7 @@ Two failure classes are invisible today even to a diligent operator reading dash
 |---|---|
 | **Connector** | one ingestion source type configured on the install; its raw data lands in a per-connector bronze schema |
 | **Sync** | one execution of the data mover for one connector's connection |
-| **Run ledger** | the append-only record of sync outcomes this PRD introduces |
+| **Sync ledger** | the append-only record of sync outcomes this PRD introduces |
 | **Sweep** | the periodic reconciliation that copies sync outcomes from the mover's job history into the ledger |
 | **Configured connector** | a connector present in the reconcile controller's latest recorded snapshot of the set it manages; absence from the latest snapshot means no longer configured |
 | **Honest unknown** | a value the system does not know rendered as unknown, never as zero or as healthy |
@@ -118,7 +119,7 @@ operator is the only human actor permitted to read this surface.
 **ID**: `cpt-insightspec-connhealth-actor-reconcile`
 
 **Role**: the periodic controller that provisions connections from connector configuration.
-Sole writer of the run ledger: each tick it sweeps the mover's job history and records sync
+Sole writer of the sync ledger: each tick it sweeps the mover's job history and records sync
 outcomes, plus a snapshot of the connector set it manages.
 
 #### Data mover
@@ -132,7 +133,7 @@ a reported record count. Source the sweep reads; never read on the page's reques
 
 **ID**: `cpt-insightspec-connhealth-actor-warehouse`
 
-**Role**: stores the run ledger and serves it to the read surface.
+**Role**: stores the sync ledger and serves it to the read surface.
 
 #### Analytics service
 
@@ -150,7 +151,7 @@ connector's recent syncs.
 ## 3. Operational Concept & Environment
 
 Facts flow one way. On a fixed cadence the reconcile loop reads the mover's job history and
-records each sync's outcome into the run ledger, alongside a snapshot of the connectors it
+records each sync's outcome into the sync ledger, alongside a snapshot of the connectors it
 manages. At read time the analytics service answers from the ledger alone — no call leaves
 the warehouse on the request path, and nothing the page shows depends on the mover being
 reachable.
@@ -168,13 +169,13 @@ reachable.
   and have no runtime-readable form.** Until they do, the surface reports facts without
   fresh/stale verdicts.
 - **Development compose stands run no mover.** The surface is not supported there beyond not
-  breaking: it renders its degraded state (see FR-9).
+  breaking: it renders its degraded state (see FR-10).
 
 ## 4. Scope
 
 ### 4.1 In Scope
 
-- The run ledger: an append-only record of sync outcomes, written by the sweep.
+- The sync ledger: an append-only record of sync outcomes, written by the sweep.
 - Sweep coverage of every sync in the mover's job history, and one-time backfill of the
   ledger from that history.
 - Recording of the currently configured connector set, so *never configured* is
@@ -226,28 +227,28 @@ later tick once it ends: a provisional state never closes a job.
 
 - [ ] `p2` - **ID**: `cpt-insightspec-connhealth-fr-bounded-history`
 
-Ledger rows are retained for a bounded period long enough to answer "when did this break"
-and "how often does it fail". Retained history outlives connection deletion in the mover,
-where a removed connection takes its job history with it.
+Ledger rows are retained for six months — long enough to answer "when did this break" and
+"how often does it fail". Retained history outlives connection deletion in the mover, where a
+removed connection takes its job history with it.
 
 #### FR-3 — First sweep backfills retained history
 
 - [ ] `p2` - **ID**: `cpt-insightspec-connhealth-fr-backfill`
 
 On an install whose ledger is empty, the first sweep ingests the mover's whole retained job
-history rather than only what happened since. The page therefore has depth on day one. The
-listing is paged and read oldest-first, so a truncated read resumes at its own edge rather
-than leaving a gap behind it.
+history rather than only what happened since, so the page has depth on day one. A backfill
+that cannot finish in one pass leaves no gap behind it: whatever it did not reach is still
+picked up by a later one.
 
 #### FR-4 — The configured set is recorded
 
 - [ ] `p2` - **ID**: `cpt-insightspec-connhealth-fr-configured-set`
 
-Each tick records which connectors the controller manages, as a complete snapshot sealed once
-it is written. A connector present in the newest sealed snapshot is configured; one absent
-from it, but holding sync history, is no longer configured. A tick that cannot read its
-inputs records nothing rather than sealing an empty snapshot, because an empty set is
-indistinguishable from "everything was removed".
+Each tick records which connectors the controller manages, as one complete snapshot. A
+connector present in the newest complete snapshot is configured; one absent from it but
+holding sync history is no longer configured. A snapshot still being written is never read as
+a complete one. A tick that cannot read its inputs records nothing rather than recording an
+empty set, because an empty set is indistinguishable from "everything was removed".
 
 ### 5.2 Presenting State
 
@@ -299,8 +300,8 @@ A caller without that role is refused, and the refusal names the surface it was 
 - [ ] `p2` - **ID**: `cpt-insightspec-connhealth-fr-empty-ledger`
 
 Before the first controller cadence, or on stands where nothing records, the page states
-plainly that nothing has been read from the mover yet, and says when the first read is due.
-It does not error and does not imply health.
+plainly that nothing has been read from the mover yet. It does not error and does not imply
+health.
 
 #### FR-11 — The read path depends on nothing external
 
@@ -311,6 +312,20 @@ call is made on the request path, and the reader holds no access to raw connecto
 form; unavailability upstream cannot degrade the page beyond the staleness of the last
 recorded facts.
 
+#### FR-12 — A stopped recorder is visible
+
+- [ ] `p1` - **ID**: `cpt-insightspec-connhealth-fr-stale-recording`
+
+Recording failures are swallowed so they cannot disturb reconciliation (NFR-2), which means a
+recorder that stops leaves the page showing its last picture indefinitely. So the page states
+when the mover was last read, dating everything below it; and when that read is far older
+than the interval between the reads before it, the page says recording appears to have
+stopped and the connector states shown may no longer be current.
+
+Both the age and the interval are recorded facts, so the page asserts nothing about a
+schedule it cannot see. Where too few reads are recorded to establish an interval, the page
+shows the age alone.
+
 ## 6. Non-Functional Requirements
 
 ### 6.1 NFR Inclusions
@@ -319,9 +334,9 @@ recorded facts.
 
 - [ ] `p2` - **ID**: `cpt-insightspec-connhealth-nfr-interactive-read`
 
-Opening the page completes within an interactive budget on large installs, because the read
-path touches only recorded facts — never raw connector data, and never a measurement taken
-while the operator waits.
+Opening the page returns within one second at p95, with the ledger holding a full retention
+window of history, because the read path touches only recorded facts — never raw connector
+data, and never a measurement taken while the operator waits.
 
 #### NFR-2 — Recording never breaks reconciliation
 
@@ -414,7 +429,7 @@ from the mover yet rather than implying anything.
 - [ ] A connector with a schema, no snapshot membership, and no syncs renders as never
       configured; present in the snapshot with no syncs, as configured and never ran; removed
       from configuration, it stops rendering configured within one controller cadence (FR-4).
-- [ ] A tick whose inputs are unreadable records nothing rather than sealing an empty
+- [ ] A tick whose inputs are unreadable records nothing rather than recording an empty
       configured set (FR-4).
 - [ ] Deleting a connection in the mover does not remove already-recorded history (FR-2).
 - [ ] On a ledger-less install the first sweep populates history from the mover's retained
@@ -426,6 +441,9 @@ from the mover yet rather than implying anything.
       (FR-9).
 - [ ] With the mover unreachable, the page still serves the last recorded facts and the
       reader holds no access to raw connector data (FR-11).
+- [ ] The page dates itself by when the mover was last read; with recording stopped long
+      enough to stand out against the preceding reads, it says so rather than presenting the
+      last picture as current (FR-12).
 - [ ] A sweep failure does not abort connector reconciliation (NFR-2); a repeated sweep does
       not change reported state (NFR-3).
 
@@ -443,8 +461,10 @@ from the mover yet rather than implying anything.
 - The mover retains job history long enough for a useful backfill window; retention shorter
   than ledger retention limits backfill, not steady-state operation. Its listing is paged, so
   the window is the mover's retention rather than one page of it.
-- A connector name carries no underscore, which keeps the bronze schema naming reversible.
-  Enforced by the connector wiring guard rather than assumed.
+- A connector name carries no underscore, which keeps the mapping between a connector name
+  and its bronze schema reversible. Nothing enforces this today, and a name that breaks it
+  would attribute syncs to the wrong connector; extending the connector wiring guard is the
+  cheapest way to turn the assumption into a fact.
 
 ## 12. Open Decisions
 
@@ -455,7 +475,8 @@ from the mover yet rather than implying anything.
 - ~~Naming of the replacement pane~~ — settled as Connector health.
 - Whether the sync history needs paging beyond its bounded window. UC-1 is served by the
   window; dating the first failure of a long series is not, and would need a cursor on the
-  read surface.
+  read surface. **Owner**: this spec's author, to settle after the page has been used for
+  triage — not before this iteration ships.
 
 ## 13. Risks
 
@@ -466,6 +487,6 @@ from the mover yet rather than implying anything.
   nothing to storage, and this surface cannot tell. Mitigation is honesty rather than
   detection: the page reports the count as reported, and no state on it says "delivering".
   Closing the gap needs measurement at sync time and is out of scope here.
-- **A tick can record a partial picture.** Mitigation: the configured-set snapshot is sealed
-  by a marker written last, and reads key on the newest sealed marker, so a half-written tick
-  is never read as a complete one.
+- **A tick can record a partial picture.** Mitigation: a tick's snapshot becomes readable
+  only once it is complete, so a half-written tick is never read as a whole one. How
+  completeness is established is DESIGN's.

--- a/scripts/ci/connector_wiring.py
+++ b/scripts/ci/connector_wiring.py
@@ -25,14 +25,15 @@ Checks
                   silver models drop out of any regenerated DDL snapshot.
   3. depends_on — that same connector MUST be declared in class_people.sql's
                   `depends_on` list, per the convention stated in that file.
-  4. name-shape — a connector name MUST NOT contain an underscore. The
-                  connector-health surface parses the name out of a URL path
-                  and accepts lowercase letters, digits and hyphens, so a name
-                  carrying an underscore makes that connector's sync history
-                  unreachable — a 400 on a row the page has already drawn.
-                  (Bronze schemas are named `bronze_<name with - turned into
-                  _>`, so the hyphen-only shape also keeps that mapping
-                  reversible.)
+  4. name-shape — a connector name MUST be non-empty, at most 64 characters,
+                  built only of lowercase letters, digits and hyphens, and must
+                  neither start nor end with a hyphen. That is the vocabulary
+                  the connector-health route's own parser accepts
+                  (`domain/connector_health/name.rs`), and it parses the name
+                  out of a URL path — so a name outside it makes that
+                  connector's sync history unreachable behind a row the page
+                  has already drawn. (The hyphen-only shape also keeps the
+                  `bronze_<name with - turned into _>` mapping reversible.)
   5. cast-types — contributors MUST NOT explicitly cast the same class_people
                   column to different types; `union_by_tag` UNION ALLs the
                   branches and ClickHouse raises Code 386 NO_COMMON_TYPE.
@@ -86,6 +87,30 @@ def _class_people_models(connector_dir: Path) -> list[Path]:
     return [p for p in sorted(dbt_dir.glob("*.sql")) if CLASS_PEOPLE_TAG in p.read_text()]
 
 
+#: The route's parser budget, in characters.
+MAX_CONNECTOR_NAME = 64
+
+
+def _name_complaints(name: str) -> list[str]:
+    """Every way this name differs from what the read surface will accept."""
+    if not name:
+        return ["is empty"]
+
+    complaints = []
+    if len(name) > MAX_CONNECTOR_NAME:
+        complaints.append(f"is longer than {MAX_CONNECTOR_NAME} characters")
+    if name.startswith("-") or name.endswith("-"):
+        complaints.append("starts or ends with a hyphen")
+
+    bad = sorted({c for c in name if not (c.isascii() and (c.islower() or c.isdigit()) or c == "-")})
+    if bad:
+        spelled = ", ".join(repr(c) for c in bad)
+        complaints.append(
+            f"carries {spelled} — use lowercase letters, digits and hyphens only"
+        )
+    return complaints
+
+
 def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--connectors-root", default="src/ingestion/connectors")
@@ -125,16 +150,12 @@ def main(argv: list[str]) -> int:
         images = descriptor.get("images") or {}
 
         # ── name shape ───────────────────────────────────────────────────────
-        # INVARIANT: the connector-health route's own parser accepts lowercase
-        # letters, digits and hyphens. See check 4 above.
+        # INVARIANT: mirrors `ConnectorName::parse` exactly. See check 4 above.
+        # Every rule it enforces is enforced here, or a descriptor passes CI and
+        # then draws a page row whose drill-down answers 400 for ever.
         name = str(descriptor.get("name", ""))
-        if "_" in name:
-            errors.append(
-                f"{rel}: connector name {name!r} carries an underscore. Use "
-                "hyphens: the connector-health route parses the name from a "
-                "URL path and refuses one, so this connector's sync history "
-                "would be unreachable."
-            )
+        for complaint in _name_complaints(name):
+            errors.append(f"{rel}: connector name {name!r} {complaint}")
 
         # ── 1. semver ────────────────────────────────────────────────────────
         if not SEMVER_RE.match(version):

--- a/scripts/ci/connector_wiring.py
+++ b/scripts/ci/connector_wiring.py
@@ -25,7 +25,15 @@ Checks
                   silver models drop out of any regenerated DDL snapshot.
   3. depends_on — that same connector MUST be declared in class_people.sql's
                   `depends_on` list, per the convention stated in that file.
-  4. cast-types — contributors MUST NOT explicitly cast the same class_people
+  4. name-shape — a connector name MUST NOT contain an underscore. The
+                  connector-health surface parses the name out of a URL path
+                  and accepts lowercase letters, digits and hyphens, so a name
+                  carrying an underscore makes that connector's sync history
+                  unreachable — a 400 on a row the page has already drawn.
+                  (Bronze schemas are named `bronze_<name with - turned into
+                  _>`, so the hyphen-only shape also keeps that mapping
+                  reversible.)
+  5. cast-types — contributors MUST NOT explicitly cast the same class_people
                   column to different types; `union_by_tag` UNION ALLs the
                   branches and ClickHouse raises Code 386 NO_COMMON_TYPE.
 
@@ -115,6 +123,18 @@ def main(argv: list[str]) -> int:
         descriptor = _load_yaml(descriptor_path)
         version = str(descriptor.get("version", ""))
         images = descriptor.get("images") or {}
+
+        # ── name shape ───────────────────────────────────────────────────────
+        # INVARIANT: the connector-health route's own parser accepts lowercase
+        # letters, digits and hyphens. See check 4 above.
+        name = str(descriptor.get("name", ""))
+        if "_" in name:
+            errors.append(
+                f"{rel}: connector name {name!r} carries an underscore. Use "
+                "hyphens: the connector-health route parses the name from a "
+                "URL path and refuses one, so this connector's sync history "
+                "would be unreachable."
+            )
 
         # ── 1. semver ────────────────────────────────────────────────────────
         if not SEMVER_RE.match(version):

--- a/src/backend/services/analytics/src/api/connector_health.rs
+++ b/src/backend/services/analytics/src/api/connector_health.rs
@@ -1,0 +1,84 @@
+//! Connector health handlers — `/v1/connector-health*`.
+//!
+//! Both routes are operator-gated and instance-wide: bronze schemas are not
+//! tenant-partitioned, so the surface cannot be scoped by tenant and is gated
+//! on the admin role instead. Neither handler calls anything but the warehouse,
+//! and neither assembles its own answer — the response shapes are pure
+//! functions over recorded facts, so what the page claims is decided somewhere
+//! a test can reach without an `AppState`.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Extension, Path};
+use axum::http::HeaderMap;
+use axum::response::IntoResponse;
+use chrono::Utc;
+use toolkit_canonical_errors::CanonicalError;
+
+use super::error::ConnectorHealthError;
+use super::{ADMIN_ONLY, AppState, require_admin};
+use crate::domain::connector_health::{
+    ConnectorHealthResponse, ConnectorName, HISTORY_WINDOW, SyncHistoryResponse, read_health,
+    read_syncs,
+};
+
+pub async fn get_connector_health(
+    Extension(state): Extension<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, CanonicalError> {
+    require_admin(&state, &headers, admin_only).await?;
+
+    let facts = read_health(&state.ch).await.map_err(read_error)?;
+
+    Ok(Json(ConnectorHealthResponse::from_facts(facts, Utc::now())))
+}
+
+pub async fn get_connector_syncs(
+    Extension(state): Extension<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(connector): Path<String>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    require_admin(&state, &headers, admin_only).await?;
+
+    let name = ConnectorName::parse(&connector).ok_or_else(unnamed_connector)?;
+    let syncs = read_syncs(&state.ch, name.as_str())
+        .await
+        .map_err(read_error)?;
+
+    Ok(Json(SyncHistoryResponse::build(
+        name.into_string(),
+        syncs,
+        HISTORY_WINDOW,
+    )))
+}
+
+/// Names the surface it refused, so an operator who followed a link knows what
+/// to ask for rather than guessing which page rejected them.
+fn admin_only() -> CanonicalError {
+    ConnectorHealthError::permission_denied()
+        .with_reason(ADMIN_ONLY)
+        .create()
+}
+
+fn unnamed_connector() -> CanonicalError {
+    ConnectorHealthError::invalid_argument()
+        .with_field_violation(
+            "connector",
+            "lowercase letters, digits and hyphens only",
+            "INVALID",
+        )
+        .create()
+}
+
+/// The reader's own failure never names the relation it could not read: a
+/// warehouse error message on an admin surface is still a warehouse error
+/// message on the wire.
+#[expect(clippy::needless_pass_by_value, reason = "used directly as map_err")]
+fn read_error(error: clickhouse::error::Error) -> CanonicalError {
+    tracing::error!(error = %error, "connector health read failed");
+    CanonicalError::internal("failed to read connector health").create()
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/backend/services/analytics/src/api/connector_health/tests.rs
+++ b/src/backend/services/analytics/src/api/connector_health/tests.rs
@@ -1,0 +1,62 @@
+//! The refusals this surface raises.
+//!
+//! Asserted against the `Problem` JSON rather than through a router, so they
+//! stay free of the production `AppState` (which needs MariaDB, ClickHouse and
+//! an identity client). What matters here is that a refused caller learns which
+//! surface refused them, and that a read failure never leaks the warehouse's
+//! own words onto the wire.
+
+use toolkit_canonical_errors::{CanonicalError, Problem};
+
+use super::*;
+
+const NAMESPACE: &str = "gts.cf.insight.analytics_api.connector_health.v1~";
+
+fn problem(error: CanonicalError) -> Result<serde_json::Value, serde_json::Error> {
+    serde_json::to_value(Problem::from(error))
+}
+
+#[test]
+fn a_refusal_names_the_surface_it_refused() -> Result<(), Box<dyn std::error::Error>> {
+    let p = problem(admin_only())?;
+    assert_eq!(p["status"], 403);
+    assert_eq!(p["context"]["resource_type"], NAMESPACE);
+    Ok(())
+}
+
+#[test]
+fn a_refusal_says_what_the_caller_is_missing() -> Result<(), Box<dyn std::error::Error>> {
+    let p = problem(admin_only())?;
+    assert_eq!(p["context"]["reason"], ADMIN_ONLY);
+    Ok(())
+}
+
+#[test]
+fn an_unusable_connector_name_is_a_bad_request_not_a_not_found()
+-> Result<(), Box<dyn std::error::Error>> {
+    let p = problem(unnamed_connector())?;
+    assert_eq!(p["status"], 400);
+    let violations = p["context"]["field_violations"]
+        .as_array()
+        .ok_or("field_violations must be an array")?;
+    assert_eq!(violations.len(), 1);
+    assert_eq!(violations[0]["field"], "connector");
+    Ok(())
+}
+
+#[test]
+fn a_read_failure_does_not_repeat_the_warehouse_to_the_caller()
+-> Result<(), Box<dyn std::error::Error>> {
+    let leaky = clickhouse::error::Error::BadResponse(
+        "Code: 60. DB::Exception: Table ingestion_history.sync_events does not exist".to_owned(),
+    );
+    let p = problem(read_error(leaky))?;
+    assert_eq!(p["status"], 500);
+    let body = serde_json::to_string(&p)?;
+    assert!(
+        !body.contains("ingestion_history"),
+        "an internal relation name must not cross the wire: {body}"
+    );
+    assert!(!body.contains("DB::Exception"), "{body}");
+    Ok(())
+}

--- a/src/backend/services/analytics/src/api/error.rs
+++ b/src/backend/services/analytics/src/api/error.rs
@@ -22,6 +22,11 @@ pub struct SavedQueryError;
 #[resource_error("gts.cf.insight.analytics_api.usage.v1~")]
 pub struct UsageError;
 
+/// Resource namespace for `/v1/connector-health*` (the operator's view of what
+/// the data mover reports about every connector's syncs).
+#[resource_error("gts.cf.insight.analytics_api.connector_health.v1~")]
+pub struct ConnectorHealthError;
+
 /// Resource namespace for `/v1/feedback*` (in-product feedback + the admin
 /// read model).
 #[resource_error("gts.cf.insight.analytics_api.feedback.v1~")]

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP API layer — routes and handlers.
 
 pub(crate) mod ai;
+mod connector_health;
 pub(crate) mod error;
 mod feedback;
 mod metric_definitions;
@@ -36,6 +37,7 @@ use tokio::sync::Semaphore;
 
 use crate::config::GearConfig;
 use crate::domain::ai::dto as ai_dto;
+use crate::domain::connector_health as connector_health_domain;
 use crate::domain::external_links::ExternalSourceRegistry;
 use crate::domain::metric_crud;
 use crate::domain::metric_definitions::listing as metric_definitions_listing;
@@ -208,6 +210,38 @@ pub(crate) fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) ->
         )
         .standard_errors(openapi)
         .handler(usage::get_usage_summary)
+        .register(router, openapi);
+
+    // Connector health: the operator's view of what the mover reports about
+    // every connector's syncs. Admin-gated inside the handler, like every other
+    // instance-wide read here.
+    router = OperationBuilder::get("/v1/connector-health")
+        .operation_id("analytics_api.connector_health.summary")
+        .summary("Recorded sync state of every connector")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<connector_health_domain::ConnectorHealthResponse>(
+            openapi,
+            StatusCode::OK,
+            "One row per connector, ordered by what needs acting on",
+        )
+        .standard_errors(openapi)
+        .handler(connector_health::get_connector_health)
+        .register(router, openapi);
+
+    router = OperationBuilder::get("/v1/connector-health/{connector}/syncs")
+        .operation_id("analytics_api.connector_health.syncs")
+        .summary("Recent syncs of one connector, newest first")
+        .authenticated()
+        .no_license_required()
+        .path_param("connector", "Connector name, as the descriptors spell it")
+        .json_response_with_schema::<connector_health_domain::SyncHistoryResponse>(
+            openapi,
+            StatusCode::OK,
+            "A bounded window of recorded syncs",
+        )
+        .standard_errors(openapi)
+        .handler(connector_health::get_connector_syncs)
         .register(router, openapi);
 
     // Sending is open to any signed-in caller; the listing is admin-gated

--- a/src/backend/services/analytics/src/api/openapi_tests.rs
+++ b/src/backend/services/analytics/src/api/openapi_tests.rs
@@ -33,6 +33,8 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
         "/v1/ai/credentials",
         "/v1/ai/explain",
         "/v1/ai/settings",
+        "/v1/connector-health",
+        "/v1/connector-health/{connector}/syncs",
         "/v1/feedback",
         "/v1/metric-definitions",
         "/v1/metric-drilldown",
@@ -53,7 +55,7 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
     }
     assert_eq!(
         paths.len(),
-        21,
+        23,
         "the contract must carry exactly the surviving paths, got {:?}",
         paths.keys().collect::<Vec<_>>()
     );

--- a/src/backend/services/analytics/src/domain/connector_health/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/live_tests.rs
@@ -230,6 +230,81 @@ async fn the_ledger_reads_answer_from_real_rows() {
     two_rows_for_one_job_resolve_to_the_newer(&ch, &at).await;
     a_dropped_connector_stops_reading_configured(&ch, &at).await;
     one_connectors_window_is_newest_first(&ch).await;
+
+    truncate(&ch).await;
+    the_resolution_survives_every_way_it_used_to_be_wrong(&ch, &at).await;
+}
+
+/// Three answers the previous shape got wrong, each measured against a real
+/// server before the shape was replaced.
+///
+/// It sorted the relation and read the winner off the top, which meant: job ids
+/// compared as text so `"9"` beat `"10"`; a NULL creation stamp sorting last in
+/// BOTH directions so an older job won outright; and two rows of one job
+/// sharing a millisecond decided by physical row order. Each produced a
+/// confident wrong answer rather than an absence.
+async fn the_resolution_survives_every_way_it_used_to_be_wrong(
+    ch: &insight_clickhouse::Client,
+    at: &Stamps,
+) {
+    insert(
+        ch,
+        &[
+            // Same creation moment, ids 9 and 10: text order says 9 is newer.
+            sync("9", "numeric", "succeeded", &at.job_older),
+            Row {
+                ts: &at.tick_1,
+                ..sync("10", "numeric", "running", &at.job_older)
+            },
+            // The same job's terminal row, written in the SAME millisecond as
+            // its provisional one.
+            Row {
+                ts: &at.tick_1,
+                records_reported: Some(0),
+                ..sync("10", "numeric", "failed", &at.job_older)
+            },
+            // A newer job the mover gave no creation stamp for.
+            sync("1", "unplaced", "succeeded", &at.job_older),
+            Row {
+                ts: &at.tick_3,
+                job_created_at: None,
+                ..sync("2", "unplaced", "failed", &at.job_newer)
+            },
+        ],
+    )
+    .await;
+
+    let facts = read_health(ch).await.expect("read");
+
+    let numeric = summary_for(&facts.summaries, "numeric");
+    let resolved = numeric.last_sync.as_ref().expect("numeric has synced");
+    assert_eq!(
+        resolved.job_id, "10",
+        "job ids are numbers: compared as text, `9` outranks `10`"
+    );
+    assert_eq!(
+        resolved.status,
+        SyncStatus::Failed,
+        "a terminal row outranks a provisional one written in the same millisecond"
+    );
+    assert_eq!(
+        resolved.records_reported,
+        Some(0),
+        "the terminal row's own reported zero, not the provisional row's absence"
+    );
+
+    let unplaced = summary_for(&facts.summaries, "unplaced");
+    let resolved = unplaced.last_sync.as_ref().expect("unplaced has synced");
+    assert_eq!(
+        resolved.job_id, "2",
+        "a job with no creation stamp must not hand the answer to an older one"
+    );
+    assert!(
+        resolved.job_created_at.is_none(),
+        "the resolved row must be one real row, not a mix of two: job 2 has no \
+         creation stamp, so this must be absent rather than job 1's stamp"
+    );
+    assert_eq!(resolved.status, SyncStatus::Failed);
 }
 
 async fn an_empty_ledger_says_so(ch: &insight_clickhouse::Client) {

--- a/src/backend/services/analytics/src/domain/connector_health/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/live_tests.rs
@@ -225,6 +225,7 @@ async fn the_ledger_reads_answer_from_real_rows() {
     let at = Stamps::fresh();
 
     an_empty_ledger_says_so(&ch).await;
+    a_sealed_empty_sweep_still_counts_as_history(&ch, &at).await;
     truncate(&ch).await;
     rows_cross_into_options(&ch, &at).await;
     two_rows_for_one_job_resolve_to_the_newer(&ch, &at).await;
@@ -305,6 +306,25 @@ async fn the_resolution_survives_every_way_it_used_to_be_wrong(
          creation stamp, so this must be absent rather than job 1's stamp"
     );
     assert_eq!(resolved.status, SyncStatus::Failed);
+}
+
+/// A sweep can seal having found no connector — a fresh install before any is
+/// configured. The mover WAS read then, so the page must date itself rather than
+/// say nothing has been read.
+async fn a_sealed_empty_sweep_still_counts_as_history(
+    ch: &insight_clickhouse::Client,
+    at: &Stamps,
+) {
+    truncate(ch).await;
+    insert(ch, &[seal("tick-empty", &at.tick_1)]).await;
+
+    let facts = read_health(ch).await.expect("read");
+    assert!(
+        facts.has_history,
+        "a sealed tick is recorded history even with no connector in it"
+    );
+    assert!(facts.sealed_at.is_some());
+    assert!(facts.summaries.is_empty());
 }
 
 async fn an_empty_ledger_says_so(ch: &insight_clickhouse::Client) {

--- a/src/backend/services/analytics/src/domain/connector_health/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/live_tests.rs
@@ -1,0 +1,390 @@
+//! Live ClickHouse tests for the sync-ledger reads.
+//!
+//! These exist because an empty table hides every failure that matters here.
+//! A `Nullable` column read into a non-`Option` field, an alias shadowing its
+//! own source, a resolution that ties between two rows of one job — all of them
+//! pass against zero rows and answer 500 the moment a sweep has run. So this
+//! inserts rows and reads them back through the real query path.
+//!
+//! `#[ignore]`d and skipping silently when `INTEGRATION_TESTS_CLICKHOUSE_URL`
+//! is unset (the convention the other live tests here use); optional auth via
+//! `INTEGRATION_TESTS_CLICKHOUSE_USER` / `..._PASSWORD`.
+//!
+//! One test, run in sequence, on purpose: the newest sealed tick and the
+//! per-connector summary are both instance-wide reads, so two of these running
+//! in parallel against a shared server would read each other's rows.
+
+#![expect(
+    clippy::expect_used,
+    reason = "a live-server setup failure should fail the test loudly"
+)]
+
+use chrono::{Duration, SecondsFormat, Utc};
+
+use super::model::SyncStatus;
+use super::read::{absent_ledger, read_health, read_syncs};
+
+const URL_VAR: &str = "INTEGRATION_TESTS_CLICKHOUSE_URL";
+
+/// The table this reads comes from the migration itself, not a copy of it: a
+/// column added there and not here would otherwise pass every test and fail on
+/// the first install to deploy both.
+const MIGRATION: &str = include_str!(
+    "../../../../../../ingestion/scripts/migrations/20260827000000_connector-sync-history.sql"
+);
+
+const TABLE: &str = "ingestion_history.sync_events";
+
+/// Stamps are anchored to now, not to a fixed date.
+///
+/// The table's TTL runs from `ts`, so a row stamped further back than the
+/// retention window is dropped the moment it lands — which reads exactly like a
+/// query that returned nothing. Fixed dates in a test therefore rot silently
+/// into a false failure the day retention passes them.
+fn ago(minutes: i64) -> String {
+    (Utc::now() - Duration::minutes(minutes))
+        .to_rfc3339_opts(SecondsFormat::Millis, false)
+        .replace('T', " ")
+        .replace("+00:00", "")
+}
+
+// Empty counts as unset: the CI matrix passes '' to entries without a
+// provisioned ClickHouse, and set-but-empty must skip exactly like absent.
+fn client_or_skip() -> Option<insight_clickhouse::Client> {
+    let url = std::env::var(URL_VAR).unwrap_or_default();
+    if url.is_empty() {
+        eprintln!("skipping: {URL_VAR} not set");
+        return None;
+    }
+    let mut config = insight_clickhouse::Config::new(url, "default");
+    if let (Ok(user), Ok(password)) = (
+        std::env::var("INTEGRATION_TESTS_CLICKHOUSE_USER"),
+        std::env::var("INTEGRATION_TESTS_CLICKHOUSE_PASSWORD"),
+    ) && !user.is_empty()
+    {
+        config = config.with_auth(user, password);
+    }
+    Some(insight_clickhouse::Client::new(config))
+}
+
+/// The HTTP interface runs one statement per request, so the migration is
+/// fanned out the way `lib/ch-exec.sh` fans it out: drop whole-line comments,
+/// split on `;`.
+async fn apply_migration(ch: &insight_clickhouse::Client) {
+    let body: String = MIGRATION
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("--"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    for statement in body.split(';') {
+        if statement.trim().is_empty() {
+            continue;
+        }
+        ch.query(statement)
+            .execute()
+            .await
+            .unwrap_or_else(|error| panic!("migration statement failed: {error}\n{statement}"));
+    }
+}
+
+async fn truncate(ch: &insight_clickhouse::Client) {
+    ch.query(&format!("TRUNCATE TABLE {TABLE}"))
+        .execute()
+        .await
+        .expect("truncate");
+}
+
+/// One row, written the way the sweep writes it — every column named, so a
+/// column this test forgets is a compile-time-invisible but run-time-loud
+/// mismatch rather than a silent DEFAULT.
+struct Row<'a> {
+    /// Set explicitly rather than left to the column's DEFAULT: three inserts
+    /// in quick succession can share a millisecond, which would make the gap
+    /// between seals zero and the interval assertion below flaky.
+    ts: &'a str,
+    tick_id: &'a str,
+    job_id: &'a str,
+    connector: &'a str,
+    event: &'a str,
+    status: &'a str,
+    started_at: Option<&'a str>,
+    job_created_at: Option<&'a str>,
+    duration_ms: Option<u64>,
+    records_reported: Option<u64>,
+}
+
+impl Row<'_> {
+    fn values(&self) -> String {
+        let moment = |value: Option<&str>| match value {
+            Some(stamp) => format!("toDateTime64('{stamp}', 3, 'UTC')"),
+            None => "NULL".to_owned(),
+        };
+        let number = |value: Option<u64>| match value {
+            Some(count) => count.to_string(),
+            None => "NULL".to_owned(),
+        };
+        format!(
+            "(toDateTime64('{}', 3, 'UTC'), '{}', '{}', '{}', '{}', '{}', {}, {}, {}, {})",
+            self.ts,
+            self.tick_id,
+            self.job_id,
+            self.connector,
+            self.event,
+            self.status,
+            moment(self.started_at),
+            moment(self.job_created_at),
+            number(self.duration_ms),
+            number(self.records_reported),
+        )
+    }
+}
+
+async fn insert(ch: &insight_clickhouse::Client, rows: &[Row<'_>]) {
+    let values: Vec<String> = rows.iter().map(Row::values).collect();
+    let sql = format!(
+        "INSERT INTO {TABLE} (ts, tick_id, job_id, connector, event, status, \
+         started_at, job_created_at, duration_ms, records_reported) VALUES {}",
+        values.join(", ")
+    );
+    ch.query(&sql).execute().await.expect("insert");
+}
+
+fn sync<'a>(job_id: &'a str, connector: &'a str, status: &'a str, created: &'a str) -> Row<'a> {
+    Row {
+        ts: created,
+        tick_id: "tick-1",
+        job_id,
+        connector,
+        event: "sync.completed",
+        status,
+        started_at: Some(created),
+        job_created_at: Some(created),
+        duration_ms: Some(1_000),
+        records_reported: Some(7),
+    }
+}
+
+fn configured<'a>(connector: &'a str, tick_id: &'a str, at: &'a str) -> Row<'a> {
+    Row {
+        ts: at,
+        tick_id,
+        job_id: "",
+        connector,
+        event: "connector.configured",
+        status: "",
+        started_at: None,
+        job_created_at: None,
+        duration_ms: None,
+        records_reported: None,
+    }
+}
+
+fn seal<'a>(tick_id: &'a str, at: &'a str) -> Row<'a> {
+    Row {
+        ts: at,
+        tick_id,
+        job_id: "",
+        connector: "",
+        event: "sweep.completed",
+        status: "",
+        started_at: None,
+        job_created_at: None,
+        duration_ms: None,
+        records_reported: None,
+    }
+}
+
+/// Three ticks a quarter of an hour apart, and three jobs beneath them.
+struct Stamps {
+    tick_1: String,
+    tick_2: String,
+    tick_3: String,
+    job_oldest: String,
+    job_older: String,
+    job_newer: String,
+}
+
+impl Stamps {
+    fn fresh() -> Self {
+        Self {
+            tick_1: ago(40),
+            tick_2: ago(25),
+            tick_3: ago(10),
+            job_oldest: ago(70),
+            job_older: ago(60),
+            job_newer: ago(45),
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "needs a live ClickHouse"]
+async fn the_ledger_reads_answer_from_real_rows() {
+    let Some(ch) = client_or_skip() else { return };
+    apply_migration(&ch).await;
+    let at = Stamps::fresh();
+
+    an_empty_ledger_says_so(&ch).await;
+    truncate(&ch).await;
+    rows_cross_into_options(&ch, &at).await;
+    two_rows_for_one_job_resolve_to_the_newer(&ch, &at).await;
+    a_dropped_connector_stops_reading_configured(&ch, &at).await;
+    one_connectors_window_is_newest_first(&ch).await;
+}
+
+async fn an_empty_ledger_says_so(ch: &insight_clickhouse::Client) {
+    truncate(ch).await;
+    let empty = read_health(ch).await.expect("empty ledger must not error");
+    assert!(!empty.has_history, "nothing recorded means no history");
+    assert!(empty.sealed_at.is_none());
+    assert!(empty.summaries.is_empty());
+    assert!(
+        empty.typical_read_interval_ms.is_none(),
+        "no ticks means no measured interval, not a zero"
+    );
+}
+
+async fn rows_cross_into_options(ch: &insight_clickhouse::Client, at: &Stamps) {
+    insert(
+        ch,
+        &[
+            sync("1", "alpha", "succeeded", &at.job_older),
+            Row {
+                started_at: None,
+                duration_ms: None,
+                records_reported: None,
+                ..sync("2", "alpha", "running", &at.job_newer)
+            },
+            sync("3", "bravo", "failed", &at.job_oldest),
+            configured("alpha", "tick-1", &at.tick_1),
+            configured("bravo", "tick-1", &at.tick_1),
+            seal("tick-1", &at.tick_1),
+        ],
+    )
+    .await;
+
+    let facts = read_health(ch).await.expect("rows must not break the read");
+    assert!(facts.has_history);
+    assert!(facts.sealed_at.is_some(), "the sealed tick dates the facts");
+    assert_eq!(facts.summaries.len(), 2, "one row per connector");
+
+    let alpha = summary_for(&facts.summaries, "alpha");
+    let alpha_sync = alpha.last_sync.as_ref().expect("alpha has synced");
+    assert_eq!(alpha_sync.job_id, "2", "the newest job wins");
+    assert_eq!(alpha_sync.status, SyncStatus::Running);
+    assert!(
+        alpha_sync.started_at.is_none(),
+        "a job not started has no start, not the epoch"
+    );
+    assert!(alpha_sync.duration_ms.is_none());
+    assert!(alpha_sync.records_reported.is_none());
+    assert!(alpha.configured);
+
+    assert_eq!(
+        facts.summaries[0].connector, "bravo",
+        "a failed sync outranks a running one"
+    );
+}
+
+async fn two_rows_for_one_job_resolve_to_the_newer(ch: &insight_clickhouse::Client, at: &Stamps) {
+    insert(
+        ch,
+        &[Row {
+            ts: &at.tick_2,
+            tick_id: "tick-2",
+            records_reported: Some(0),
+            ..sync("2", "alpha", "failed", &at.job_newer)
+        }],
+    )
+    .await;
+
+    let facts = read_health(ch).await.expect("read");
+    let alpha = summary_for(&facts.summaries, "alpha");
+    let alpha_sync = alpha.last_sync.as_ref().expect("alpha has synced");
+    assert_eq!(
+        alpha_sync.status,
+        SyncStatus::Failed,
+        "the newest row of a job is its account, not the first one seen"
+    );
+    assert_eq!(
+        alpha_sync.records_reported,
+        Some(0),
+        "a reported zero is a measurement"
+    );
+}
+
+async fn a_dropped_connector_stops_reading_configured(
+    ch: &insight_clickhouse::Client,
+    at: &Stamps,
+) {
+    // Two further seals a known distance apart, so the interval below is a fact
+    // this test states rather than one it reads back out of the query.
+    insert(
+        ch,
+        &[
+            seal("tick-2", &at.tick_2),
+            configured("alpha", "tick-3", &at.tick_3),
+            seal("tick-3", &at.tick_3),
+        ],
+    )
+    .await;
+
+    let facts = read_health(ch).await.expect("read");
+    let bravo = summary_for(&facts.summaries, "bravo");
+    assert!(
+        !bravo.configured,
+        "dropped from the snapshot means no longer configured"
+    );
+    assert_eq!(
+        facts.summaries.last().map(|row| row.connector.as_str()),
+        Some("bravo"),
+        "a removed connector sorts last, not first"
+    );
+    assert_eq!(
+        facts.typical_read_interval_ms,
+        Some(15 * 60 * 1_000),
+        "three seals fifteen minutes apart make the measured interval fifteen \
+         minutes — measured, not read from a chart value"
+    );
+}
+
+async fn one_connectors_window_is_newest_first(ch: &insight_clickhouse::Client) {
+    let history = read_syncs(ch, "alpha").await.expect("history");
+    assert_eq!(history.len(), 2, "one row per job, not per recorded row");
+    assert_eq!(history[0].job_id, "2", "newest first");
+    assert_eq!(history[1].job_id, "1");
+
+    let missing = read_syncs(ch, "nobody").await.expect("no such connector");
+    assert!(
+        missing.is_empty(),
+        "an unknown connector is empty, not an error"
+    );
+}
+
+fn summary_for<'a>(
+    summaries: &'a [super::model::ConnectorSummary],
+    connector: &str,
+) -> &'a super::model::ConnectorSummary {
+    summaries
+        .iter()
+        .find(|row| row.connector == connector)
+        .unwrap_or_else(|| panic!("no summary for {connector}"))
+}
+
+#[tokio::test]
+#[ignore = "needs a live ClickHouse"]
+async fn a_missing_relation_is_recognised_by_its_real_error() {
+    let Some(ch) = client_or_skip() else { return };
+
+    let error = ch
+        .query("SELECT 1 FROM ingestion_history.no_such_table")
+        .fetch_all::<u8>()
+        .await
+        .expect_err("reading a table that is not there must fail");
+
+    assert!(
+        absent_ledger(&error),
+        "the absent-relation classifier must recognise what ClickHouse \
+         actually says, not what it was assumed to say: {error}"
+    );
+}

--- a/src/backend/services/analytics/src/domain/connector_health/mod.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/mod.rs
@@ -1,0 +1,24 @@
+//! Connector health — what the ledger records about every connector's syncs.
+//!
+//! The write side is the reconcile loop's sweep
+//! (`src/ingestion/reconcile-connectors/python/sweep`), which copies the data
+//! mover's own account of each sync into `ingestion_history.sync_events`. This
+//! module only reads it, and reads nothing else: no mover call, no cluster API,
+//! no bronze access. That is what lets the page answer during exactly the
+//! incident an operator opens it for.
+//!
+//! Spec: `docs/components/backend/analytics/specs/connector-health`.
+
+mod model;
+mod name;
+mod read;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+mod live_tests;
+
+pub(crate) use model::{ConnectorHealthResponse, SyncHistoryResponse};
+pub(crate) use name::ConnectorName;
+pub(crate) use read::{HISTORY_WINDOW, read_health, read_syncs};

--- a/src/backend/services/analytics/src/domain/connector_health/model.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/model.rs
@@ -1,0 +1,258 @@
+//! The shape the page reads, and the order it reads rows in. No I/O.
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Every status the mover's job listing documents, plus the one this service
+/// adds for a word it did not recognise.
+///
+/// Parsed at the boundary so nothing downstream holds a string it cannot
+/// interpret. The variants carry the mover's own words rather than a
+/// translation of them: this surface reports someone else's account, and
+/// renaming `succeeded` to `ok` on the way in would be this service asserting
+/// something the mover did not say.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SyncStatus {
+    Pending,
+    Running,
+    Incomplete,
+    Succeeded,
+    Failed,
+    Cancelled,
+    /// The recorded word was outside the mover's documented vocabulary. Not a
+    /// failure and not a success — a state the page could not read.
+    Unknown,
+}
+
+impl SyncStatus {
+    pub(crate) fn parse(raw: &str) -> Self {
+        match raw {
+            "pending" => Self::Pending,
+            "running" => Self::Running,
+            "incomplete" => Self::Incomplete,
+            "succeeded" => Self::Succeeded,
+            "failed" => Self::Failed,
+            "cancelled" => Self::Cancelled,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Incomplete => "incomplete",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// What a row needs from the reader, worst first.
+///
+/// Never serialised. A verdict on the wire is a verdict some other client
+/// reads differently, so the service sorts by this and ships only the facts
+/// the sort was derived from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Attention {
+    /// A sync that did not finish what it set out to do.
+    Failing,
+    /// A state the page cannot read.
+    Unreadable,
+    /// Something is happening, or the last thing that happened was fine.
+    Settled,
+    /// Configured, with nothing recorded against it yet.
+    NeverRan,
+    /// Absent from the newest sealed snapshot, but holding history.
+    NoLongerConfigured,
+}
+
+/// One connector's newest recorded sync, as the ledger holds it.
+#[derive(Debug, Clone)]
+pub(crate) struct LastSync {
+    pub job_id: String,
+    pub status: SyncStatus,
+    pub started_at: Option<DateTime<Utc>>,
+    /// The axis the ledger orders jobs along. Used to sort within a band and
+    /// never serialised — the page has no use for a job's creation time.
+    pub job_created_at: Option<DateTime<Utc>>,
+    pub duration_ms: Option<u64>,
+    pub records_reported: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ConnectorSummary {
+    pub connector: String,
+    pub configured: bool,
+    pub last_sync: Option<LastSync>,
+}
+
+impl ConnectorSummary {
+    pub(crate) fn attention(&self) -> Attention {
+        let Some(sync) = self.last_sync.as_ref() else {
+            return if self.configured {
+                Attention::NeverRan
+            } else {
+                Attention::NoLongerConfigured
+            };
+        };
+        if !self.configured {
+            return Attention::NoLongerConfigured;
+        }
+        match sync.status {
+            SyncStatus::Failed | SyncStatus::Incomplete => Attention::Failing,
+            SyncStatus::Unknown => Attention::Unreadable,
+            SyncStatus::Pending
+            | SyncStatus::Running
+            | SyncStatus::Succeeded
+            | SyncStatus::Cancelled => Attention::Settled,
+        }
+    }
+
+    /// When this connector was last heard from, for ordering inside a band.
+    fn last_activity(&self) -> Option<DateTime<Utc>> {
+        let sync = self.last_sync.as_ref()?;
+        sync.started_at.or(sync.job_created_at)
+    }
+}
+
+/// Worst first; inside a band, most recent activity first.
+///
+/// A connector with no activity at all sorts after one that has some, in both
+/// bands where that can happen — the alternative is a row with nothing in it
+/// leading a band it shares with rows that do.
+pub(crate) fn by_attention(summaries: &mut [ConnectorSummary]) {
+    summaries.sort_by(|left, right| {
+        left.attention()
+            .cmp(&right.attention())
+            // Descending, and `None` is the smallest `Option` — so a row with
+            // no activity lands at the end of its band rather than the front.
+            .then_with(|| right.last_activity().cmp(&left.last_activity()))
+            .then_with(|| left.connector.cmp(&right.connector))
+    });
+}
+
+/// What the summary read found.
+///
+/// An absent ledger yields the same shape as an empty one with `has_history`
+/// false, so the caller has one path rather than a special case for an install
+/// whose migration has not run.
+#[derive(Debug, Default)]
+pub(crate) struct LedgerFacts {
+    pub sealed_at: Option<DateTime<Utc>>,
+    pub typical_read_interval_ms: Option<u64>,
+    pub summaries: Vec<ConnectorSummary>,
+    pub has_history: bool,
+}
+
+// ── the wire ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct SyncFact {
+    /// The mover's own job identity.
+    pub job_id: String,
+    /// The mover's own word for how the sync ended, or `unknown` where the
+    /// recorded word was outside its documented vocabulary.
+    pub status: String,
+    /// Absent for a job the mover had not started.
+    pub started_at: Option<String>,
+    /// Absent for a job still in flight, and for one the mover gave no usable
+    /// pair of stamps for. Never zero to mean absent.
+    pub duration_ms: Option<u64>,
+    /// What the mover states it moved. Absent where it reported no count at
+    /// all, which is a different answer from a reported zero.
+    pub records_reported: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct ConnectorHealth {
+    pub connector: String,
+    /// Present in the newest sealed snapshot of the set the controller manages.
+    pub configured: bool,
+    /// Absent for a configured connector that has never synced.
+    pub last_sync: Option<SyncFact>,
+}
+
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct ConnectorHealthResponse {
+    /// When this answer was computed. Dates the answer; `checked_at` dates the
+    /// facts in it.
+    pub as_of: String,
+    /// When the mover was last read. Absent before the first sweep sealed.
+    pub checked_at: Option<String>,
+    /// The median gap between the recent sealed ticks. Measured, not
+    /// configured — nothing on this path knows what cadence was intended.
+    /// Absent where too few ticks are recorded to establish one.
+    pub typical_read_interval_ms: Option<u64>,
+    /// False when nothing has been recorded at all, so the page can say so
+    /// instead of implying health.
+    pub history_available: bool,
+    pub connectors: Vec<ConnectorHealth>,
+}
+impl toolkit::api::api_dto::ResponseApiDto for ConnectorHealthResponse {}
+
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct SyncHistoryResponse {
+    pub connector: String,
+    /// A bounded window, newest first — not the full retained history.
+    pub syncs: Vec<SyncFact>,
+    /// How many rows this window holds at most, so the page can say the list
+    /// is a window rather than everything.
+    pub window: u32,
+}
+impl toolkit::api::api_dto::ResponseApiDto for SyncHistoryResponse {}
+
+impl ConnectorHealthResponse {
+    /// Assembles the answer from recorded facts and the reader's own clock.
+    ///
+    /// `as_of` is passed in rather than read here so the assembly is a function
+    /// of its inputs — and so a test can state the instant the page was built
+    /// instead of racing it.
+    pub(crate) fn from_facts(facts: LedgerFacts, as_of: DateTime<Utc>) -> Self {
+        Self {
+            as_of: stamp(as_of),
+            checked_at: facts.sealed_at.map(stamp),
+            typical_read_interval_ms: facts.typical_read_interval_ms,
+            history_available: facts.has_history,
+            connectors: facts.summaries.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl SyncHistoryResponse {
+    pub(crate) fn build(connector: String, syncs: Vec<LastSync>, window: u32) -> Self {
+        Self {
+            connector,
+            syncs: syncs.into_iter().map(Into::into).collect(),
+            window,
+        }
+    }
+}
+
+pub(crate) fn stamp(moment: DateTime<Utc>) -> String {
+    moment.to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+impl From<LastSync> for SyncFact {
+    fn from(sync: LastSync) -> Self {
+        Self {
+            job_id: sync.job_id,
+            status: sync.status.as_str().to_owned(),
+            started_at: sync.started_at.map(stamp),
+            duration_ms: sync.duration_ms,
+            records_reported: sync.records_reported,
+        }
+    }
+}
+
+impl From<ConnectorSummary> for ConnectorHealth {
+    fn from(summary: ConnectorSummary) -> Self {
+        Self {
+            connector: summary.connector,
+            configured: summary.configured,
+            last_sync: summary.last_sync.map(Into::into),
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/connector_health/model.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/model.rs
@@ -37,6 +37,17 @@ impl SyncStatus {
         }
     }
 
+    /// The statuses that will not change again. A job carrying one of these has
+    /// said its last word, so within a job a terminal row outranks a
+    /// provisional one however the clocks compare — a provisional state never
+    /// closes a job, and never reopens one either.
+    pub(crate) const TERMINAL: [Self; 4] = [
+        Self::Succeeded,
+        Self::Failed,
+        Self::Cancelled,
+        Self::Incomplete,
+    ];
+
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Pending => "pending",

--- a/src/backend/services/analytics/src/domain/connector_health/name.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/name.rs
@@ -1,0 +1,36 @@
+//! The connector name as it crosses the request boundary.
+
+/// A connector name, parsed once at the edge so no raw path segment reaches a
+/// query.
+///
+/// The vocabulary is what the descriptors use: lowercase letters, digits and
+/// hyphens. Underscores are excluded deliberately — a connector name maps onto
+/// a bronze schema name by replacing hyphens with underscores, so a name
+/// carrying one already makes that mapping ambiguous.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConnectorName(String);
+
+const MAX_LEN: usize = 64;
+
+impl ConnectorName {
+    pub(crate) fn parse(raw: &str) -> Option<Self> {
+        if raw.is_empty() || raw.len() > MAX_LEN {
+            return None;
+        }
+        if raw.starts_with('-') || raw.ends_with('-') {
+            return None;
+        }
+        let allowed = raw
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+        allowed.then(|| Self(raw.to_owned()))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn into_string(self) -> String {
+        self.0
+    }
+}

--- a/src/backend/services/analytics/src/domain/connector_health/read.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/read.rs
@@ -22,6 +22,16 @@ const SWEEP_COMPLETED: &str = "sweep.completed";
 /// Rows in a connector's expandable history. A window, not the retention.
 pub(crate) const HISTORY_WINDOW: u32 = 50;
 
+/// Connectors the summary will serve.
+///
+/// The set is bounded by the build's descriptor list in practice, so this is a
+/// backstop rather than a page: an install cannot reach it by configuring more
+/// connectors, only by accumulating names in the ledger that no build has. It
+/// exists because an unbounded response is a bug however unlikely the input —
+/// and because reaching it should be visible rather than silent, the read logs
+/// when it truncates.
+const CONNECTOR_LIMIT: u32 = 500;
+
 /// Sealed ticks sampled for the median gap between reads. Enough to survive one
 /// unusual interval; short enough that a cadence change shows up quickly.
 const INTERVAL_SAMPLE: u32 = 20;
@@ -127,7 +137,8 @@ static LAST_SYNC_SQL: LazyLock<String> = LazyLock::new(|| {
          FROM (SELECT connector, argMax(tuple({SYNC_COLUMNS}), ord) AS winner \
                FROM (SELECT connector, {SYNC_COLUMNS}, {order} AS ord \
                      FROM {TABLE} WHERE event = '{SYNC_COMPLETED}') \
-               GROUP BY connector)",
+               GROUP BY connector \
+               ORDER BY connector LIMIT ?)",
         order = &*ROW_ORDER
     )
 });
@@ -259,16 +270,31 @@ pub(crate) async fn read_health(
         ch.query(&READ_INTERVAL_SQL)
             .bind(INTERVAL_SAMPLE)
             .fetch_one::<IntervalRow>(),
-        ch.query(&LAST_SYNC_SQL).fetch_all::<SyncRow>(),
+        ch.query(&LAST_SYNC_SQL)
+            .bind(CONNECTOR_LIMIT)
+            .fetch_all::<SyncRow>(),
         configured_set(ch, sealed.as_ref().map(|tick| tick.tick_id.as_str())),
     )?;
 
+    // A sealed tick IS recorded history, even when it found no connector: the
+    // mover was read, and the page must say when rather than claim nothing has
+    // been read. Deriving this from the rows alone would make a sealed empty
+    // install indistinguishable from one that has never recorded anything.
+    if syncs.len() >= CONNECTOR_LIMIT as usize {
+        tracing::warn!(
+            limit = CONNECTOR_LIMIT,
+            "connector health truncated the summary; the ledger holds at least \
+             as many connector names as the response can carry"
+        );
+    }
+
+    let has_history = sealed.is_some() || !syncs.is_empty();
     let summaries = merge(syncs, &configured);
     Ok(LedgerFacts {
         sealed_at: sealed.map(|tick| tick.sealed_at),
         typical_read_interval_ms: (interval.gaps >= MIN_GAPS_FOR_INTERVAL)
             .then_some(interval.interval_ms),
-        has_history: !summaries.is_empty() || !configured.is_empty(),
+        has_history,
         summaries,
     })
 }
@@ -538,10 +564,30 @@ mod guards {
     }
 
     #[test]
-    fn history_is_a_bounded_window() {
-        assert!(
-            SYNC_HISTORY_SQL.contains("LIMIT ?"),
-            "the window must be bound"
-        );
+    fn every_row_returning_read_is_bounded() {
+        // An unbounded response is a bug however unlikely the input, and the
+        // repository's own rule is to bound it at the edge.
+        for (name, sql) in [
+            ("SYNC_HISTORY_SQL", SYNC_HISTORY_SQL.as_str()),
+            ("LAST_SYNC_SQL", LAST_SYNC_SQL.as_str()),
+            ("SEALED_TICK_SQL", SEALED_TICK_SQL.as_str()),
+            ("READ_INTERVAL_SQL", READ_INTERVAL_SQL.as_str()),
+        ] {
+            assert!(
+                normalised(sql).contains("limit "),
+                "{name} can return an unbounded number of rows",
+            );
+        }
+    }
+
+    /// The configured set is the one read with no row limit, deliberately: it is
+    /// filtered to a single tick, so its size is the number of connectors that
+    /// tick managed — and dropping members of a snapshot would make it read as a
+    /// smaller set than the one that was sealed.
+    #[test]
+    fn the_configured_set_is_bounded_by_its_tick_not_by_a_limit() {
+        let sql = normalised(&CONFIGURED_SET_SQL);
+        assert!(sql.contains("tick_id = ?"), "{sql}");
+        assert!(!sql.contains("limit "), "{sql}");
     }
 }

--- a/src/backend/services/analytics/src/domain/connector_health/read.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/read.rs
@@ -66,26 +66,69 @@ static READ_INTERVAL_SQL: LazyLock<String> = LazyLock::new(|| {
     )
 });
 
-/// The newest sync per connector, resolved in two steps.
+/// Orders every recorded row of every sync, newest last. Never NULL.
 ///
-/// The inner step takes the newest ROW per job: a job seen in flight and later
-/// seen finished has two rows sharing one creation time, so resolving straight
-/// to the newest job would tie between them and could answer `running` for a
-/// sync that ended. The outer step then takes the newest JOB per connector.
+/// Four components, each earning its place:
 ///
-/// Both steps use `LIMIT 1 BY` rather than `argMax`: `argMax` ignores rows
-/// whose value argument is NULL, so a sync row without a creation time would
-/// take its whole connector out of the answer instead of merely losing the
-/// comparison.
+/// * `coalesce(job_created_at, ts)` — the axis the ledger places jobs along,
+///   falling back to when the row was recorded. A NULL here would be worse than
+///   a fallback: ClickHouse sorts NULLs last in BOTH directions, so a job the
+///   mover gave no creation time would not merely lose the comparison — a
+///   different, older job would win it, and the page would present a stale
+///   success as the current state.
+/// * `toUInt64OrZero(job_id)` — the mover's ids are numbers stored as text, so
+///   comparing them as text makes `"9"` newer than `"10"`.
+/// * the terminal flag — within one job a final row outranks a provisional one
+///   whatever the clocks say. Two rows of one job can share a millisecond, and
+///   without this the answer is decided by physical row order.
+/// * `ts` — the last resort, newest recorded wins.
+static ROW_ORDER: LazyLock<String> = LazyLock::new(|| {
+    let terminal = SyncStatus::TERMINAL
+        .iter()
+        .map(|status| format!("'{}'", status.as_str()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "(coalesce(job_created_at, ts), toUInt64OrZero(job_id), \
+          status IN ({terminal}), ts)"
+    )
+});
+
+/// The columns a resolved sync carries, as one tuple.
+///
+/// INVARIANT: resolved as a single tuple, never column by column. `argMax`
+/// ignores rows whose value argument is NULL, so six independent `argMax`
+/// calls answer from six independently-chosen rows — one column taken from
+/// the newest job and another from an older one whose value happened not to
+/// be NULL, producing a row that never existed.
+const SYNC_COLUMNS: &str = "job_id, status, started_at, job_created_at, \
+     duration_ms, records_reported";
+
+/// The unpacked tuple, under names no ledger column carries.
+///
+/// A `resolved_` prefix rather than the column's own name: an alias equal to a
+/// column name is harmless where nothing in scope carries that column, but a
+/// guard that must know which of the two cases it is looking at is a guard
+/// with an exception. This keeps the rule absolute.
+const UNPACK_WINNER: &str = "winner.1 AS resolved_job_id, \
+     winner.2 AS resolved_status, winner.3 AS resolved_started_at, \
+     winner.4 AS resolved_job_created_at, winner.5 AS resolved_duration_ms, \
+     winner.6 AS resolved_records_reported";
+
+/// The newest sync per connector.
+///
+/// An aggregate, not a sort. Sorting the relation by a column outside its sort
+/// key reads and orders the whole retention window to answer with one row per
+/// connector — measured at hundreds of megabytes where this stays at single
+/// digits, and the service caps its own query memory.
 static LAST_SYNC_SQL: LazyLock<String> = LazyLock::new(|| {
     format!(
-        "SELECT connector, job_id, status, started_at, job_created_at, \
-           duration_ms, records_reported \
-         FROM (SELECT connector, job_id, status, started_at, job_created_at, \
-                      duration_ms, records_reported \
-               FROM {TABLE} WHERE event = '{SYNC_COMPLETED}' \
-               ORDER BY job_id, ts DESC LIMIT 1 BY job_id) \
-         ORDER BY connector, job_created_at DESC, job_id DESC LIMIT 1 BY connector"
+        "SELECT connector, {UNPACK_WINNER} \
+         FROM (SELECT connector, argMax(tuple({SYNC_COLUMNS}), ord) AS winner \
+               FROM (SELECT connector, {SYNC_COLUMNS}, {order} AS ord \
+                     FROM {TABLE} WHERE event = '{SYNC_COMPLETED}') \
+               GROUP BY connector)",
+        order = &*ROW_ORDER
     )
 });
 
@@ -97,16 +140,21 @@ static CONFIGURED_SET_SQL: LazyLock<String> = LazyLock::new(|| {
     )
 });
 
-/// One connector's recent syncs, newest first, one row per job.
+/// One connector's recent syncs, one row per job, newest first.
+///
+/// Narrowed by the sort key's first two columns before anything is grouped, so
+/// the aggregate sees one connector's rows rather than the whole relation.
 static SYNC_HISTORY_SQL: LazyLock<String> = LazyLock::new(|| {
     format!(
-        "SELECT job_id, status, started_at, job_created_at, duration_ms, \
-           records_reported \
-         FROM (SELECT job_id, status, started_at, job_created_at, duration_ms, \
-                      records_reported \
-               FROM {TABLE} WHERE event = '{SYNC_COMPLETED}' AND connector = ? \
-               ORDER BY job_id, ts DESC LIMIT 1 BY job_id) \
-         ORDER BY job_created_at DESC, job_id DESC LIMIT ?"
+        "SELECT {UNPACK_WINNER} \
+         FROM (SELECT argMax(tuple({SYNC_COLUMNS}), ord) AS winner, \
+                      max(ord) AS newest \
+               FROM (SELECT {SYNC_COLUMNS}, {order} AS ord \
+                     FROM {TABLE} \
+                     WHERE event = '{SYNC_COMPLETED}' AND connector = ?) \
+               GROUP BY job_id) \
+         ORDER BY newest DESC LIMIT ?",
+        order = &*ROW_ORDER
     )
 });
 
@@ -137,28 +185,55 @@ struct IntervalRow {
 /// INVARIANT: every `Nullable` column is `Option` here. A non-`Option` field
 /// against a nullable column is rejected while decoding the row, which yields a
 /// 500 — and only once rows exist, so an empty ledger hides it completely.
+/// INVARIANT: every `Nullable` column is `Option` here. A non-`Option` field
+/// against a nullable column is rejected while decoding the row, which yields a
+/// 500 — and only once rows exist, so an empty ledger hides it completely.
+///
+/// The `resolved_` names are the SQL aliases, not the domain's: the statement
+/// must not alias anything to a ledger column name, and the rename keeps that
+/// constraint in the one place it belongs.
 #[derive(Debug, Deserialize, clickhouse::Row)]
 struct SyncRow {
     connector: String,
+    #[serde(rename = "resolved_job_id")]
     job_id: String,
+    #[serde(rename = "resolved_status")]
     status: String,
-    #[serde(with = "clickhouse::serde::chrono::datetime64::millis::option")]
+    #[serde(
+        rename = "resolved_started_at",
+        with = "clickhouse::serde::chrono::datetime64::millis::option"
+    )]
     started_at: Option<DateTime<Utc>>,
-    #[serde(with = "clickhouse::serde::chrono::datetime64::millis::option")]
+    #[serde(
+        rename = "resolved_job_created_at",
+        with = "clickhouse::serde::chrono::datetime64::millis::option"
+    )]
     job_created_at: Option<DateTime<Utc>>,
+    #[serde(rename = "resolved_duration_ms")]
     duration_ms: Option<u64>,
+    #[serde(rename = "resolved_records_reported")]
     records_reported: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, clickhouse::Row)]
 struct HistoryRow {
+    #[serde(rename = "resolved_job_id")]
     job_id: String,
+    #[serde(rename = "resolved_status")]
     status: String,
-    #[serde(with = "clickhouse::serde::chrono::datetime64::millis::option")]
+    #[serde(
+        rename = "resolved_started_at",
+        with = "clickhouse::serde::chrono::datetime64::millis::option"
+    )]
     started_at: Option<DateTime<Utc>>,
-    #[serde(with = "clickhouse::serde::chrono::datetime64::millis::option")]
+    #[serde(
+        rename = "resolved_job_created_at",
+        with = "clickhouse::serde::chrono::datetime64::millis::option"
+    )]
     job_created_at: Option<DateTime<Utc>>,
+    #[serde(rename = "resolved_duration_ms")]
     duration_ms: Option<u64>,
+    #[serde(rename = "resolved_records_reported")]
     records_reported: Option<u64>,
 }
 
@@ -295,8 +370,14 @@ pub(super) fn absent_ledger(error: &clickhouse::error::Error) -> bool {
 mod guards {
     use super::*;
 
-    /// Every SQL constant here, so a new one joins the guards automatically
-    /// rather than being remembered into them.
+    /// The migration itself, not a copy of it: a column added there and not
+    /// here would otherwise drop silently out of the guard below.
+    const MIGRATION: &str = include_str!(
+        "../../../../../../ingestion/scripts/migrations/20260827000000_connector-sync-history.sql"
+    );
+
+    /// Every SQL statement this module issues, so a new one joins the guards
+    /// automatically rather than being remembered into them.
     fn statements() -> [(&'static str, &'static str); 5] {
         [
             ("SEALED_TICK_SQL", SEALED_TICK_SQL.as_str()),
@@ -307,108 +388,153 @@ mod guards {
         ]
     }
 
-    /// Every column the ledger holds. An alias colliding with one of these is
-    /// the bug this guards: the alias shadows the column for every other
-    /// expression in the same SELECT, so an aggregate reading that column reads
-    /// the alias instead and ClickHouse answers `ILLEGAL_AGGREGATION`.
-    const LEDGER_COLUMNS: [&str; 11] = [
-        "event_id",
-        "ts",
-        "tick_id",
-        "job_id",
-        "connector",
-        "event",
-        "status",
-        "started_at",
-        "job_created_at",
-        "duration_ms",
-        "records_reported",
-    ];
-
-    fn aliases(sql: &str) -> Vec<&str> {
-        sql.split(" AS ")
-            .skip(1)
-            .filter_map(|tail| {
-                tail.split(|c: char| !c.is_alphanumeric() && c != '_')
-                    .next()
-            })
-            .filter(|alias| !alias.is_empty())
+    /// The ledger's column names, read out of the `CREATE TABLE` block.
+    fn ledger_columns() -> Vec<String> {
+        let body = MIGRATION
+            .split_once("CREATE TABLE")
+            .and_then(|(_, tail)| tail.split_once('('))
+            .map(|(_, tail)| tail)
+            .unwrap_or_default();
+        body.lines()
+            .map(str::trim)
+            .take_while(|line| !line.starts_with(')'))
+            .filter_map(|line| line.split_whitespace().next())
+            .filter(|name| name.chars().all(|c| c.is_ascii_lowercase() || c == '_'))
+            .map(str::to_owned)
             .collect()
     }
 
+    /// Lower-cased, whitespace-collapsed, quoting stripped.
+    ///
+    /// Every one of these is invisible to a raw substring scan and shadows a
+    /// column exactly the same way in ClickHouse: `AS  ts`, `as ts`, a newline
+    /// between the two, and `AS "ts"`.
+    fn normalised(sql: &str) -> String {
+        sql.to_ascii_lowercase()
+            .replace(['`', '"'], " ")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    #[test]
+    fn the_column_list_comes_from_the_migration() {
+        let columns = ledger_columns();
+        for expected in ["event_id", "ts", "tick_id", "job_id", "connector", "event"] {
+            assert!(
+                columns.iter().any(|c| c == expected),
+                "missing {expected}: {columns:?}"
+            );
+        }
+        assert_eq!(columns.len(), 11, "{columns:?}");
+    }
+
+    /// An alias that repeats a column name shadows that column for every other
+    /// expression in the same SELECT, so an aggregate reading it reads the alias
+    /// instead and ClickHouse answers `ILLEGAL_AGGREGATION`.
     #[test]
     fn no_statement_aliases_a_value_to_a_ledger_column_name() {
+        let columns = ledger_columns();
         for (name, sql) in statements() {
-            for alias in aliases(sql) {
+            let flat = normalised(sql);
+            for column in &columns {
                 assert!(
-                    !LEDGER_COLUMNS.contains(&alias),
-                    "{name} aliases a value to `{alias}`, which is a column of \
-                     the ledger: the alias shadows the column for every other \
-                     expression in the same SELECT",
+                    !flat.contains(&format!(" as {column}")),
+                    "{name} aliases a value to `{column}`, a ledger column",
+                );
+                assert!(
+                    !flat.contains(&format!(") {column}")),
+                    "{name} implicitly aliases a value to `{column}`, a ledger column",
                 );
             }
         }
     }
 
     #[test]
-    fn the_alias_scan_finds_what_it_is_meant_to_find() {
-        assert_eq!(aliases("SELECT max(ts) AS ts FROM t"), vec!["ts"]);
-        assert_eq!(
-            aliases("SELECT ts AS sealed_at, x AS y"),
-            vec!["sealed_at", "y"]
+    fn the_alias_scan_catches_every_spelling_of_the_shadow() {
+        let columns = ledger_columns();
+        let shadows = [
+            "select max(ts) AS ts from t",
+            "select max(ts) AS  ts from t",
+            "select max(ts) as ts from t",
+            "select max(ts) ts from t",
+            "select max(ts)\nAS ts from t",
+            "select max(ts) AS\nts from t",
+            "select max(ts) AS \"ts\" from t",
+        ];
+        for shadow in shadows {
+            let flat = normalised(shadow);
+            let caught = columns.iter().any(|column| {
+                flat.contains(&format!(" as {column}")) || flat.contains(&format!(") {column}"))
+            });
+            assert!(caught, "the guard would miss: {shadow}");
+        }
+
+        let innocent = normalised("select ts as sealed_at, x as y from t");
+        assert!(
+            !columns
+                .iter()
+                .any(|c| innocent.contains(&format!(" as {c}"))),
+            "the guard must not fire on an alias that is not a column name"
         );
-        assert!(aliases("SELECT ts FROM t").is_empty());
     }
 
     #[test]
     fn every_statement_reads_only_the_ledger() {
         for (name, sql) in statements() {
-            for tail in sql.split("FROM ").skip(1) {
+            for tail in normalised(sql).split("from ").skip(1) {
                 assert!(
                     tail.starts_with('(') || tail.starts_with(TABLE),
                     "{name} reads something other than the ledger \
-                     (`FROM {}`); the page must answer from one relation (FR-11)",
+                     (`from {}`); the page must answer from one relation (FR-11)",
                     tail.split_whitespace().next().unwrap_or(""),
                 );
             }
         }
     }
 
-    /// Both codes ClickHouse answers when the ledger is not there, verbatim.
-    /// The live test pins that these are what it actually says; this pins that
-    /// the classifier reads them and nothing else.
     #[test]
-    fn an_absent_relation_is_classified_and_a_real_failure_is_not() {
-        let absent = [
-            "Code: 60. DB::Exception: Table ingestion_history.sync_events does not exist",
-            "Code: 81. DB::Exception: Database ingestion_history does not exist",
-            "  Code: 60. DB::Exception: leading whitespace still counts",
-        ];
-        for payload in absent {
-            let error = clickhouse::error::Error::BadResponse(payload.to_owned());
-            assert!(absent_ledger(&error), "should classify: {payload}");
-        }
-
-        let real = [
-            "Code: 241. DB::Exception: Memory limit exceeded",
-            "Code: 497. DB::Exception: Not enough privileges",
-            "Code: 600. DB::Exception: a code merely starting with 60",
-        ];
-        for payload in real {
-            let error = clickhouse::error::Error::BadResponse(payload.to_owned());
-            assert!(
-                !absent_ledger(&error),
-                "an unreadable ledger must not be reported as an empty one: {payload}"
+    fn the_resolution_never_aggregates_a_column_on_its_own() {
+        // Six independent `argMax` calls answer from six independently-chosen
+        // rows, because `argMax` skips a NULL value argument per column. Both
+        // resolutions must aggregate the tuple.
+        for (name, sql) in [
+            ("LAST_SYNC_SQL", LAST_SYNC_SQL.as_str()),
+            ("SYNC_HISTORY_SQL", SYNC_HISTORY_SQL.as_str()),
+        ] {
+            let flat = normalised(sql);
+            assert_eq!(
+                flat.matches("argmax(").count(),
+                1,
+                "{name} must resolve one tuple, not one column at a time",
             );
+            assert!(flat.contains("argmax(tuple("), "{name}");
         }
     }
 
     #[test]
-    fn a_transport_failure_is_never_an_absent_relation() {
-        // Serving an empty page because the network dropped would report "no
-        // connector has ever synced" during exactly the outage that matters.
-        let error = clickhouse::error::Error::Custom("connection reset".to_owned());
-        assert!(!absent_ledger(&error));
+    fn the_row_order_is_never_null() {
+        // A NULL sort key does not lose a comparison in ClickHouse — it wins a
+        // different one, because NULLs sort last in both directions.
+        let order = normalised(&ROW_ORDER);
+        assert!(order.contains("coalesce(job_created_at, ts)"), "{order}");
+        assert!(order.contains("touint64orzero(job_id)"), "{order}");
+        assert!(order.contains("status in ("), "{order}");
+    }
+
+    #[test]
+    fn the_terminal_vocabulary_is_rendered_from_one_source() {
+        for status in SyncStatus::TERMINAL {
+            assert!(
+                ROW_ORDER.contains(status.as_str()),
+                "the row order must know {} is terminal",
+                status.as_str()
+            );
+        }
+        assert!(
+            !ROW_ORDER.contains(SyncStatus::Running.as_str()),
+            "a provisional status must not read as terminal"
+        );
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/connector_health/read.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/read.rs
@@ -1,0 +1,421 @@
+//! Reading the sync ledger. Every statement here touches one relation.
+//!
+//! The ledger is written by the reconcile loop and read here; the two never
+//! meet. That is what lets this page answer while the mover, the cluster API
+//! and the ingestion pipeline are all unreachable.
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+use super::model::{ConnectorSummary, LastSync, LedgerFacts, SyncStatus};
+
+/// DDL owned by `scripts/migrations/20260827000000_connector-sync-history.sql`;
+/// the query-path role holds `SELECT` here and nothing that writes.
+const TABLE: &str = "ingestion_history.sync_events";
+
+const SYNC_COMPLETED: &str = "sync.completed";
+const CONNECTOR_CONFIGURED: &str = "connector.configured";
+const SWEEP_COMPLETED: &str = "sweep.completed";
+
+/// Rows in a connector's expandable history. A window, not the retention.
+pub(crate) const HISTORY_WINDOW: u32 = 50;
+
+/// Sealed ticks sampled for the median gap between reads. Enough to survive one
+/// unusual interval; short enough that a cadence change shows up quickly.
+const INTERVAL_SAMPLE: u32 = 20;
+
+/// Two gaps is the fewest that has a median worth reporting.
+const MIN_GAPS_FOR_INTERVAL: u64 = 2;
+
+/// The newest tick that finished writing.
+///
+/// INVARIANT: the timestamp is aliased `sealed_at`, never `ts`. An alias that
+/// shadows its own source column is read by every other expression in the same
+/// SELECT — including the aggregate that needs the column — and ClickHouse
+/// answers `ILLEGAL_AGGREGATION` rather than a wrong number. The guard test
+/// below fails if a future edit reintroduces the shadow.
+static SEALED_TICK_SQL: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "SELECT tick_id, ts AS sealed_at FROM {TABLE} \
+         WHERE event = '{SWEEP_COMPLETED}' ORDER BY ts DESC LIMIT 1"
+    )
+});
+
+/// How often the mover has actually been read lately.
+///
+/// `arrayDifference` over the sorted stamps yields the gaps with a leading
+/// zero, which the filter drops along with any two seals inside the same
+/// millisecond. Measured rather than configured: reading an intended cadence
+/// from chart values would let the page assert a schedule it cannot verify.
+static READ_INTERVAL_SQL: LazyLock<String> = LazyLock::new(|| {
+    // SAFETY: `median` of an empty array is NaN, and `toUInt64(NaN)` is
+    // CANNOT_CONVERT_TYPE — a 500 on every install whose ledger is empty, which
+    // is every install before its first sweep. `ifNull` does not catch it: NaN
+    // is a value, not a null. So the length is checked before the median is
+    // taken, and the gap count is reported separately for the caller to judge.
+    format!(
+        "SELECT toUInt64(if(length(gap_list) > 0, arrayReduce('median', gap_list), 0)) \
+             AS interval_ms, \
+           toUInt64(length(gap_list)) AS gaps \
+         FROM (SELECT arrayFilter(x -> x > 0, \
+                        arrayDifference(arraySort(groupArray(seal_ms)))) AS gap_list \
+               FROM (SELECT toUnixTimestamp64Milli(ts) AS seal_ms FROM {TABLE} \
+                     WHERE event = '{SWEEP_COMPLETED}' ORDER BY ts DESC LIMIT ?))"
+    )
+});
+
+/// The newest sync per connector, resolved in two steps.
+///
+/// The inner step takes the newest ROW per job: a job seen in flight and later
+/// seen finished has two rows sharing one creation time, so resolving straight
+/// to the newest job would tie between them and could answer `running` for a
+/// sync that ended. The outer step then takes the newest JOB per connector.
+///
+/// Both steps use `LIMIT 1 BY` rather than `argMax`: `argMax` ignores rows
+/// whose value argument is NULL, so a sync row without a creation time would
+/// take its whole connector out of the answer instead of merely losing the
+/// comparison.
+static LAST_SYNC_SQL: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "SELECT connector, job_id, status, started_at, job_created_at, \
+           duration_ms, records_reported \
+         FROM (SELECT connector, job_id, status, started_at, job_created_at, \
+                      duration_ms, records_reported \
+               FROM {TABLE} WHERE event = '{SYNC_COMPLETED}' \
+               ORDER BY job_id, ts DESC LIMIT 1 BY job_id) \
+         ORDER BY connector, job_created_at DESC, job_id DESC LIMIT 1 BY connector"
+    )
+});
+
+/// The set the controller managed on one sealed tick.
+static CONFIGURED_SET_SQL: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "SELECT DISTINCT connector FROM {TABLE} \
+         WHERE event = '{CONNECTOR_CONFIGURED}' AND tick_id = ?"
+    )
+});
+
+/// One connector's recent syncs, newest first, one row per job.
+static SYNC_HISTORY_SQL: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "SELECT job_id, status, started_at, job_created_at, duration_ms, \
+           records_reported \
+         FROM (SELECT job_id, status, started_at, job_created_at, duration_ms, \
+                      records_reported \
+               FROM {TABLE} WHERE event = '{SYNC_COMPLETED}' AND connector = ? \
+               ORDER BY job_id, ts DESC LIMIT 1 BY job_id) \
+         ORDER BY job_created_at DESC, job_id DESC LIMIT ?"
+    )
+});
+
+/// `UNKNOWN_TABLE` and `UNKNOWN_DATABASE`. The ledger is absent on an install
+/// whose migration has not run and on a stand where nothing records, and the
+/// page must say "nothing has been read yet" there rather than fail.
+///
+/// SAFETY: the trailing period is load-bearing. Without it `Code: 60` also
+/// prefixes `Code: 600`, `Code: 601` and so on — so a future ClickHouse error
+/// in that range would be classified as an absent ledger and the page would
+/// serve an empty list during a real failure. The live test pins that this is
+/// the shape ClickHouse actually produces.
+const ABSENT_RELATION_CODES: [&str; 2] = ["Code: 60.", "Code: 81."];
+
+#[derive(Debug, Deserialize, clickhouse::Row)]
+struct SealedTickRow {
+    tick_id: String,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
+    sealed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize, clickhouse::Row)]
+struct IntervalRow {
+    interval_ms: u64,
+    gaps: u64,
+}
+
+/// INVARIANT: every `Nullable` column is `Option` here. A non-`Option` field
+/// against a nullable column is rejected while decoding the row, which yields a
+/// 500 — and only once rows exist, so an empty ledger hides it completely.
+#[derive(Debug, Deserialize, clickhouse::Row)]
+struct SyncRow {
+    connector: String,
+    job_id: String,
+    status: String,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis::option")]
+    started_at: Option<DateTime<Utc>>,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis::option")]
+    job_created_at: Option<DateTime<Utc>>,
+    duration_ms: Option<u64>,
+    records_reported: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, clickhouse::Row)]
+struct HistoryRow {
+    job_id: String,
+    status: String,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis::option")]
+    started_at: Option<DateTime<Utc>>,
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis::option")]
+    job_created_at: Option<DateTime<Utc>>,
+    duration_ms: Option<u64>,
+    records_reported: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, clickhouse::Row)]
+struct ConnectorRow {
+    connector: String,
+}
+
+pub(crate) async fn read_health(
+    ch: &insight_clickhouse::Client,
+) -> Result<LedgerFacts, clickhouse::error::Error> {
+    let sealed = match ch
+        .query(&SEALED_TICK_SQL)
+        .fetch_optional::<SealedTickRow>()
+        .await
+    {
+        Ok(row) => row,
+        Err(error) if absent_ledger(&error) => return Ok(LedgerFacts::default()),
+        Err(error) => return Err(error),
+    };
+
+    let (interval, syncs, configured) = tokio::try_join!(
+        ch.query(&READ_INTERVAL_SQL)
+            .bind(INTERVAL_SAMPLE)
+            .fetch_one::<IntervalRow>(),
+        ch.query(&LAST_SYNC_SQL).fetch_all::<SyncRow>(),
+        configured_set(ch, sealed.as_ref().map(|tick| tick.tick_id.as_str())),
+    )?;
+
+    let summaries = merge(syncs, &configured);
+    Ok(LedgerFacts {
+        sealed_at: sealed.map(|tick| tick.sealed_at),
+        typical_read_interval_ms: (interval.gaps >= MIN_GAPS_FOR_INTERVAL)
+            .then_some(interval.interval_ms),
+        has_history: !summaries.is_empty() || !configured.is_empty(),
+        summaries,
+    })
+}
+
+/// Bound to the tick resolved once above, never re-resolved per statement: a
+/// sweep landing between two reads would otherwise answer with the newer
+/// configured set beside the older facts — a state that existed on no tick.
+async fn configured_set(
+    ch: &insight_clickhouse::Client,
+    tick_id: Option<&str>,
+) -> Result<HashSet<String>, clickhouse::error::Error> {
+    let Some(tick_id) = tick_id else {
+        return Ok(HashSet::new());
+    };
+    let rows = ch
+        .query(&CONFIGURED_SET_SQL)
+        .bind(tick_id)
+        .fetch_all::<ConnectorRow>()
+        .await?;
+    Ok(rows.into_iter().map(|row| row.connector).collect())
+}
+
+pub(crate) async fn read_syncs(
+    ch: &insight_clickhouse::Client,
+    connector: &str,
+) -> Result<Vec<LastSync>, clickhouse::error::Error> {
+    let rows = match ch
+        .query(&SYNC_HISTORY_SQL)
+        .bind(connector)
+        .bind(HISTORY_WINDOW)
+        .fetch_all::<HistoryRow>()
+        .await
+    {
+        Ok(rows) => rows,
+        Err(error) if absent_ledger(&error) => return Ok(Vec::new()),
+        Err(error) => return Err(error),
+    };
+    Ok(rows.into_iter().map(HistoryRow::into_sync).collect())
+}
+
+impl HistoryRow {
+    fn into_sync(self) -> LastSync {
+        LastSync {
+            job_id: self.job_id,
+            status: SyncStatus::parse(&self.status),
+            started_at: self.started_at,
+            job_created_at: self.job_created_at,
+            duration_ms: self.duration_ms,
+            records_reported: self.records_reported,
+        }
+    }
+}
+
+/// The union of what synced and what is configured.
+///
+/// A connector that was never configured and never synced appears in neither,
+/// so it cannot be listed — the reader may read this one relation and nothing
+/// else, and no record of such a connector exists in it.
+fn merge(syncs: Vec<SyncRow>, configured: &HashSet<String>) -> Vec<ConnectorSummary> {
+    let mut by_connector: HashMap<String, Option<LastSync>> = configured
+        .iter()
+        .map(|connector| (connector.clone(), None))
+        .collect();
+
+    for row in syncs {
+        let sync = LastSync {
+            job_id: row.job_id,
+            status: SyncStatus::parse(&row.status),
+            started_at: row.started_at,
+            job_created_at: row.job_created_at,
+            duration_ms: row.duration_ms,
+            records_reported: row.records_reported,
+        };
+        by_connector.insert(row.connector, Some(sync));
+    }
+
+    let mut summaries: Vec<ConnectorSummary> = by_connector
+        .into_iter()
+        .map(|(connector, last_sync)| ConnectorSummary {
+            configured: configured.contains(&connector),
+            connector,
+            last_sync,
+        })
+        .collect();
+    super::model::by_attention(&mut summaries);
+    summaries
+}
+
+pub(super) fn absent_ledger(error: &clickhouse::error::Error) -> bool {
+    let clickhouse::error::Error::BadResponse(payload) = error else {
+        return false;
+    };
+    ABSENT_RELATION_CODES
+        .iter()
+        .any(|code| payload.trim_start().starts_with(code))
+}
+
+#[cfg(test)]
+mod guards {
+    use super::*;
+
+    /// Every SQL constant here, so a new one joins the guards automatically
+    /// rather than being remembered into them.
+    fn statements() -> [(&'static str, &'static str); 5] {
+        [
+            ("SEALED_TICK_SQL", SEALED_TICK_SQL.as_str()),
+            ("READ_INTERVAL_SQL", READ_INTERVAL_SQL.as_str()),
+            ("LAST_SYNC_SQL", LAST_SYNC_SQL.as_str()),
+            ("CONFIGURED_SET_SQL", CONFIGURED_SET_SQL.as_str()),
+            ("SYNC_HISTORY_SQL", SYNC_HISTORY_SQL.as_str()),
+        ]
+    }
+
+    /// Every column the ledger holds. An alias colliding with one of these is
+    /// the bug this guards: the alias shadows the column for every other
+    /// expression in the same SELECT, so an aggregate reading that column reads
+    /// the alias instead and ClickHouse answers `ILLEGAL_AGGREGATION`.
+    const LEDGER_COLUMNS: [&str; 11] = [
+        "event_id",
+        "ts",
+        "tick_id",
+        "job_id",
+        "connector",
+        "event",
+        "status",
+        "started_at",
+        "job_created_at",
+        "duration_ms",
+        "records_reported",
+    ];
+
+    fn aliases(sql: &str) -> Vec<&str> {
+        sql.split(" AS ")
+            .skip(1)
+            .filter_map(|tail| {
+                tail.split(|c: char| !c.is_alphanumeric() && c != '_')
+                    .next()
+            })
+            .filter(|alias| !alias.is_empty())
+            .collect()
+    }
+
+    #[test]
+    fn no_statement_aliases_a_value_to_a_ledger_column_name() {
+        for (name, sql) in statements() {
+            for alias in aliases(sql) {
+                assert!(
+                    !LEDGER_COLUMNS.contains(&alias),
+                    "{name} aliases a value to `{alias}`, which is a column of \
+                     the ledger: the alias shadows the column for every other \
+                     expression in the same SELECT",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_alias_scan_finds_what_it_is_meant_to_find() {
+        assert_eq!(aliases("SELECT max(ts) AS ts FROM t"), vec!["ts"]);
+        assert_eq!(
+            aliases("SELECT ts AS sealed_at, x AS y"),
+            vec!["sealed_at", "y"]
+        );
+        assert!(aliases("SELECT ts FROM t").is_empty());
+    }
+
+    #[test]
+    fn every_statement_reads_only_the_ledger() {
+        for (name, sql) in statements() {
+            for tail in sql.split("FROM ").skip(1) {
+                assert!(
+                    tail.starts_with('(') || tail.starts_with(TABLE),
+                    "{name} reads something other than the ledger \
+                     (`FROM {}`); the page must answer from one relation (FR-11)",
+                    tail.split_whitespace().next().unwrap_or(""),
+                );
+            }
+        }
+    }
+
+    /// Both codes ClickHouse answers when the ledger is not there, verbatim.
+    /// The live test pins that these are what it actually says; this pins that
+    /// the classifier reads them and nothing else.
+    #[test]
+    fn an_absent_relation_is_classified_and_a_real_failure_is_not() {
+        let absent = [
+            "Code: 60. DB::Exception: Table ingestion_history.sync_events does not exist",
+            "Code: 81. DB::Exception: Database ingestion_history does not exist",
+            "  Code: 60. DB::Exception: leading whitespace still counts",
+        ];
+        for payload in absent {
+            let error = clickhouse::error::Error::BadResponse(payload.to_owned());
+            assert!(absent_ledger(&error), "should classify: {payload}");
+        }
+
+        let real = [
+            "Code: 241. DB::Exception: Memory limit exceeded",
+            "Code: 497. DB::Exception: Not enough privileges",
+            "Code: 600. DB::Exception: a code merely starting with 60",
+        ];
+        for payload in real {
+            let error = clickhouse::error::Error::BadResponse(payload.to_owned());
+            assert!(
+                !absent_ledger(&error),
+                "an unreadable ledger must not be reported as an empty one: {payload}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_transport_failure_is_never_an_absent_relation() {
+        // Serving an empty page because the network dropped would report "no
+        // connector has ever synced" during exactly the outage that matters.
+        let error = clickhouse::error::Error::Custom("connection reset".to_owned());
+        assert!(!absent_ledger(&error));
+    }
+
+    #[test]
+    fn history_is_a_bounded_window() {
+        assert!(
+            SYNC_HISTORY_SQL.contains("LIMIT ?"),
+            "the window must be bound"
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/connector_health/tests.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/tests.rs
@@ -1,0 +1,344 @@
+//! What the page shows, and the order it shows it in.
+
+#![expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "a broken fixture should fail the test loudly"
+)]
+
+use chrono::{DateTime, TimeZone, Utc};
+
+use super::model::{Attention, ConnectorSummary, LastSync, LedgerFacts, SyncStatus, by_attention};
+use super::model::{ConnectorHealth, ConnectorHealthResponse, SyncFact, SyncHistoryResponse};
+use super::name::ConnectorName;
+
+fn moment(offset: i64) -> DateTime<Utc> {
+    Utc.timestamp_opt(1_700_000_000 + offset, 0)
+        .single()
+        .unwrap()
+}
+
+fn sync(status: SyncStatus, started: Option<i64>) -> LastSync {
+    LastSync {
+        job_id: "8412".to_owned(),
+        status,
+        started_at: started.map(moment),
+        job_created_at: started.map(|at| moment(at - 10)),
+        duration_ms: Some(142_000),
+        records_reported: Some(12_400),
+    }
+}
+
+fn summary(name: &str, configured: bool, last: Option<LastSync>) -> ConnectorSummary {
+    ConnectorSummary {
+        connector: name.to_owned(),
+        configured,
+        last_sync: last,
+    }
+}
+
+// ── the mover's vocabulary ─────────────────────────────────────────────────
+
+#[test]
+fn every_documented_status_survives_the_round_trip() {
+    for word in [
+        "pending",
+        "running",
+        "incomplete",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "unknown",
+    ] {
+        assert_eq!(
+            SyncStatus::parse(word).as_str(),
+            word,
+            "should store the mover's own word: {word}"
+        );
+    }
+}
+
+#[test]
+fn a_word_outside_the_vocabulary_reads_as_unknown() {
+    for word in ["", "SUCCEEDED", "succeeded_partially", "ok", "  running"] {
+        assert_eq!(
+            SyncStatus::parse(word),
+            SyncStatus::Unknown,
+            "should not be interpreted: {word:?}"
+        );
+    }
+}
+
+// ── what needs acting on ───────────────────────────────────────────────────
+
+#[test]
+fn a_sync_that_did_not_finish_its_work_needs_attention_first() {
+    for status in [SyncStatus::Failed, SyncStatus::Incomplete] {
+        let row = summary("a", true, Some(sync(status, Some(0))));
+        assert_eq!(row.attention(), Attention::Failing, "{status:?}");
+    }
+}
+
+#[test]
+fn an_unreadable_state_is_not_filed_with_the_quiet_ones() {
+    let row = summary("a", true, Some(sync(SyncStatus::Unknown, Some(0))));
+    assert_eq!(row.attention(), Attention::Unreadable);
+}
+
+#[test]
+fn an_active_or_finished_sync_is_settled() {
+    for status in [
+        SyncStatus::Pending,
+        SyncStatus::Running,
+        SyncStatus::Succeeded,
+        SyncStatus::Cancelled,
+    ] {
+        let row = summary("a", true, Some(sync(status, Some(0))));
+        assert_eq!(row.attention(), Attention::Settled, "{status:?}");
+    }
+}
+
+#[test]
+fn a_configured_connector_with_no_sync_has_never_run() {
+    assert_eq!(summary("a", true, None).attention(), Attention::NeverRan);
+}
+
+#[test]
+fn history_without_configuration_reads_as_no_longer_configured() {
+    let row = summary("a", false, Some(sync(SyncStatus::Succeeded, Some(0))));
+    assert_eq!(row.attention(), Attention::NoLongerConfigured);
+}
+
+#[test]
+fn a_removed_connector_is_not_reported_as_failing() {
+    // A connector taken out of configuration is a decision, not a fault — even
+    // when the last thing it did was fail.
+    let row = summary("a", false, Some(sync(SyncStatus::Failed, Some(0))));
+    assert_eq!(row.attention(), Attention::NoLongerConfigured);
+}
+
+// ── the order ──────────────────────────────────────────────────────────────
+
+#[test]
+fn rows_are_ordered_worst_first() {
+    let mut rows = vec![
+        summary("quiet", true, Some(sync(SyncStatus::Succeeded, Some(0)))),
+        summary("gone", false, Some(sync(SyncStatus::Succeeded, Some(0)))),
+        summary("fresh", true, None),
+        summary("murky", true, Some(sync(SyncStatus::Unknown, Some(0)))),
+        summary("broken", true, Some(sync(SyncStatus::Failed, Some(0)))),
+    ];
+    by_attention(&mut rows);
+    let order: Vec<&str> = rows.iter().map(|row| row.connector.as_str()).collect();
+    assert_eq!(order, ["broken", "murky", "quiet", "fresh", "gone"]);
+}
+
+#[test]
+fn inside_a_band_the_most_recent_activity_comes_first() {
+    let mut rows = vec![
+        summary("older", true, Some(sync(SyncStatus::Failed, Some(100)))),
+        summary("newest", true, Some(sync(SyncStatus::Failed, Some(900)))),
+        summary("middle", true, Some(sync(SyncStatus::Failed, Some(500)))),
+    ];
+    by_attention(&mut rows);
+    let order: Vec<&str> = rows.iter().map(|row| row.connector.as_str()).collect();
+    assert_eq!(order, ["newest", "middle", "older"]);
+}
+
+#[test]
+fn a_row_with_no_activity_sorts_after_rows_that_have_some() {
+    let mut rows = vec![
+        summary("unstarted", true, Some(sync(SyncStatus::Failed, None))),
+        summary("started", true, Some(sync(SyncStatus::Failed, Some(1)))),
+    ];
+    by_attention(&mut rows);
+    assert_eq!(rows[0].connector, "started");
+}
+
+#[test]
+fn the_order_is_stable_for_rows_that_tie() {
+    let mut rows = vec![
+        summary("zulu", true, None),
+        summary("alpha", true, None),
+        summary("mike", true, None),
+    ];
+    by_attention(&mut rows);
+    let order: Vec<&str> = rows.iter().map(|row| row.connector.as_str()).collect();
+    assert_eq!(order, ["alpha", "mike", "zulu"], "ties break on the name");
+}
+
+// ── the wire ───────────────────────────────────────────────────────────────
+
+#[test]
+fn absence_crosses_the_wire_as_absence() {
+    let fact = SyncFact::from(LastSync {
+        job_id: "1".to_owned(),
+        status: SyncStatus::Pending,
+        started_at: None,
+        job_created_at: Some(moment(0)),
+        duration_ms: None,
+        records_reported: None,
+    });
+    assert!(fact.started_at.is_none());
+    assert!(fact.duration_ms.is_none());
+    assert!(
+        fact.records_reported.is_none(),
+        "an unmeasured count must not ship as zero"
+    );
+}
+
+#[test]
+fn a_reported_zero_crosses_the_wire_as_zero() {
+    let fact = SyncFact::from(LastSync {
+        records_reported: Some(0),
+        ..sync(SyncStatus::Succeeded, Some(0))
+    });
+    assert_eq!(fact.records_reported, Some(0));
+}
+
+#[test]
+fn the_creation_time_is_not_serialised() {
+    // It exists to order rows, and a job's creation time is not something the
+    // page has any use for. Serialising it would invite a client to read it as
+    // the start.
+    let json = serde_json::to_string(&SyncFact::from(sync(SyncStatus::Succeeded, Some(0))))
+        .expect("serialisable");
+    assert!(!json.contains("job_created_at"), "{json}");
+}
+
+#[test]
+fn a_configured_connector_that_never_synced_ships_a_null_last_sync() {
+    let health = ConnectorHealth::from(summary("a", true, None));
+    assert!(health.configured);
+    assert!(health.last_sync.is_none());
+}
+
+#[test]
+fn stamps_are_rfc3339_in_utc_with_millis() {
+    assert_eq!(super::model::stamp(moment(0)), "2023-11-14T22:13:20.000Z");
+}
+
+// ── the name at the boundary ───────────────────────────────────────────────
+
+#[test]
+fn a_descriptor_style_name_parses() {
+    for name in ["jira", "claude-team", "git-gitlab", "a1"] {
+        assert!(ConnectorName::parse(name).is_some(), "should accept {name}");
+    }
+}
+
+#[test]
+fn anything_that_is_not_a_connector_name_is_refused() {
+    let long = "a".repeat(65);
+    for name in [
+        "",
+        "-leading",
+        "trailing-",
+        "Upper",
+        "with_underscore",
+        "with space",
+        "quote'; DROP",
+        "../etc",
+        long.as_str(),
+    ] {
+        assert!(
+            ConnectorName::parse(name).is_none(),
+            "should refuse {name:?}"
+        );
+    }
+}
+
+#[test]
+fn an_underscore_is_refused_because_the_bronze_mapping_needs_it() {
+    assert!(ConnectorName::parse("ai_dev").is_none());
+}
+
+// ── the answer the page receives ───────────────────────────────────────────
+
+#[test]
+fn the_answer_carries_two_clocks_and_the_measured_interval() {
+    let response = ConnectorHealthResponse::from_facts(
+        LedgerFacts {
+            sealed_at: Some(moment(0)),
+            typical_read_interval_ms: Some(900_000),
+            summaries: vec![summary(
+                "a",
+                true,
+                Some(sync(SyncStatus::Succeeded, Some(0))),
+            )],
+            has_history: true,
+        },
+        moment(600),
+    );
+    assert_eq!(response.as_of, super::model::stamp(moment(600)));
+    assert_eq!(
+        response.checked_at.as_deref(),
+        Some("2023-11-14T22:13:20.000Z")
+    );
+    assert_eq!(response.typical_read_interval_ms, Some(900_000));
+    assert!(response.history_available);
+    assert_eq!(response.connectors.len(), 1);
+}
+
+#[test]
+fn an_empty_ledger_answers_without_a_checked_at() {
+    let response = ConnectorHealthResponse::from_facts(LedgerFacts::default(), moment(0));
+    assert!(response.checked_at.is_none(), "nothing has been read yet");
+    assert!(response.typical_read_interval_ms.is_none());
+    assert!(!response.history_available);
+    assert!(response.connectors.is_empty());
+    assert!(!response.as_of.is_empty(), "the answer still dates itself");
+}
+
+#[test]
+fn the_answer_keeps_the_order_it_was_given() {
+    // The service sorts by what needs acting on; the page must not have to
+    // re-derive that, so the order it receives is the order it renders.
+    let mut summaries = vec![
+        summary("quiet", true, Some(sync(SyncStatus::Succeeded, Some(0)))),
+        summary("broken", true, Some(sync(SyncStatus::Failed, Some(0)))),
+    ];
+    by_attention(&mut summaries);
+    let response = ConnectorHealthResponse::from_facts(
+        LedgerFacts {
+            summaries,
+            has_history: true,
+            ..LedgerFacts::default()
+        },
+        moment(0),
+    );
+    let order: Vec<&str> = response
+        .connectors
+        .iter()
+        .map(|row| row.connector.as_str())
+        .collect();
+    assert_eq!(order, ["broken", "quiet"]);
+}
+
+#[test]
+fn the_window_says_how_large_it_is() {
+    let response = SyncHistoryResponse::build(
+        "example-tracker".to_owned(),
+        vec![sync(SyncStatus::Succeeded, Some(0))],
+        50,
+    );
+    assert_eq!(response.connector, "example-tracker");
+    assert_eq!(response.window, 50, "the page can say the list is a window");
+    assert_eq!(response.syncs.len(), 1);
+}
+
+#[test]
+fn a_connector_with_no_recorded_sync_answers_an_empty_window() {
+    let response = SyncHistoryResponse::build("nobody".to_owned(), Vec::new(), 50);
+    assert!(response.syncs.is_empty());
+    assert_eq!(response.window, 50, "still a window, just an empty one");
+}
+
+// ── the name at the boundary, both ways ────────────────────────────────────
+
+#[test]
+fn a_parsed_name_round_trips_unchanged() {
+    let parsed = ConnectorName::parse("claude-team").expect("a valid name");
+    assert_eq!(parsed.as_str(), "claude-team");
+    assert_eq!(parsed.into_string(), "claude-team");
+}

--- a/src/backend/services/analytics/src/domain/mod.rs
+++ b/src/backend/services/analytics/src/domain/mod.rs
@@ -1,4 +1,5 @@
 pub mod ai;
+pub(crate) mod connector_health;
 pub mod contract_version;
 pub(crate) mod date_window;
 pub mod external_links;

--- a/src/frontend/src/api/connector-health-client.test.ts
+++ b/src/frontend/src/api/connector-health-client.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api/fetch-with-auth", () => ({ fetchWithAuth: vi.fn() }));
+
+import { fetchWithAuth } from "@/api/fetch-with-auth";
+
+import { getConnectorHealth, getConnectorSyncs } from "./connector-health-client";
+import { AnalyticsApiError } from "./analytics-client";
+
+const mockFetch = fetchWithAuth as unknown as ReturnType<typeof vi.fn>;
+
+function response(
+  body: unknown,
+  init?: { ok?: boolean; status?: number },
+): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("getConnectorHealth", () => {
+  it("reads the instance-wide summary", async () => {
+    const summary = {
+      as_of: "2026-01-15T09:12:00.000Z",
+      checked_at: "2026-01-15T09:06:00.000Z",
+      typical_read_interval_ms: 900_000,
+      history_available: true,
+      connectors: [],
+    };
+    mockFetch.mockResolvedValueOnce(response(summary));
+
+    await expect(getConnectorHealth()).resolves.toEqual(summary);
+    expect(mockFetch).toHaveBeenCalledWith("/api/analytics/v1/connector-health");
+  });
+
+  it("surfaces a refusal as an API error rather than an empty page", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ title: "forbidden" }, { ok: false, status: 403 }),
+    );
+
+    await expect(getConnectorHealth()).rejects.toBeInstanceOf(AnalyticsApiError);
+  });
+});
+
+describe("getConnectorSyncs", () => {
+  it("reads one connector's window", async () => {
+    const history = { connector: "example-tracker", syncs: [], window: 50 };
+    mockFetch.mockResolvedValueOnce(response(history));
+
+    await expect(getConnectorSyncs("example-tracker")).resolves.toEqual(history);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/analytics/v1/connector-health/example-tracker/syncs",
+    );
+  });
+
+  it("encodes the connector, so a name never becomes part of the path", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ connector: "x", syncs: [], window: 50 }),
+    );
+
+    await getConnectorSyncs("a/b?c");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/analytics/v1/connector-health/a%2Fb%3Fc/syncs",
+    );
+  });
+
+  it("surfaces a failure rather than an empty window", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response(null, { ok: false, status: 500 }),
+    );
+
+    await expect(getConnectorSyncs("example-tracker")).rejects.toBeInstanceOf(
+      AnalyticsApiError,
+    );
+  });
+});

--- a/src/frontend/src/api/connector-health-client.ts
+++ b/src/frontend/src/api/connector-health-client.ts
@@ -24,33 +24,41 @@ export type SyncStatus =
  * One recorded sync.
  *
  * Every nullable field means "nobody measured this", never "this was zero" —
- * `records_reported: 0` is a sync that moved nothing, and `null` is a sync the
- * mover reported no count for at all.
+ * `records_reported: 0` is a sync that moved nothing, and an absent value is a
+ * sync the mover reported no count for at all.
+ *
+ * Absent AND nullable, deliberately. The generated contract lists only
+ * `job_id` and `status` as required, following this service's convention for
+ * every DTO, so a contract-legal response may omit the key entirely. Typing
+ * these as `T | null` reads as safer and is not: `tsc` then lets a caller
+ * assume the key is present, and the value that arrives is `undefined`.
  */
 export interface SyncFact {
   job_id: string;
-  status: SyncStatus;
-  started_at: string | null;
-  duration_ms: number | null;
-  records_reported: number | null;
+  /** The contract types this as a bare string, so a word this union does not
+   * carry is a legal response — the mover's vocabulary can grow. */
+  status: SyncStatus | string;
+  started_at?: string | null;
+  duration_ms?: number | null;
+  records_reported?: number | null;
 }
 
 export interface ConnectorHealth {
   connector: string;
   configured: boolean;
-  last_sync: SyncFact | null;
+  last_sync?: SyncFact | null;
 }
 
 export interface ConnectorHealthSummary {
   /** When the service computed this answer. */
   as_of: string;
-  /** When the mover was last read. Null before the first sweep sealed. */
-  checked_at: string | null;
+  /** When the mover was last read. Absent before the first sweep sealed. */
+  checked_at?: string | null;
   /**
    * The median gap between the recent reads, measured from the record itself —
-   * not a configured schedule. Null where too few reads are recorded.
+   * not a configured schedule. Absent where too few reads are recorded.
    */
-  typical_read_interval_ms: number | null;
+  typical_read_interval_ms?: number | null;
   /** False when nothing has been recorded at all. */
   history_available: boolean;
   /** Already ordered by what needs acting on; the page does not re-sort. */

--- a/src/frontend/src/api/connector-health-client.ts
+++ b/src/frontend/src/api/connector-health-client.ts
@@ -1,0 +1,85 @@
+import { AnalyticsApiError } from "@/api/analytics-client";
+import { fetchWithAuth } from "@/api/fetch-with-auth";
+
+const BASE =
+  (import.meta.env.VITE_API_BASE as string | undefined) ?? "/api/analytics/v1";
+
+/**
+ * The mover's own word for how a sync ended, carried through unchanged.
+ *
+ * `unknown` is the service's addition: a recorded word outside the mover's
+ * documented vocabulary. It is not a failure and not a success — a state the
+ * page could not read.
+ */
+export type SyncStatus =
+  | "pending"
+  | "running"
+  | "incomplete"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "unknown";
+
+/**
+ * One recorded sync.
+ *
+ * Every nullable field means "nobody measured this", never "this was zero" —
+ * `records_reported: 0` is a sync that moved nothing, and `null` is a sync the
+ * mover reported no count for at all.
+ */
+export interface SyncFact {
+  job_id: string;
+  status: SyncStatus;
+  started_at: string | null;
+  duration_ms: number | null;
+  records_reported: number | null;
+}
+
+export interface ConnectorHealth {
+  connector: string;
+  configured: boolean;
+  last_sync: SyncFact | null;
+}
+
+export interface ConnectorHealthSummary {
+  /** When the service computed this answer. */
+  as_of: string;
+  /** When the mover was last read. Null before the first sweep sealed. */
+  checked_at: string | null;
+  /**
+   * The median gap between the recent reads, measured from the record itself —
+   * not a configured schedule. Null where too few reads are recorded.
+   */
+  typical_read_interval_ms: number | null;
+  /** False when nothing has been recorded at all. */
+  history_available: boolean;
+  /** Already ordered by what needs acting on; the page does not re-sort. */
+  connectors: ConnectorHealth[];
+}
+
+export interface ConnectorSyncHistory {
+  connector: string;
+  syncs: SyncFact[];
+  /** The most rows this window can hold, so the page can say it is a window. */
+  window: number;
+}
+
+export async function getConnectorHealth(): Promise<ConnectorHealthSummary> {
+  const res = await fetchWithAuth(`${BASE}/connector-health`);
+  if (!res.ok) {
+    throw new AnalyticsApiError(res.status, await res.json().catch(() => null));
+  }
+  return (await res.json()) as ConnectorHealthSummary;
+}
+
+export async function getConnectorSyncs(
+  connector: string,
+): Promise<ConnectorSyncHistory> {
+  const res = await fetchWithAuth(
+    `${BASE}/connector-health/${encodeURIComponent(connector)}/syncs`,
+  );
+  if (!res.ok) {
+    throw new AnalyticsApiError(res.status, await res.json().catch(() => null));
+  }
+  return (await res.json()) as ConnectorSyncHistory;
+}

--- a/src/frontend/src/components/portal/connector-health.test.tsx
+++ b/src/frontend/src/components/portal/connector-health.test.tsx
@@ -93,21 +93,39 @@ describe("the pane prints what it was served", () => {
     expect(names).toEqual(["zulu", "alpha", "mike"]);
   });
 
-  it("expands only the row that was clicked, even when two share a name", async () => {
-    // The name is the server's to choose. Keying expansion on it opens both.
-    mocks.summary.data = summary({
-      connectors: [
-        { connector: "alpha", configured: true, last_sync: null },
-        { connector: "alpha", configured: false, last_sync: null },
-      ],
-    });
-    render(<ConnectorHealthPane />);
+  it("keeps the same row expanded when the served order changes", async () => {
+    // The page polls, so a row's position is not its identity. Keying expansion
+    // on the position opens a different connector the moment the order moves.
+    const alpha = {
+      connector: "alpha",
+      configured: true,
+      last_sync: { job_id: "1", status: "succeeded" as const, started_at: NOW },
+    };
+    const bravo = {
+      connector: "bravo",
+      configured: true,
+      last_sync: { job_id: "2", status: "failed" as const, started_at: NOW },
+    };
+    mocks.summary.data = summary({ connectors: [alpha, bravo] });
+    const { rerender } = render(<ConnectorHealthPane />);
 
-    const toggles = screen.getAllByRole("button", { name: "alpha" });
-    await userEvent.click(toggles[0]);
+    await userEvent.click(screen.getByRole("button", { name: "alpha" }));
+    expect(screen.getByRole("button", { name: "alpha" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
 
-    expect(toggles[0]).toHaveAttribute("aria-expanded", "true");
-    expect(toggles[1]).toHaveAttribute("aria-expanded", "false");
+    mocks.summary.data = summary({ connectors: [bravo, alpha] });
+    rerender(<ConnectorHealthPane />);
+
+    expect(screen.getByRole("button", { name: "alpha" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "bravo" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
   });
 
   it("prints an unmeasured number as absence, not as a zero", () => {

--- a/src/frontend/src/components/portal/connector-health.test.tsx
+++ b/src/frontend/src/components/portal/connector-health.test.tsx
@@ -63,29 +63,25 @@ beforeEach(() => {
 
 describe("the pane prints what it was served", () => {
   it("keeps the served order rather than sorting again", () => {
+    // Deliberately an order no local rule reproduces: not alphabetical, not
+    // severity-first, not by job id. A two-row fixture whose served order also
+    // happens to be the severity order proves nothing.
     mocks.summary.data = summary({
       connectors: [
         {
-          connector: "broken",
+          connector: "zulu",
           configured: true,
-          last_sync: {
-            job_id: "2",
-            status: "failed",
-            started_at: NOW,
-            duration_ms: 1_000,
-            records_reported: 0,
-          },
+          last_sync: { job_id: "1", status: "succeeded", started_at: NOW },
         },
         {
           connector: "alpha",
           configured: true,
-          last_sync: {
-            job_id: "1",
-            status: "succeeded",
-            started_at: NOW,
-            duration_ms: 2_000,
-            records_reported: 5,
-          },
+          last_sync: { job_id: "9", status: "failed", started_at: NOW },
+        },
+        {
+          connector: "mike",
+          configured: true,
+          last_sync: { job_id: "5", status: "running", started_at: NOW },
         },
       ],
     });
@@ -94,7 +90,24 @@ describe("the pane prints what it was served", () => {
     const names = screen
       .getAllByRole("button", { expanded: false })
       .map((button) => button.textContent);
-    expect(names).toEqual(["broken", "alpha"]);
+    expect(names).toEqual(["zulu", "alpha", "mike"]);
+  });
+
+  it("expands only the row that was clicked, even when two share a name", async () => {
+    // The name is the server's to choose. Keying expansion on it opens both.
+    mocks.summary.data = summary({
+      connectors: [
+        { connector: "alpha", configured: true, last_sync: null },
+        { connector: "alpha", configured: false, last_sync: null },
+      ],
+    });
+    render(<ConnectorHealthPane />);
+
+    const toggles = screen.getAllByRole("button", { name: "alpha" });
+    await userEvent.click(toggles[0]);
+
+    expect(toggles[0]).toHaveAttribute("aria-expanded", "true");
+    expect(toggles[1]).toHaveAttribute("aria-expanded", "false");
   });
 
   it("prints an unmeasured number as absence, not as a zero", () => {
@@ -159,6 +172,19 @@ describe("the pane prints what it was served", () => {
     // exactly the claim it was written to disclaim.
     expect(screen.queryByText(/healthy|up to date|fine/i)).not.toBeInTheDocument();
   });
+
+  it("does not say nothing has been read when something has", () => {
+    // An empty table and a never-read ledger are different states. Keying the
+    // copy on the row count makes the body contradict the header one line up.
+    mocks.summary.data = summary({ connectors: [], history_available: true });
+    render(<ConnectorHealthPane />);
+
+    expect(screen.getByText(/last checked/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/nothing has been read/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/reported no connector/i)).toBeInTheDocument();
+  });
 });
 
 describe("the pane dates itself", () => {
@@ -167,14 +193,23 @@ describe("the pane dates itself", () => {
     expect(screen.getByText(/last checked 1 min ago/i)).toBeInTheDocument();
   });
 
-  it("raises a stopped recorder as an alert, not as prose", () => {
-    mocks.summary.data = summary({
-      checked_at: "2026-01-15T10:00:00.000Z",
-    });
+  it("announces a stopped recorder together with its consequence", () => {
+    mocks.summary.data = summary({ checked_at: "2026-01-15T04:00:00.000Z" });
     render(<ConnectorHealthPane />);
 
-    const alert = screen.getByRole("alert");
-    expect(alert).toHaveTextContent(/recording appears to have stopped/i);
+    // One permanently mounted region, so the announcement does not depend on a
+    // role appearing on a node that already existed — and it holds the
+    // consequence as well as the headline, which is the half a reader needs.
+    const region = screen.getByRole("status");
+    expect(region).toHaveTextContent(/recording appears to have stopped/i);
+    expect(region).toHaveTextContent(/may no longer be current/i);
+  });
+
+  it("says it cannot date the page when the two clocks disagree", () => {
+    mocks.summary.data = summary({ checked_at: "2026-01-16T00:00:00.000Z" });
+    render(<ConnectorHealthPane />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(/cannot tell when/i);
   });
 });
 

--- a/src/frontend/src/components/portal/connector-health.test.tsx
+++ b/src/frontend/src/components/portal/connector-health.test.tsx
@@ -1,0 +1,315 @@
+// @vitest-environment jsdom
+/**
+ * The pane's job is to print what it was served, and to be honest about what
+ * it was not served. So the tests here check that it does not re-order the
+ * rows (the service ordered them by what needs acting on), that an unmeasured
+ * number renders as absence rather than a zero, and that a stopped recorder
+ * reaches a screen reader as an alert rather than as ordinary prose.
+ */
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ConnectorHealthSummary,
+  ConnectorSyncHistory,
+} from "@/api/connector-health-client";
+
+const mocks = vi.hoisted(() => ({
+  summary: {
+    data: undefined as ConnectorHealthSummary | undefined,
+    isPending: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+  syncs: {
+    data: undefined as ConnectorSyncHistory | undefined,
+    isPending: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+}));
+
+vi.mock("@/queries/connector-health", () => ({
+  useConnectorHealth: () => mocks.summary,
+  useConnectorSyncs: () => mocks.syncs,
+}));
+
+import { ConnectorHealthPane } from "./connector-health";
+
+const NOW = "2026-01-15T12:00:00.000Z";
+
+function summary(over: Partial<ConnectorHealthSummary> = {}): ConnectorHealthSummary {
+  return {
+    as_of: NOW,
+    checked_at: "2026-01-15T11:59:00.000Z",
+    typical_read_interval_ms: 900_000,
+    history_available: true,
+    connectors: [],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mocks.summary.refetch.mockClear();
+  mocks.syncs.refetch.mockClear();
+  mocks.summary.isPending = false;
+  mocks.summary.isError = false;
+  mocks.summary.data = summary();
+  mocks.syncs.isPending = false;
+  mocks.syncs.isError = false;
+  mocks.syncs.data = { connector: "alpha", syncs: [], window: 50 };
+});
+
+describe("the pane prints what it was served", () => {
+  it("keeps the served order rather than sorting again", () => {
+    mocks.summary.data = summary({
+      connectors: [
+        {
+          connector: "broken",
+          configured: true,
+          last_sync: {
+            job_id: "2",
+            status: "failed",
+            started_at: NOW,
+            duration_ms: 1_000,
+            records_reported: 0,
+          },
+        },
+        {
+          connector: "alpha",
+          configured: true,
+          last_sync: {
+            job_id: "1",
+            status: "succeeded",
+            started_at: NOW,
+            duration_ms: 2_000,
+            records_reported: 5,
+          },
+        },
+      ],
+    });
+    render(<ConnectorHealthPane />);
+
+    const names = screen
+      .getAllByRole("button", { expanded: false })
+      .map((button) => button.textContent);
+    expect(names).toEqual(["broken", "alpha"]);
+  });
+
+  it("prints an unmeasured number as absence, not as a zero", () => {
+    mocks.summary.data = summary({
+      connectors: [
+        {
+          connector: "alpha",
+          configured: true,
+          last_sync: {
+            job_id: "1",
+            status: "running",
+            started_at: null,
+            duration_ms: null,
+            records_reported: null,
+          },
+        },
+      ],
+    });
+    render(<ConnectorHealthPane />);
+
+    const row = screen.getByRole("button", { name: "alpha" }).closest("tr");
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getAllByText("—")).toHaveLength(3);
+    expect(within(row as HTMLElement).queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("says a reported zero is a zero", () => {
+    mocks.summary.data = summary({
+      connectors: [
+        {
+          connector: "alpha",
+          configured: true,
+          last_sync: {
+            job_id: "1",
+            status: "succeeded",
+            started_at: NOW,
+            duration_ms: 0,
+            records_reported: 0,
+          },
+        },
+      ],
+    });
+    render(<ConnectorHealthPane />);
+
+    const row = screen.getByRole("button", { name: "alpha" }).closest("tr");
+    expect(within(row as HTMLElement).getByText("0")).toBeInTheDocument();
+  });
+
+  it("says nothing has been recorded instead of implying health", () => {
+    mocks.summary.data = summary({
+      connectors: [],
+      history_available: false,
+      checked_at: null,
+    });
+    render(<ConnectorHealthPane />);
+
+    expect(
+      screen.getByText(/nothing has been read from the connectors yet/i),
+    ).toBeInTheDocument();
+    // Deliberately blunt: the word must not appear at all, not even negated.
+    // "Nothing here says the connectors are healthy" reads, at a glance, as
+    // exactly the claim it was written to disclaim.
+    expect(screen.queryByText(/healthy|up to date|fine/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("the pane dates itself", () => {
+  it("reports when the mover was last read", () => {
+    render(<ConnectorHealthPane />);
+    expect(screen.getByText(/last checked 1 min ago/i)).toBeInTheDocument();
+  });
+
+  it("raises a stopped recorder as an alert, not as prose", () => {
+    mocks.summary.data = summary({
+      checked_at: "2026-01-15T10:00:00.000Z",
+    });
+    render(<ConnectorHealthPane />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/recording appears to have stopped/i);
+  });
+});
+
+describe("a read that failed says so", () => {
+  it("offers a retry instead of an empty table", async () => {
+    mocks.summary.isError = true;
+    mocks.summary.data = undefined;
+    render(<ConnectorHealthPane />);
+
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /retry|try again/i }));
+    expect(mocks.summary.refetch).toHaveBeenCalled();
+  });
+
+  it("waits rather than rendering an empty page while the read is in flight", () => {
+    mocks.summary.isPending = true;
+    mocks.summary.data = undefined;
+    render(<ConnectorHealthPane />);
+
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.queryByText(/nothing has been read/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps a failed window inside its own row", async () => {
+    mocks.summary.data = summary({
+      connectors: [{ connector: "alpha", configured: true, last_sync: null }],
+    });
+    mocks.syncs.isError = true;
+    mocks.syncs.data = undefined;
+    render(<ConnectorHealthPane />);
+
+    await userEvent.click(screen.getByRole("button", { name: "alpha" }));
+
+    // The summary above it is still readable — one connector's unreadable
+    // history must not take the page down with it.
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /retry|try again/i }));
+    expect(mocks.syncs.refetch).toHaveBeenCalled();
+  });
+
+  it("says a connector has no recorded sync rather than showing an empty list", async () => {
+    mocks.summary.data = summary({
+      connectors: [{ connector: "alpha", configured: true, last_sync: null }],
+    });
+    mocks.syncs.data = { connector: "alpha", syncs: [], window: 50 };
+    render(<ConnectorHealthPane />);
+
+    await userEvent.click(screen.getByRole("button", { name: "alpha" }));
+
+    expect(
+      screen.getByText(/no sync has been recorded for this connector/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("a row expands to its recent syncs", () => {
+  it("is operable from the keyboard and announces its state", async () => {
+    mocks.summary.data = summary({
+      connectors: [
+        {
+          connector: "alpha",
+          configured: true,
+          last_sync: {
+            job_id: "1",
+            status: "succeeded",
+            started_at: NOW,
+            duration_ms: 1_000,
+            records_reported: 5,
+          },
+        },
+      ],
+    });
+    mocks.syncs.data = {
+      connector: "alpha",
+      syncs: [
+        {
+          job_id: "1",
+          status: "succeeded",
+          started_at: NOW,
+          duration_ms: 1_000,
+          records_reported: 5,
+        },
+      ],
+      window: 50,
+    };
+    render(<ConnectorHealthPane />);
+
+    const toggle = screen.getByRole("button", { name: "alpha" });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/recent syncs/i)).toBeInTheDocument();
+  });
+
+  it("says the list is a window rather than the whole history", async () => {
+    mocks.summary.data = summary({
+      connectors: [
+        { connector: "alpha", configured: true, last_sync: null },
+      ],
+    });
+    mocks.syncs.data = {
+      connector: "alpha",
+      syncs: [
+        {
+          job_id: "1",
+          status: "succeeded",
+          started_at: NOW,
+          duration_ms: 1_000,
+          records_reported: 5,
+        },
+      ],
+      window: 50,
+    };
+    render(<ConnectorHealthPane />);
+
+    await userEvent.click(screen.getByRole("button", { name: "alpha" }));
+
+    expect(
+      screen.getByText(/the most recent 50, not the full history/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not take the row out of the table to make it clickable", () => {
+    mocks.summary.data = summary({
+      connectors: [
+        { connector: "alpha", configured: true, last_sync: null },
+      ],
+    });
+    render(<ConnectorHealthPane />);
+
+    // One header row plus one body row. A `role="button"` on a `<tr>` would
+    // remove it from the table for a screen reader, which is why the toggle is
+    // a real button inside the row instead.
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+  });
+});

--- a/src/frontend/src/components/portal/connector-health.tsx
+++ b/src/frontend/src/components/portal/connector-health.tsx
@@ -29,7 +29,7 @@ import { cn } from "@/lib/utils";
 /** Tone carries emphasis; the word beside it carries the meaning. */
 const TONE_STYLE: Record<ConnectorTone, string> = {
   failing: "bg-destructive/15 text-destructive",
-  unknown: "bg-warning/15 text-warning-foreground",
+  unknown: "bg-warning/15 text-warning",
   active: "bg-primary/15 text-primary",
   ok: "bg-success/15 text-success",
   idle: "bg-muted text-muted-foreground",
@@ -39,7 +39,7 @@ const COLUMNS = 5;
 
 export function ConnectorHealthPane() {
   const { data, isPending, isError, refetch } = useConnectorHealth();
-  const [expanded, setExpanded] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<number | null>(null);
 
   if (isPending) return <CenteredSpinner className="min-h-[60vh]" />;
   if (isError || data === undefined) {
@@ -58,26 +58,28 @@ export function ConnectorHealthPane() {
         <h1 className="text-lg font-semibold tracking-tight">
           Connector health
         </h1>
-        <p
+        <div
+          role="status"
+          aria-live="polite"
           className={cn(
             "text-sm",
-            recording.state === "stopped"
+            recording.state === "stopped" || recording.state === "unreadable"
               ? "text-destructive"
               : "text-muted-foreground",
           )}
-          role={recording.state === "stopped" ? "alert" : undefined}
         >
-          {recording.label}
-        </p>
-        {recording.detail !== "" && (
-          <p className="text-sm text-muted-foreground">{recording.detail}</p>
-        )}
+          <p>{recording.label}</p>
+          {/* Inside the region, not beside it: the warning's consequence is the
+              half a reader most needs announced. */}
+          {recording.detail !== "" && <p>{recording.detail}</p>}
+        </div>
       </div>
 
       {data.connectors.length === 0 ? (
         <div className="rounded-lg border p-6 text-sm text-muted-foreground">
-          No connector has been recorded yet. This page reports what has been
-          read from the data mover, and nothing has been read.
+          {recording.state === "never_read"
+            ? "No connector has been recorded yet. This page reports what has been read from the data mover, and nothing has been read."
+            : "The data mover was read and reported no connector. Nothing here says a connector is missing — only that none was recorded."}
         </div>
       ) : (
         <div className="overflow-x-auto rounded-lg border">
@@ -92,11 +94,15 @@ export function ConnectorHealthPane() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {data.connectors.map((row) => {
+              {data.connectors.map((row, index) => {
                 const state = describeConnector(row);
-                const open = expanded === row.connector;
+                // Keyed on position, not on the name: the name is the server's
+                // to choose and two rows carrying one name would expand
+                // together and share a React key.
+                const open = expanded === index;
+                const panelId = `connector-syncs-${index}`;
                 return [
-                  <TableRow key={row.connector} data-state-name={state.state}>
+                  <TableRow key={`row-${index}`} data-state-name={state.state}>
                     <TableCell>
                       {/* A real button rather than a role on the row: an
                           overridden role takes the row out of the table for a
@@ -105,9 +111,8 @@ export function ConnectorHealthPane() {
                         type="button"
                         className="text-left font-medium underline-offset-2 hover:underline"
                         aria-expanded={open}
-                        onClick={() =>
-                          setExpanded(open ? null : row.connector)
-                        }
+                        aria-controls={panelId}
+                        onClick={() => setExpanded(open ? null : index)}
                       >
                         {row.connector}
                       </button>
@@ -128,8 +133,8 @@ export function ConnectorHealthPane() {
                     </TableCell>
                   </TableRow>,
                   open ? (
-                    <TableRow key={`${row.connector}-syncs`}>
-                      <TableCell colSpan={COLUMNS} className="bg-muted/40">
+                    <TableRow key={`syncs-${index}`}>
+                      <TableCell colSpan={COLUMNS} id={panelId} className="bg-muted/40">
                         <RecentSyncs connector={row.connector} />
                       </TableCell>
                     </TableRow>
@@ -191,7 +196,7 @@ function SyncLine({ sync }: { sync: SyncFact }) {
       <span className="tabular-nums text-muted-foreground">
         {formatRecords(sync.records_reported)} records
       </span>
-      {sync.records_reported === null && (
+      {sync.records_reported == null && (
         <span className="sr-only">
           {UNMEASURED} means the mover reported no count, not a count of zero
         </span>

--- a/src/frontend/src/components/portal/connector-health.tsx
+++ b/src/frontend/src/components/portal/connector-health.tsx
@@ -39,7 +39,7 @@ const COLUMNS = 5;
 
 export function ConnectorHealthPane() {
   const { data, isPending, isError, refetch } = useConnectorHealth();
-  const [expanded, setExpanded] = useState<number | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
 
   if (isPending) return <CenteredSpinner className="min-h-[60vh]" />;
   if (isError || data === undefined) {
@@ -94,15 +94,17 @@ export function ConnectorHealthPane() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {data.connectors.map((row, index) => {
+              {data.connectors.map((row) => {
                 const state = describeConnector(row);
-                // Keyed on position, not on the name: the name is the server's
-                // to choose and two rows carrying one name would expand
-                // together and share a React key.
-                const open = expanded === index;
-                const panelId = `connector-syncs-${index}`;
+                // Keyed on the connector, not on the row's position. The page
+                // polls, so a position can come to mean a different connector
+                // between renders and the wrong row would open. The name is
+                // safe to key on: the read groups by connector, so the response
+                // cannot carry two rows sharing one.
+                const open = expanded === row.connector;
+                const panelId = `connector-syncs-${row.connector}`;
                 return [
-                  <TableRow key={`row-${index}`} data-state-name={state.state}>
+                  <TableRow key={row.connector} data-state-name={state.state}>
                     <TableCell>
                       {/* A real button rather than a role on the row: an
                           overridden role takes the row out of the table for a
@@ -112,7 +114,7 @@ export function ConnectorHealthPane() {
                         className="text-left font-medium underline-offset-2 hover:underline"
                         aria-expanded={open}
                         aria-controls={panelId}
-                        onClick={() => setExpanded(open ? null : index)}
+                        onClick={() => setExpanded(open ? null : row.connector)}
                       >
                         {row.connector}
                       </button>
@@ -133,7 +135,7 @@ export function ConnectorHealthPane() {
                     </TableCell>
                   </TableRow>,
                   open ? (
-                    <TableRow key={`syncs-${index}`}>
+                    <TableRow key={`syncs-${row.connector}`}>
                       <TableCell colSpan={COLUMNS} id={panelId} className="bg-muted/40">
                         <RecentSyncs connector={row.connector} />
                       </TableCell>

--- a/src/frontend/src/components/portal/connector-health.tsx
+++ b/src/frontend/src/components/portal/connector-health.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+
+import type { SyncFact } from "@/api/connector-health-client";
+import { CenteredSpinner } from "@/components/widgets/centered-spinner";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  UNMEASURED,
+  describeConnector,
+  describeRecording,
+  describeSync,
+  formatDuration,
+  formatRecords,
+  formatStarted,
+  type ConnectorTone,
+} from "@/lib/portal/connector-health";
+import { useConnectorHealth, useConnectorSyncs } from "@/queries/connector-health";
+import { TEXT_LABEL } from "@/lib/type-scale";
+import { cn } from "@/lib/utils";
+
+/** Tone carries emphasis; the word beside it carries the meaning. */
+const TONE_STYLE: Record<ConnectorTone, string> = {
+  failing: "bg-destructive/15 text-destructive",
+  unknown: "bg-warning/15 text-warning-foreground",
+  active: "bg-primary/15 text-primary",
+  ok: "bg-success/15 text-success",
+  idle: "bg-muted text-muted-foreground",
+};
+
+const COLUMNS = 5;
+
+export function ConnectorHealthPane() {
+  const { data, isPending, isError, refetch } = useConnectorHealth();
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  if (isPending) return <CenteredSpinner className="min-h-[60vh]" />;
+  if (isError || data === undefined) {
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon variant="card" state="error" onRetry={() => refetch()} />
+      </div>
+    );
+  }
+
+  const recording = describeRecording(data);
+
+  return (
+    <div className="flex flex-col gap-4 p-4 md:p-6">
+      <div>
+        <h1 className="text-lg font-semibold tracking-tight">
+          Connector health
+        </h1>
+        <p
+          className={cn(
+            "text-sm",
+            recording.state === "stopped"
+              ? "text-destructive"
+              : "text-muted-foreground",
+          )}
+          role={recording.state === "stopped" ? "alert" : undefined}
+        >
+          {recording.label}
+        </p>
+        {recording.detail !== "" && (
+          <p className="text-sm text-muted-foreground">{recording.detail}</p>
+        )}
+      </div>
+
+      {data.connectors.length === 0 ? (
+        <div className="rounded-lg border p-6 text-sm text-muted-foreground">
+          No connector has been recorded yet. This page reports what has been
+          read from the data mover, and nothing has been read.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Connector</TableHead>
+                <TableHead>State</TableHead>
+                <TableHead>Last sync started</TableHead>
+                <TableHead className="text-right">Duration</TableHead>
+                <TableHead className="text-right">Records reported</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.connectors.map((row) => {
+                const state = describeConnector(row);
+                const open = expanded === row.connector;
+                return [
+                  <TableRow key={row.connector} data-state-name={state.state}>
+                    <TableCell>
+                      {/* A real button rather than a role on the row: an
+                          overridden role takes the row out of the table for a
+                          screen reader, which costs more than it buys. */}
+                      <button
+                        type="button"
+                        className="text-left font-medium underline-offset-2 hover:underline"
+                        aria-expanded={open}
+                        onClick={() =>
+                          setExpanded(open ? null : row.connector)
+                        }
+                      >
+                        {row.connector}
+                      </button>
+                    </TableCell>
+                    <TableCell>
+                      <Badge className={cn("font-medium", TONE_STYLE[state.tone])}>
+                        {state.label}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="tabular-nums">
+                      {formatStarted(row.last_sync?.started_at ?? null)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatDuration(row.last_sync?.duration_ms ?? null)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatRecords(row.last_sync?.records_reported ?? null)}
+                    </TableCell>
+                  </TableRow>,
+                  open ? (
+                    <TableRow key={`${row.connector}-syncs`}>
+                      <TableCell colSpan={COLUMNS} className="bg-muted/40">
+                        <RecentSyncs connector={row.connector} />
+                      </TableCell>
+                    </TableRow>
+                  ) : null,
+                ];
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RecentSyncs({ connector }: { connector: string }) {
+  const { data, isPending, isError, refetch } = useConnectorSyncs(connector);
+
+  if (isPending) return <CenteredSpinner className="min-h-24" />;
+  if (isError || data === undefined) {
+    return (
+      <div className="max-w-md">
+        <ComingSoon variant="card" state="error" onRetry={() => refetch()} />
+      </div>
+    );
+  }
+  if (data.syncs.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No sync has been recorded for this connector.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className={TEXT_LABEL}>
+        Recent syncs — the most recent {data.window}, not the full history
+      </p>
+      <ul className="flex flex-col gap-1">
+        {data.syncs.map((sync) => (
+          <SyncLine key={sync.job_id} sync={sync} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SyncLine({ sync }: { sync: SyncFact }) {
+  const state = describeSync(sync);
+  return (
+    <li className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+      <Badge className={cn("font-medium", TONE_STYLE[state.tone])}>
+        {state.label}
+      </Badge>
+      <span className="tabular-nums">{formatStarted(sync.started_at)}</span>
+      <span className="tabular-nums text-muted-foreground">
+        {formatDuration(sync.duration_ms)}
+      </span>
+      <span className="tabular-nums text-muted-foreground">
+        {formatRecords(sync.records_reported)} records
+      </span>
+      {sync.records_reported === null && (
+        <span className="sr-only">
+          {UNMEASURED} means the mover reported no count, not a count of zero
+        </span>
+      )}
+    </li>
+  );
+}

--- a/src/frontend/src/components/portal/manage-view.test.tsx
+++ b/src/frontend/src/components/portal/manage-view.test.tsx
@@ -49,6 +49,8 @@ vi.mock("@/components/portal/connector-health", () => ({
   ConnectorHealthPane: () => <div data-testid="connector-health-pane" />,
 }));
 
+import { MANAGE_ITEMS } from "@/lib/portal/nav-model";
+
 import { ManageView } from "./manage-view";
 
 function def(over: Partial<MetricDefinition>): MetricDefinition {
@@ -74,6 +76,14 @@ beforeEach(() => {
   mocks.q.refetch.mockClear();
   mocks.q.isLoading = false;
   mocks.q.isError = false;
+  // The gate is hoisted module state, so a test that flips it leaves it flipped
+  // for every test below — order-dependent today, wrong tomorrow.
+  adminGate.value = {
+    isAdmin: false,
+    isPending: false,
+    isError: false,
+    retry: () => undefined,
+  };
   mocks.q.data = [
     {
       prefix: "git",
@@ -162,6 +172,9 @@ describe("Manage · Connector health", () => {
     expect(
       screen.queryByTestId("connector-health-pane"),
     ).not.toBeInTheDocument();
+    // A gate rendering nothing at all would satisfy the line above, and would
+    // leave a non-admin on a blank screen with nothing to act on.
+    expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 
   it("opens for an operator", () => {
@@ -171,11 +184,13 @@ describe("Manage · Connector health", () => {
     expect(screen.getByTestId("connector-health-pane")).toBeInTheDocument();
   });
 
-  it("no longer answers to the pane it replaced", () => {
-    adminGate.value = { ...adminGate.value, isAdmin: true };
-    render(<ManageView item="data-health" />);
-
-    expect(screen.getByText(/not built yet/i)).toBeInTheDocument();
+  it("no longer offers the pane it replaced", () => {
+    // Asserting what `ManageView` does with `item="data-health"` would be
+    // unfalsifiable: `item` is always the output of `resolveZoneItem`, and
+    // `data-health` is no longer a manage item, so the app can never pass it.
+    // What is reachable — and what a stale bookmark meets — is the nav model.
+    expect(MANAGE_ITEMS.map((entry) => entry.id)).toContain("connector-health");
+    expect(MANAGE_ITEMS.map((entry) => entry.id)).not.toContain("data-health");
   });
 });
 

--- a/src/frontend/src/components/portal/manage-view.test.tsx
+++ b/src/frontend/src/components/portal/manage-view.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 /**
  * Manage-zone surfaces read the UNIFIED registry, not the legacy catalog:
- * the table lists `metric_key`s `/v1/metric-results` actually serves, spells
- * out an unobserved definition as "no data yet" rather than hiding it, and
- * Data health separates "schema checks out" from "has ever produced a row".
+ * the table lists `metric_key`s `/v1/metric-results` actually serves and
+ * spells out an unobserved definition as "no data yet" rather than hiding it.
+ *
+ * Connector health has its own test file; here only its place in the zone and
+ * its gate are under test.
  */
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -41,6 +43,10 @@ vi.mock("@/queries/identity-me", () => ({
 // The console itself has its own test file; here only the gate is under test.
 vi.mock("@/components/portal/identities-view", () => ({
   IdentitiesView: () => <div data-testid="identities-view" />,
+}));
+
+vi.mock("@/components/portal/connector-health", () => ({
+  ConnectorHealthPane: () => <div data-testid="connector-health-pane" />,
 }));
 
 import { ManageView } from "./manage-view";
@@ -148,17 +154,28 @@ describe("Manage · What's new", () => {
   });
 });
 
-describe("Manage · Data health", () => {
-  it("counts schema statuses and, separately, definitions with no data", () => {
+describe("Manage · Connector health", () => {
+  it("is instance-wide, so a non-admin is refused rather than shown an empty page", () => {
+    adminGate.value = { ...adminGate.value, isAdmin: false };
+    render(<ManageView item="connector-health" />);
+
+    expect(
+      screen.queryByTestId("connector-health-pane"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens for an operator", () => {
+    adminGate.value = { ...adminGate.value, isAdmin: true };
+    render(<ManageView item="connector-health" />);
+
+    expect(screen.getByTestId("connector-health-pane")).toBeInTheDocument();
+  });
+
+  it("no longer answers to the pane it replaced", () => {
+    adminGate.value = { ...adminGate.value, isAdmin: true };
     render(<ManageView item="data-health" />);
-    expect(screen.getByText(/across 3 metrics/)).toBeInTheDocument();
-    // 2 ok · 1 error · 0 unchecked · 1 without any observation
-    const tile = (label: string) =>
-      screen.getByText(label).closest("div")?.parentElement?.textContent ?? "";
-    expect(tile("ok")).toMatch(/^2/);
-    expect(tile("error")).toMatch(/^1/);
-    expect(tile("unchecked")).toMatch(/^0/);
-    expect(tile("no data yet")).toMatch(/^1/);
+
+    expect(screen.getByText(/not built yet/i)).toBeInTheDocument();
   });
 });
 

--- a/src/frontend/src/components/portal/manage-view.tsx
+++ b/src/frontend/src/components/portal/manage-view.tsx
@@ -16,13 +16,13 @@ import type {
   MetricDefinitionSchemaStatus,
   MetricDefinition,
 } from "@/api/metric-definitions-client";
+import { ConnectorHealthPane } from "@/components/portal/connector-health";
 import { IdentitiesView } from "@/components/portal/identities-view";
 import { PlatformUsage } from "@/components/portal/platform-usage";
 import { useIsAdmin } from "@/queries/identity-me";
 import { useMetricDefinitions } from "@/queries/metric-definitions";
 import { AiAssistantBody } from "@/screens/ai-assistant";
 import { WhatsNewBody } from "@/screens/whats-new";
-import { TEXT_FIGURE } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 
 const STATUS_STYLE: Record<MetricDefinitionSchemaStatus, string> = {
@@ -32,7 +32,8 @@ const STATUS_STYLE: Record<MetricDefinitionSchemaStatus, string> = {
 };
 
 /**
- * Manage-zone surfaces (Metric catalog, Data health, Identities, What's new).
+ * Manage-zone surfaces (Metric catalog, Connector health, Identities, What's
+ * new).
  *
  * The two catalog surfaces read the **unified** registry
  * (`GET /v1/metric-definitions`) — the set
@@ -43,7 +44,12 @@ const STATUS_STYLE: Record<MetricDefinitionSchemaStatus, string> = {
  */
 export function ManageView({ item }: { item: string | null }) {
   if (item === "metric-catalog") return <MetricCatalogTable />;
-  if (item === "data-health") return <DataHealth />;
+  if (item === "connector-health")
+    return (
+      <AdminGate>
+        <ConnectorHealthPane />
+      </AdminGate>
+    );
   if (item === "identities")
     return (
       <AdminGate>
@@ -196,59 +202,6 @@ function MetricCatalogTable() {
             ))}
           </TableBody>
         </Table>
-      </div>
-    </div>
-  );
-}
-
-function DataHealth() {
-  const { metrics, isLoading, isError, refetch } = useFlatDefinitions();
-  if (isLoading) return <CenteredSpinner className="min-h-[60vh]" />;
-  if (isError)
-    return (
-      <div className="mx-auto w-full max-w-md p-8">
-        <ComingSoon variant="card" state="error" onRetry={() => refetch()} />
-      </div>
-    );
-
-  const counts: Record<MetricDefinitionSchemaStatus, number> = {
-    ok: 0,
-    error: 0,
-    unchecked: 0,
-  };
-  for (const m of metrics) counts[m.schema_status] += 1;
-  // A definition whose schema checks out can still have never produced a row
-  // for this tenant — two separate questions, so show both answers.
-  const noData = metrics.filter((m) => m.last_observed_date == null).length;
-
-  return (
-    <div className="flex flex-col gap-4 p-4 md:p-6">
-      <div>
-        <h1 className="text-lg font-semibold tracking-tight">Data health</h1>
-        <p className="text-sm text-muted-foreground">
-          Schema-check status across {metrics.length} metrics
-        </p>
-      </div>
-      <div className="grid grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] gap-3">
-        {(["ok", "error", "unchecked"] as const).map((s) => (
-          <div key={s} className="rounded-lg border bg-card p-4">
-            <div className={TEXT_FIGURE}>{counts[s]}</div>
-            <div
-              className={cn(
-                "mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-medium",
-                STATUS_STYLE[s]
-              )}
-            >
-              {s}
-            </div>
-          </div>
-        ))}
-        <div className="rounded-lg border bg-card p-4">
-          <div className={TEXT_FIGURE}>{noData}</div>
-          <div className="mt-1 inline-flex rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-            no data yet
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/src/frontend/src/lib/portal/connector-health.test.ts
+++ b/src/frontend/src/lib/portal/connector-health.test.ts
@@ -50,7 +50,7 @@ function row(over: Partial<ConnectorHealth> = {}): ConnectorHealth {
 describe("what a row says", () => {
   it("gives every recorded status its own word", () => {
     const words: Record<SyncStatus, string> = {
-      pending: "syncing",
+      pending: "queued",
       running: "syncing",
       incomplete: "sync incomplete",
       succeeded: "sync ok",
@@ -109,11 +109,59 @@ describe("what a row says", () => {
     expect(murky.tone).not.toBe("idle");
   });
 
+  it("keeps queued apart from syncing", () => {
+    // Merging them makes a row say "syncing" beside a start of "—", and erases
+    // the only signal separating "not picked up" from "running now".
+    const queued = describeConnector(row({ last_sync: sync({ status: "pending" }) }));
+    const running = describeConnector(row({ last_sync: sync({ status: "running" }) }));
+    expect(queued.state).not.toBe(running.state);
+    expect(queued.label).not.toBe(running.label);
+  });
+
+  it("reads a status this build has never heard of as unreadable", () => {
+    // The contract types status as a bare string, so the mover's vocabulary can
+    // grow without this build changing. That must not crash and must not be
+    // filed as quiet.
+    const view = describeConnector(
+      row({ last_sync: sync({ status: "materialising" as never }) }),
+    );
+    expect(view.state).toBe("state_unknown");
+    expect(view.tone).toBe("unknown");
+  });
+
   it("carries a word for every tone, so colour is never the only signal", () => {
     const statuses: SyncStatus[] = ["succeeded", "failed", "running", "unknown"];
     for (const status of statuses) {
       expect(describeSync(sync({ status })).label.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("a contract-legal response with absent keys", () => {
+  // Every nullable field is optional in the generated contract, so the key can
+  // be missing rather than null. Typing them as `T | null` let `tsc` believe
+  // otherwise, and the page threw on a legal response.
+  it("a row with no last_sync key reads as never synced", () => {
+    const view = describeConnector({ connector: "a", configured: true });
+    expect(view.state).toBe("never_synced");
+  });
+
+  it("absent measurements print as absence rather than throwing", () => {
+    expect(formatRecords(undefined)).toBe(UNMEASURED);
+    expect(formatDuration(undefined)).toBe(UNMEASURED);
+    expect(formatStarted(undefined)).toBe(UNMEASURED);
+  });
+
+  it("a summary with no checked_at key says nothing has been read", () => {
+    const view = describeRecording({
+      as_of: "2026-01-15T12:00:00.000Z",
+      history_available: true,
+    });
+    expect(view.state).toBe("never_read");
+  });
+
+  it("a sync with no status at all is unreadable, not quiet", () => {
+    expect(describeSync({ job_id: "1" } as never).state).toBe("state_unknown");
   });
 });
 
@@ -139,6 +187,29 @@ describe("an unmeasured value is not a zero", () => {
     expect(formatDuration(90_000)).toBe("1m 30s");
     expect(formatDuration(3_930_000)).toBe("1h 5m");
   });
+
+  it("never carries sixty of the unit below", () => {
+    // Rounding each unit independently produces `1m 60s` and `60.0 s`, neither
+    // of which is a duration.
+    expect(formatDuration(119_600)).toBe("2m 0s");
+    expect(formatDuration(59_950)).toBe("1m 0s");
+    expect(formatDuration(3_599_600)).toBe("1h 0m");
+  });
+
+  it("prints a malformed measurement as absence, not as a number", () => {
+    expect(formatDuration(-5_000)).toBe(UNMEASURED);
+    expect(formatRecords(-1)).toBe(UNMEASURED);
+    expect(formatDuration(Number.NaN)).toBe(UNMEASURED);
+  });
+
+  it("refuses a stamp that is not a real timestamp", () => {
+    // `Date.parse` reads "2026" and "0" as dates, so a truncated stamp would
+    // render as a confident absolute time.
+    for (const junk of ["2026", "0", "yesterday", "2026-13-45T99:99:99Z"]) {
+      expect(formatStarted(junk)).toBe(UNMEASURED);
+    }
+    expect(formatStarted("2026-01-15T09:00:00.000Z")).toBe("2026-01-15 09:00:00Z");
+  });
 });
 
 describe("what the page says about its own freshness", () => {
@@ -150,56 +221,99 @@ describe("what the page says about its own freshness", () => {
     ...over,
   });
 
+  const checkedAgo = (ms: number) =>
+    new Date(Date.parse("2026-01-15T12:00:00.000Z") - ms).toISOString();
+
   it("says nothing has been read rather than implying health", () => {
     const view = describeRecording(summary({ history_available: false }));
     expect(view.state).toBe("never_read");
     expect(view.label).not.toMatch(/healthy|ok|fine/i);
   });
 
-  it("says nothing has been read when no tick has sealed", () => {
-    expect(describeRecording(summary({ checked_at: null })).state).toBe(
-      "never_read",
-    );
-  });
-
   it("presents recent facts as current", () => {
     expect(describeRecording(summary()).state).toBe("current");
   });
 
-  it("tolerates one missed read", () => {
+  it("tolerates one missed read but not three", () => {
+    const interval = 15 * MINUTE;
+    // Just inside the threshold, and just past it — the boundary the multiplier
+    // actually decides, rather than a value nowhere near it.
+    expect(
+      describeRecording(
+        summary({ checked_at: checkedAgo(interval * STALE_AFTER_INTERVALS) }),
+      ).state,
+    ).toBe("current");
+    expect(
+      describeRecording(
+        summary({ checked_at: checkedAgo(interval * STALE_AFTER_INTERVALS + 1) }),
+      ).state,
+    ).toBe("stopped");
+  });
+
+  it("states the age without claiming a stop it cannot support", () => {
+    // With no measured interval there is no cadence to be late against.
+    // Inventing a threshold here would have the page conclude something
+    // nothing in the record says — so it reports the age and says the cadence
+    // is unknown.
     const view = describeRecording(
-      summary({ checked_at: "2026-01-15T11:40:00.000Z" }),
+      summary({ typical_read_interval_ms: null, checked_at: checkedAgo(6 * 60 * MINUTE) }),
+    );
+    expect(view.state).toBe("unmeasured");
+    expect(view.label).toMatch(/last checked 6 h ago/i);
+    expect(view.label).not.toMatch(/stopped/i);
+    expect(view.detail).toMatch(/too few reads/i);
+  });
+
+  it("treats a zero measured interval as no measurement at all", () => {
+    // Two ticks inside one millisecond make the median zero, which is not a
+    // cadence either.
+    const view = describeRecording(
+      summary({ typical_read_interval_ms: 0, checked_at: checkedAgo(6 * 60 * MINUTE) }),
+    );
+    expect(view.state).toBe("unmeasured");
+  });
+
+  it("still says the age is long, so the fact is not hidden", () => {
+    const view = describeRecording(
+      summary({ typical_read_interval_ms: null, checked_at: checkedAgo(200 * 24 * 60 * MINUTE) }),
+    );
+    expect(view.label).toMatch(/200 d ago/);
+  });
+
+  it("does not cry stopped because a burst shortened the interval", () => {
+    // A restart loop or a manual tick drags the median down; multiplying that
+    // by three would flag a live install.
+    const view = describeRecording(
+      summary({ typical_read_interval_ms: 1_000, checked_at: checkedAgo(5 * MINUTE) }),
     );
     expect(view.state).toBe("current");
   });
 
-  it("stops presenting its facts as current once recording has plainly stopped", () => {
-    // Past STALE_AFTER_INTERVALS of the measured interval.
-    const age = 15 * MINUTE * (STALE_AFTER_INTERVALS + 1);
-    const checked = new Date(
-      Date.parse("2026-01-15T12:00:00.000Z") - age,
-    ).toISOString();
-    const view = describeRecording(summary({ checked_at: checked }));
-    expect(view.state).toBe("stopped");
-    expect(view.detail).toMatch(/may no longer be current/i);
-  });
-
-  it("claims nothing about a cadence it has not measured", () => {
-    // With no measured interval there is nothing to compare an age against, so
-    // the page reports the age and stops there.
+  it("does not let a long measured interval hide a stopped recorder", () => {
+    // Clamped to an hour, so three of them is three hours.
     const view = describeRecording(
       summary({
-        typical_read_interval_ms: null,
-        checked_at: "2026-01-01T00:00:00.000Z",
+        typical_read_interval_ms: 30 * 24 * 60 * MINUTE,
+        checked_at: checkedAgo(4 * 60 * MINUTE),
       }),
     );
-    expect(view.state).toBe("current");
-    expect(view.label).toMatch(/last checked/i);
+    expect(view.state).toBe("stopped");
   });
 
-  it("survives an unreadable stamp without asserting a time", () => {
-    const view = describeRecording(summary({ checked_at: "nope" }));
-    expect(view.label).toMatch(/unreadable/i);
+  it("dates nothing when the two clocks disagree", () => {
+    // `checked_at` after `as_of` means neither stamp can date the page.
+    // Reporting "just now" there asserts a freshness with no basis.
+    const view = describeRecording(
+      summary({ checked_at: "2026-01-16T00:00:00.000Z" }),
+    );
+    expect(view.state).toBe("unreadable");
+    expect(view.label).not.toMatch(/just now/i);
+  });
+
+  it("dates nothing when a stamp will not parse", () => {
+    expect(describeRecording(summary({ checked_at: "nope" })).state).toBe(
+      "unreadable",
+    );
   });
 });
 

--- a/src/frontend/src/lib/portal/connector-health.test.ts
+++ b/src/frontend/src/lib/portal/connector-health.test.ts
@@ -1,0 +1,213 @@
+/**
+ * What the page claims, and what it refuses to claim.
+ *
+ * The rules under test are the ones a reader would otherwise have to infer
+ * from cells: that configuration is read before the sync outcome, that an
+ * unmeasured value never prints as a zero, and that the page stops presenting
+ * its own facts as current once recording has plainly stopped.
+ */
+import { describe, expect, it } from "vitest";
+
+import type {
+  ConnectorHealth,
+  SyncFact,
+  SyncStatus,
+} from "@/api/connector-health-client";
+import {
+  STALE_AFTER_INTERVALS,
+  UNMEASURED,
+  describeAge,
+  describeConnector,
+  describeRecording,
+  describeSync,
+  formatDuration,
+  formatRecords,
+  formatStarted,
+} from "@/lib/portal/connector-health";
+
+const MINUTE = 60_000;
+
+function sync(over: Partial<SyncFact> = {}): SyncFact {
+  return {
+    job_id: "8412",
+    status: "succeeded",
+    started_at: "2026-01-15T09:00:00.000Z",
+    duration_ms: 142_000,
+    records_reported: 12_400,
+    ...over,
+  };
+}
+
+function row(over: Partial<ConnectorHealth> = {}): ConnectorHealth {
+  return {
+    connector: "example-tracker",
+    configured: true,
+    last_sync: sync(),
+    ...over,
+  };
+}
+
+describe("what a row says", () => {
+  it("gives every recorded status its own word", () => {
+    const words: Record<SyncStatus, string> = {
+      pending: "syncing",
+      running: "syncing",
+      incomplete: "sync incomplete",
+      succeeded: "sync ok",
+      failed: "sync failed",
+      cancelled: "sync cancelled",
+      unknown: "state unknown",
+    };
+    for (const [status, label] of Object.entries(words)) {
+      expect(describeConnector(row({ last_sync: sync({ status: status as SyncStatus }) })).label).toBe(
+        label,
+      );
+    }
+  });
+
+  it("never says a connector is delivering", () => {
+    const statuses: SyncStatus[] = [
+      "pending",
+      "running",
+      "incomplete",
+      "succeeded",
+      "failed",
+      "cancelled",
+      "unknown",
+    ];
+    const labels = statuses.map(
+      (status) => describeConnector(row({ last_sync: sync({ status }) })).label,
+    );
+    for (const label of [...labels, "no longer configured", "never synced"]) {
+      expect(label).not.toMatch(/deliver|healthy|fresh|up to date/i);
+    }
+  });
+
+  it("reads configuration before the sync outcome", () => {
+    // A connector taken out of configuration is a decision, not a fault, even
+    // when the last thing it did was fail.
+    const removed = describeConnector(
+      row({ configured: false, last_sync: sync({ status: "failed" }) }),
+    );
+    expect(removed.state).toBe("no_longer_configured");
+    expect(removed.tone).not.toBe("failing");
+  });
+
+  it("separates never synced from no longer configured", () => {
+    expect(describeConnector(row({ last_sync: null })).state).toBe(
+      "never_synced",
+    );
+    expect(
+      describeConnector(row({ configured: false, last_sync: null })).state,
+    ).toBe("no_longer_configured");
+  });
+
+  it("gives an unreadable state its own tone, not the quiet one", () => {
+    const murky = describeConnector(row({ last_sync: sync({ status: "unknown" }) }));
+    expect(murky.tone).toBe("unknown");
+    expect(murky.tone).not.toBe("ok");
+    expect(murky.tone).not.toBe("idle");
+  });
+
+  it("carries a word for every tone, so colour is never the only signal", () => {
+    const statuses: SyncStatus[] = ["succeeded", "failed", "running", "unknown"];
+    for (const status of statuses) {
+      expect(describeSync(sync({ status })).label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("an unmeasured value is not a zero", () => {
+  it("prints absence as absence", () => {
+    expect(formatDuration(null)).toBe(UNMEASURED);
+    expect(formatRecords(null)).toBe(UNMEASURED);
+    expect(formatStarted(null)).toBe(UNMEASURED);
+  });
+
+  it("prints a measured zero as zero", () => {
+    expect(formatRecords(0)).toBe("0");
+    expect(formatDuration(0)).toBe("0 ms");
+  });
+
+  it("prints an unparseable stamp as absence rather than as an epoch", () => {
+    expect(formatStarted("not a date")).toBe(UNMEASURED);
+  });
+
+  it("reads durations at the scale they arrive in", () => {
+    expect(formatDuration(900)).toBe("900 ms");
+    expect(formatDuration(1_500)).toBe("1.5 s");
+    expect(formatDuration(90_000)).toBe("1m 30s");
+    expect(formatDuration(3_930_000)).toBe("1h 5m");
+  });
+});
+
+describe("what the page says about its own freshness", () => {
+  const summary = (over: Partial<Parameters<typeof describeRecording>[0]> = {}) => ({
+    as_of: "2026-01-15T12:00:00.000Z",
+    checked_at: "2026-01-15T11:59:00.000Z",
+    typical_read_interval_ms: 15 * MINUTE,
+    history_available: true,
+    ...over,
+  });
+
+  it("says nothing has been read rather than implying health", () => {
+    const view = describeRecording(summary({ history_available: false }));
+    expect(view.state).toBe("never_read");
+    expect(view.label).not.toMatch(/healthy|ok|fine/i);
+  });
+
+  it("says nothing has been read when no tick has sealed", () => {
+    expect(describeRecording(summary({ checked_at: null })).state).toBe(
+      "never_read",
+    );
+  });
+
+  it("presents recent facts as current", () => {
+    expect(describeRecording(summary()).state).toBe("current");
+  });
+
+  it("tolerates one missed read", () => {
+    const view = describeRecording(
+      summary({ checked_at: "2026-01-15T11:40:00.000Z" }),
+    );
+    expect(view.state).toBe("current");
+  });
+
+  it("stops presenting its facts as current once recording has plainly stopped", () => {
+    // Past STALE_AFTER_INTERVALS of the measured interval.
+    const age = 15 * MINUTE * (STALE_AFTER_INTERVALS + 1);
+    const checked = new Date(
+      Date.parse("2026-01-15T12:00:00.000Z") - age,
+    ).toISOString();
+    const view = describeRecording(summary({ checked_at: checked }));
+    expect(view.state).toBe("stopped");
+    expect(view.detail).toMatch(/may no longer be current/i);
+  });
+
+  it("claims nothing about a cadence it has not measured", () => {
+    // With no measured interval there is nothing to compare an age against, so
+    // the page reports the age and stops there.
+    const view = describeRecording(
+      summary({
+        typical_read_interval_ms: null,
+        checked_at: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    expect(view.state).toBe("current");
+    expect(view.label).toMatch(/last checked/i);
+  });
+
+  it("survives an unreadable stamp without asserting a time", () => {
+    const view = describeRecording(summary({ checked_at: "nope" }));
+    expect(view.label).toMatch(/unreadable/i);
+  });
+});
+
+describe("ages read coarsely", () => {
+  it("does not pretend to a precision a periodic read does not have", () => {
+    expect(describeAge(5_000)).toBe("just now");
+    expect(describeAge(5 * MINUTE)).toBe("5 min ago");
+    expect(describeAge(3 * 60 * MINUTE)).toBe("3 h ago");
+    expect(describeAge(50 * 60 * MINUTE)).toBe("2 d ago");
+  });
+});

--- a/src/frontend/src/lib/portal/connector-health.ts
+++ b/src/frontend/src/lib/portal/connector-health.ts
@@ -14,27 +14,43 @@ import type {
  * facts and never a verdict the record cannot back: nothing here says a
  * connector is delivering, because the ledger holds the mover's own account of
  * its syncs and nothing that corroborates it.
+ *
+ * Every function here is total over what the contract permits — which includes
+ * an absent key for any nullable field, and a status word this build has never
+ * heard of. A partial function would take the whole portal to its error
+ * boundary on a legal response.
  */
 export type ConnectorTone = "failing" | "unknown" | "active" | "ok" | "idle";
 
+export type ConnectorStateName =
+  | "no_longer_configured"
+  | "never_synced"
+  | "queued"
+  | "syncing"
+  | "sync_failed"
+  | "sync_incomplete"
+  | "sync_cancelled"
+  | "state_unknown"
+  | "sync_ok";
+
 export interface ConnectorStateView {
   /** Stable identifier, for tests and for the row's data attribute. */
-  state:
-    | "no_longer_configured"
-    | "never_synced"
-    | "syncing"
-    | "sync_failed"
-    | "sync_incomplete"
-    | "sync_cancelled"
-    | "state_unknown"
-    | "sync_ok";
+  state: ConnectorStateName;
   /** What the row says. Never colour alone. */
   label: string;
   tone: ConnectorTone;
 }
 
+/**
+ * One entry per word the mover uses, kept apart.
+ *
+ * `pending` and `running` are not merged. A queued job has no start time, so
+ * merging them makes the row say "syncing" beside a start of "—" — and erases
+ * the only signal that separates "queued and not picked up" from "running now",
+ * which is one of the states an operator opens this page for.
+ */
 const STATE: Record<SyncStatus, ConnectorStateView> = {
-  pending: { state: "syncing", label: "syncing", tone: "active" },
+  pending: { state: "queued", label: "queued", tone: "active" },
   running: { state: "syncing", label: "syncing", tone: "active" },
   failed: { state: "sync_failed", label: "sync failed", tone: "failing" },
   incomplete: {
@@ -63,6 +79,11 @@ const NEVER_SYNCED: ConnectorStateView = {
   tone: "idle",
 };
 
+/** A word outside this build's vocabulary is a state it cannot read. */
+function stateOf(status: string | undefined): ConnectorStateView {
+  return STATE[status as SyncStatus] ?? STATE.unknown;
+}
+
 /**
  * Configuration is read before the sync outcome, deliberately.
  *
@@ -72,8 +93,13 @@ const NEVER_SYNCED: ConnectorStateView = {
  */
 export function describeConnector(row: ConnectorHealth): ConnectorStateView {
   if (!row.configured) return NO_LONGER_CONFIGURED;
-  if (row.last_sync === null) return NEVER_SYNCED;
-  return STATE[row.last_sync.status] ?? STATE.unknown;
+  if (row.last_sync == null) return NEVER_SYNCED;
+  return stateOf(row.last_sync.status);
+}
+
+/** The status word for one sync in the expanded history. */
+export function describeSync(sync: SyncFact): ConnectorStateView {
+  return stateOf(sync.status);
 }
 
 /* ── what the page says about its own freshness ───────────────────────── */
@@ -82,18 +108,26 @@ export function describeConnector(row: ConnectorHealth): ConnectorStateView {
  * How many typical intervals may pass before the page stops presenting its
  * facts as current.
  *
- * One missed read is a hiccup; three in a row is a recorder that stopped. The
- * page cannot know the intended cadence — nothing on the read path does — so
- * the comparison is against the interval actually observed between recent
- * reads.
+ * One missed read is a hiccup; three in a row is a recorder that stopped.
  */
 export const STALE_AFTER_INTERVALS = 3;
 
+/**
+ * The band a measured interval is clamped into before it is multiplied.
+ *
+ * Both ends are load-bearing. Without a floor, a burst of closely spaced
+ * sweeps — a restart loop, a manual tick — drags the median down and the page
+ * then reports a live install as stopped. Without a ceiling, a long measured
+ * interval would let a genuinely stopped recorder sit unreported for days.
+ */
+const MIN_INTERVAL_MS = 5 * 60_000;
+const MAX_INTERVAL_MS = 60 * 60_000;
+
 export interface RecordingView {
-  state: "never_read" | "stopped" | "current";
+  state: "never_read" | "stopped" | "unmeasured" | "current" | "unreadable";
   /** The headline sentence. */
   label: string;
-  /** The reassurance or the warning under it, empty when there is nothing to add. */
+  /** The warning or reassurance under it; empty when there is nothing to add. */
   detail: string;
 }
 
@@ -103,7 +137,7 @@ export function describeRecording(
     "as_of" | "checked_at" | "typical_read_interval_ms" | "history_available"
   >,
 ): RecordingView {
-  if (!summary.history_available || summary.checked_at === null) {
+  if (!summary.history_available || summary.checked_at == null) {
     return {
       state: "never_read",
       label: "Nothing has been read from the connectors yet",
@@ -113,14 +147,31 @@ export function describeRecording(
   }
 
   const age = ageMs(summary.as_of, summary.checked_at);
-  const interval = summary.typical_read_interval_ms;
-  const stopped =
-    age !== null &&
-    interval !== null &&
-    interval > 0 &&
-    age > interval * STALE_AFTER_INTERVALS;
+  if (age === null) {
+    return {
+      state: "unreadable",
+      label: "Cannot tell when the connectors were last read",
+      detail: "Nothing below can be dated, so treat it as unverified.",
+    };
+  }
 
-  if (stopped) {
+  const threshold = staleAfter(summary.typical_read_interval_ms);
+
+  // No measured interval, so there is no cadence to be late against. The page
+  // states the age and says the cadence is unknown — rather than inventing a
+  // threshold and asserting that recording stopped, which is a conclusion
+  // nothing in the record supports.
+  if (threshold === null) {
+    return {
+      state: "unmeasured",
+      label: `Last checked ${describeAge(age)}`,
+      detail:
+        "Too few reads are recorded to know how often this should happen, so " +
+        "nothing here says whether that is normal.",
+    };
+  }
+
+  if (age > threshold) {
     return {
       state: "stopped",
       label: `Last checked ${describeAge(age)} — recording appears to have stopped`,
@@ -128,21 +179,54 @@ export function describeRecording(
     };
   }
 
-  return {
-    state: "current",
-    label:
-      age === null
-        ? "Last checked at an unreadable time"
-        : `Last checked ${describeAge(age)}`,
-    detail: "",
-  };
+  return { state: "current", label: `Last checked ${describeAge(age)}`, detail: "" };
 }
 
+/**
+ * How old a read may be before the page stops presenting its facts as current,
+ * or null where the record cannot say.
+ *
+ * The interval is clamped into a band first. Without a floor, a burst of
+ * closely spaced sweeps — a restart loop, a manual tick — drags the median down
+ * and a live install then reads as stopped. Without a ceiling, one unusually
+ * long gap would let a genuinely stopped recorder sit unreported for days.
+ */
+function staleAfter(interval: number | null | undefined): number | null {
+  if (interval == null || !Number.isFinite(interval) || interval <= 0) {
+    return null;
+  }
+  const clamped = Math.min(Math.max(interval, MIN_INTERVAL_MS), MAX_INTERVAL_MS);
+  return clamped * STALE_AFTER_INTERVALS;
+}
+
+/**
+ * How long ago the mover was read, or null where the pair cannot say.
+ *
+ * A negative age is not clamped to zero: the two stamps come from clocks that
+ * are supposed to agree, and one ahead of the other means neither can date the
+ * page. Reporting "just now" there would be the page asserting a freshness it
+ * has no basis for.
+ */
 function ageMs(asOf: string, checkedAt: string): number | null {
-  const now = Date.parse(asOf);
-  const then = Date.parse(checkedAt);
-  if (Number.isNaN(now) || Number.isNaN(then)) return null;
-  return Math.max(0, now - then);
+  const now = parseStamp(asOf);
+  const then = parseStamp(checkedAt);
+  if (now === null || then === null) return null;
+  const age = now - then;
+  return age >= 0 ? age : null;
+}
+
+/**
+ * `Date.parse` alone is far too lenient to be a guard: it reads `"2026"` as a
+ * date and `"0"` as one too, so a truncated or garbage stamp would render as a
+ * confident absolute timestamp. The service emits RFC 3339, so requiring that
+ * shape costs nothing and refuses everything else.
+ */
+const RFC3339 = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/;
+
+function parseStamp(raw: string | null | undefined): number | null {
+  if (typeof raw !== "string" || !RFC3339.test(raw)) return null;
+  const parsed = Date.parse(raw);
+  return Number.isNaN(parsed) ? null : parsed;
 }
 
 const MINUTE_MS = 60_000;
@@ -168,29 +252,37 @@ export function describeAge(ageInMs: number): string {
  */
 export const UNMEASURED = "—";
 
-export function formatDuration(durationMs: number | null): string {
-  if (durationMs === null) return UNMEASURED;
-  if (durationMs < 1_000) return `${durationMs} ms`;
-  const seconds = durationMs / 1_000;
-  if (seconds < 60) return `${seconds.toFixed(1)} s`;
-  const minutes = Math.floor(seconds / 60);
-  const rest = Math.round(seconds % 60);
-  if (minutes < 60) return `${minutes}m ${rest}s`;
-  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+/**
+ * A duration, or absence.
+ *
+ * Rounding is done once, at the top, so no unit can carry 60 of the one below
+ * it — `1m 60s` and `60.0 s` are not durations. A negative value is malformed
+ * rather than measured, and prints as absence.
+ */
+export function formatDuration(durationMs: number | null | undefined): string {
+  if (durationMs == null || !Number.isFinite(durationMs) || durationMs < 0) {
+    return UNMEASURED;
+  }
+  if (durationMs < 1_000) return `${Math.round(durationMs)} ms`;
+
+  const totalSeconds = Math.round(durationMs / 1_000);
+  if (totalSeconds < 60) return `${(durationMs / 1_000).toFixed(1)} s`;
+
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (totalMinutes < 60) return `${totalMinutes}m ${seconds}s`;
+  return `${Math.floor(totalMinutes / 60)}h ${totalMinutes % 60}m`;
 }
 
-export function formatRecords(records: number | null): string {
-  return records === null ? UNMEASURED : records.toLocaleString("en-US");
+export function formatRecords(records: number | null | undefined): string {
+  if (records == null || !Number.isFinite(records) || records < 0) {
+    return UNMEASURED;
+  }
+  return records.toLocaleString("en-US");
 }
 
-export function formatStarted(startedAt: string | null): string {
-  if (startedAt === null) return UNMEASURED;
-  const parsed = Date.parse(startedAt);
-  if (Number.isNaN(parsed)) return UNMEASURED;
-  return new Date(parsed).toISOString().replace("T", " ").slice(0, 19) + "Z";
-}
-
-/** The status word for one sync in the expanded history. */
-export function describeSync(sync: SyncFact): ConnectorStateView {
-  return STATE[sync.status] ?? STATE.unknown;
+export function formatStarted(startedAt: string | null | undefined): string {
+  const parsed = parseStamp(startedAt);
+  if (parsed === null) return UNMEASURED;
+  return `${new Date(parsed).toISOString().replace("T", " ").slice(0, 19)}Z`;
 }

--- a/src/frontend/src/lib/portal/connector-health.ts
+++ b/src/frontend/src/lib/portal/connector-health.ts
@@ -1,0 +1,196 @@
+import type {
+  ConnectorHealth,
+  ConnectorHealthSummary,
+  SyncFact,
+  SyncStatus,
+} from "@/api/connector-health-client";
+
+/**
+ * Every word this page says about a connector, and the one function that
+ * decides which of them applies.
+ *
+ * The precedence lives here rather than spread across cells so that "what does
+ * this row claim" is a question with one answer. The page reports recorded
+ * facts and never a verdict the record cannot back: nothing here says a
+ * connector is delivering, because the ledger holds the mover's own account of
+ * its syncs and nothing that corroborates it.
+ */
+export type ConnectorTone = "failing" | "unknown" | "active" | "ok" | "idle";
+
+export interface ConnectorStateView {
+  /** Stable identifier, for tests and for the row's data attribute. */
+  state:
+    | "no_longer_configured"
+    | "never_synced"
+    | "syncing"
+    | "sync_failed"
+    | "sync_incomplete"
+    | "sync_cancelled"
+    | "state_unknown"
+    | "sync_ok";
+  /** What the row says. Never colour alone. */
+  label: string;
+  tone: ConnectorTone;
+}
+
+const STATE: Record<SyncStatus, ConnectorStateView> = {
+  pending: { state: "syncing", label: "syncing", tone: "active" },
+  running: { state: "syncing", label: "syncing", tone: "active" },
+  failed: { state: "sync_failed", label: "sync failed", tone: "failing" },
+  incomplete: {
+    state: "sync_incomplete",
+    label: "sync incomplete",
+    tone: "failing",
+  },
+  cancelled: {
+    state: "sync_cancelled",
+    label: "sync cancelled",
+    tone: "idle",
+  },
+  succeeded: { state: "sync_ok", label: "sync ok", tone: "ok" },
+  unknown: { state: "state_unknown", label: "state unknown", tone: "unknown" },
+};
+
+const NO_LONGER_CONFIGURED: ConnectorStateView = {
+  state: "no_longer_configured",
+  label: "no longer configured",
+  tone: "idle",
+};
+
+const NEVER_SYNCED: ConnectorStateView = {
+  state: "never_synced",
+  label: "never synced",
+  tone: "idle",
+};
+
+/**
+ * Configuration is read before the sync outcome, deliberately.
+ *
+ * A connector taken out of configuration is a decision, not a fault, and its
+ * last sync having failed does not change that — reporting it as failing would
+ * send an operator to fix something nobody asked for any more.
+ */
+export function describeConnector(row: ConnectorHealth): ConnectorStateView {
+  if (!row.configured) return NO_LONGER_CONFIGURED;
+  if (row.last_sync === null) return NEVER_SYNCED;
+  return STATE[row.last_sync.status] ?? STATE.unknown;
+}
+
+/* ── what the page says about its own freshness ───────────────────────── */
+
+/**
+ * How many typical intervals may pass before the page stops presenting its
+ * facts as current.
+ *
+ * One missed read is a hiccup; three in a row is a recorder that stopped. The
+ * page cannot know the intended cadence — nothing on the read path does — so
+ * the comparison is against the interval actually observed between recent
+ * reads.
+ */
+export const STALE_AFTER_INTERVALS = 3;
+
+export interface RecordingView {
+  state: "never_read" | "stopped" | "current";
+  /** The headline sentence. */
+  label: string;
+  /** The reassurance or the warning under it, empty when there is nothing to add. */
+  detail: string;
+}
+
+export function describeRecording(
+  summary: Pick<
+    ConnectorHealthSummary,
+    "as_of" | "checked_at" | "typical_read_interval_ms" | "history_available"
+  >,
+): RecordingView {
+  if (!summary.history_available || summary.checked_at === null) {
+    return {
+      state: "never_read",
+      label: "Nothing has been read from the connectors yet",
+      detail:
+        "This page fills in once the reconcile loop has read the data mover once.",
+    };
+  }
+
+  const age = ageMs(summary.as_of, summary.checked_at);
+  const interval = summary.typical_read_interval_ms;
+  const stopped =
+    age !== null &&
+    interval !== null &&
+    interval > 0 &&
+    age > interval * STALE_AFTER_INTERVALS;
+
+  if (stopped) {
+    return {
+      state: "stopped",
+      label: `Last checked ${describeAge(age)} — recording appears to have stopped`,
+      detail: "The connector states below may no longer be current.",
+    };
+  }
+
+  return {
+    state: "current",
+    label:
+      age === null
+        ? "Last checked at an unreadable time"
+        : `Last checked ${describeAge(age)}`,
+    detail: "",
+  };
+}
+
+function ageMs(asOf: string, checkedAt: string): number | null {
+  const now = Date.parse(asOf);
+  const then = Date.parse(checkedAt);
+  if (Number.isNaN(now) || Number.isNaN(then)) return null;
+  return Math.max(0, now - then);
+}
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/** Coarse on purpose: the exact second of a periodic read is never the point. */
+export function describeAge(ageInMs: number): string {
+  if (ageInMs < MINUTE_MS) return "just now";
+  if (ageInMs < HOUR_MS) return `${Math.floor(ageInMs / MINUTE_MS)} min ago`;
+  if (ageInMs < DAY_MS) return `${Math.floor(ageInMs / HOUR_MS)} h ago`;
+  return `${Math.floor(ageInMs / DAY_MS)} d ago`;
+}
+
+/* ── the cells ────────────────────────────────────────────────────────── */
+
+/**
+ * What an unmeasured value prints.
+ *
+ * Every absent number on this page renders as this rather than as a zero: the
+ * two are different answers, and a zero where nobody measured would be the page
+ * asserting something no one recorded.
+ */
+export const UNMEASURED = "—";
+
+export function formatDuration(durationMs: number | null): string {
+  if (durationMs === null) return UNMEASURED;
+  if (durationMs < 1_000) return `${durationMs} ms`;
+  const seconds = durationMs / 1_000;
+  if (seconds < 60) return `${seconds.toFixed(1)} s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = Math.round(seconds % 60);
+  if (minutes < 60) return `${minutes}m ${rest}s`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}
+
+export function formatRecords(records: number | null): string {
+  return records === null ? UNMEASURED : records.toLocaleString("en-US");
+}
+
+export function formatStarted(startedAt: string | null): string {
+  if (startedAt === null) return UNMEASURED;
+  const parsed = Date.parse(startedAt);
+  if (Number.isNaN(parsed)) return UNMEASURED;
+  return new Date(parsed).toISOString().replace("T", " ").slice(0, 19) + "Z";
+}
+
+/** The status word for one sync in the expanded history. */
+export function describeSync(sync: SyncFact): ConnectorStateView {
+  return STATE[sync.status] ?? STATE.unknown;
+}

--- a/src/frontend/src/lib/portal/nav-model.test.ts
+++ b/src/frontend/src/lib/portal/nav-model.test.ts
@@ -63,7 +63,7 @@ describe("resolveZoneItem", () => {
   });
 
   it("keeps a Manage item the URL names, and falls back for one it does not", () => {
-    expect(resolveZoneItem("manage", "data-health")).toBe("data-health");
+    expect(resolveZoneItem("manage", "connector-health")).toBe("connector-health");
     expect(resolveZoneItem("manage", "trend")).toBe("metric-catalog");
   });
 

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -338,7 +338,7 @@ export const MANAGE_ITEMS: readonly PaneItem[] = [
   { id: "snapshots", label: "Org snapshots", icon: Clock },
   { id: "group-mgmt", label: "Group management", icon: Users },
   { id: "scorecard-mgmt", label: "Scorecard management", icon: BarChart3 },
-  { id: "data-health", label: "Data health", icon: ShieldCheck },
+  { id: "connector-health", label: "Connector health", icon: ShieldCheck, adminOnly: true },
   { id: "platform-usage", label: "Platform usage", icon: Activity, adminOnly: true },
   { id: "mcp", label: "MCP servers", icon: Server },
   { id: "config", label: "Config & setup", icon: Settings2 },

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -916,6 +916,7 @@ export const handlers = [
   ),
   ...savedQueryHandlers(),
   ...customMetricHandlers(),
+  ...connectorHealthHandlers(),
   ...usageHandlers(),
   ...feedbackHandlers(),
   ...aiAssistHandlers(),
@@ -1015,6 +1016,87 @@ function syntheticDays(count: number) {
     });
   }
   return days;
+}
+
+/**
+ * Connector health in mock mode.
+ *
+ * Deliberately not all-green: one failing connector, one queued, one never
+ * synced and one no longer configured, so the demo shows what the page is for
+ * rather than a wall of successes. `records_reported: 0` on the failed sync and
+ * a missing count on the queued one keep the absence-versus-zero distinction
+ * visible in the mock too.
+ */
+function connectorHealthHandlers() {
+  const now = new Date();
+  const minutesAgo = (minutes: number) =>
+    new Date(now.getTime() - minutes * 60_000).toISOString();
+
+  const syncs = [
+    {
+      job_id: "8414",
+      status: "failed",
+      started_at: minutesAgo(18),
+      duration_ms: 142_000,
+      records_reported: 0,
+    },
+    {
+      job_id: "8409",
+      status: "succeeded",
+      started_at: minutesAgo(78),
+      duration_ms: 138_500,
+      records_reported: 12_400,
+    },
+  ];
+
+  return [
+    http.get("/api/analytics/v1/connector-health", () =>
+      HttpResponse.json({
+        as_of: now.toISOString(),
+        checked_at: minutesAgo(6),
+        typical_read_interval_ms: 15 * 60_000,
+        history_available: true,
+        connectors: [
+          { connector: "example-tracker", configured: true, last_sync: syncs[0] },
+          {
+            connector: "example-directory",
+            configured: true,
+            last_sync: { job_id: "8415", status: "pending" },
+          },
+          {
+            connector: "example-messaging",
+            configured: true,
+            last_sync: {
+              job_id: "8402",
+              status: "succeeded",
+              started_at: minutesAgo(24),
+              duration_ms: 41_000,
+              records_reported: 903,
+            },
+          },
+          { connector: "example-warehouse", configured: true, last_sync: null },
+          {
+            connector: "example-retired",
+            configured: false,
+            last_sync: {
+              job_id: "7801",
+              status: "succeeded",
+              started_at: minutesAgo(60 * 26),
+              duration_ms: 90_000,
+              records_reported: 55,
+            },
+          },
+        ],
+      }),
+    ),
+    http.get("/api/analytics/v1/connector-health/:connector/syncs", ({ params }) =>
+      HttpResponse.json({
+        connector: String(params.connector),
+        window: 50,
+        syncs: String(params.connector) === "example-warehouse" ? [] : syncs,
+      }),
+    ),
+  ];
 }
 
 function usageHandlers() {

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -1032,22 +1032,42 @@ function connectorHealthHandlers() {
   const minutesAgo = (minutes: number) =>
     new Date(now.getTime() - minutes * 60_000).toISOString();
 
-  const syncs = [
-    {
-      job_id: "8414",
-      status: "failed",
-      started_at: minutesAgo(18),
-      duration_ms: 142_000,
-      records_reported: 0,
-    },
-    {
-      job_id: "8409",
-      status: "succeeded",
-      started_at: minutesAgo(78),
-      duration_ms: 138_500,
-      records_reported: 12_400,
-    },
-  ];
+  const sync = (
+    job_id: string,
+    status: string,
+    startedMinutesAgo: number | null,
+    duration_ms: number | null,
+    records_reported: number | null,
+  ) => ({
+    job_id,
+    status,
+    started_at: startedMinutesAgo === null ? null : minutesAgo(startedMinutesAgo),
+    duration_ms,
+    records_reported,
+  });
+
+  // One history per connector, newest first, so each connector's expansion
+  // agrees with the row above it. A demo whose drill-down contradicts its own
+  // summary teaches the reader to distrust both.
+  const histories: Record<string, ReturnType<typeof sync>[]> = {
+    "example-tracker": [
+      sync("8414", "failed", 18, 142_000, 0),
+      sync("8409", "succeeded", 78, 138_500, 12_400),
+    ],
+    "example-directory": [sync("8415", "pending", null, null, null)],
+    "example-messaging": [
+      sync("8402", "succeeded", 24, 41_000, 903),
+      sync("8388", "succeeded", 84, 39_100, 874),
+    ],
+    "example-warehouse": [],
+    "example-retired": [sync("7801", "succeeded", 60 * 26, 90_000, 55)],
+  };
+
+  const summaryRow = (connector: string, configured: boolean) => ({
+    connector,
+    configured,
+    last_sync: histories[connector]?.[0] ?? null,
+  });
 
   return [
     http.get("/api/analytics/v1/connector-health", () =>
@@ -1057,45 +1077,22 @@ function connectorHealthHandlers() {
         typical_read_interval_ms: 15 * 60_000,
         history_available: true,
         connectors: [
-          { connector: "example-tracker", configured: true, last_sync: syncs[0] },
-          {
-            connector: "example-directory",
-            configured: true,
-            last_sync: { job_id: "8415", status: "pending" },
-          },
-          {
-            connector: "example-messaging",
-            configured: true,
-            last_sync: {
-              job_id: "8402",
-              status: "succeeded",
-              started_at: minutesAgo(24),
-              duration_ms: 41_000,
-              records_reported: 903,
-            },
-          },
-          { connector: "example-warehouse", configured: true, last_sync: null },
-          {
-            connector: "example-retired",
-            configured: false,
-            last_sync: {
-              job_id: "7801",
-              status: "succeeded",
-              started_at: minutesAgo(60 * 26),
-              duration_ms: 90_000,
-              records_reported: 55,
-            },
-          },
+          summaryRow("example-tracker", true),
+          summaryRow("example-directory", true),
+          summaryRow("example-messaging", true),
+          summaryRow("example-warehouse", true),
+          summaryRow("example-retired", false),
         ],
       }),
     ),
-    http.get("/api/analytics/v1/connector-health/:connector/syncs", ({ params }) =>
-      HttpResponse.json({
-        connector: String(params.connector),
+    http.get("/api/analytics/v1/connector-health/:connector/syncs", ({ params }) => {
+      const connector = String(params.connector);
+      return HttpResponse.json({
+        connector,
         window: 50,
-        syncs: String(params.connector) === "example-warehouse" ? [] : syncs,
-      }),
-    ),
+        syncs: histories[connector] ?? [],
+      });
+    }),
   ];
 }
 

--- a/src/frontend/src/queries/connector-health.test.tsx
+++ b/src/frontend/src/queries/connector-health.test.tsx
@@ -8,11 +8,12 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const session = vi.hoisted(() => ({ value: "scope-a" as string }));
 vi.mock("@/auth/use-auth", () => ({
-  useAuth: () => ({ session: null }),
+  useAuth: () => ({ session: session.value }),
 }));
 vi.mock("@/auth/session-scope", () => ({
-  sessionAuthorizationScope: () => "scope",
+  sessionAuthorizationScope: (value: unknown) => value as string,
 }));
 vi.mock("@/api/connector-health-client", () => ({
   getConnectorHealth: vi.fn(),
@@ -47,6 +48,7 @@ const SUMMARY = {
 beforeEach(() => {
   mockSummary.mockReset();
   mockSyncs.mockReset();
+  session.value = "scope-a";
 });
 
 describe("useConnectorHealth", () => {
@@ -69,6 +71,62 @@ describe("useConnectorHealth", () => {
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("one session's answer is never served to another", () => {
+  it("caches under a key that carries the authorization scope", async () => {
+    // The surface is instance-wide and operator-gated, so a cached answer
+    // crossing a session boundary would show one caller what another was
+    // allowed to see.
+    //
+    // Asserted on the KEY, not on a refetch count: both hooks set
+    // `staleTime: 0`, so a second observer refetches whatever the key is — a
+    // fetch-count test passes with the scope removed from the key entirely,
+    // which is exactly the regression it would exist to catch.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    const wrap = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children);
+
+    mockSummary.mockResolvedValue(SUMMARY);
+    const first = renderHook(() => useConnectorHealth(), { wrapper: wrap });
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+
+    session.value = "scope-b";
+    const second = renderHook(() => useConnectorHealth(), { wrapper: wrap });
+    await waitFor(() => expect(second.result.current.isSuccess).toBe(true));
+
+    const keys = client
+      .getQueryCache()
+      .getAll()
+      .map((query) => JSON.stringify(query.queryKey));
+    expect(new Set(keys).size).toBe(2);
+    expect(keys.some((key) => key.includes("scope-a"))).toBe(true);
+    expect(keys.some((key) => key.includes("scope-b"))).toBe(true);
+  });
+
+  it("keys the per-connector window by scope as well", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    const wrap = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children);
+
+    mockSyncs.mockResolvedValue({ connector: "alpha", syncs: [], window: 50 });
+    const first = renderHook(() => useConnectorSyncs("alpha"), { wrapper: wrap });
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+
+    session.value = "scope-b";
+    const second = renderHook(() => useConnectorSyncs("alpha"), { wrapper: wrap });
+    await waitFor(() => expect(second.result.current.isSuccess).toBe(true));
+
+    const keys = client
+      .getQueryCache()
+      .getAll()
+      .map((query) => JSON.stringify(query.queryKey));
+    expect(new Set(keys).size).toBe(2);
   });
 });
 

--- a/src/frontend/src/queries/connector-health.test.tsx
+++ b/src/frontend/src/queries/connector-health.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * The two hooks' contracts: the per-connector window waits for a connector
+ * rather than firing with a placeholder, and neither hands back a cached answer
+ * across sessions.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/auth/use-auth", () => ({
+  useAuth: () => ({ session: null }),
+}));
+vi.mock("@/auth/session-scope", () => ({
+  sessionAuthorizationScope: () => "scope",
+}));
+vi.mock("@/api/connector-health-client", () => ({
+  getConnectorHealth: vi.fn(),
+  getConnectorSyncs: vi.fn(),
+}));
+
+import * as client from "@/api/connector-health-client";
+import {
+  useConnectorHealth,
+  useConnectorSyncs,
+} from "@/queries/connector-health";
+
+const mockSummary = vi.mocked(client.getConnectorHealth);
+const mockSyncs = vi.mocked(client.getConnectorSyncs);
+
+function wrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+}
+
+const SUMMARY = {
+  as_of: "2026-01-15T12:00:00.000Z",
+  checked_at: "2026-01-15T11:59:00.000Z",
+  typical_read_interval_ms: 900_000,
+  history_available: true,
+  connectors: [],
+};
+
+beforeEach(() => {
+  mockSummary.mockReset();
+  mockSyncs.mockReset();
+});
+
+describe("useConnectorHealth", () => {
+  it("serves the recorded summary", async () => {
+    mockSummary.mockResolvedValue(SUMMARY);
+
+    const { result } = renderHook(() => useConnectorHealth(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(SUMMARY);
+  });
+
+  it("surfaces a failure rather than an empty page", async () => {
+    mockSummary.mockRejectedValue(new Error("refused"));
+
+    const { result } = renderHook(() => useConnectorHealth(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useConnectorSyncs", () => {
+  it("does not ask for a window until a connector is chosen", () => {
+    const { result } = renderHook(() => useConnectorSyncs(null), {
+      wrapper: wrapper(),
+    });
+
+    expect(mockSyncs).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("reads the chosen connector's window", async () => {
+    const history = { connector: "alpha", syncs: [], window: 50 };
+    mockSyncs.mockResolvedValue(history);
+
+    const { result } = renderHook(() => useConnectorSyncs("alpha"), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSyncs).toHaveBeenCalledWith("alpha");
+    expect(result.current.data).toEqual(history);
+  });
+});

--- a/src/frontend/src/queries/connector-health.ts
+++ b/src/frontend/src/queries/connector-health.ts
@@ -11,6 +11,10 @@ import { useAuth } from "@/auth/use-auth";
 
 const KEY = ["connector-health"] as const;
 
+/** How often the open page asks again. Well inside the reconcile cadence, so
+ * the age it prints is never more than a minute behind the truth. */
+const RECHECK_MS = 60_000;
+
 export function useConnectorHealth(): UseQueryResult<ConnectorHealthSummary> {
   const { session } = useAuth();
   return useQuery({
@@ -21,6 +25,11 @@ export function useConnectorHealth(): UseQueryResult<ConnectorHealthSummary> {
     // recorded when they last looked.
     staleTime: 0,
     refetchOnMount: "always",
+    // INVARIANT: the page's own freshness line is the gap between two stamps
+    // the SERVER sent, so it does not move on its own. Without this the age
+    // freezes the moment the page renders, and an operator watching an incident
+    // would never see recording stop.
+    refetchInterval: RECHECK_MS,
   });
 }
 

--- a/src/frontend/src/queries/connector-health.ts
+++ b/src/frontend/src/queries/connector-health.ts
@@ -1,0 +1,37 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import {
+  getConnectorHealth,
+  getConnectorSyncs,
+  type ConnectorHealthSummary,
+  type ConnectorSyncHistory,
+} from "@/api/connector-health-client";
+import { sessionAuthorizationScope } from "@/auth/session-scope";
+import { useAuth } from "@/auth/use-auth";
+
+const KEY = ["connector-health"] as const;
+
+export function useConnectorHealth(): UseQueryResult<ConnectorHealthSummary> {
+  const { session } = useAuth();
+  return useQuery({
+    queryKey: [...KEY, "summary", sessionAuthorizationScope(session)],
+    queryFn: () => getConnectorHealth(),
+    // The answer is only as fresh as the last sweep, and an operator opening
+    // this page during an incident wants what is recorded now — not what was
+    // recorded when they last looked.
+    staleTime: 0,
+    refetchOnMount: "always",
+  });
+}
+
+export function useConnectorSyncs(
+  connector: string | null,
+): UseQueryResult<ConnectorSyncHistory> {
+  const { session } = useAuth();
+  return useQuery({
+    queryKey: [...KEY, "syncs", connector, sessionAuthorizationScope(session)],
+    queryFn: () => getConnectorSyncs(connector as string),
+    enabled: connector !== null,
+    staleTime: 0,
+  });
+}

--- a/src/ingestion/reconcile-connectors/README.md
+++ b/src/ingestion/reconcile-connectors/README.md
@@ -19,8 +19,23 @@ src/ingestion/reconcile-connectors/
 ├── main.sh                  CLI dispatch
 ├── lib/                     sourceable libs (no top-level CLI)
 ├── python/                  pure-python helpers (CLI via argparse)
+│   └── sweep/               the sync-history sweep (reads stdin, not argv)
 └── templates/               Argo/K8s YAML templates
 ```
+
+## The sync-history sweep
+
+The tick's last layer copies the mover's account of every sync into
+`ingestion_history.sync_events`, which is what the Connector health page reads.
+`lib/sweep.sh` gathers — connector to connection map, token — and
+`python3 -m sweep` plans and writes.
+
+It cannot fail a tick: `sweep_run` always returns 0, so a broken recorder costs
+the page its freshness and costs reconciliation nothing. It adds no environment
+of its own, reusing the `RECONCILE_DEST_CLICKHOUSE_*` credentials the Bronze
+destination already needs.
+
+Spec: `docs/components/backend/analytics/specs/connector-health`.
 
 ## Environment variables
 

--- a/src/ingestion/reconcile-connectors/lib/reconcile.sh
+++ b/src/ingestion/reconcile-connectors/lib/reconcile.sh
@@ -1517,6 +1517,12 @@ reconcile_run() {
   # Layer 4 — GC (skipped when --no-gc).
   reconcile_gc_orphans
 
+  # Layer 5 — record what the mover says about every sync. Deliberately last
+  # and deliberately unable to fail the tick: `sweep_run` always returns 0, so
+  # a broken recorder costs the page its freshness and costs reconciliation
+  # nothing.
+  sweep_run
+
   log_run_summary "${_RECONCILE_CHANGED}" "${_RECONCILE_FAILED}"
   log_close
   return $(( _RECONCILE_FAILED > 0 ? 2 : 0 ))

--- a/src/ingestion/reconcile-connectors/lib/sweep.sh
+++ b/src/ingestion/reconcile-connectors/lib/sweep.sh
@@ -100,9 +100,16 @@ sweep__build_work() {
     [[ -n "${name}" ]] || continue
     : "${rest}"  # read into it deliberately; nothing here needs the other columns
     conn_name="$(reconcile_compute_connection_name "${name}")"
-    conn_id="$(printf '%s' "${connections}" \
-      | python3 "${_SWEEP_PY_DIR}/filter_connection_by_name.py" --name "${conn_name}" \
-      | head -1)"
+    # Not piped into `head`: without `pipefail` that hides a nonzero exit from
+    # the filter, and a failed lookup would read as "no connection yet" — which
+    # would seal a snapshot claiming a connector the mover was never asked
+    # about. Take the first line after the status has been checked.
+    if ! conn_id="$(printf '%s' "${connections}" \
+      | python3 "${_SWEEP_PY_DIR}/filter_connection_by_name.py" --name "${conn_name}")"; then
+      log_line WARN "sweep: cannot resolve a connection for ${name}; recording nothing this tick"
+      return 1
+    fi
+    conn_id="${conn_id%%$'\n'*}"
     if [[ -n "${conn_id}" ]]; then
       entries+=("$(jq -cn --arg n "${name}" --arg c "${conn_id}" \
         '{name: $n, connection_id: $c}')")

--- a/src/ingestion/reconcile-connectors/lib/sweep.sh
+++ b/src/ingestion/reconcile-connectors/lib/sweep.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Copy the mover's account of every sync into the connector sync ledger.
+#
+# Runs at the end of a reconcile tick, which already authenticates to the mover
+# and knows which connectors it manages. This file is the gatherer: it resolves
+# the connector -> connection map, mints the token, and hands the work to
+# `python3 -m sweep` on stdin. The planning and the writing live there.
+#
+# INVARIANT: this never fails a tick. Observability is subordinate to the thing
+# observed — a sweep that cannot record must not stop connectors from being
+# reconciled — so every path returns 0 and says what happened in the log.
+#
+# Spec: docs/components/backend/analytics/specs/connector-health.
+# ---------------------------------------------------------------------------
+
+# NOTE: this file is sourced; no top-level `set -euo pipefail`.
+
+_SWEEP_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_SWEEP_PY_DIR="$(cd "${_SWEEP_LIB_DIR}/../python" && pwd)"
+
+# ---------------------------------------------------------------------------
+# sweep_run
+# Records this tick's syncs and configured set. Always returns 0.
+# ---------------------------------------------------------------------------
+sweep_run() {
+  if [[ "${RECONCILE_DRY_RUN:-}" == "1" ]]; then
+    log_line INFO "sweep: dry run, recording nothing"
+    return 0
+  fi
+
+  local tick_id
+  tick_id="${RECONCILE_RUN_ID:-}"
+  if [[ -z "${tick_id}" ]]; then
+    # Outside the cluster there is no workflow pod to name the tick after.
+    tick_id="local-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+  fi
+
+  local workspace_id
+  if ! workspace_id="$(ab_workspace_id)"; then
+    log_line WARN "sweep: cannot resolve the workspace; recording nothing this tick"
+    return 0
+  fi
+
+  local connections
+  if ! connections="$(ab_list_connections "${workspace_id}")"; then
+    log_line WARN "sweep: cannot list connections; recording nothing this tick"
+    return 0
+  fi
+
+  local work
+  if ! work="$(sweep__build_work "${tick_id}" "${connections}")"; then
+    log_line WARN "sweep: cannot describe this tick's work; recording nothing"
+    return 0
+  fi
+
+  local token
+  if ! token="$(ab_get_token)"; then
+    log_line WARN "sweep: cannot mint a mover token; recording nothing this tick"
+    return 0
+  fi
+
+  # SAFETY: the token rides the child's environment, never its argv — argv is
+  # world-readable inside the pod and the environment is not.
+  local output status=0
+  output="$(printf '%s' "${work}" \
+    | AIRBYTE_TOKEN="${token}" PYTHONPATH="${_SWEEP_PY_DIR}" python3 -m sweep 2>&1)" \
+    || status=$?
+
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] && log_line INFO "${line}"
+  done <<< "${output}"
+
+  if (( status != 0 )); then
+    log_line WARN "sweep: this tick recorded nothing or only part of it (exit ${status}); reconciliation is unaffected"
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# sweep__build_work <tick_id> <connections_json>
+# Emits the JSON the sweep reads on stdin:
+#   {"tick_id": "...", "connectors": [{"name": ..., "connection_id": ...}]}
+#
+# A connector with no connection yet is left out rather than reported with an
+# empty id: it is configured but has nothing to read, and the snapshot below
+# still records it as managed.
+# ---------------------------------------------------------------------------
+sweep__build_work() {
+  local tick_id="$1"
+  local connections="$2"
+
+  local entries=()
+  local name rest conn_name conn_id
+  # Re-delimited on US for the same reason reconcile_run does it: TAB is
+  # IFS-whitespace, so empty descriptor fields would collapse and shift. Only
+  # the name is read here; `rest` absorbs the columns this sweep has no use for.
+  while IFS=$'\037' read -r name rest; do
+    [[ -n "${name}" ]] || continue
+    : "${rest}"  # read into it deliberately; nothing here needs the other columns
+    conn_name="$(reconcile_compute_connection_name "${name}")"
+    conn_id="$(printf '%s' "${connections}" \
+      | python3 "${_SWEEP_PY_DIR}/filter_connection_by_name.py" --name "${conn_name}" \
+      | head -1)"
+    [[ -n "${conn_id}" ]] || continue
+    entries+=("$(jq -cn --arg n "${name}" --arg c "${conn_id}" \
+      '{name: $n, connection_id: $c}')")
+  done < <(disc_load_descriptors | tr '\t' '\037')
+
+  local joined
+  joined="$(IFS=,; printf '%s' "${entries[*]:-}")"
+  jq -cn --arg t "${tick_id}" --argjson c "[${joined}]" \
+    '{tick_id: $t, connectors: $c}'
+}

--- a/src/ingestion/reconcile-connectors/lib/sweep.sh
+++ b/src/ingestion/reconcile-connectors/lib/sweep.sh
@@ -111,8 +111,12 @@ sweep__build_work() {
     fi
   done < <(disc_load_descriptors | tr '\t' '\037')
 
-  local joined
-  joined="$(IFS=,; printf '%s' "${entries[*]:-}")"
-  jq -cn --arg t "${tick_id}" --argjson c "[${joined}]" \
+  # `jq -s` slurps the stream into an array, so the objects never have to be
+  # joined by hand — no separator to get wrong and no `IFS` to reassign.
+  local connectors_json='[]'
+  if (( ${#entries[@]} > 0 )); then
+    connectors_json="$(printf '%s\n' "${entries[@]}" | jq -sc '.')"
+  fi
+  jq -cn --arg t "${tick_id}" --argjson c "${connectors_json}" \
     '{tick_id: $t, connectors: $c}'
 }

--- a/src/ingestion/reconcile-connectors/lib/sweep.sh
+++ b/src/ingestion/reconcile-connectors/lib/sweep.sh
@@ -82,9 +82,10 @@ sweep_run() {
 # Emits the JSON the sweep reads on stdin:
 #   {"tick_id": "...", "connectors": [{"name": ..., "connection_id": ...}]}
 #
-# A connector with no connection yet is left out rather than reported with an
-# empty id: it is configured but has nothing to read, and the snapshot below
-# still records it as managed.
+# A connector the mover has no connection for yet is reported WITHOUT a
+# connection id rather than dropped. It is configured — which is the first thing
+# the page answers — and simply has nothing to read yet; dropping it would make
+# "configured and never ran" a state the page could not show.
 # ---------------------------------------------------------------------------
 sweep__build_work() {
   local tick_id="$1"
@@ -102,9 +103,12 @@ sweep__build_work() {
     conn_id="$(printf '%s' "${connections}" \
       | python3 "${_SWEEP_PY_DIR}/filter_connection_by_name.py" --name "${conn_name}" \
       | head -1)"
-    [[ -n "${conn_id}" ]] || continue
-    entries+=("$(jq -cn --arg n "${name}" --arg c "${conn_id}" \
-      '{name: $n, connection_id: $c}')")
+    if [[ -n "${conn_id}" ]]; then
+      entries+=("$(jq -cn --arg n "${name}" --arg c "${conn_id}" \
+        '{name: $n, connection_id: $c}')")
+    else
+      entries+=("$(jq -cn --arg n "${name}" '{name: $n}')")
+    fi
   done < <(disc_load_descriptors | tr '\t' '\037')
 
   local joined

--- a/src/ingestion/reconcile-connectors/main.sh
+++ b/src/ingestion/reconcile-connectors/main.sh
@@ -38,6 +38,8 @@ source "${SCRIPT_DIR}/lib/validate.sh"
 source "${SCRIPT_DIR}/lib/reconcile.sh"
 # shellcheck source=lib/adopt.sh
 source "${SCRIPT_DIR}/lib/adopt.sh"
+# shellcheck source=lib/sweep.sh
+source "${SCRIPT_DIR}/lib/sweep.sh"
 
 # ---------------------------------------------------------------------------
 # usage — print CLI help and exit. Called for -h/--help and on bad args.

--- a/src/ingestion/reconcile-connectors/python/sweep/__init__.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/__init__.py
@@ -1,0 +1,10 @@
+"""Copy the data mover's account of every sync into the connector sync ledger.
+
+The mover is the only record of what synced, its history is bounded, and it
+disappears with a deleted connection. This package runs inside the reconcile
+tick, which already authenticates to the mover, and copies that account into
+`ingestion_history.sync_events` so the connector health page can answer from
+one relation while everything above it is down.
+
+Spec: docs/components/backend/analytics/specs/connector-health.
+"""

--- a/src/ingestion/reconcile-connectors/python/sweep/__main__.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/__main__.py
@@ -1,0 +1,127 @@
+"""One sweep tick: copy the mover's account, record the configured set, seal.
+
+Reads its work from stdin as JSON so no connector list or connection id ever
+lands in argv:
+
+    {"tick_id": "...",
+     "connectors": [{"name": "example-tracker", "connection_id": "..."}]}
+
+Exits non-zero on any failure. The caller in the reconcile loop swallows that
+deliberately and visibly — observability is subordinate to the thing observed,
+and no tick may abort because recording broke.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, NamedTuple
+
+from . import plan
+from .ledger import Ledger, LedgerError
+from .mover import Mover, MoverError
+
+
+class UnreadableWork(ValueError):
+    """The tick's own instructions could not be read."""
+
+
+class Connector(NamedTuple):
+    name: str
+    connection_id: str
+
+
+def _log(message: str) -> None:
+    print(f"sweep: {message}", file=sys.stderr, flush=True)
+
+
+def _read_work(stream: Any) -> tuple[str, list[Connector]]:
+    try:
+        work = json.load(stream)
+    except json.JSONDecodeError as error:
+        raise UnreadableWork(f"work is not JSON: {error}") from error
+    if not isinstance(work, dict):
+        raise UnreadableWork("work is not an object")
+
+    tick_id = work.get("tick_id")
+    if not isinstance(tick_id, str) or not tick_id.strip():
+        raise UnreadableWork("work carries no tick_id")
+
+    raw = work.get("connectors")
+    if not isinstance(raw, list):
+        raise UnreadableWork("work carries no connectors array")
+
+    connectors = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        connection_id = item.get("connection_id")
+        if isinstance(name, str) and name and isinstance(connection_id, str):
+            connectors.append(Connector(name, connection_id))
+    return tick_id.strip(), connectors
+
+
+def run(stream: Any) -> int:
+    try:
+        tick_id, connectors = _read_work(stream)
+    except UnreadableWork as error:
+        _log(f"cannot read this tick's work: {error}")
+        return 1
+
+    # INVARIANT: an empty configured set is indistinguishable from "everything
+    # was removed", so a tick with nothing to record records nothing at all —
+    # not an empty snapshot, and no seal to make one readable.
+    if not connectors:
+        _log("no connectors resolved; recording nothing rather than an empty set")
+        return 1
+
+    try:
+        ledger = Ledger.from_env()
+        mover = Mover.from_env()
+    except (LedgerError, MoverError) as error:
+        _log(f"cannot reach the inputs: {error}")
+        return 1
+
+    # The connection map is what turns a job into a connector. A job on a
+    # connection absent from it is skipped rather than guessed at.
+    by_connection = {c.connection_id: c.name for c in connectors}
+
+    incomplete = False
+    written = 0
+    try:
+        watermark = ledger.watermark()
+        closed = ledger.closed_job_ids(watermark)
+        entries, truncated = mover.sync_jobs(plan.as_listing_stamp(watermark))
+        if truncated:
+            incomplete = True
+            _log(
+                "history deeper than one tick may read; recorded what was "
+                "reached and will continue from that edge next tick"
+            )
+
+        planned = plan.plan_syncs(entries, by_connection, tick_id, closed)
+        for refusal in planned.skipped:
+            _log(f"skipped job {refusal.job_id or '<unnamed>'}: {refusal.reason}")
+
+        written += ledger.insert(planned.rows)
+    except (LedgerError, MoverError) as error:
+        # The configured set is a fact about configuration, not about whether
+        # the listing answered, so it is still worth sealing — but the caller
+        # learns the tick was incomplete.
+        incomplete = True
+        _log(f"could not record this tick's syncs: {error}")
+
+    try:
+        written += ledger.insert(plan.plan_snapshot(by_connection.values(), tick_id))
+        written += ledger.insert([plan.plan_seal(tick_id)])
+    except LedgerError as error:
+        _log(f"cannot seal this tick: {error}")
+        return 1
+
+    _log(f"tick {tick_id}: {written} rows across {len(connectors)} connectors")
+    return 1 if incomplete else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run(sys.stdin))

--- a/src/ingestion/reconcile-connectors/python/sweep/__main__.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/__main__.py
@@ -28,7 +28,10 @@ class UnreadableWork(ValueError):
 
 class Connector(NamedTuple):
     name: str
-    connection_id: str
+    #: Absent for a connector the controller manages but the mover has no
+    #: connection for yet. It is still configured — that is the first thing the
+    #: page answers — it simply has nothing to read.
+    connection_id: str | None
 
 
 def _log(message: str) -> None:
@@ -51,14 +54,21 @@ def _read_work(stream: Any) -> tuple[str, list[Connector]]:
     if not isinstance(raw, list):
         raise UnreadableWork("work carries no connectors array")
 
+    # INVARIANT: every entry or none. Skipping a malformed one would seal a
+    # SHORT list as this tick's complete snapshot, and the read side treats a
+    # sealed snapshot as authoritative — so the connector that fell out would
+    # render as no longer configured rather than as unread.
     connectors = []
-    for item in raw:
+    for position, item in enumerate(raw):
         if not isinstance(item, dict):
-            continue
+            raise UnreadableWork(f"connector {position} is not an object")
         name = item.get("name")
+        if not isinstance(name, str) or not name:
+            raise UnreadableWork(f"connector {position} carries no name")
         connection_id = item.get("connection_id")
-        if isinstance(name, str) and name and isinstance(connection_id, str):
-            connectors.append(Connector(name, connection_id))
+        if connection_id is not None and not isinstance(connection_id, str):
+            raise UnreadableWork(f"connector {name!r} carries an unusable connection id")
+        connectors.append(Connector(name, connection_id or None))
     return tick_id.strip(), connectors
 
 
@@ -83,10 +93,17 @@ def run(stream: Any) -> int:
         _log(f"cannot reach the inputs: {error}")
         return 1
 
-    # The connection map is what turns a job into a connector. A job on a
-    # connection absent from it is skipped rather than guessed at.
-    by_connection = {c.connection_id: c.name for c in connectors}
+    # Two different sets, deliberately. The connection map turns a job into a
+    # connector, so it holds only connectors the mover has a connection for; a
+    # job on a connection absent from it is skipped rather than guessed at. The
+    # configured set is every connector the controller manages, whether or not
+    # the mover has caught up — a connector awaiting its first connection is
+    # configured and has never synced, which is a state the page must be able to
+    # show.
+    by_connection = {c.connection_id: c.name for c in connectors if c.connection_id}
+    configured = [c.name for c in connectors]
 
+    read_failed = False
     incomplete = False
     written = 0
     try:
@@ -105,21 +122,41 @@ def run(stream: Any) -> int:
             _log(f"skipped job {refusal.job_id or '<unnamed>'}: {refusal.reason}")
 
         written += ledger.insert(planned.rows)
-    except (LedgerError, MoverError) as error:
-        # The configured set is a fact about configuration, not about whether
-        # the listing answered, so it is still worth sealing — but the caller
-        # learns the tick was incomplete.
-        incomplete = True
-        _log(f"could not record this tick's syncs: {error}")
+
+        # The read start is floored, so a job open longer than that floor will
+        # never be asked about again. Say so, rather than leaving its last
+        # provisional word standing as the page's answer.
+        stranded = plan.plan_abandoned(ledger.abandoned_jobs(watermark), tick_id)
+        if stranded:
+            _log(
+                f"{len(stranded)} job(s) have fallen below the read start; "
+                "recording their state as unreadable"
+            )
+            written += ledger.insert(stranded)
+    # Every failure, not only the two typed ones: an unanticipated shape in the
+    # listing would otherwise escape and skip the seal by accident rather than by
+    # decision, which is the same outcome reached without the reasoning.
+    except Exception as error:  # noqa: BLE001
+        read_failed = True
+        _log(f"could not read this tick's syncs: {error!r}")
+
+    # INVARIANT: the seal is what dates the page — the read surface reports the
+    # newest sealed tick as "when the mover was last read". A tick that never
+    # read the mover must not seal, or an install whose mover is unreachable
+    # keeps reporting that it was just checked, and the page can never say
+    # recording has stopped.
+    if read_failed:
+        _log("the mover was not read; leaving this tick unsealed")
+        return 1
 
     try:
-        written += ledger.insert(plan.plan_snapshot(by_connection.values(), tick_id))
+        written += ledger.insert(plan.plan_snapshot(configured, tick_id))
         written += ledger.insert([plan.plan_seal(tick_id)])
     except LedgerError as error:
         _log(f"cannot seal this tick: {error}")
         return 1
 
-    _log(f"tick {tick_id}: {written} rows across {len(connectors)} connectors")
+    _log(f"tick {tick_id}: {written} rows across {len(configured)} connectors")
     return 1 if incomplete else 0
 
 

--- a/src/ingestion/reconcile-connectors/python/sweep/ledger.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/ledger.py
@@ -1,0 +1,149 @@
+"""Reading from and writing to the sync ledger over ClickHouse's HTTP interface.
+
+Credentials come from the `RECONCILE_DEST_CLICKHOUSE_*` env the reconcile loop
+already requires for the Bronze destination, so the sweep adds no chart value.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterable
+from typing import Any
+
+from . import status as vocab
+from .plan import SYNC_COMPLETED
+
+TABLE = "ingestion_history.sync_events"
+
+_TIMEOUT_SECS = 30
+
+#: `LowCardinality(String)` and quoted into SQL below, so the vocabulary is
+#: rendered rather than bound. Everything here is a literal from this module.
+_TERMINAL_LIST = ", ".join(f"'{word}'" for word in sorted(vocab.TERMINAL_STATUSES))
+
+
+class LedgerError(RuntimeError):
+    """Anything that stopped the sweep from reading or writing the ledger."""
+
+
+class Ledger:
+    def __init__(self, url: str, user: str, password: str) -> None:
+        self._url = url.rstrip("/")
+        self._user = user
+        self._password = password
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> Ledger:
+        source = os.environ if env is None else env
+        missing = [
+            name
+            for name in (
+                "RECONCILE_DEST_CLICKHOUSE_HOST",
+                "RECONCILE_DEST_CLICKHOUSE_PORT",
+                "RECONCILE_DEST_CLICKHOUSE_USERNAME",
+                "RECONCILE_DEST_CLICKHOUSE_PASSWORD",
+            )
+            if not source.get(name)
+        ]
+        if missing:
+            raise LedgerError(f"ClickHouse env incomplete: {', '.join(missing)}")
+        proto_key = "RECONCILE_DEST_CLICKHOUSE_PROTOCOL"
+        protocol = source.get(proto_key, "http")  # RULE-DEFAULTS-OK: chart-rendered constant, same fallback the Bronze destination config uses
+        host = source["RECONCILE_DEST_CLICKHOUSE_HOST"]
+        port = source["RECONCILE_DEST_CLICKHOUSE_PORT"]
+        return cls(
+            f"{protocol}://{host}:{port}",
+            source["RECONCILE_DEST_CLICKHOUSE_USERNAME"],
+            source["RECONCILE_DEST_CLICKHOUSE_PASSWORD"],
+        )
+
+    def _post(self, body: bytes, query: str | None = None) -> str:
+        url = self._url + "/"
+        if query is not None:
+            url += "?query=" + urllib.parse.quote(query)
+        request = urllib.request.Request(url, data=body, method="POST")
+        request.add_header("X-ClickHouse-User", self._user)
+        request.add_header("X-ClickHouse-Key", self._password)
+        try:
+            with urllib.request.urlopen(request, timeout=_TIMEOUT_SECS) as response:
+                return response.read().decode()
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode(errors="replace").strip()
+            raise LedgerError(f"ClickHouse rejected the request: {detail}") from error
+        except OSError as error:
+            raise LedgerError(f"ClickHouse unreachable: {error}") from error
+
+    def _select(self, sql: str) -> list[dict[str, Any]]:
+        raw = self._post(f"{sql} FORMAT JSONEachRow".encode())
+        return [json.loads(line) for line in raw.splitlines() if line.strip()]
+
+    def watermark(self) -> str | None:
+        """Where the next read of the mover's listing should start.
+
+        Not the newest job recorded: that is the one most likely still running,
+        and a watermark standing on it would never let a later tick see how it
+        ended — the page would show a sync running forever.
+
+        So the watermark is the oldest job still open, and only when nothing is
+        open does it move up to the newest job recorded. Every unfinished job
+        therefore stays at or above the line and is re-read until it closes,
+        which costs one duplicate row per tick while it runs. No assumption
+        about how many jobs the mover runs at once is needed for that to hold.
+
+        None means nothing is recorded yet, and the first sweep reads the whole
+        retained history.
+        """
+        rows = self._select(
+            "SELECT toString(coalesce(min(if(open, job_created_at, NULL)), "
+            "max(job_created_at))) AS watermark FROM ("
+            "  SELECT job_created_at, "
+            f"    status NOT IN ({_TERMINAL_LIST}) AS open "
+            f"  FROM {TABLE} WHERE event = '{SYNC_COMPLETED}' "
+            "    AND job_created_at IS NOT NULL "
+            "  ORDER BY job_id, ts DESC LIMIT 1 BY job_id)"
+        )
+        if not rows:
+            return None
+        covered = rows[0].get("watermark")
+        return covered if isinstance(covered, str) and covered else None
+
+    def closed_job_ids(self, since: str | None) -> frozenset[str]:
+        """Jobs the ledger already holds a terminal status for.
+
+        Bounded by the same watermark the listing is: those are the only jobs
+        this tick can be handed, and an unbounded read would grow with the
+        table's whole retention.
+        """
+        window = ""
+        if since is not None:
+            window = f" AND job_created_at >= {_quote(since)}"
+        rows = self._select(
+            f"SELECT DISTINCT job_id FROM {TABLE} "
+            f"WHERE event = '{SYNC_COMPLETED}' "
+            f"AND status IN ({_TERMINAL_LIST}){window}"
+        )
+        return frozenset(str(row["job_id"]) for row in rows)
+
+    def insert(self, rows: Iterable[dict[str, Any]]) -> int:
+        """Append rows. Returns how many were written."""
+        payload = "\n".join(json.dumps(row) for row in rows)
+        if not payload:
+            return 0
+        self._post(payload.encode(), query=f"INSERT INTO {TABLE} FORMAT JSONEachRow")
+        return payload.count("\n") + 1
+
+
+def _quote(value: str) -> str:
+    """Single-quote a literal for ClickHouse.
+
+    The HTTP interface takes no bind parameters on this path, and connector
+    names come from descriptors on disk rather than from a request — but a name
+    is still a string, and a string spliced into SQL unquoted is a habit worth
+    not having.
+    """
+    escaped = value.replace("\\", "\\\\").replace("'", "\\'")
+    return f"'{escaped}'"

--- a/src/ingestion/reconcile-connectors/python/sweep/ledger.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/ledger.py
@@ -71,6 +71,10 @@ class Ledger:
             raise LedgerError(f"ClickHouse env incomplete: {', '.join(missing)}")
         proto_key = "RECONCILE_DEST_CLICKHOUSE_PROTOCOL"
         protocol = source.get(proto_key, "http")  # RULE-DEFAULTS-OK: chart-rendered constant, same fallback the Bronze destination config uses
+        # SAFETY: urllib honours `file://`, so the scheme is pinned rather than
+        # taken on trust from the environment.
+        if protocol not in ("http", "https"):
+            raise LedgerError(f"{proto_key} must be http or https, not {protocol!r}")
         host = source["RECONCILE_DEST_CLICKHOUSE_HOST"]
         port = source["RECONCILE_DEST_CLICKHOUSE_PORT"]
         return cls(
@@ -87,6 +91,7 @@ class Ledger:
         request.add_header("X-ClickHouse-User", self._user)
         request.add_header("X-ClickHouse-Key", self._password)
         try:
+            # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             with urllib.request.urlopen(request, timeout=_TIMEOUT_SECS) as response:
                 return response.read().decode()
         except urllib.error.HTTPError as error:

--- a/src/ingestion/reconcile-connectors/python/sweep/ledger.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/ledger.py
@@ -21,9 +21,27 @@ TABLE = "ingestion_history.sync_events"
 
 _TIMEOUT_SECS = 30
 
+#: How far behind the newest recorded job the watermark may be dragged by a job
+#: that never closes. Long enough that no real sync is missed by it; short
+#: enough that a stuck job costs one bounded re-read per tick rather than the
+#: whole retention window.
+LOOKBACK_DAYS = 7
+
 #: `LowCardinality(String)` and quoted into SQL below, so the vocabulary is
 #: rendered rather than bound. Everything here is a literal from this module.
 _TERMINAL_LIST = ", ".join(f"'{word}'" for word in sorted(vocab.TERMINAL_STATUSES))
+
+#: What stops a job counting as open for the read start.
+#:
+#: `UNKNOWN` joins the terminal words here and only here. It stays NON-terminal
+#: for coverage, because an unreadable status is one to keep re-reading while the
+#: job is still in the window. What this list adds is that an already-marked job
+#: is neither searched for again — the marker would otherwise be written once a
+#: tick for ever — nor allowed to drag the read start back to its own creation
+#: time.
+_OPEN_EXCLUDED = ", ".join(
+    f"'{word}'" for word in sorted({*vocab.TERMINAL_STATUSES, vocab.UNKNOWN})
+)
 
 
 class LedgerError(RuntimeError):
@@ -86,25 +104,35 @@ class Ledger:
 
         Not the newest job recorded: that is the one most likely still running,
         and a watermark standing on it would never let a later tick see how it
-        ended — the page would show a sync running forever.
+        ended — the page would show a sync running for ever. So it stands on the
+        oldest job still open, and only when nothing is open does it move up to
+        the newest job recorded.
 
-        So the watermark is the oldest job still open, and only when nothing is
-        open does it move up to the newest job recorded. Every unfinished job
-        therefore stays at or above the line and is re-read until it closes,
-        which costs one duplicate row per tick while it runs. No assumption
-        about how many jobs the mover runs at once is needed for that to hold.
+        INVARIANT: floored at `LOOKBACK_DAYS` behind the newest recorded job.
+        Without a floor, one job that can never close pins the read start for
+        ever — and three inputs produce one: a connection deleted while a job
+        was running (the mover drops the job, so its last recorded word stays
+        provisional), a status word a later mover release adds (stored as
+        `unknown`, which is deliberately non-terminal), and a creation stamp the
+        column cannot hold. Once the start is pinned and more jobs than one tick
+        may read sit above it, the newest syncs stop being read at all and the
+        page freezes on stale data with only a log line to say so.
 
         None means nothing is recorded yet, and the first sweep reads the whole
         retained history.
         """
         rows = self._select(
-            "SELECT toString(coalesce(min(if(open, job_created_at, NULL)), "
-            "max(job_created_at))) AS watermark FROM ("
-            "  SELECT job_created_at, "
-            f"    status NOT IN ({_TERMINAL_LIST}) AS open "
-            f"  FROM {TABLE} WHERE event = '{SYNC_COMPLETED}' "
-            "    AND job_created_at IS NOT NULL "
-            "  ORDER BY job_id, ts DESC LIMIT 1 BY job_id)"
+            "SELECT toString(if(open_count > 0, "
+            f"    greatest(oldest_open, newest - INTERVAL {LOOKBACK_DAYS} DAY), "
+            "    newest)) AS watermark "
+            "FROM (SELECT countIf(open) AS open_count, "
+            "             min(if(open, job_created_at, NULL)) AS oldest_open, "
+            "             max(job_created_at) AS newest "
+            "      FROM (SELECT job_created_at, "
+            f"                   status NOT IN ({_OPEN_EXCLUDED}) AS open "
+            f"            FROM {TABLE} WHERE event = '{SYNC_COMPLETED}' "
+            "              AND job_created_at IS NOT NULL "
+            "            ORDER BY job_id, ts DESC LIMIT 1 BY job_id))"
         )
         if not rows:
             return None
@@ -127,6 +155,30 @@ class Ledger:
             f"AND status IN ({_TERMINAL_LIST}){window}"
         )
         return frozenset(str(row["job_id"]) for row in rows)
+
+    def abandoned_jobs(self, watermark: str | None) -> list[dict[str, str]]:
+        """Jobs still recorded as open that have fallen below the read start.
+
+        The read start is floored so one job that never closes cannot pin it for
+        ever. The cost of that floor is these jobs: the mover will not be asked
+        about them again, so their last recorded word — a provisional one — would
+        stand as the page's answer indefinitely, and the page would report a sync
+        as running years after it stopped being visible.
+
+        Naming them lets the sweep record what is actually true: their state can
+        no longer be read.
+        """
+        if watermark is None:
+            return []
+        return self._select(
+            "SELECT job_id, connector, toString(job_created_at) AS created FROM ("
+            "  SELECT job_id, connector, job_created_at, status "
+            f"  FROM {TABLE} WHERE event = '{SYNC_COMPLETED}' "
+            "    AND job_created_at IS NOT NULL "
+            "  ORDER BY job_id, ts DESC LIMIT 1 BY job_id) "
+            f"WHERE status NOT IN ({_OPEN_EXCLUDED}) "
+            f"  AND job_created_at < {_quote(watermark)}"
+        )
 
     def insert(self, rows: Iterable[dict[str, Any]]) -> int:
         """Append rows. Returns how many were written."""

--- a/src/ingestion/reconcile-connectors/python/sweep/mover.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/mover.py
@@ -79,6 +79,12 @@ class Mover:
         deadline = time.monotonic() + BUDGET_SECS
         collected: list[dict[str, Any]] = []
         for page in range(MAX_PAGES):
+            # Before the request, not after it: a page started with a second of
+            # budget left still takes the full request timeout, so checking
+            # afterwards lets the read overshoot by one timeout and delay the
+            # seal that dates the page.
+            if page > 0 and time.monotonic() >= deadline:
+                return collected, True
             entries, served = self._page(page * PAGE_SIZE, created_at_start)
             collected.extend(entries)
             # INVARIANT: measured against what the server SERVED, not what
@@ -87,8 +93,6 @@ class Mover:
             # half way would report itself complete.
             if served < PAGE_SIZE:
                 return collected, False
-            if time.monotonic() >= deadline:
-                return collected, True
         return collected, True
 
     def _page(

--- a/src/ingestion/reconcile-connectors/python/sweep/mover.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/mover.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -30,6 +31,16 @@ PAGE_SIZE = 100
 #: A termination backstop, not a coverage bound. Ascending order makes a stop
 #: resumable, so this caps one tick and never what the ledger ends up holding.
 MAX_PAGES = 50
+
+#: The whole listing read's budget, across every page.
+#:
+#: INVARIANT: must stay well under the workflow pod's own deadline. `MAX_PAGES`
+#: alone bounds nothing in time — fifty pages at the per-request timeout is
+#: longer than the tick is allowed to live, and a tick killed part-way never
+#: reaches its own summary line, so the run reads as aborted and the next one is
+#: skipped. `sweep_run` returning 0 on every path does not protect a tick from a
+#: sweep that simply takes too long.
+BUDGET_SECS = 300
 
 
 class MoverError(RuntimeError):
@@ -57,17 +68,28 @@ class Mover:
     def sync_jobs(self, created_at_start: str | None) -> tuple[list[dict[str, Any]], bool]:
         """Every sync job created at or after the watermark, oldest first.
 
-        Returns the entries and whether the page cap stopped the read.
+        Returns the entries and whether the read stopped short — of the page cap
+        or of the time budget. Either way what was collected is contiguous from
+        the watermark, so a short read is a delay rather than a gap.
         """
+        deadline = time.monotonic() + BUDGET_SECS
         collected: list[dict[str, Any]] = []
         for page in range(MAX_PAGES):
-            entries = self._page(page * PAGE_SIZE, created_at_start)
+            entries, served = self._page(page * PAGE_SIZE, created_at_start)
             collected.extend(entries)
-            if len(entries) < PAGE_SIZE:
+            # INVARIANT: measured against what the server SERVED, not what
+            # survived filtering. A full page carrying one unusable element
+            # would otherwise look like a short page, and a read that stopped
+            # half way would report itself complete.
+            if served < PAGE_SIZE:
                 return collected, False
+            if time.monotonic() >= deadline:
+                return collected, True
         return collected, True
 
-    def _page(self, offset: int, created_at_start: str | None) -> list[dict[str, Any]]:
+    def _page(
+        self, offset: int, created_at_start: str | None
+    ) -> tuple[list[dict[str, Any]], int]:
         query = {
             "jobType": "sync",
             "orderBy": "createdAt|ASC",
@@ -82,7 +104,8 @@ class Mover:
         entries = payload.get("data")
         if not isinstance(entries, list):
             raise MoverError("job listing carries no data array")
-        return [entry for entry in entries if isinstance(entry, dict)]
+        usable = [entry for entry in entries if isinstance(entry, dict)]
+        return usable, len(entries)
 
     def _get(self, path: str) -> dict[str, Any]:
         request = urllib.request.Request(self._url + path, method="GET")

--- a/src/ingestion/reconcile-connectors/python/sweep/mover.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/mover.py
@@ -1,0 +1,101 @@
+"""Reading the data mover's job listing.
+
+One endpoint, four query parameters, one response field. The mover exposes far
+more; depending on it would tie the page's history to details that are not
+contract-stable across mover upgrades, and the whole point of copying this
+account is to keep a durable record of what a changing source said.
+
+Two of those parameters do the work that would otherwise be ours: the listing is
+asked for in ascending creation order and filtered from a watermark. Ascending
+order is what makes a capped read safe — whatever the cap leaves unread is NEWER
+than everything collected, so the next tick resumes at that edge instead of the
+watermark jumping over a gap.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+_TIMEOUT_SECS = 60
+
+#: One page. Transport shape, not policy — it changes how many round trips cover
+#: the same jobs, never which jobs are covered.
+PAGE_SIZE = 100
+
+#: A termination backstop, not a coverage bound. Ascending order makes a stop
+#: resumable, so this caps one tick and never what the ledger ends up holding.
+MAX_PAGES = 50
+
+
+class MoverError(RuntimeError):
+    """Anything that stopped the sweep from reading the mover."""
+
+
+class Mover:
+    def __init__(self, url: str, token: str) -> None:
+        self._url = url.rstrip("/")
+        self._token = token
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> Mover:
+        source = os.environ if env is None else env
+        url = source.get("AIRBYTE_URL")
+        # SAFETY: the token is minted by the shell and handed over in the
+        # environment, never in argv — argv is world-readable inside the pod.
+        token = source.get("AIRBYTE_TOKEN")
+        if not url:
+            raise MoverError("AIRBYTE_URL is not set")
+        if not token:
+            raise MoverError("AIRBYTE_TOKEN is not set")
+        return cls(url, token)
+
+    def sync_jobs(self, created_at_start: str | None) -> tuple[list[dict[str, Any]], bool]:
+        """Every sync job created at or after the watermark, oldest first.
+
+        Returns the entries and whether the page cap stopped the read.
+        """
+        collected: list[dict[str, Any]] = []
+        for page in range(MAX_PAGES):
+            entries = self._page(page * PAGE_SIZE, created_at_start)
+            collected.extend(entries)
+            if len(entries) < PAGE_SIZE:
+                return collected, False
+        return collected, True
+
+    def _page(self, offset: int, created_at_start: str | None) -> list[dict[str, Any]]:
+        query = {
+            "jobType": "sync",
+            "orderBy": "createdAt|ASC",
+            "limit": str(PAGE_SIZE),
+            "offset": str(offset),
+        }
+        if created_at_start:
+            query["createdAtStart"] = created_at_start
+        path = "/api/public/v1/jobs?" + urllib.parse.urlencode(query)
+
+        payload = self._get(path)
+        entries = payload.get("data")
+        if not isinstance(entries, list):
+            raise MoverError("job listing carries no data array")
+        return [entry for entry in entries if isinstance(entry, dict)]
+
+    def _get(self, path: str) -> dict[str, Any]:
+        request = urllib.request.Request(self._url + path, method="GET")
+        request.add_header("Accept", "application/json")
+        request.add_header("Authorization", f"Bearer {self._token}")
+        try:
+            with urllib.request.urlopen(request, timeout=_TIMEOUT_SECS) as response:
+                decoded = json.load(response)
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode(errors="replace").strip()[:400]
+            raise MoverError(f"mover rejected the listing: {error.code} {detail}") from error
+        except (OSError, json.JSONDecodeError) as error:
+            raise MoverError(f"mover unreadable: {error}") from error
+        if not isinstance(decoded, dict):
+            raise MoverError("mover returned no object")
+        return decoded

--- a/src/ingestion/reconcile-connectors/python/sweep/mover.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/mover.py
@@ -61,6 +61,10 @@ class Mover:
         token = source.get("AIRBYTE_TOKEN")
         if not url:
             raise MoverError("AIRBYTE_URL is not set")
+        # SAFETY: urllib honours `file://`, so the scheme is pinned rather than
+        # taken on trust from the environment.
+        if not url.startswith(("http://", "https://")):
+            raise MoverError("AIRBYTE_URL must be an http or https URL")
         if not token:
             raise MoverError("AIRBYTE_TOKEN is not set")
         return cls(url, token)
@@ -112,6 +116,7 @@ class Mover:
         request.add_header("Accept", "application/json")
         request.add_header("Authorization", f"Bearer {self._token}")
         try:
+            # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             with urllib.request.urlopen(request, timeout=_TIMEOUT_SECS) as response:
                 decoded = json.load(response)
         except urllib.error.HTTPError as error:

--- a/src/ingestion/reconcile-connectors/python/sweep/plan.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/plan.py
@@ -12,6 +12,7 @@ duration, so both are parsed rather than cast.
 
 from __future__ import annotations
 
+import math
 import re
 from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime
@@ -125,7 +126,7 @@ def duration_ms(duration: object) -> int | None:
         # A bare number is seconds, which is what the listing's own duration
         # spells out; anything else would be this reading a unit into a field
         # the mover documents as ISO-8601.
-        return _bounded(int(float(duration) * 1000)) if duration >= 0 else None
+        return _bounded(float(duration) * 1000) if duration >= 0 else None
     if not isinstance(duration, str) or not duration.strip():
         return None
 
@@ -140,16 +141,22 @@ def duration_ms(duration: object) -> int | None:
         for name, seconds in _SECONDS_PER.items()
         if parts[name] is not None
     )
-    return _bounded(round(total * 1000))
+    return _bounded(total * 1000)
 
 
-def _bounded(value: int) -> int | None:
+def _bounded(value: float) -> int | None:
     """A magnitude the column can hold, or None.
 
     `UInt64` wraps rather than rejects, so an out-of-range count would be stored
     as a different number and labelled as the mover's own.
+
+    Finiteness is checked HERE rather than at each call site: `int(inf)` raises,
+    and an exception on one malformed field costs the whole tick its seal — a
+    listing that sends one nonsense number would stop the page's clock.
     """
-    return value if 0 <= value <= _MAX_UINT64 else None
+    if not math.isfinite(value):
+        return None
+    return int(value) if 0 <= value <= _MAX_UINT64 else None
 
 
 def records_reported(entry: Mapping[str, Any]) -> int | None:
@@ -169,7 +176,7 @@ def records_reported(entry: Mapping[str, Any]) -> int | None:
             return None
     if not isinstance(value, (int, float)):
         return None
-    return _bounded(int(value)) if value >= 0 else None
+    return _bounded(value) if value >= 0 else None
 
 
 def sync_row(
@@ -179,7 +186,11 @@ def sync_row(
     raw_id = entry.get("jobId")
     if raw_id is None or isinstance(raw_id, bool):
         return Skipped("", "listing entry carries no job identity")
-    job_id = str(raw_id)
+    job_id = str(raw_id).strip()
+    if not job_id:
+        # Several such jobs would share one key and replace each other during
+        # resolution, so the page would answer with whichever landed last.
+        return Skipped("", "listing entry carries an empty job identity")
 
     connection = entry.get("connectionId")
     connector = connectors.get(str(connection)) if connection is not None else None

--- a/src/ingestion/reconcile-connectors/python/sweep/plan.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/plan.py
@@ -26,6 +26,18 @@ SWEEP_COMPLETED = "sweep.completed"
 #: ClickHouse reads `DateTime64(3, 'UTC')` from this shape.
 _MOMENT_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
+#: What `DateTime64(3)` can hold. A stamp outside it is not rejected on insert —
+#: ClickHouse CLAMPS it silently, so a year 1000 stamp lands as 1900 and a year
+#: 9999 stamp as 2299. Either would make the page state a moment nobody
+#: recorded, and a clamped-low stamp would additionally pin the sweep's own
+#: watermark to 1900 and re-read the whole retained history every tick.
+_EARLIEST_MOMENT = datetime(1900, 1, 1, tzinfo=UTC)
+_LATEST_MOMENT = datetime(2299, 12, 31, tzinfo=UTC)
+
+#: `UInt64`. A larger value is not rejected either — it wraps, and the page
+#: would label the wrapped number as what the mover reported.
+_MAX_UINT64 = 2**64 - 1
+
 #: Columns inapplicable to a row class carry an empty string rather than NULL:
 #: they are `LowCardinality(String)`, and every read filters by `event` before
 #: touching them.
@@ -71,7 +83,10 @@ def moment(stamp: object) -> str | None:
         return None
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(UTC).strftime(_MOMENT_FORMAT)[:-3]
+    parsed = parsed.astimezone(UTC)
+    if not _EARLIEST_MOMENT <= parsed <= _LATEST_MOMENT:
+        return None
+    return parsed.strftime(_MOMENT_FORMAT)[:-3]
 
 
 def entry_moment(entry: Mapping[str, Any]) -> str | None:
@@ -107,7 +122,10 @@ def duration_ms(duration: object) -> int | None:
     if isinstance(duration, bool):
         return None
     if isinstance(duration, (int, float)):
-        return int(float(duration) * 1000) if duration >= 0 else None
+        # A bare number is seconds, which is what the listing's own duration
+        # spells out; anything else would be this reading a unit into a field
+        # the mover documents as ISO-8601.
+        return _bounded(int(float(duration) * 1000)) if duration >= 0 else None
     if not isinstance(duration, str) or not duration.strip():
         return None
 
@@ -122,7 +140,16 @@ def duration_ms(duration: object) -> int | None:
         for name, seconds in _SECONDS_PER.items()
         if parts[name] is not None
     )
-    return round(total * 1000)
+    return _bounded(round(total * 1000))
+
+
+def _bounded(value: int) -> int | None:
+    """A magnitude the column can hold, or None.
+
+    `UInt64` wraps rather than rejects, so an out-of-range count would be stored
+    as a different number and labelled as the mover's own.
+    """
+    return value if 0 <= value <= _MAX_UINT64 else None
 
 
 def records_reported(entry: Mapping[str, Any]) -> int | None:
@@ -132,9 +159,17 @@ def records_reported(entry: Mapping[str, Any]) -> int | None:
     are different answers, and the page prints them differently.
     """
     value = entry.get("rowsSynced")
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
+    if isinstance(value, bool):
         return None
-    return int(value) if value >= 0 else None
+    if isinstance(value, str):
+        # A count the listing sent as text is still a count.
+        try:
+            value = int(value)
+        except ValueError:
+            return None
+    if not isinstance(value, (int, float)):
+        return None
+    return _bounded(int(value)) if value >= 0 else None
 
 
 def sync_row(
@@ -197,6 +232,40 @@ def plan_syncs(
             continue
         rows.append(planned)
     return Plan(rows, skipped)
+
+
+def plan_abandoned(
+    jobs: Iterable[Mapping[str, str]], tick_id: str
+) -> list[dict[str, Any]]:
+    """Mark jobs the sweep can no longer read as unreadable.
+
+    A job that has fallen below the read start will not be asked about again, so
+    its last provisional word would otherwise stand as the page's answer for
+    ever — the page reporting a sync as running long after it stopped being
+    visible. `unknown` is the honest replacement: not a failure, not a success,
+    a state that can no longer be read.
+    """
+    rows = []
+    for job in jobs:
+        job_id = str(job.get("job_id", ""))
+        connector = str(job.get("connector", ""))
+        created = str(job.get("created", ""))
+        if not job_id or not connector or not created:
+            continue
+        rows.append(
+            {
+                "tick_id": tick_id,
+                "job_id": job_id,
+                "connector": connector,
+                "event": SYNC_COMPLETED,
+                "status": vocab.UNKNOWN,
+                "started_at": None,
+                "job_created_at": created,
+                "duration_ms": None,
+                "records_reported": None,
+            }
+        )
+    return rows
 
 
 def _bare_row(tick_id: str, event: str, connector: str) -> dict[str, Any]:

--- a/src/ingestion/reconcile-connectors/python/sweep/plan.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/plan.py
@@ -1,0 +1,231 @@
+"""Decide which rows a tick writes. Pure functions over values — no I/O.
+
+The shell gathers, the planner decides, and the planner is what the tests
+exercise. Its rules are this change's densest logic: which jobs to cover, which
+already-recorded rows close a job, and which jobs cannot be placed at all.
+
+Every field read here comes from the mover's own listing entry, whose shape is
+flat: `jobId`, `connectionId`, `status`, `createdAt`, `startTime`, `duration`,
+`rowsSynced`. The stamps are ISO-8601 strings and the duration is an ISO-8601
+duration, so both are parsed rather than cast.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+from typing import Any, NamedTuple
+
+from . import status as vocab
+
+SYNC_COMPLETED = "sync.completed"
+CONNECTOR_CONFIGURED = "connector.configured"
+SWEEP_COMPLETED = "sweep.completed"
+
+#: ClickHouse reads `DateTime64(3, 'UTC')` from this shape.
+_MOMENT_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
+
+#: Columns inapplicable to a row class carry an empty string rather than NULL:
+#: they are `LowCardinality(String)`, and every read filters by `event` before
+#: touching them.
+_ABSENT = ""
+
+#: `PnDTnHnMnS`, any component optional, seconds possibly fractional.
+_ISO_DURATION = re.compile(
+    r"^P(?:(?P<days>\d+(?:\.\d+)?)D)?"
+    r"(?:T(?:(?P<hours>\d+(?:\.\d+)?)H)?"
+    r"(?:(?P<minutes>\d+(?:\.\d+)?)M)?"
+    r"(?:(?P<seconds>\d+(?:\.\d+)?)S)?)?$"
+)
+
+_SECONDS_PER = {"days": 86_400.0, "hours": 3_600.0, "minutes": 60.0, "seconds": 1.0}
+
+
+class Skipped(NamedTuple):
+    """A job the planner refused, and why. Logged, never written."""
+
+    job_id: str
+    reason: str
+
+
+class Plan(NamedTuple):
+    rows: list[dict[str, Any]]
+    skipped: list[Skipped]
+
+
+def moment(stamp: object) -> str | None:
+    """Format the mover's ISO-8601 stamp for ClickHouse; None when unusable.
+
+    A stamp that will not parse is not a moment. Substituting the epoch would
+    make the page state a time nobody recorded, and would put the job at the
+    bottom of every ordering the ledger does along this axis.
+    """
+    if not isinstance(stamp, str) or not stamp.strip():
+        return None
+    try:
+        # `fromisoformat` takes the `Z` suffix directly from 3.11 on, which is
+        # the shape the listing actually sends.
+        parsed = datetime.fromisoformat(stamp.strip())
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC).strftime(_MOMENT_FORMAT)[:-3]
+
+
+def entry_moment(entry: Mapping[str, Any]) -> str | None:
+    """One listing entry's creation moment, in the ledger's own form.
+
+    The single reader of that field: the watermark is compared against it and
+    the planner records it, and the two must never disagree about what an
+    entry's creation time is.
+    """
+    return moment(entry.get("createdAt"))
+
+
+def as_listing_stamp(recorded: str | None) -> str | None:
+    """The ledger's stamp in the form the mover's listing filter understands.
+
+    The two formats differ by a space and a suffix, and sending the wrong one is
+    silent: a listing handed `2026-08-27 16:00:00.000` does not filter on it, so
+    the sweep would re-read the whole history every tick and think it had
+    filtered. Converting in one named place is the only way that stays visible.
+    """
+    if recorded is None:
+        return None
+    return recorded.strip().replace(" ", "T") + "Z"
+
+
+def duration_ms(duration: object) -> int | None:
+    """Milliseconds from the mover's ISO-8601 duration (`PT1M37S`).
+
+    None for anything that does not parse. Reporting a duration shorter than the
+    truth because one component went unread would be worse than reporting none:
+    the page would state a measurement nobody made.
+    """
+    if isinstance(duration, bool):
+        return None
+    if isinstance(duration, (int, float)):
+        return int(float(duration) * 1000) if duration >= 0 else None
+    if not isinstance(duration, str) or not duration.strip():
+        return None
+
+    matched = _ISO_DURATION.match(duration.strip().upper())
+    if matched is None:
+        return None
+    parts = matched.groupdict()
+    if all(value is None for value in parts.values()):
+        return None
+    total = sum(
+        float(parts[name]) * seconds
+        for name, seconds in _SECONDS_PER.items()
+        if parts[name] is not None
+    )
+    return round(total * 1000)
+
+
+def records_reported(entry: Mapping[str, Any]) -> int | None:
+    """What the mover states it moved. None where it reported no count at all.
+
+    None rather than zero: a sync that moved nothing and a sync nobody counted
+    are different answers, and the page prints them differently.
+    """
+    value = entry.get("rowsSynced")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return int(value) if value >= 0 else None
+
+
+def sync_row(
+    entry: Mapping[str, Any], connectors: Mapping[str, str], tick_id: str
+) -> dict[str, Any] | Skipped:
+    """One ledger row for one listing entry, or the reason it cannot be recorded."""
+    raw_id = entry.get("jobId")
+    if raw_id is None or isinstance(raw_id, bool):
+        return Skipped("", "listing entry carries no job identity")
+    job_id = str(raw_id)
+
+    connection = entry.get("connectionId")
+    connector = connectors.get(str(connection)) if connection is not None else None
+    if not connector:
+        # A job on a connection this install does not manage: another tenant's,
+        # or one left behind by a connector since removed. Recording it under a
+        # guessed name would put syncs on the wrong row.
+        return Skipped(job_id, "job belongs to no managed connection")
+
+    # SAFETY: the summary resolves the newest sync per connector along this
+    # column, and a row without it can never win that comparison. Recording it
+    # anyway would hide the connector rather than the row.
+    created = entry_moment(entry)
+    if created is None:
+        return Skipped(job_id, "job carries no readable creation time")
+
+    return {
+        "tick_id": tick_id,
+        "job_id": job_id,
+        "connector": connector,
+        "event": SYNC_COMPLETED,
+        "status": vocab.normalise(entry.get("status")),
+        "started_at": moment(entry.get("startTime")),
+        "job_created_at": created,
+        "duration_ms": duration_ms(entry.get("duration")),
+        "records_reported": records_reported(entry),
+    }
+
+
+def plan_syncs(
+    entries: Iterable[Mapping[str, Any]],
+    connectors: Mapping[str, str],
+    tick_id: str,
+    closed_job_ids: frozenset[str],
+) -> Plan:
+    """Rows for the jobs this tick still has something to say about.
+
+    A job the ledger already holds with a terminal status is left alone: its
+    account cannot change, so re-recording it would only add a row resolving to
+    the same answer.
+    """
+    rows: list[dict[str, Any]] = []
+    skipped: list[Skipped] = []
+    for entry in entries:
+        planned = sync_row(entry, connectors, tick_id)
+        if isinstance(planned, Skipped):
+            skipped.append(planned)
+            continue
+        if planned["job_id"] in closed_job_ids:
+            continue
+        rows.append(planned)
+    return Plan(rows, skipped)
+
+
+def _bare_row(tick_id: str, event: str, connector: str) -> dict[str, Any]:
+    return {
+        "tick_id": tick_id,
+        "job_id": _ABSENT,
+        "connector": connector,
+        "event": event,
+        "status": _ABSENT,
+        "started_at": None,
+        "job_created_at": None,
+        "duration_ms": None,
+        "records_reported": None,
+    }
+
+
+def plan_snapshot(connectors: Iterable[str], tick_id: str) -> list[dict[str, Any]]:
+    """One row per connector the controller manages this tick."""
+    return [
+        _bare_row(tick_id, CONNECTOR_CONFIGURED, connector)
+        for connector in sorted(set(connectors))
+    ]
+
+
+def plan_seal(tick_id: str) -> dict[str, Any]:
+    """The marker written last, which makes the tick's snapshot readable.
+
+    INVARIANT: nothing else may be written under this tick id afterwards. A read
+    keys the configured set on the newest sealed tick, so a row arriving after
+    its seal would join a snapshot already being read as complete.
+    """
+    return _bare_row(tick_id, SWEEP_COMPLETED, _ABSENT)

--- a/src/ingestion/reconcile-connectors/python/sweep/status.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/status.py
@@ -1,0 +1,41 @@
+"""The vocabulary a recorded sync outcome may carry.
+
+The mover's own words are stored verbatim. Nothing is translated on the way
+in: a surface that reports someone else's account should not paraphrase it,
+and a translation table is one more place for a meaning to be lost. What the
+boundary does instead is close the set — a word outside the mover's documented
+vocabulary is stored as `UNKNOWN`, so no reader ever holds a value it cannot
+interpret.
+"""
+
+from __future__ import annotations
+
+#: Every status the mover's job listing documents.
+MOVER_STATUSES = frozenset(
+    {"pending", "running", "incomplete", "succeeded", "failed", "cancelled"}
+)
+
+#: What a word outside `MOVER_STATUSES` becomes. Not a failure and not a
+#: success — a state the reader could not read.
+UNKNOWN = "unknown"
+
+#: A job carrying one of these will not change again, so the ledger already
+#: holds its last word.
+#:
+#: INVARIANT: `UNKNOWN` is deliberately absent. Coverage fails closed — a
+#: status we could not read is one we keep re-reading until it becomes one we
+#: can, at the cost of a duplicate row that resolves to the same answer.
+TERMINAL_STATUSES = frozenset({"succeeded", "failed", "cancelled", "incomplete"})
+
+
+def normalise(raw: object) -> str:
+    """Map the mover's reported status onto the closed set."""
+    if not isinstance(raw, str):
+        return UNKNOWN
+    word = raw.strip().lower()
+    return word if word in MOVER_STATUSES else UNKNOWN
+
+
+def is_terminal(status: str) -> bool:
+    """Whether a recorded status closes its job for coverage purposes."""
+    return status in TERMINAL_STATUSES

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
@@ -166,9 +166,13 @@ class _StubMover:
 
 
 def _query(sql: str) -> str:
+    # SAFETY: urllib honours `file://`. The URL is an opt-in env var, so the
+    # scheme is pinned rather than taken on trust.
+    assert CH_URL and CH_URL.startswith(("http://", "https://")), CH_URL
     request = urllib.request.Request(f"{CH_URL}/", data=sql.encode(), method="POST")
     request.add_header("X-ClickHouse-User", CH_USER)
     request.add_header("X-ClickHouse-Key", CH_PASSWORD)
+    # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
     with urllib.request.urlopen(request, timeout=30) as response:
         return response.read().decode()
 

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
@@ -28,7 +28,7 @@ import threading
 import unittest
 import urllib.parse
 import urllib.request
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Self
@@ -50,8 +50,18 @@ DAY = "2026-08-27"
 
 
 def _stamp(hour_offset: int) -> str:
-    """An ISO-8601 stamp, the shape the listing sends."""
-    return f"{DAY}T{BASE_HOUR + hour_offset:02d}:00:00Z"
+    """An ISO-8601 stamp, the shape the listing sends.
+
+    Anchored to a fixed day and offset in hours, so a test can name a moment
+    before the fixtures (a negative offset) without arithmetic at the call site.
+    """
+    moment = datetime(2026, 8, 27, BASE_HOUR, tzinfo=UTC) + timedelta(hours=hour_offset)
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _ch_stamp(iso: str) -> str:
+    """The ledger's own stamp form, for a direct INSERT."""
+    return iso.replace("T", " ").replace("Z", "") + ".000"
 
 
 def _parse_iso(stamp: str) -> datetime:
@@ -341,12 +351,128 @@ class SweptRowsLandAndResolve(unittest.TestCase):
         self.assertEqual(_count(f"SELECT count() AS n FROM {TABLE}"), 0)
 
     def test_an_unreachable_mover_records_nothing_and_does_not_seal(self) -> None:
-        # No stub server running: every listing call fails.
+        """The seal dates the page, so an unread tick must not place one.
+
+        Sealing anyway would keep `checked_at` advancing on an install whose
+        mover is unreachable — the page would report that it was just checked
+        for ever, and could never say recording had stopped.
+        """
+        # No stub server running: the listing call fails.
         code = self._tick("tick-y")
         self.assertEqual(code, 1, "the caller learns the tick was incomplete")
+        for event in ("sync.completed", "connector.configured", "sweep.completed"):
+            self.assertEqual(
+                _count(
+                    f"SELECT count() AS n FROM {TABLE} WHERE event = '{event}'"
+                ),
+                0,
+                f"an unread tick must write no {event} row",
+            )
+
+    def test_a_connector_awaiting_its_first_connection_is_still_configured(self) -> None:
+        """Configured is the first thing the page answers, and it does not
+        depend on whether the mover has caught up yet."""
+        work = json.dumps(
+            {
+                "tick_id": "tick-w",
+                "connectors": [
+                    {"name": CONNECTOR, "connection_id": CONNECTION},
+                    {"name": "awaiting-connection"},
+                ],
+            }
+        )
+        with _StubMover():
+            self.assertEqual(self.entry.run(io.StringIO(work)), 0)
+
+        configured = {
+            row["connector"]
+            for row in _rows(
+                f"SELECT connector FROM {TABLE} WHERE event = 'connector.configured'"
+            )
+        }
+        self.assertEqual(configured, {CONNECTOR, "awaiting-connection"})
+
+    def test_a_job_that_fell_below_the_read_start_stops_reading_as_running(self) -> None:
+        """The floor's own cost, paid honestly.
+
+        A job open longer than the floor will never be asked about again, so its
+        last provisional word would otherwise stand as the page's answer for
+        ever — the page reporting a sync as running long after it stopped being
+        visible. The sweep records what is true instead: its state can no longer
+        be read.
+        """
+        stale = _stamp(-24 * 60)
+        _query(
+            f"INSERT INTO {TABLE} (ts, tick_id, job_id, connector, event, status, "
+            "started_at, job_created_at, duration_ms, records_reported) VALUES "
+            f"(now64(3), 'old', 'stranded', '{CONNECTOR}', 'sync.completed', 'running', "
+            f"NULL, toDateTime64('{_ch_stamp(stale)}', 3, 'UTC'), NULL, NULL)"
+        )
+        with _StubMover():
+            # Two ticks: the read start is resolved before this tick's rows
+            # land, so the floor only moves past the stranded job once newer
+            # jobs are recorded. One tick of delay, and it settles itself.
+            self._tick("tick-a")
+            self._tick("tick-b")
+
+        resolved = _rows(
+            f"SELECT status FROM {TABLE} WHERE event = 'sync.completed' "
+            "AND job_id = 'stranded' ORDER BY ts DESC LIMIT 1"
+        )
         self.assertEqual(
-            _count(f"SELECT count() AS n FROM {TABLE} WHERE event = 'sync.completed'"),
-            0,
+            resolved[0]["status"],
+            "unknown",
+            "a job the sweep can no longer see must not keep reading as running",
+        )
+
+    def test_a_stranded_job_is_marked_once_and_not_every_tick(self) -> None:
+        """`unknown` is what stops the job being named again.
+
+        The marker is a row like any other, so without excluding an
+        already-marked job from the search the sweep would write one per tick for
+        ever. `unknown` earns its place in that exclusion here and nowhere else:
+        it stays NON-terminal for coverage, because an unreadable status is one
+        to keep re-reading while the job is still in the window.
+        """
+        stale = _stamp(-24 * 60)
+        _query(
+            f"INSERT INTO {TABLE} (ts, tick_id, job_id, connector, event, status, "
+            "started_at, job_created_at, duration_ms, records_reported) VALUES "
+            f"(now64(3), 'old', 'stranded', '{CONNECTOR}', 'sync.completed', 'running', "
+            f"NULL, toDateTime64('{_ch_stamp(stale)}', 3, 'UTC'), NULL, NULL)"
+        )
+        with _StubMover():
+            self._tick("tick-a")
+            self._tick("tick-b")
+            self._tick("tick-c")
+
+        markers = _count(
+            f"SELECT count() AS n FROM {TABLE} WHERE job_id = 'stranded' "
+            "AND status = 'unknown'"
+        )
+        self.assertEqual(markers, 1, "the marker must settle, not repeat")
+
+    def test_a_stuck_open_job_does_not_pin_the_watermark_for_ever(self) -> None:
+        """One job that can never close would otherwise drag the read start back
+        to its own creation time on every tick, until more jobs than a tick may
+        read sit above it and the newest syncs stop being read at all."""
+        stale = _stamp(-24 * 60)  # a month back, in the same shape the mover sends
+        _query(
+            f"INSERT INTO {TABLE} (ts, tick_id, job_id, connector, event, status, "
+            "started_at, job_created_at, duration_ms, records_reported) VALUES "
+            f"(now64(3), 'old', 'stuck', '{CONNECTOR}', 'sync.completed', 'running', "
+            f"NULL, toDateTime64('{_ch_stamp(stale)}', 3, 'UTC'), NULL, NULL)"
+        )
+        with _StubMover() as mover:
+            self._tick("tick-a")
+            mover.requests.clear()
+            self._tick("tick-b")
+
+        since = _parse_iso(mover.requests[0]["createdAtStart"])
+        self.assertGreater(
+            since,
+            _parse_iso(stale),
+            "the stuck job must not hold the read start at its own creation time",
         )
 
 

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
@@ -1,0 +1,354 @@
+"""Opt-in end-to-end sweep: a stub mover, a real ClickHouse, real rows.
+
+Pure tests cover what the planner decides; this covers what actually lands. It
+exists because an empty table hides everything that matters here — a column the
+insert omits, a NULL the reader cannot take, a frontier that stops a job from
+ever being re-read. Every one of those passes against zero rows.
+
+Skipped unless a server is offered, so CI stays dependency-free:
+
+    docker run -d --rm --name ch -p 38310:8123 \\
+        -e CLICKHOUSE_USER=insight -e CLICKHOUSE_PASSWORD=insight \\
+        clickhouse/clickhouse-server:25.7.5
+    src/ingestion/scripts/lib/ch-exec.sh < the migration, then
+    SWEEP_TEST_CH_URL=http://localhost:38310 \\
+    SWEEP_TEST_CH_USER=insight SWEEP_TEST_CH_PASSWORD=insight \\
+        python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests
+
+Run: python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import threading
+import unittest
+import urllib.parse
+import urllib.request
+from datetime import datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Self
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+
+CH_URL = os.environ.get("SWEEP_TEST_CH_URL")
+CH_USER = os.environ.get("SWEEP_TEST_CH_USER", "default")  # RULE-DEFAULTS-OK: local throwaway server's own default user
+CH_PASSWORD = os.environ.get("SWEEP_TEST_CH_PASSWORD", "")  # RULE-DEFAULTS-OK: that user has no password
+
+TABLE = "ingestion_history.sync_events"
+CONNECTOR = "example-tracker"
+CONNECTION = "connection-under-test"
+STUB_PORT = 38399
+TOKEN = "stub-token"
+
+BASE_HOUR = 8
+DAY = "2026-08-27"
+
+
+def _stamp(hour_offset: int) -> str:
+    """An ISO-8601 stamp, the shape the listing sends."""
+    return f"{DAY}T{BASE_HOUR + hour_offset:02d}:00:00Z"
+
+
+def _parse_iso(stamp: str) -> datetime:
+    """Refuses anything that is not ISO-8601, so a mis-sent watermark fails the
+    test rather than quietly matching every entry."""
+    return datetime.fromisoformat(stamp)
+
+
+def _closed_job(index: int) -> dict:
+    return {
+        "jobId": 500 + index,
+        "connectionId": CONNECTION,
+        "status": "succeeded",
+        "createdAt": _stamp(index),
+        "startTime": _stamp(index),
+        "duration": "PT3M10S",
+        "rowsSynced": 100 * index,
+    }
+
+
+def _running_job() -> dict:
+    """No start, no duration, no count — the mover has nothing to report yet."""
+    return {
+        "jobId": 999,
+        "connectionId": CONNECTION,
+        "status": "running",
+        "createdAt": _stamp(8),
+    }
+
+
+def _finished_job() -> dict:
+    return {
+        "jobId": 999,
+        "connectionId": CONNECTION,
+        "status": "failed",
+        "createdAt": _stamp(8),
+        "startTime": _stamp(8),
+        "duration": "PT5M",
+        "rowsSynced": 0,
+    }
+
+
+class _StubMover:
+    """The public job listing, serving only what the sweep asks it for.
+
+    Asserts the two query parameters the sweep's correctness rests on: ascending
+    creation order, so a capped read leaves only NEWER jobs unread, and the
+    watermark filter, so a steady tick does not re-read the whole history.
+    """
+
+    def __init__(self, page_size: int = 100) -> None:
+        self.oldest_first = [_closed_job(i) for i in range(7)] + [_running_job()]
+        self.page_size = page_size
+        self.requests: list[dict[str, str]] = []
+        stub = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                if self.headers.get("Authorization") != f"Bearer {TOKEN}":
+                    self.send_error(401)
+                    return
+                query = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+                flat = {key: value[0] for key, value in query.items()}
+                stub.requests.append(flat)
+
+                assert flat.get("orderBy") == "createdAt|ASC", flat
+                assert flat.get("jobType") == "sync", flat
+
+                entries = stub.oldest_first
+                since = flat.get("createdAtStart")
+                if since is not None:
+                    # A real listing parses this. Comparing the two stamp forms
+                    # as raw strings is what let a wrongly-formatted watermark
+                    # look like a working filter.
+                    edge = _parse_iso(since)
+                    entries = [e for e in entries if _parse_iso(e["createdAt"]) >= edge]
+                offset = int(flat.get("offset", "0"))
+                window = entries[offset : offset + stub.page_size]
+
+                payload = json.dumps({"data": window}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, *args: object) -> None:
+                pass
+
+        self._server = HTTPServer(("127.0.0.1", STUB_PORT), Handler)
+
+    def __enter__(self) -> Self:
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+
+    def job_finishes(self) -> None:
+        self.oldest_first[-1] = _finished_job()
+
+
+def _query(sql: str) -> str:
+    request = urllib.request.Request(f"{CH_URL}/", data=sql.encode(), method="POST")
+    request.add_header("X-ClickHouse-User", CH_USER)
+    request.add_header("X-ClickHouse-Key", CH_PASSWORD)
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.read().decode()
+
+
+def _rows(sql: str) -> list[dict]:
+    raw = _query(f"{sql} FORMAT JSONEachRow")
+    return [json.loads(line) for line in raw.splitlines() if line.strip()]
+
+
+def _count(sql: str) -> int:
+    """`UInt64` crosses JSON as a string — ClickHouse quotes it so a JS reader
+    cannot silently lose precision. Every numeric assertion here goes through
+    this rather than comparing against a bare int and passing by accident."""
+    value = _rows(sql)[0]["n"]
+    return int(value)
+
+
+@unittest.skipUnless(CH_URL, "set SWEEP_TEST_CH_URL to run")
+class SweptRowsLandAndResolve(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        from sweep import __main__ as entry
+
+        cls.entry = entry
+        os.environ.update(
+            {
+                "AIRBYTE_URL": f"http://127.0.0.1:{STUB_PORT}",
+                "AIRBYTE_TOKEN": TOKEN,
+                "RECONCILE_DEST_CLICKHOUSE_PROTOCOL": (
+                    "https" if CH_URL.startswith("https") else "http"
+                ),
+                "RECONCILE_DEST_CLICKHOUSE_HOST": CH_URL.split("//", 1)[1].split(":")[0],
+                "RECONCILE_DEST_CLICKHOUSE_PORT": CH_URL.rsplit(":", 1)[1],
+                "RECONCILE_DEST_CLICKHOUSE_USERNAME": CH_USER,
+                "RECONCILE_DEST_CLICKHOUSE_PASSWORD": CH_PASSWORD,
+            }
+        )
+
+    def setUp(self) -> None:
+        _query(f"TRUNCATE TABLE {TABLE}")
+
+    def _tick(self, tick_id: str) -> int:
+        work = json.dumps(
+            {
+                "tick_id": tick_id,
+                "connectors": [{"name": CONNECTOR, "connection_id": CONNECTION}],
+            }
+        )
+        return self.entry.run(io.StringIO(work))
+
+    def test_a_first_sweep_lands_the_whole_retained_history(self) -> None:
+        with _StubMover() as mover:
+            self.assertEqual(self._tick("tick-a"), 0)
+            self.assertIsNone(
+                mover.requests[0].get("createdAtStart"),
+                "an empty ledger reads everything, unfiltered",
+            )
+
+        syncs = _rows(
+            f"SELECT job_id FROM {TABLE} WHERE event = 'sync.completed' ORDER BY job_id"
+        )
+        self.assertEqual(len(syncs), 8, "seven closed jobs plus the running one")
+
+    def test_a_later_tick_reads_from_the_watermark_not_from_the_start(self) -> None:
+        with _StubMover() as mover:
+            self._tick("tick-a")
+            mover.requests.clear()
+            self._tick("tick-b")
+
+            since = mover.requests[0].get("createdAtStart")
+            self.assertIsNotNone(since, "a populated ledger must filter")
+            # Not merely "a stamp": one the listing can parse. The ledger's own
+            # form differs by a space, and a listing handed that form filters on
+            # nothing at all.
+            self.assertEqual(_parse_iso(since).tzinfo is None, False, since)
+
+    def test_the_watermark_does_not_step_over_an_unfinished_job(self) -> None:
+        """It stands on the oldest OPEN job, so that job is read again.
+
+        Standing it on the newest job recorded would leave the one most likely
+        still running below the line, and the page would show it running for
+        ever.
+        """
+        with _StubMover() as mover:
+            self._tick("tick-a")
+            mover.requests.clear()
+            self._tick("tick-b")
+
+        since = mover.requests[0]["createdAtStart"]
+        self.assertLessEqual(
+            _parse_iso(since),
+            _parse_iso(_stamp(8)),
+            "the still-running job must stay at or above the watermark",
+        )
+
+    def test_the_tick_seals_after_its_snapshot(self) -> None:
+        with _StubMover():
+            self._tick("tick-a")
+
+        seal = _rows(
+            f"SELECT tick_id, toString(ts) AS ts FROM {TABLE} "
+            "WHERE event = 'sweep.completed'"
+        )
+        snapshot = _rows(
+            f"SELECT toString(max(ts)) AS ts FROM {TABLE} "
+            "WHERE event = 'connector.configured'"
+        )
+        self.assertEqual(len(seal), 1)
+        self.assertGreaterEqual(
+            seal[0]["ts"], snapshot[0]["ts"], "the seal must be written last"
+        )
+
+    def test_a_second_tick_adds_no_row_for_a_closed_job(self) -> None:
+        with _StubMover():
+            self._tick("tick-a")
+            self._tick("tick-b")
+
+        closed = _rows(
+            f"SELECT job_id, count() AS seen FROM {TABLE} "
+            "WHERE event = 'sync.completed' AND status = 'succeeded' "
+            "GROUP BY job_id HAVING seen > 1"
+        )
+        self.assertEqual(closed, [], "a job with a final account is left alone")
+
+    def test_a_running_job_is_re_recorded_once_it_ends(self) -> None:
+        """The one behaviour every other test here would pass without."""
+        with _StubMover() as mover:
+            self._tick("tick-a")
+            mover.job_finishes()
+            self._tick("tick-b")
+
+        resolved = _rows(
+            f"SELECT status, records_reported FROM {TABLE} "
+            "WHERE event = 'sync.completed' AND job_id = '999' "
+            "ORDER BY ts DESC LIMIT 1"
+        )
+        self.assertEqual(resolved[0]["status"], "failed")
+        self.assertEqual(
+            int(resolved[0]["records_reported"]),
+            0,
+            "a reported zero is not an absence",
+        )
+
+    def test_the_summary_resolves_to_the_newest_row_of_the_newest_job(self) -> None:
+        with _StubMover() as mover:
+            self._tick("tick-a")
+            mover.job_finishes()
+            self._tick("tick-b")
+
+        summary = _rows(
+            "SELECT connector, job_id, status FROM ("
+            f"  SELECT connector, job_id, status, job_created_at FROM {TABLE}"
+            "   WHERE event = 'sync.completed'"
+            "   ORDER BY job_id, ts DESC LIMIT 1 BY job_id"
+            ") ORDER BY connector, job_created_at DESC, job_id DESC LIMIT 1 BY connector"
+        )
+        self.assertEqual(len(summary), 1)
+        self.assertEqual(summary[0]["job_id"], "999")
+        self.assertEqual(summary[0]["status"], "failed")
+
+    def test_an_unfinished_job_stores_no_start_and_no_duration(self) -> None:
+        with _StubMover():
+            self._tick("tick-a")
+
+        running = _rows(
+            f"SELECT started_at, duration_ms, records_reported FROM {TABLE} "
+            "WHERE event = 'sync.completed' AND job_id = '999'"
+        )
+        self.assertIsNone(running[0]["started_at"])
+        self.assertIsNone(running[0]["duration_ms"])
+        self.assertIsNone(running[0]["records_reported"])
+
+    def test_no_connectors_records_nothing_at_all(self) -> None:
+        """An empty configured set is indistinguishable from "all removed"."""
+        with _StubMover():
+            code = self.entry.run(
+                io.StringIO(json.dumps({"tick_id": "tick-z", "connectors": []}))
+            )
+        self.assertEqual(code, 1)
+        self.assertEqual(_count(f"SELECT count() AS n FROM {TABLE}"), 0)
+
+    def test_an_unreachable_mover_records_nothing_and_does_not_seal(self) -> None:
+        # No stub server running: every listing call fails.
+        code = self._tick("tick-y")
+        self.assertEqual(code, 1, "the caller learns the tick was incomplete")
+        self.assertEqual(
+            _count(f"SELECT count() AS n FROM {TABLE} WHERE event = 'sync.completed'"),
+            0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_mover.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_mover.py
@@ -1,0 +1,107 @@
+"""How the listing read decides it has read enough.
+
+Two decisions, both easy to get subtly wrong and neither visible from the rows
+that land: whether a short page means the end of the listing, and whether the
+read ran out of time. Getting either wrong makes an incomplete tick report
+itself complete, which is the one thing that stops FR-12 from ever firing.
+
+Run: python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+
+from sweep import mover as mover_module
+from sweep.mover import Mover
+
+
+class _Listing(Mover):
+    """A mover whose pages are supplied rather than fetched.
+
+    Overrides `_page`, the one seam between the read's decisions and its
+    transport, so the decisions can be driven without a server.
+    """
+
+    def __init__(self, pages: list[tuple[int, int]]) -> None:
+        super().__init__("http://mover.invalid", "token")
+        #: (usable entries, entries the server served) per page.
+        self._pages = pages
+        self.requested: list[int] = []
+
+    def _page(self, offset: int, created_at_start: str | None):
+        self.requested.append(offset)
+        index = len(self.requested) - 1
+        usable, served = self._pages[index] if index < len(self._pages) else (0, 0)
+        return [{"jobId": offset + n} for n in range(usable)], served
+
+
+class AShortPageEndsTheRead(unittest.TestCase):
+    def test_a_page_shorter_than_the_size_is_the_end_of_the_listing(self) -> None:
+        listing = _Listing([(mover_module.PAGE_SIZE, mover_module.PAGE_SIZE), (5, 5)])
+        entries, truncated = listing.sync_jobs(None)
+
+        self.assertEqual(len(entries), mover_module.PAGE_SIZE + 5)
+        self.assertFalse(truncated)
+        self.assertEqual(len(listing.requested), 2)
+
+    def test_a_full_page_carrying_an_unusable_entry_is_not_a_short_page(self) -> None:
+        """The end-of-listing test must read what the SERVER served.
+
+        Measuring the filtered length instead makes a full page with one
+        unusable element look like the end of the listing: the read stops, the
+        tick reports itself complete, and the jobs above it wait for a tick that
+        thinks it has nothing to do.
+        """
+        full = mover_module.PAGE_SIZE
+        listing = _Listing([(full - 1, full), (3, 3)])
+        entries, truncated = listing.sync_jobs(None)
+
+        self.assertEqual(
+            len(listing.requested), 2, "the read must continue past the filtered page"
+        )
+        self.assertEqual(len(entries), full - 1 + 3)
+        self.assertFalse(truncated)
+
+
+class TheReadHasATimeBudget(unittest.TestCase):
+    def test_an_exhausted_budget_stops_the_read_and_says_so(self) -> None:
+        """The page cap alone bounds nothing in time.
+
+        Fifty pages at the per-request timeout outlives the tick's own deadline,
+        and a tick killed part-way never reaches its summary — so the run reads
+        as aborted and the next one is skipped.
+        """
+        full = mover_module.PAGE_SIZE
+        listing = _Listing([(full, full)] * 4)
+        original = mover_module.BUDGET_SECS
+        mover_module.BUDGET_SECS = 0
+        try:
+            entries, truncated = listing.sync_jobs(None)
+        finally:
+            mover_module.BUDGET_SECS = original
+
+        self.assertTrue(truncated, "a read that ran out of time is not a complete read")
+        self.assertEqual(len(listing.requested), 1, "it stops rather than finishing")
+        self.assertEqual(len(entries), full, "and keeps what it did read")
+
+    def test_the_budget_leaves_room_under_the_ticks_own_deadline(self) -> None:
+        # The workflow pod's deadline is 1800s; the sweep is its last layer and
+        # still has the ledger writes and the seal to do afterwards.
+        self.assertLess(mover_module.BUDGET_SECS, 900)
+
+    def test_the_page_cap_is_a_backstop_not_the_budget(self) -> None:
+        full = mover_module.PAGE_SIZE
+        listing = _Listing([(full, full)] * (mover_module.MAX_PAGES + 5))
+        _, truncated = listing.sync_jobs(None)
+
+        self.assertTrue(truncated)
+        self.assertEqual(len(listing.requested), mover_module.MAX_PAGES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
@@ -1,0 +1,237 @@
+"""What a tick decides to write.
+
+Run: python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+
+from sweep import plan
+from sweep import status as vocab
+
+CONNECTOR = "example-tracker"
+TICK = "tick-1"
+
+CONNECTION = "connection-under-test"
+CONNECTORS = {CONNECTION: CONNECTOR}
+
+CREATED = "2026-08-27T08:00:00Z"
+STARTED = "2026-08-27T08:00:30Z"
+
+
+def entry(**overrides) -> dict:
+    """One entry of the mover's job listing, in the shape it serves.
+
+    Flat, ISO-8601 stamps, an ISO-8601 duration, and the record count on the
+    entry itself — there is no nested job or attempts array on this listing.
+    """
+    listing_entry = {
+        "jobId": 8412,
+        "connectionId": CONNECTION,
+        "status": "succeeded",
+        "createdAt": CREATED,
+        "startTime": STARTED,
+        "duration": "PT2M22S",
+        "rowsSynced": 12_400,
+    }
+    listing_entry.update(overrides)
+    return listing_entry
+
+
+def row(**overrides) -> dict:
+    planned = plan.sync_row(entry(**overrides), CONNECTORS, TICK)
+    assert not isinstance(planned, plan.Skipped), planned
+    return planned
+
+
+class StatusKeepsTheMoversWord(unittest.TestCase):
+    def test_documented_statuses_are_stored_verbatim(self) -> None:
+        for word in sorted(vocab.MOVER_STATUSES):
+            with self.subTest(word=word):
+                self.assertEqual(row(status=word)["status"], word)
+
+    def test_an_undocumented_word_is_stored_as_unknown(self) -> None:
+        for word in ("SUCCEEDED_PARTIALLY", "", None, 7, "  "):
+            with self.subTest(word=word):
+                self.assertEqual(
+                    row(status=word)["status"],
+                    vocab.UNKNOWN,
+                    f"should not pass through: {word!r}",
+                )
+
+    def test_case_and_padding_do_not_produce_an_unknown(self) -> None:
+        self.assertEqual(row(status=" Succeeded ")["status"], "succeeded")
+
+    def test_unknown_does_not_close_a_job(self) -> None:
+        """Coverage fails closed: a status we could not read is re-read."""
+        self.assertFalse(vocab.is_terminal(vocab.UNKNOWN))
+
+    def test_an_unfinished_status_does_not_close_a_job(self) -> None:
+        for word in ("pending", "running"):
+            with self.subTest(word=word):
+                self.assertFalse(vocab.is_terminal(word))
+
+
+class AJobMustBePlaceable(unittest.TestCase):
+    def test_a_job_with_no_creation_time_is_refused(self) -> None:
+        for absent in (None, 0, -1, "yesterday", True):
+            with self.subTest(absent=absent):
+                planned = plan.sync_row(
+                    entry(createdAt=absent), CONNECTORS, TICK
+                )
+                self.assertIsInstance(
+                    planned, plan.Skipped, f"should refuse createdAt={absent!r}"
+                )
+
+    def test_a_job_with_no_identity_is_refused(self) -> None:
+        planned = plan.sync_row(entry(jobId=None), CONNECTORS, TICK)
+        self.assertIsInstance(planned, plan.Skipped)
+
+    def test_an_entry_with_no_job_is_refused(self) -> None:
+        planned = plan.sync_row({"connectionId": CONNECTION}, CONNECTORS, TICK)
+        self.assertIsInstance(planned, plan.Skipped)
+
+    def test_a_refusal_carries_its_reason(self) -> None:
+        planned = plan.sync_row(entry(createdAt=None), CONNECTORS, TICK)
+        self.assertIn("creation time", planned.reason)
+
+
+class AbsenceIsNotZero(unittest.TestCase):
+    def test_a_job_not_started_has_no_start_and_no_duration(self) -> None:
+        bare = {
+            "jobId": 1,
+            "connectionId": CONNECTION,
+            "status": "pending",
+            "createdAt": CREATED,
+        }
+        planned = plan.sync_row(bare, CONNECTORS, TICK)
+        self.assertIsNone(planned["started_at"])
+        self.assertIsNone(planned["duration_ms"])
+        self.assertIsNone(planned["records_reported"])
+
+    def test_a_reported_zero_survives_as_zero(self) -> None:
+        """A sync that moved nothing is not a sync nobody counted."""
+        self.assertEqual(row(rowsSynced=0)["records_reported"], 0)
+
+    def test_no_reported_count_at_all_is_absent(self) -> None:
+        for absent in (None, "", "many", True):
+            with self.subTest(absent=absent):
+                self.assertIsNone(row(rowsSynced=absent)["records_reported"])
+
+    def test_a_negative_count_is_absent_rather_than_recorded(self) -> None:
+        self.assertIsNone(row(rowsSynced=-1)["records_reported"])
+
+    def test_a_duration_that_will_not_parse_is_absent(self) -> None:
+        """Reading only some components would report a span shorter than the
+        truth, which is worse than reporting none."""
+        for absent in ("1m37s", "P", "", None, "PT", "garbage"):
+            with self.subTest(absent=absent):
+                self.assertIsNone(row(duration=absent)["duration_ms"])
+
+
+class WhatIsRead(unittest.TestCase):
+    def test_the_stamps_are_read_as_iso_8601(self) -> None:
+        planned = row()
+        self.assertEqual(planned["job_created_at"], "2026-08-27 08:00:00.000")
+        self.assertEqual(planned["started_at"], "2026-08-27 08:00:30.000")
+
+    def test_a_stamp_with_an_offset_is_normalised_to_utc(self) -> None:
+        planned = row(createdAt="2026-08-27T11:00:00+03:00")
+        self.assertEqual(planned["job_created_at"], "2026-08-27 08:00:00.000")
+
+    def test_an_epoch_number_is_not_a_stamp(self) -> None:
+        """The listing sends strings. A number here would be a different
+        endpoint's shape, and guessing at it would date every job to 1970."""
+        planned = plan.sync_row(entry(createdAt=1_700_000_000), CONNECTORS, TICK)
+        self.assertIsInstance(planned, plan.Skipped)
+
+    def test_the_duration_is_read_as_an_iso_8601_duration(self) -> None:
+        cases = {
+            "PT1M37S": 97_000,
+            "PT2H3M4.5S": 7_384_500,
+            "P1DT1S": 86_401_000,
+            "PT0.25S": 250,
+        }
+        for text, expected in cases.items():
+            with self.subTest(duration=text):
+                self.assertEqual(row(duration=text)["duration_ms"], expected)
+
+    def test_the_reported_count_is_read_from_the_entry(self) -> None:
+        self.assertEqual(row()["records_reported"], 12_400)
+
+
+class AJobMustBelongToAManagedConnection(unittest.TestCase):
+    def test_a_job_on_an_unmanaged_connection_is_refused(self) -> None:
+        """The listing is instance-wide, so it carries jobs this install does
+        not manage. Guessing a connector for one would file syncs on the wrong
+        row."""
+        planned = plan.sync_row(entry(connectionId="someone-else"), CONNECTORS, TICK)
+        self.assertIsInstance(planned, plan.Skipped)
+        self.assertIn("managed connection", planned.reason)
+
+    def test_a_job_with_no_connection_is_refused(self) -> None:
+        planned = plan.sync_row(entry(connectionId=None), CONNECTORS, TICK)
+        self.assertIsInstance(planned, plan.Skipped)
+
+    def test_the_connector_comes_from_the_map_not_the_name(self) -> None:
+        planned = plan.sync_row(entry(), {CONNECTION: "renamed"}, TICK)
+        self.assertEqual(planned["connector"], "renamed")
+
+
+class CoverageSkipsWhatIsClosed(unittest.TestCase):
+    def test_a_job_already_terminal_in_the_ledger_is_left_alone(self) -> None:
+        planned = plan.plan_syncs(
+            [entry()], CONNECTORS, TICK, frozenset({"8412"})
+        )
+        self.assertEqual(planned.rows, [])
+
+    def test_a_job_not_yet_closed_is_recorded_again(self) -> None:
+        planned = plan.plan_syncs([entry()], CONNECTORS, TICK, frozenset())
+        self.assertEqual(len(planned.rows), 1)
+
+    def test_refusals_are_reported_beside_the_rows(self) -> None:
+        planned = plan.plan_syncs(
+            [entry(), entry(jobId=7, createdAt=None)], CONNECTORS, TICK, frozenset()
+        )
+        self.assertEqual(len(planned.rows), 1)
+        self.assertEqual(len(planned.skipped), 1)
+        self.assertEqual(planned.skipped[0].job_id, "7")
+
+
+class EveryRowClassFillsEveryColumn(unittest.TestCase):
+    """The insert names no columns, so a row missing one would silently take a
+    DEFAULT — and a row carrying an extra one would be rejected outright."""
+
+    def test_the_three_classes_agree_on_their_columns(self) -> None:
+        sync = row()
+        snapshot = plan.plan_snapshot([CONNECTOR], TICK)[0]
+        seal = plan.plan_seal(TICK)
+        self.assertEqual(set(snapshot), set(sync))
+        self.assertEqual(set(seal), set(sync))
+
+    def test_a_snapshot_row_names_its_connector_and_nothing_else(self) -> None:
+        snapshot = plan.plan_snapshot([CONNECTOR], TICK)[0]
+        self.assertEqual(snapshot["connector"], CONNECTOR)
+        self.assertEqual(snapshot["event"], plan.CONNECTOR_CONFIGURED)
+        self.assertEqual(snapshot["job_id"], "")
+        self.assertEqual(snapshot["status"], "")
+        self.assertIsNone(snapshot["job_created_at"])
+
+    def test_the_seal_names_no_connector(self) -> None:
+        seal = plan.plan_seal(TICK)
+        self.assertEqual(seal["event"], plan.SWEEP_COMPLETED)
+        self.assertEqual(seal["connector"], "")
+        self.assertEqual(seal["tick_id"], TICK)
+
+    def test_a_snapshot_holds_each_connector_once(self) -> None:
+        rows = plan.plan_snapshot([CONNECTOR, CONNECTOR, "other"], TICK)
+        self.assertEqual([r["connector"] for r in rows], ["example-tracker", "other"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
@@ -126,6 +126,22 @@ class AbsenceIsNotZero(unittest.TestCase):
     def test_a_negative_count_is_absent_rather_than_recorded(self) -> None:
         self.assertIsNone(row(rowsSynced=-1)["records_reported"])
 
+    def test_a_non_finite_number_is_absent_rather_than_an_exception(self) -> None:
+        """`int(inf)` raises, and one malformed field would cost the whole tick
+        its seal — which stops the page's own clock."""
+        for absent in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(absent=absent):
+                self.assertIsNone(row(duration=absent)["duration_ms"])
+                self.assertIsNone(row(rowsSynced=absent)["records_reported"])
+
+    def test_an_empty_job_identity_is_refused(self) -> None:
+        """Several such jobs would share one key and replace each other during
+        resolution, so the page would answer with whichever landed last."""
+        for empty in ("", "   "):
+            with self.subTest(empty=empty):
+                planned = plan.sync_row(entry(jobId=empty), CONNECTORS, TICK)
+                self.assertIsInstance(planned, plan.Skipped)
+
     def test_a_duration_that_will_not_parse_is_absent(self) -> None:
         """Reading only some components would report a span shorter than the
         truth, which is worse than reporting none."""

--- a/src/ingestion/scripts/bootstrap-db/presentation-role.sql
+++ b/src/ingestion/scripts/bootstrap-db/presentation-role.sql
@@ -1,6 +1,7 @@
 -- presentation_ro: read-only-by-construction role for the presentation query
 -- path (#1963). Contract = SELECT only; `presentation` = SELECT/INSERT/CREATE;
--- `product_usage` = SELECT/INSERT only, its DDL owned by a migration;
+-- `product_usage` = SELECT/INSERT only, `ingestion_history` = SELECT only,
+-- both with DDL owned by a migration;
 -- no DROP/ALTER/TRUNCATE anywhere. Idempotent. Needs an admin with
 -- access_management (compose/e2e/bitnami already have it; see README.md).
 -- Spec: docs/domain/presentation-layer/specs.
@@ -22,3 +23,11 @@ GRANT SELECT, INSERT, CREATE ON presentation.* TO presentation_ro;
 -- admin-gated usage summary; analytics checks the admin role itself for reads
 -- of this database that arrive by any other route.
 GRANT SELECT, INSERT ON product_usage.* TO presentation_ro;
+
+-- ingestion_history (read-only): connector sync history. The writer is the
+-- reconcile loop, which authenticates as the ingestion admin, so this role
+-- takes SELECT and nothing else — not INSERT, not CREATE. Its DDL comes from
+-- migrations/20260827000000_connector-sync-history.sql. The grant lands before
+-- the database exists on a fresh install (apply-ch-migrations.sh provisions the
+-- role first); ClickHouse grants by name, so that ordering is fine.
+GRANT SELECT ON ingestion_history.* TO presentation_ro;

--- a/src/ingestion/scripts/migrations/20260827000000_connector-sync-history.sql
+++ b/src/ingestion/scripts/migrations/20260827000000_connector-sync-history.sql
@@ -8,8 +8,8 @@
 -- defined value on every class — see the design's domain model. Columns are
 -- nullable only where "nobody measured" and "measured zero" are different
 -- answers; `job_created_at` is nullable because snapshot rows are not about a
--- job at all, and is never NULL on a sync row (the summary resolves with
--- argMax over it, and argMax ignores NULL value arguments).
+-- job at all, and is never NULL on a sync row — the read surface orders jobs
+-- along it, and a row without it cannot be placed among them.
 --
 -- Spec: docs/components/backend/analytics/specs/connector-health.
 

--- a/src/ingestion/scripts/migrations/20260827000000_connector-sync-history.sql
+++ b/src/ingestion/scripts/migrations/20260827000000_connector-sync-history.sql
@@ -1,0 +1,33 @@
+-- Connector sync history: what the data mover reports about every sync, copied
+-- by the reconcile sweep so the record outlives the mover's own job retention
+-- (a deleted connection takes its job history with it). Its own database:
+-- `presentation` is swept by metric exports and customer extracts, which must
+-- never carry service rows.
+--
+-- Three row classes share the table, told apart by `event`. Every column has a
+-- defined value on every class — see the design's domain model. Columns are
+-- nullable only where "nobody measured" and "measured zero" are different
+-- answers; `job_created_at` is nullable because snapshot rows are not about a
+-- job at all, and is never NULL on a sync row (the summary resolves with
+-- argMax over it, and argMax ignores NULL value arguments).
+--
+-- Spec: docs/components/backend/analytics/specs/connector-health.
+
+CREATE DATABASE IF NOT EXISTS ingestion_history;
+
+CREATE TABLE IF NOT EXISTS ingestion_history.sync_events (
+    event_id         UUID DEFAULT generateUUIDv4(),
+    ts               DateTime64(3, 'UTC') DEFAULT now64(3),
+    tick_id          String,
+    job_id           String,
+    connector        LowCardinality(String),
+    event            LowCardinality(String),
+    status           LowCardinality(String),
+    started_at       Nullable(DateTime64(3, 'UTC')),
+    job_created_at   Nullable(DateTime64(3, 'UTC')),
+    duration_ms      Nullable(UInt64),
+    records_reported Nullable(UInt64)
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(ts)
+ORDER BY (event, connector, ts, event_id)
+TTL toDateTime(ts) + INTERVAL 6 MONTH;

--- a/src/ingestion/scripts/tests/test_ledger_grants.py
+++ b/src/ingestion/scripts/tests/test_ledger_grants.py
@@ -10,6 +10,11 @@ pins. What must hold here is narrower and absolute: on the ledger the query path
 reads and nothing more. Its writer is the reconcile loop, under different
 credentials entirely, so a write grant here would be a grant nothing uses — and
 the surface reporting on ingestion could edit its own evidence.
+
+Read as STATEMENTS, not lines. A guard that greps for lines both starting with
+`GRANT` and naming the database is blind to three ways in, each of which leaves
+such a guard green: a wildcard (`GRANT ALL ON *.*`), a grant split across two
+lines, and a grant of some other role that itself carries writes.
 """
 
 from __future__ import annotations
@@ -34,36 +39,88 @@ WRITE_PRIVILEGES = (
     "ALL",
 )
 
+#: Objects a grant can name that reach the ledger. Upper-cased, because the
+#: statements are: a case mismatch here would make every check below match
+#: nothing and pass without asserting anything.
+LEDGER_OBJECTS = (
+    f"{LEDGER_DB.upper()}.*",
+    f"{LEDGER_DB.upper()}.SYNC_EVENTS",
+    "*.*",
+)
 
-def ledger_grants() -> list[str]:
-    """Every GRANT statement that names the ledger database."""
-    text = ROLE_SQL.read_text()
-    return [
-        " ".join(line.split())
-        for line in text.splitlines()
-        if line.strip().upper().startswith("GRANT") and LEDGER_DB in line
+
+def statements() -> list[str]:
+    """The file as statements: comments dropped, whitespace collapsed, upper-cased."""
+    lines = [
+        line for line in ROLE_SQL.read_text().splitlines() if not line.strip().startswith("--")
     ]
+    body = " ".join(lines)
+    return [" ".join(part.split()).upper() for part in body.split(";") if part.strip()]
+
+
+def grants() -> list[str]:
+    return [stmt for stmt in statements() if stmt.startswith("GRANT ")]
+
+
+def _privileges_and_object(grant: str) -> tuple[str, str] | None:
+    """`GRANT SELECT ON db.* TO role` -> `("SELECT", "DB.*")`; None for a role grant."""
+    if " ON " not in grant:
+        return None
+    head, _, tail = grant.partition(" ON ")
+    obj = tail.split(" TO ")[0].strip()
+    return head[len("GRANT ") :].strip(), obj
 
 
 def test_the_reader_is_granted_select_on_the_ledger() -> None:
-    grants = ledger_grants()
+    reaching = [
+        grant
+        for grant in grants()
+        if (parsed := _privileges_and_object(grant))
+        and parsed[1] == f"{LEDGER_DB.upper()}.*"
+        and READER_ROLE.upper() in grant
+    ]
 
-    assert grants, f"{ROLE_SQL.name} grants the reader nothing on {LEDGER_DB}"
-    assert any(
-        "SELECT" in grant.upper() and READER_ROLE in grant for grant in grants
-    ), f"the read surface cannot read the ledger: {grants}"
+    assert reaching, f"{ROLE_SQL.name} grants the reader nothing on {LEDGER_DB}"
+    assert any("SELECT" in grant for grant in reaching), reaching
 
 
-def test_the_reader_is_granted_nothing_that_writes() -> None:
-    for grant in ledger_grants():
-        privileges = grant.upper().split(" ON ", 1)[0]
+def test_nothing_that_writes_the_ledger_is_granted_to_the_reader() -> None:
+    """Covers the wildcard and the multi-line spellings as well as the plain one."""
+    for grant in grants():
+        parsed = _privileges_and_object(grant)
+        if parsed is None:
+            continue
+        privileges, obj = parsed
+        if obj not in LEDGER_OBJECTS or READER_ROLE.upper() not in grant:
+            continue
         for write in WRITE_PRIVILEGES:
             assert write not in privileges, (
-                f"the query path must not be able to change what it reports on: "
-                f"{grant}"
+                f"the query path must not be able to change what it reports on: {grant}"
             )
 
 
-def test_the_ledger_database_is_named_exactly_once() -> None:
-    """A second grant is how a write slips in beside a legitimate read."""
-    assert len(ledger_grants()) == 1, ledger_grants()
+def test_the_reader_carries_no_other_role() -> None:
+    """A role grant names no database, so a guard reading objects cannot see it —
+    and whatever that role carries, the reader carries too."""
+    for grant in grants():
+        if _privileges_and_object(grant) is not None:
+            continue
+        assert READER_ROLE.upper() not in grant, (
+            f"the reader must hold only its own grants: {grant}"
+        )
+
+
+def test_nothing_revokes_the_reader_s_own_access() -> None:
+    """A REVOKE after the grant breaks the page without failing any grant check."""
+    for stmt in statements():
+        assert not stmt.startswith("REVOKE "), f"unexpected REVOKE: {stmt}"
+
+
+def test_the_ledger_is_granted_in_exactly_one_statement() -> None:
+    """A second statement is how a write slips in beside a legitimate read."""
+    reaching = [
+        grant
+        for grant in grants()
+        if (parsed := _privileges_and_object(grant)) and parsed[1] in LEDGER_OBJECTS
+    ]
+    assert len(reaching) == 1, reaching

--- a/src/ingestion/scripts/tests/test_ledger_grants.py
+++ b/src/ingestion/scripts/tests/test_ledger_grants.py
@@ -1,0 +1,69 @@
+"""The sync ledger's grant surface, asserted from the role definition's text.
+
+The adversarial role test next door needs a live ClickHouse and skips without
+one, so it never runs in CI. This reads the SQL instead: no server, no skip, and
+it fails the moment the ledger hands the query-path role a write.
+
+The role is not read-only in general — `presentation` is create/insert-only for
+it and `product_usage` is insert-only, both of which `test_presentation_role.py`
+pins. What must hold here is narrower and absolute: on the ledger the query path
+reads and nothing more. Its writer is the reconcile loop, under different
+credentials entirely, so a write grant here would be a grant nothing uses — and
+the surface reporting on ingestion could edit its own evidence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+BOOTSTRAP = Path(__file__).resolve().parents[1] / "bootstrap-db"
+ROLE_SQL = BOOTSTRAP / "presentation-role.sql"
+LEDGER_DB = "ingestion_history"
+READER_ROLE = "presentation_ro"
+
+#: Anything that could change a recorded fact. The ledger is append-only and the
+#: read surface is a reader; either half failing makes the page a liar.
+WRITE_PRIVILEGES = (
+    "INSERT",
+    "ALTER",
+    "DROP",
+    "TRUNCATE",
+    "DELETE",
+    "UPDATE",
+    "CREATE",
+    "ALL",
+)
+
+
+def ledger_grants() -> list[str]:
+    """Every GRANT statement that names the ledger database."""
+    text = ROLE_SQL.read_text()
+    return [
+        " ".join(line.split())
+        for line in text.splitlines()
+        if line.strip().upper().startswith("GRANT") and LEDGER_DB in line
+    ]
+
+
+def test_the_reader_is_granted_select_on_the_ledger() -> None:
+    grants = ledger_grants()
+
+    assert grants, f"{ROLE_SQL.name} grants the reader nothing on {LEDGER_DB}"
+    assert any(
+        "SELECT" in grant.upper() and READER_ROLE in grant for grant in grants
+    ), f"the read surface cannot read the ledger: {grants}"
+
+
+def test_the_reader_is_granted_nothing_that_writes() -> None:
+    for grant in ledger_grants():
+        privileges = grant.upper().split(" ON ", 1)[0]
+        for write in WRITE_PRIVILEGES:
+            assert write not in privileges, (
+                f"the query path must not be able to change what it reports on: "
+                f"{grant}"
+            )
+
+
+def test_the_ledger_database_is_named_exactly_once() -> None:
+    """A second grant is how a write slips in beside a legitimate read."""
+    assert len(ledger_grants()) == 1, ledger_grants()

--- a/src/ingestion/scripts/tests/test_presentation_role.py
+++ b/src/ingestion/scripts/tests/test_presentation_role.py
@@ -49,6 +49,10 @@ CONTRACT_DBS = ("silver", "person", "identity", "insight")
 # Append-only: SELECT + INSERT, but no CREATE — its DDL comes from migrations.
 USAGE_DB = "product_usage"
 
+# Read-only: SELECT and nothing else. Its writer is the reconcile loop, which
+# authenticates as the ingestion admin, so the query path never needs INSERT.
+HISTORY_DB = "ingestion_history"
+
 PROBE_USER = "pres_role_probe"
 PROBE_PASSWORD = "probe"
 
@@ -100,7 +104,7 @@ def _apply(path: Path) -> None:
 def probe():
     """Provision the contract + presentation objects and a probe user carrying
     only the presentation_ro role. Torn down afterwards."""
-    for db in (*CONTRACT_DBS, "presentation", USAGE_DB):
+    for db in (*CONTRACT_DBS, "presentation", USAGE_DB, HISTORY_DB):
         assert _admin(f"CREATE DATABASE IF NOT EXISTS {db}")[0]
     for db in CONTRACT_DBS:
         assert _admin(f"CREATE TABLE IF NOT EXISTS {db}.probe (x UInt8) ENGINE=MergeTree ORDER BY x")[0]
@@ -118,6 +122,7 @@ def probe():
     finally:
         _admin("DROP TABLE IF EXISTS presentation.scratch")
         _admin(f"DROP TABLE IF EXISTS {USAGE_DB}.probe")
+        _admin(f"DROP TABLE IF EXISTS {HISTORY_DB}.probe")
         for db in CONTRACT_DBS:
             _admin(f"DROP TABLE IF EXISTS {db}.probe")
         _admin(f"DROP USER IF EXISTS {PROBE_USER}")
@@ -179,6 +184,31 @@ def test_usage_is_append_only(probe) -> None:
         assert "ACCESS_DENIED" in resp, resp
 
 
+def test_sync_history_is_read_only(probe) -> None:
+    """SELECT allowed in ingestion_history; INSERT denied along with the rest.
+
+    The distinction from `product_usage`: adoption events are written by the
+    same service that serves them, so that database needs INSERT. Sync history
+    is written by the reconcile loop under different credentials entirely, so a
+    grant letting the query path write here would be a grant nothing uses — and
+    the surface reporting on ingestion could edit its own evidence.
+    """
+    assert _admin(
+        f"CREATE TABLE IF NOT EXISTS {HISTORY_DB}.probe (x UInt8) ENGINE=MergeTree ORDER BY x"
+    )[0]
+    assert probe(f"SELECT sum(x) FROM {HISTORY_DB}.probe")[0], "history SELECT must be allowed"
+    for sql in (
+        f"INSERT INTO {HISTORY_DB}.probe VALUES (7)",
+        f"CREATE TABLE {HISTORY_DB}.made_up (x UInt8) ENGINE=MergeTree ORDER BY x",
+        f"DROP TABLE {HISTORY_DB}.probe",
+        f"TRUNCATE TABLE {HISTORY_DB}.probe",
+        f"ALTER TABLE {HISTORY_DB}.probe ADD COLUMN y UInt8",
+    ):
+        ok, resp = probe(sql)
+        assert not ok, f"{HISTORY_DB} must reject: {sql!r}"
+        assert "ACCESS_DENIED" in resp, resp
+
+
 # ── #1964: the persistent grant-less `presentation` user, provisioned by the
 #    real provision-presentation-access.sh (not a throwaway probe) ──
 
@@ -192,7 +222,7 @@ def presentation_user():
     if not (shutil.which("bash") and shutil.which("curl")):
         pytest.skip("provision-presentation-access.sh needs bash + curl")
 
-    for db in (*CONTRACT_DBS, "presentation", USAGE_DB):
+    for db in (*CONTRACT_DBS, "presentation", USAGE_DB, HISTORY_DB):
         assert _admin(f"CREATE DATABASE IF NOT EXISTS {db}")[0]
     for db in CONTRACT_DBS:
         assert _admin(f"CREATE TABLE IF NOT EXISTS {db}.probe (x UInt8) ENGINE=MergeTree ORDER BY x")[0]

--- a/tests/lib/insight_stand/coverage.py
+++ b/tests/lib/insight_stand/coverage.py
@@ -146,6 +146,14 @@ BLOCKED: dict[str, frozenset[int]] = {
     # `test_usage.py` covers them rather than blocking them.
     "GET /v1/usage/config": frozenset({400, 403, 404, 409}),
     "GET /v1/usage/summary": frozenset({404, 409}),
+    # Connector health. Neither read addresses a row — an unknown connector is
+    # an empty window, not a not-found — so neither has a 404 or a conflict
+    # path. The summary subtracts 400 as well: it takes no input at all, so
+    # there is nothing about the request to reject. The per-connector window
+    # does have a 400 (a name its parser refuses) and both have a 403, and
+    # `test_connector_health.py` covers those rather than blocking them.
+    "GET /v1/connector-health": frozenset({400, 404, 409}),
+    "GET /v1/connector-health/{connector}/syncs": frozenset({404, 409}),
 }
 
 

--- a/tests/stand/api/analytics/test_connector_health.py
+++ b/tests/stand/api/analytics/test_connector_health.py
@@ -1,0 +1,172 @@
+"""The `/v1/connector-health` pair on analytics — what each connector recorded.
+
+    GET /v1/connector-health                     200 admin · 403 everybody else
+    GET /v1/connector-health/{connector}/syncs   200 admin · 403 everybody else
+
+Both are `.authenticated()` at the edge with the operator gate inside the
+handler, the same shape `/v1/usage/summary` and the feedback listing use, so the
+gateway sees two ordinary authenticated routes and the refusal is only
+observable with a session.
+
+The read is instance-wide on purpose: the schemas it reports on are not
+partitioned by tenant, so there is no tenant-scoped variant to fall back to and
+a non-admin is refused outright rather than served a narrowed view.
+
+What this module does NOT assert is any figure. A compose stand runs no data
+mover, so nothing writes the ledger there and every count is legitimately
+absent; asserting one would pin the suite to a stand that happened to have been
+seeded. What holds on any stand is the shape, the gate, and the two honesty
+properties the page turns on — that an empty ledger says so instead of implying
+health, and that an unknown connector is an empty window rather than an error.
+
+The 401 half is in `test_gateway.py`, swept over every operation at once.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_stand import PersonaSession, analytics_path
+
+from ..operations import SOME_CONNECTOR
+from ..schemas import ConnectorHealthResponse, ProblemDocument, SyncHistoryResponse
+
+SUMMARY = analytics_path("/v1/connector-health")
+
+
+def _syncs(connector: str) -> str:
+    return analytics_path(f"/v1/connector-health/{connector}/syncs")
+
+
+@pytest.fixture(scope="module")
+def summary(admin_operator_session: PersonaSession) -> ConnectorHealthResponse:
+    """Read the summary once: it is instance-wide, so every test sees the same
+    answer and none of them races another into writing one."""
+    response = admin_operator_session.client.get(SUMMARY)
+    assert response.status_code == 200, (
+        f"summary answered {response.status_code}: {response.text[:300]}"
+    )
+    return response.parse(ConnectorHealthResponse)
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.reliability
+def test_the_summary_validates_against_the_published_contract(
+    summary: ConnectorHealthResponse,
+) -> None:
+    """A contract test, not a data test.
+
+    `extra="forbid"` on the generated model means an undeclared field fails
+    here, which is the drift worth catching: the page is written against the
+    contract and the service is what actually serializes.
+    """
+    assert summary.as_of, "the answer must date itself even with nothing recorded"
+    for row in summary.connectors:
+        assert row.connector, "a row with no connector names nothing"
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.reliability
+def test_an_unrecorded_install_says_so_rather_than_implying_health(
+    summary: ConnectorHealthResponse,
+) -> None:
+    """A compose stand runs no mover, so this is the state it is actually in.
+
+    The two fields have to agree: claiming history while naming no moment the
+    mover was read would let the page present a picture nothing produced.
+    """
+    if summary.history_available:
+        assert summary.checked_at is not None, (
+            "history is claimed but no read is dated — the page would present "
+            "facts it cannot place in time"
+        )
+        return
+
+    assert summary.checked_at is None
+    assert summary.typical_read_interval_ms is None, (
+        "an interval measured from no reads is not a measurement"
+    )
+    assert summary.connectors == [], (
+        "no history recorded, yet connectors are reported: "
+        f"{[row.connector for row in summary.connectors]}"
+    )
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.reliability
+def test_an_unknown_connector_is_an_empty_window_not_an_error(
+    admin_operator_session: PersonaSession,
+) -> None:
+    """Asking about a connector with no recorded sync is a normal question.
+
+    Answering 404 would make the page's own drill-down look broken on a
+    connector that simply has not synced yet.
+    """
+    response = admin_operator_session.client.get(_syncs(SOME_CONNECTOR))
+    assert response.status_code == 200, (
+        f"answered {response.status_code}: {response.text[:300]}"
+    )
+    window = response.parse(SyncHistoryResponse)
+    assert window.connector == SOME_CONNECTOR
+    assert window.syncs == []
+    assert window.window > 0, "the page needs the window's size to say it is one"
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.reliability
+def test_a_name_the_route_cannot_parse_is_refused_as_a_bad_request(
+    admin_operator_session: PersonaSession,
+) -> None:
+    """`404` would say the connector does not exist; it says the name is unusable.
+
+    The distinction matters to whoever reads the refusal: one sends them looking
+    for a missing connector, the other tells them the link is wrong.
+    """
+    response = admin_operator_session.client.get(_syncs("Not_A_Name"))
+    assert response.status_code == 400, (
+        f"answered {response.status_code}: {response.text[:300]}"
+    )
+    problem = response.parse(ProblemDocument)
+    assert problem.status == 400
+
+
+@pytest.mark.reliability
+def test_a_lead_is_refused_both_surfaces(lead_session: PersonaSession) -> None:
+    """An ordinary authenticated caller, not an anonymous one.
+
+    The gate is inside the handler, so this is the only place it is observable —
+    the edge admits the request and the refusal comes from the role check.
+    """
+    for path in (SUMMARY, _syncs(SOME_CONNECTOR)):
+        response = lead_session.client.get(path)
+        assert response.status_code == 403, (
+            f"{path} answered {response.status_code} for a lead: {response.text[:300]}"
+        )
+        assert response.parse(ProblemDocument).status == 403
+
+
+@pytest.mark.reliability
+def test_a_realm_admin_without_the_operator_row_is_still_refused(
+    realm_admin_session: PersonaSession,
+) -> None:
+    """The gate reads an active `admin` row, not the realm role.
+
+    Worth its own case: a senior person's view of the organisation is not
+    administrative authority over the install, and a gate that accepted the
+    realm role would pass every other test here.
+    """
+    response = realm_admin_session.client.get(SUMMARY)
+    assert response.status_code == 403, (
+        f"answered {response.status_code}: {response.text[:300]}"
+    )
+
+
+@pytest.mark.reliability
+def test_a_caller_from_another_tenant_is_refused(
+    other_tenant_session: PersonaSession,
+) -> None:
+    """The surface is instance-wide, so there is no narrowed view to fall back
+    to — a caller outside this install's operator role gets nothing."""
+    response = other_tenant_session.client.get(SUMMARY)
+    assert response.status_code == 403, (
+        f"answered {response.status_code}: {response.text[:300]}"
+    )

--- a/tests/stand/api/analytics/test_connector_health.py
+++ b/tests/stand/api/analytics/test_connector_health.py
@@ -1,7 +1,8 @@
 """The `/v1/connector-health` pair on analytics — what each connector recorded.
 
     GET /v1/connector-health                     200 admin · 403 everybody else
-    GET /v1/connector-health/{connector}/syncs   200 admin · 403 everybody else
+    GET /v1/connector-health/{connector}/syncs   200 admin · 400 unparseable name ·
+                                                 403 everybody else
 
 Both are `.authenticated()` at the edge with the operator gate inside the
 handler, the same shape `/v1/usage/summary` and the feedback listing use, so the
@@ -129,7 +130,7 @@ def test_a_name_the_route_cannot_parse_is_refused_as_a_bad_request(
     assert problem.status == 400
 
 
-@pytest.mark.reliability
+@pytest.mark.security
 def test_a_lead_is_refused_both_surfaces(lead_session: PersonaSession) -> None:
     """An ordinary authenticated caller, not an anonymous one.
 
@@ -144,7 +145,7 @@ def test_a_lead_is_refused_both_surfaces(lead_session: PersonaSession) -> None:
         assert response.parse(ProblemDocument).status == 403
 
 
-@pytest.mark.reliability
+@pytest.mark.security
 def test_a_realm_admin_without_the_operator_row_is_still_refused(
     realm_admin_session: PersonaSession,
 ) -> None:
@@ -160,7 +161,8 @@ def test_a_realm_admin_without_the_operator_row_is_still_refused(
     )
 
 
-@pytest.mark.reliability
+@pytest.mark.requires_seed("other_tenant_lead")
+@pytest.mark.security
 def test_a_caller_from_another_tenant_is_refused(
     other_tenant_session: PersonaSession,
 ) -> None:

--- a/tests/stand/api/operations.py
+++ b/tests/stand/api/operations.py
@@ -35,6 +35,12 @@ SOME_ID: Final[str] = "01900000-0000-7000-8000-000000000000"
 #: string, not a UUID, so it needs its own recognisable value.
 SOME_ACCOUNT_ID: Final[str] = "stand-in-account"
 
+#: Stand-in for `{connector}`, which is a hyphenated descriptor name. Hyphenated
+#: on purpose: the route's own parser accepts lowercase letters, digits and
+#: hyphens and refuses anything else, so a stand-in outside that shape would be
+#: refused before the gate under test was reached.
+SOME_CONNECTOR: Final[str] = "stand-in-connector"
+
 #: Stand-in for `{metric_key}`, which is a dotted `family.name` string rather
 #: than a UUID. Kept a DOTTED key on purpose: the literal `export`/`import`
 #: segments of the sibling routes must not collide with it, so the template
@@ -49,6 +55,7 @@ _PARAMETERS: Final[dict[str, str]] = {
     SOME_ID: "{id}",
     SOME_METRIC_KEY: "{metric_key}",
     SOME_ACCOUNT_ID: "{account_id}",
+    SOME_CONNECTOR: "{connector}",
 }
 
 
@@ -128,6 +135,11 @@ ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     # invisible here and asserted in test_feedback.py.
     _a("POST", "/v1/feedback"),
     _a("GET", "/v1/feedback"),
+    # Connector health. Both are `.authenticated()` at the edge with the
+    # operator gate inside the handler, so the refusal is invisible here and
+    # asserted in test_connector_health.py.
+    _a("GET", "/v1/connector-health"),
+    _a("GET", f"/v1/connector-health/{SOME_CONNECTOR}/syncs"),
 )
 
 #: identity-resolution — 26 operations. `/health` and `/healthz` are the host

--- a/tests/stand/api/schemas/__init__.py
+++ b/tests/stand/api/schemas/__init__.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from .analytics import (
+    ConnectorHealthResponse,
     CustomMetric,
     CustomMetricInput,
     CustomMetricListResponse,
@@ -54,6 +55,7 @@ from .analytics import (
     RunResponse,
     SavedQuery,
     SavedQueryListResponse,
+    SyncHistoryResponse,
     UsageConfigResponse,
     UsageSummaryResponse,
 )
@@ -127,6 +129,7 @@ __all__: Sequence[str] = (
     "AccountBindingResponse",
     "AccountSearchResponse",
     "AttentionResponse",
+    "ConnectorHealthResponse",
     "CorrectionResponse",
     "CustomMetric",
     "CustomMetricInput",
@@ -158,6 +161,7 @@ __all__: Sequence[str] = (
     "Subchart",
     "SubchartForest",
     "SubchartNode",
+    "SyncHistoryResponse",
     "SyncOperationList",
     "UsageConfigResponse",
     "UsageSummaryResponse",

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -826,6 +826,26 @@ class SnapshotSeries(BaseModel):
     points: list[float | None] = Field(..., description='Readings per bucket, oldest first; a gap is null.')
 
 
+class SyncFact(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    duration_ms: int | None = Field(None, description='Absent for a job still in flight, and for one the mover gave no usable\npair of stamps for. Never zero to mean absent.', ge=0)
+    job_id: str = Field(..., description="The mover's own job identity.")
+    records_reported: int | None = Field(None, description='What the mover states it moved. Absent where it reported no count at\nall, which is a different answer from a reported zero.', ge=0)
+    started_at: str | None = Field(None, description='Absent for a job the mover had not started.')
+    status: str = Field(..., description="The mover's own word for how the sync ended, or `unknown` where the\nrecorded word was outside its documented vocabulary.")
+
+
+class SyncHistoryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    connector: str
+    syncs: list[SyncFact] = Field(..., description='A bounded window, newest first — not the full retained history.')
+    window: int = Field(..., description='How many rows this window holds at most, so the page can say the list\nis a window rather than everything.', ge=0)
+
+
 class TelemetryRecord(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
@@ -960,6 +980,26 @@ class BreakdownValueDto(BaseModel):
     dimensions: list[MetricDimensionDto]
     entity_id: str
     value: float | None = None
+
+
+class ConnectorHealth(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    configured: bool = Field(..., description='Present in the newest sealed snapshot of the set the controller manages.')
+    connector: str
+    last_sync: SyncFact | None = None
+
+
+class ConnectorHealthResponse(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    as_of: str = Field(..., description='When this answer was computed. Dates the answer; `checked_at` dates the\nfacts in it.')
+    checked_at: str | None = Field(None, description='When the mover was last read. Absent before the first sweep sealed.')
+    connectors: list[ConnectorHealth]
+    history_available: bool = Field(..., description='False when nothing has been recorded at all, so the page can say so\ninstead of implying health.')
+    typical_read_interval_ms: int | None = Field(None, description='The median gap between the recent sealed ticks. Measured, not\nconfigured — nothing on this path knows what cadence was intended.\nAbsent where too few ticks are recorded to establish one.', ge=0)
 
 
 class ContextEntryResponse(BaseModel):


### PR DESCRIPTION
**Why.** Nothing reported whether ingestion was working: the pane named *Data health* counted schema-check statuses of metric definitions, so a connector that quietly stopped looked identical to one never configured.

**What changed.** The reconcile tick copies the data mover's own job listing into `ingestion_history.sync_events`; two operator-gated routes serve one page from that table alone, so it answers while the mover is down.

![Connector health](https://raw.githubusercontent.com/constructorfabric/insight/pr-2903-assets/connector-health.png)

One row per state the page can tell apart, and the two distinctions it exists for: `0` records is a measured zero, `—` is nobody measured. Mock data — the banner is the app's own.

**Out of scope, with reasons in the PRD.** Whether a sync's data reached storage, transform outcome, what triggered a sync, per-stream volume, freshness verdicts, and alerting ([#723](https://github.com/constructorfabric/insight/issues/723), [#744](https://github.com/constructorfabric/insight/issues/744)).

**Verified.** 698 analytics tests incl. live-ClickHouse, 60 sweep tests, 2261 frontend, all gates green. Summary read measured at 5 MiB / 42 ms over two million recorded syncs. Six review passes acted on; each fix pinned and checked by mutation. **Not verified:** the page against a real stand — the shot above is mock mode.
