### PR TITLE
fix(jira): name the work item in Jira task evidence rows

### DIFF
--- a/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
@@ -22,7 +22,12 @@ name: jira
 # event_kind gains the 'availability' and 'lifecycle' values — and per
 # ADR-0015 a major bump dispatches the one-shot sync with dbt --full-refresh
 # that rebuilds those tables; no ALTER migrations are shipped.
-version: "4.0.0"
+# 5.0.0 (major): jira-enrich carries the issue summary into the class contract's
+# `title`, so task evidence rows can name the work item. MAJOR because the fix
+# only reaches rows the binary writes, and it skips any issue that already has
+# them — the deploy hook empties the staging table and the one-shot sync a major
+# dispatches is what re-bootstraps every issue with its summary (#2738).
+version: "5.0.0"
 schedule: "0 3 * * *"
 workflow: sync
 # CI build metadata + runtime image refs (ADR-0016). The `images:` block is

--- a/src/ingestion/connectors/task-tracking/jira/enrich/src/core/mod.rs
+++ b/src/ingestion/connectors/task-tracking/jira/enrich/src/core/mod.rs
@@ -22,7 +22,7 @@ pub fn process_issue(
 ) -> Vec<FieldHistoryRecord> {
     match existing {
         None => bootstrap(meta, snapshot, events_sorted),
-        Some(existing_state) => incremental(meta, events_sorted, existing_state),
+        Some(existing_state) => incremental(meta, snapshot, events_sorted, existing_state),
     }
 }
 
@@ -94,7 +94,12 @@ fn bootstrap(
         };
         let prev = state.remove(&ev.field_id).unwrap_or_else(FieldValue::empty);
         let next = apply_delta(prev, &ev.delta, field_meta.cardinality);
-        out.push(emit_changelog_row(ev, field_meta, &next));
+        out.push(emit_changelog_row(
+            ev,
+            field_meta,
+            snapshot.title.as_deref(),
+            &next,
+        ));
         state.insert(ev.field_id.clone(), next);
     }
 
@@ -105,6 +110,7 @@ fn bootstrap(
 /// are already in silver from a prior bootstrap). Only forward-apply new events.
 fn incremental(
     meta: &HashMap<FieldId, FieldMeta>,
+    snapshot: &IssueSnapshot,
     events_sorted: &[DeltaEvent],
     existing: &HashMap<FieldId, LastState>,
 ) -> Vec<FieldHistoryRecord> {
@@ -130,7 +136,12 @@ fn incremental(
         };
         let prev = state.remove(&ev.field_id).unwrap_or_else(FieldValue::empty);
         let next = apply_delta(prev, &ev.delta, field_meta.cardinality);
-        out.push(emit_changelog_row(ev, field_meta, &next));
+        out.push(emit_changelog_row(
+            ev,
+            field_meta,
+            snapshot.title.as_deref(),
+            &next,
+        ));
         state.insert(ev.field_id.clone(), next);
     }
 
@@ -272,6 +283,7 @@ fn emit_creation_row(snapshot: &IssueSnapshot) -> FieldHistoryRecord {
         data_source: DataSource::Jira,
         issue_id: snapshot.issue_id.clone(),
         id_readable: snapshot.id_readable.clone(),
+        title: snapshot.title.clone(),
         event_id: synthetic_initial_event_id(&snapshot.issue_id),
         event_at: snapshot.created_at,
         event_kind: EventKind::SyntheticInitial,
@@ -304,6 +316,7 @@ fn emit_synthetic_initial_row(
         data_source: DataSource::Jira,
         issue_id: snapshot.issue_id.clone(),
         id_readable: snapshot.id_readable.clone(),
+        title: snapshot.title.clone(),
         event_id: synthetic_initial_event_id(&snapshot.issue_id),
         event_at: snapshot.created_at,
         event_kind: EventKind::SyntheticInitial,
@@ -328,6 +341,7 @@ fn emit_synthetic_initial_row(
 fn emit_changelog_row(
     ev: &DeltaEvent,
     meta: &FieldMeta,
+    title: Option<&str>,
     state_after: &FieldValue,
 ) -> FieldHistoryRecord {
     let (delta_action, delta_value_id, delta_value_display) = match &ev.delta {
@@ -352,6 +366,7 @@ fn emit_changelog_row(
         data_source: DataSource::Jira,
         issue_id: ev.issue_id.clone(),
         id_readable: ev.id_readable.clone(),
+        title: title.map(str::to_owned),
         event_id: ev.event_id.clone(),
         event_at: ev.event_at,
         event_kind: EventKind::Changelog,

--- a/src/ingestion/connectors/task-tracking/jira/enrich/src/core/tests.rs
+++ b/src/ingestion/connectors/task-tracking/jira/enrich/src/core/tests.rs
@@ -74,6 +74,7 @@ fn snap(current: HashMap<String, FieldValue>, created: DateTime<Utc>) -> IssueSn
         insight_source_id: "jira-alpha".into(),
         issue_id: "10042".into(),
         id_readable: "PROJ-123".into(),
+        title: Some("Widget renders twice".into()),
         created_at: created,
         reporter_id: Some("acc-1".into()),
         current_fields: current,
@@ -474,6 +475,89 @@ fn incremental_emits_only_new_events() {
     assert_eq!(out[1].value_ids, vec!["3".to_string()]);
     for row in &out {
         assert_eq!(row.event_kind, EventKind::Changelog);
+    }
+}
+
+#[test]
+fn every_emitted_row_carries_the_issue_summary() {
+    let meta = meta_map();
+    let status = meta_status();
+
+    let snapshot = snap(
+        HashMap::from([(
+            "status".to_string(),
+            FieldValue {
+                ids: vec!["2".into()],
+                displays: vec!["In Progress".into()],
+            },
+        )]),
+        ts(2026, 1, 1, 10),
+    );
+    let events = vec![ev(
+        "cl-1",
+        ts(2026, 1, 2, 9),
+        &status,
+        set(Some("1"), Some("2")),
+    )];
+
+    let bootstrap = process_issue(&meta, &snapshot, &events, None);
+    let existing = HashMap::from([(
+        "status".to_string(),
+        LastState {
+            value: FieldValue {
+                ids: vec!["1".into()],
+                displays: vec!["To Do".into()],
+            },
+            last_event_at: ts(2026, 1, 1, 10),
+        },
+    )]);
+    let incremental = process_issue(&meta, &snapshot, &events, Some(&existing));
+
+    assert!(!bootstrap.is_empty());
+    assert!(!incremental.is_empty());
+    for row in bootstrap.iter().chain(&incremental) {
+        assert_eq!(
+            row.title.as_deref(),
+            Some("Widget renders twice"),
+            "should carry the summary: {:?}/{}",
+            row.event_kind,
+            row.field_id
+        );
+    }
+}
+
+#[test]
+fn an_issue_without_a_summary_leaves_the_title_empty() {
+    let meta = meta_map();
+    let status = meta_status();
+
+    let mut snapshot = snap(
+        HashMap::from([(
+            "status".to_string(),
+            FieldValue {
+                ids: vec!["2".into()],
+                displays: vec!["In Progress".into()],
+            },
+        )]),
+        ts(2026, 1, 1, 10),
+    );
+    snapshot.title = None;
+
+    let events = vec![ev(
+        "cl-1",
+        ts(2026, 1, 2, 9),
+        &status,
+        set(Some("1"), Some("2")),
+    )];
+    let out = process_issue(&meta, &snapshot, &events, None);
+
+    assert!(!out.is_empty());
+    for row in &out {
+        assert_eq!(
+            row.title, None,
+            "should not fall back to an identifier: {}",
+            row.id_readable
+        );
     }
 }
 

--- a/src/ingestion/connectors/task-tracking/jira/enrich/src/core/types.rs
+++ b/src/ingestion/connectors/task-tracking/jira/enrich/src/core/types.rs
@@ -81,6 +81,9 @@ pub struct IssueSnapshot {
     pub insight_source_id: String,
     pub issue_id: IssueId,
     pub id_readable: IdReadable,
+    /// The issue summary. `None` when the source reports none — never falls back to an
+    /// identifier, so an evidence row with no summary renders empty rather than a key twice.
+    pub title: Option<String>,
     pub created_at: DateTime<Utc>,
     pub reporter_id: Option<String>,
     pub current_fields: HashMap<FieldId, FieldValue>,
@@ -135,6 +138,8 @@ pub struct FieldHistoryRecord {
     pub data_source: DataSource,
     pub issue_id: IssueId,
     pub id_readable: IdReadable,
+    /// Per-issue, not per-event: every row of one issue carries the same summary.
+    pub title: Option<String>,
     pub event_id: String,
     pub event_at: DateTime<Utc>,
     pub event_kind: EventKind,

--- a/src/ingestion/connectors/task-tracking/jira/enrich/src/io/reader.rs
+++ b/src/ingestion/connectors/task-tracking/jira/enrich/src/io/reader.rs
@@ -174,6 +174,7 @@ struct IssueHeaderRow {
     insight_source_id: String,
     jira_id: String,
     id_readable: String,
+    title: Option<String>,
     created_ms: i64,
     reporter_id: Option<String>,
 }
@@ -202,9 +203,13 @@ pub async fn fetch_all_snapshots(
             // FINAL forces ReplacingMergeTree merges on read. Bronze `jira_issue` is
             // append-only (Airbyte destinationSyncMode='append'); without FINAL the reader
             // can see multiple unmerged rows per issue when syncs overlap with merges.
+            // INVARIANT: despite its name, `custom_fields_json` holds the issue's WHOLE
+            // `fields` object (connector.yaml promotes `record['fields'] | tojson`), so the
+            // summary is a plain member of it and needs no promoted bronze column.
             "SELECT COALESCE(source_id, '')                 AS insight_source_id, \
                     COALESCE(toString(jira_id), '')         AS jira_id, \
                     COALESCE(toString(id_readable), '')     AS id_readable, \
+                    nullIf(JSONExtractString(COALESCE(custom_fields_json, ''), 'summary'), '') AS title, \
                     COALESCE(toInt64(toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(created, 3))), 0) AS created_ms, \
                     reporter_id \
              FROM bronze_jira.jira_issue AS ji FINAL \
@@ -225,6 +230,7 @@ pub async fn fetch_all_snapshots(
                 insight_source_id: h.insight_source_id,
                 issue_id: h.jira_id,
                 id_readable: h.id_readable,
+                title: h.title,
                 created_at: created,
                 reporter_id: h.reporter_id,
                 current_fields: HashMap::new(),

--- a/src/ingestion/connectors/task-tracking/jira/enrich/src/io/writer.rs
+++ b/src/ingestion/connectors/task-tracking/jira/enrich/src/io/writer.rs
@@ -28,6 +28,7 @@ pub struct FieldHistoryInsert {
     pub data_source: String,
     pub issue_id: String,
     pub id_readable: String,
+    pub title: Option<String>,
     pub event_id: String,
     #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
     pub event_at: DateTime<Utc>,
@@ -66,6 +67,7 @@ impl From<FieldHistoryRecord> for FieldHistoryInsert {
             data_source: data_source.into(),
             issue_id: r.issue_id,
             id_readable: r.id_readable,
+            title: r.title,
             event_id: r.event_id,
             event_at: r.event_at,
             event_kind: event_kind_enum(r.event_kind),

--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -205,6 +205,47 @@ SQL
 
 heal_task_field_history_table silver class_task_field_history
 
+# The column above only makes room for the summary; jira-enrich fills it. That
+# binary skips any issue that already has rows, so on a warm installation the
+# summary never reaches a Jira issue whose changelog has gone quiet — and a
+# closed issue, the kind task metrics count, never moves again. Emptying the
+# staging table makes the next enrich run bootstrap every issue from bronze,
+# which is the only channel that rewrites those rows.
+#
+# The window is invisible downstream: this hook builds tag:gold only, silver's
+# delete+insert removes just the unique_keys the incoming batch carries (an
+# empty Jira arm carries none), and the sync pipeline runs enrich before dbt.
+#
+# Self-limiting instead of ledger-backed, per this script's re-run contract:
+# rows but not one title means the table predates the enrich change, and the
+# bronze probe keeps an instance whose issues genuinely carry no summary from
+# truncating on every deploy.
+
+# SAFETY: callers use `ch_answer_is_yes ... || return 0`, which disables `set -e`
+# for the body — a probe failure (auth/transient, or a column the DDL macro has
+# not added yet, since it runs at dbt on-run-start below) reads as "no" and the
+# caller skips its heal rather than aborting the deploy.
+ch_answer_is_yes() {
+  local query="$1" answer
+  answer="$(printf '%s' "$query" | _ch_http_query | tr -d '[:space:]')"
+  [[ "$answer" == "1" ]]
+}
+
+heal_jira_task_history_titles() {
+  ch_table_is_real staging jira__task_field_history || return 0
+  ch_table_is_real bronze_jira jira_issue || return 0
+  ch_answer_is_yes "SELECT count() = 1 FROM system.columns WHERE database='staging' AND table='jira__task_field_history' AND name='title'" || return 0
+  ch_answer_is_yes "SELECT count() > 0 AND countIf(title IS NOT NULL) = 0 FROM staging.jira__task_field_history" || return 0
+  ch_answer_is_yes "SELECT count() > 0 FROM bronze_jira.jira_issue WHERE JSONExtractString(COALESCE(custom_fields_json, ''), 'summary') != ''" || return 0
+
+  echo "  staging.jira__task_field_history (emptied; next enrich run re-bootstraps it with summaries)"
+  run_ch <<SQL
+TRUNCATE TABLE staging.jira__task_field_history;
+SQL
+}
+
+heal_jira_task_history_titles
+
 echo "=== Healing git file-change object id columns ==="
 # The file-change object ids arrive at the tail of every projection that feeds
 # class_git_file_changes. Pre-existing tables lack them and the positional


### PR DESCRIPTION
Closes #2738.

**Why.** A Jira task-evidence row shows its key and a blank summary, while the same panel names the work item for GitHub rows.

**What changed.** `jira-enrich` reads the summary from the issue's own bronze record and writes it to `title` — the class-contract column the evidence panel already reads.

**The deploy hook empties the staging table.** The binary skips any issue that already has rows, so a warm installation would keep NULL titles wherever a changelog has gone quiet. The guards read the data rather than a ledger, so it fires once and then stops.

**Descriptor 4.0.0 → 5.0.0, a major.** A major dispatches the one-shot sync that re-bootstraps every issue right after reconcile, instead of waiting for the next cron.

**Out of scope.** The seed writes `class_task_field_history` directly without `title`, so a seeded stand still renders blank summaries.

**Verified.** 52 core tests, `cargo build --features io`, `cargo fmt --check`, `shellcheck -x` on the migrate script. Neither the heal nor the bronze summary query was run against a live ClickHouse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Jira issue summaries now appear as titles on task-history records.
  * Titles are included for both newly imported issues and ongoing updates.
  * Issues without a summary remain untitled rather than using an identifier.

* **Bug Fixes**
  * Existing Jira task-history data is automatically refreshed when needed so titles are populated consistently.
  * Jira connector updates ensure issue titles are preserved across history records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->