### PR TITLE
feat(github): collect Projects V2 boards and project their status into the task class

### DIFF
--- a/.github/trufflehog-allowlist.txt
+++ b/.github/trufflehog-allowlist.txt
@@ -125,6 +125,7 @@ beee0351c639ec18  Lob                src/ingestion/connectors/git/github-v2/test
 bb3a7fbda6080765  Lob                src/ingestion/connectors/git/github/tests/test_github_streams.py  # test function name; `test_` + 35 chars is also the Lob key shape
 6c468f60e43fd1a7  Lob                src/ingestion/connectors/git/github/tests/test_github_streams.py  # test function name; `test_` + 35 chars is also the Lob key shape
 73541b8bbce187c2  Lob                src/ingestion/connectors/git/github/tests/test_github_streams.py  # test function name; `test_` + 35 chars is also the Lob key shape
+948bef05dac17ef1  Lob                src/ingestion/connectors/git/github/tests/test_github_streams.py  # test function name; `test_` + 35 chars is also the Lob key shape
 286b669ccca78278  Lob                src/ingestion/connectors/git/gitlab/tests/test_file_changes_stream.py  # test function name; `test_` + 35 chars is also the Lob key shape
 063a530576b20665  Lob                src/ingestion/connectors/git/gitlab/tests/test_mr_child.py  # test function name; `test_` + 35 chars is also the Lob key shape
 6975843dfd4f4686  Lob                src/ingestion/connectors/git/gitlab/tests/test_windowing.py  # test function name; `test_` + 35 chars is also the Lob key shape

--- a/docs/domain/task-tracking/specs/feature-github-projects/DESIGN.md
+++ b/docs/domain/task-tracking/specs/feature-github-projects/DESIGN.md
@@ -1,0 +1,219 @@
+# Technical Design — Projects V2 Boards
+
+Collecting GitHub Projects V2 board data, and projecting a board's status column
+into the task class as its own field. Phase 2 of
+[GitHub Issues as a task tracker](../feature-github-issues/DESIGN.md), whose
+§11.1 records the API capabilities this design builds on; nothing here re-opens
+those findings.
+
+<!-- toc -->
+
+- [1. Scope](#1-scope)
+- [2. Streams](#2-streams)
+  - [2.1 The board enumerator](#21-the-board-enumerator)
+  - [2.2 Field catalogue](#22-field-catalogue)
+  - [2.3 Cards](#23-cards)
+  - [2.4 Timeline additions](#24-timeline-additions)
+- [3. Why a day sits in two row keys](#3-why-a-day-sits-in-two-row-keys)
+- [4. The incremental filter and its silent failure](#4-the-incremental-filter-and-its-silent-failure)
+- [5. Identity: what a board status is called](#5-identity-what-a-board-status-is-called)
+- [6. Board status is not the issue's state](#6-board-status-is-not-the-issues-state)
+- [7. Binding coverage is not enforced yet](#7-binding-coverage-is-not-enforced-yet)
+- [8. Silver](#8-silver)
+- [9. Rollout](#9-rollout)
+- [10. Deferred](#10-deferred)
+
+<!-- tocstop -->
+
+## 1. Scope
+
+**In.** Board field definitions with their select options; card snapshots with
+their current field values; board status history per board, retroactively
+recoverable from issue timelines; board membership history. A board's status
+column reaches `class_task_field_history` as its own field and becomes bindable.
+
+**Out.** History of non-status board fields — no API exposes it. Webhooks. Any
+mechanism that combines a board's status with the issue's own lifecycle.
+
+## 2. Streams
+
+### 2.1 The board enumerator
+
+`projects_all_parent` in `definitions` returns `{id, number}` per board and
+nothing else. The existing `projects_v2` stream carries the board header and
+would have been re-requested once per child; the two board substreams partition
+over the slim enumerator instead. Closed boards are kept: a closed board holds
+history and never changes again, so skipping it loses the record without saving
+a sync.
+
+### 2.2 Field catalogue
+
+`project_fields`, one row per (board, field, collection day). Every member type
+of `ProjectV2FieldConfiguration` is spelled out — the union exposes no interface
+carrying `id`/`name` in common, the same shape `issue_fields` already uses.
+Select options are hoisted to `options_json`; a multi-select names them
+`multiSelectOptions` rather than `options`, and both land in the same column.
+
+`is_mirror` states whether a field is board data or a projection of an issue
+property. It is computed from an **allow-list** of authored types (`TEXT`,
+`SINGLE_SELECT`, `MULTI_SELECT`, `NUMBER`, `DATE`, `ITERATION`) so a mirror type
+GitHub adds later defaults to excluded rather than to competing with the issue's
+own field for the same fact.
+
+### 2.3 Cards
+
+`project_items`, one row per (card, day the card changed), carrying the card's
+current field values as `field_values_json`. Draft cards are filtered out: they
+have no issue behind them and no identity outside the board.
+
+### 2.4 Timeline additions
+
+`issue_timeline_events` gains `project_id`, `project_number` and
+`was_automated`, and collects `AddedToProjectV2Event` and
+`RemovedFromProjectV2Event`. The board discriminator is what makes a status
+event resolvable at all: every board defines its own status field, and an issue
+on several boards interleaves all their status events in this one timeline.
+
+## 3. Why a day sits in two row keys
+
+GitHub keeps no history of a board field, an option rename, or a non-status card
+value. `ProjectV2Item` and each field value carry `updatedAt`, which says when a
+value was last touched and never what it was before. A succession of snapshots
+is therefore the only possible record, and the day in the key is what makes one:
+bronze is a `ReplacingMergeTree` keyed on `unique_key`, so a re-collection
+inside one day replaces its row while a new day adds one.
+
+The two keys take their day from different places, and the difference matters.
+`project_items` uses the card's own `updatedAt`, so re-reading an unchanged card
+inside the overlap window rewrites the same row — the stream is a change log,
+not a daily dump. `project_fields` uses the collection day, because a field's
+`updatedAt` is not guaranteed to move when one of its options is renamed, and
+catching renames is the whole point of keeping the catalogue's history.
+
+## 4. The incremental filter and its silent failure
+
+`ProjectV2.items` accepts a `query` argument that filters server-side on the
+card's update date, so no full board re-fetch is needed. Two properties of that
+filter drive the design:
+
+- **Granularity is a day.** A full ISO timestamp returns zero rows. The cursor's
+  `datetime_format` is `%Y-%m-%d`, which is also what renders into the query
+  string, so a timestamp cannot reach it.
+- **A rejected qualifier is indistinguishable from no changes.** It returns zero
+  rows with no GraphQL error: green sync, empty stream. `assert_boards_yield_cards`
+  guards the outcome — a source holding board field definitions and board status
+  events but no cards at all is the shape a rejected filter leaves behind, and
+  none of the three conditions holds for an organization with genuinely empty
+  boards.
+
+`lookback_window` is one day, so a day is re-read every sync. That is deliberate
+rather than tolerated: the row key carries the day the card changed, so the
+re-read rewrites the same row.
+
+A client-side cut on top of the server filter is NOT used. The CDK applies
+`is_client_side_incremental` in the record selector, before the transformations
+that rename `updatedAt` to `updated_at` — the cursor field it looks for does not
+exist yet, and every record is dropped silently. State observation runs after
+the transformations, which is why the cursor field is the bronze column name.
+
+## 5. Identity: what a board status is called
+
+A status event states the board and two column **names**. It names no field
+object, and there is no option identifier anywhere in it — while a card snapshot
+carries `optionId` and no history. So the two sides of the same fact arrive
+keyed differently, and neither key is usable on its own:
+
+- Option identifiers are inherited from the board template, so boards created
+  from it share identifiers and then rename the columns independently. The same
+  identifier can read as one column name on one board and an unrelated one on
+  another.
+- Column names are only unique within a board.
+
+The board is the one thing every board status fact carries, so the board is the
+identity:
+
+| | |
+|---|---|
+| `field_id` | `project_status:<project node id>` |
+| `value_id` | `<project node id>:<lower-cased column name>` |
+| `value_display` | the column name as the board states it |
+
+The value key has to carry the board as well, not just the field key:
+`class_task_statuses.status_id` is unique per source and gold joins
+`field_history.value_ids[1]` to it, so a bare column name would collapse two
+boards' same-named columns into one dimension row. Lower-cased because a board
+states its own casing and two spellings of one column are one column.
+
+A rename produces a new value key and needs a new mapping row. That is what the
+configuration tables' validity axis is for, and the catalogue's snapshot history
+is what still resolves the old name for events that carry it.
+
+## 6. Board status is not the issue's state
+
+An issue is open or closed. A board column is a separate field, one per board.
+Nothing merges them: they reach silver as different `field_id` values, they are
+bound separately, and which of them feeds a measure is the operator's binding.
+
+This is not merely a convention — merging is currently a **defect**, because
+nothing chooses between two fields bound to one role. `task_field_roles_current`
+emits one row per field, every consumer joins it by role and takes what comes
+back, and `config.task_field_roles.precedence` is read by nothing. Two fields
+bound to `status` therefore interleave their timelines into one ordered event
+array and produce spans belonging to neither. `assert_one_field_per_role`
+refuses that configuration until precedence is honoured.
+
+## 7. Binding coverage is not enforced yet
+
+Boards multiply the field set: one status field per board, so enforcing binding
+coverage means one authored row per board — and the configuration tables are
+written by hand, with no authoring surface. `task_board_bindings_enforced`
+(default false) therefore excludes board fields from
+`assert_every_field_is_bound_or_ignored` and `assert_bound_values_are_mapped`.
+
+It relaxes the reporting, never the invariant. An unbound or unmapped board
+value still produces no dimension row and still reaches no category — it goes
+unreported instead of failing the build. A board an operator has bound works
+exactly as any other field; a board nobody has touched is inert.
+
+## 8. Silver
+
+- `github__task_field_history` gains board status changelog rows through the
+  same event pipeline as every other field. Board status is excluded from
+  initial-value synthesis: an initial row is dated at the issue's creation, but
+  a card can join a board long after, so synthesising one would fabricate a
+  span the issue never had. Nothing is lost — adding a card emits its own status
+  event whose previous value is empty.
+- `github__task_statuses` admits both families, keyed on `value_id` alone; a
+  board value already carries its board, so they cannot collide.
+- `github__task_field_metadata` declares one bindable board status per board
+  that actually defines a select column, with `project_key` recording the board.
+  A board with no select field can never emit a status event, so declaring one
+  for it would invite a binding that resolves nothing.
+- Membership events reach bronze and stop there. The class contract has no
+  membership field, and inventing one is not needed by any measure yet.
+
+## 9. Rollout
+
+New streams have no state; their first sync is complete by definition. The two
+board streams create their own bronze relations on first sync, and the bronze
+reconciler adds the three new `issue_timeline_events` columns.
+
+Those three columns are populated only for events collected after the change.
+Issue timelines are retained indefinitely, so clearing the
+`issue_timeline_events` cursor and re-walking recovers the whole board status
+history — the same rollout step phase 1 documents in its §9, with the same
+unverified item: confirm whether the Airbyte version in use truncates the
+destination stream on a state clear. Card field values cannot be backfilled.
+
+## 10. Deferred
+
+- **Honouring `precedence`**, which is what would let an issue's own lifecycle
+  and a board column coexist as status sources instead of being mutually
+  exclusive.
+- **An authoring surface for bindings**, without which enforcing board coverage
+  is not reasonable. A generator that emits reviewable rows from the collected
+  catalogue is the cheap version.
+- **Board views and automation definitions.** `ProjectV2.views` carries an
+  operator-facing layout; workflow definitions likely need elevated permission.
+- **Membership in silver**, if a measure ever wants "which boards was this on".
+- **Iteration field values** are collected but nothing reads them.

--- a/src/ingestion/connectors/git/github/README.md
+++ b/src/ingestion/connectors/git/github/README.md
@@ -25,6 +25,8 @@ feeds the shared `class_git_*` silver models.
 | pull_request_review_comments | `/repos/{r}/pulls/comments` | updated_at, server-side `since` |
 | issues | `/repos/{r}/issues` | updated_at, server-side `since`; PRs filtered out |
 | projects_v2 | GraphQL `organization.projectsV2` | full refresh |
+| project_fields | GraphQL `ProjectV2.fields`, per board | full refresh, one row per (field, collection day) |
+| project_items | GraphQL `ProjectV2.items`, per board | card `updatedAt`, server-side `updated:>=DATE` (day granularity) |
 | issue_fields | GraphQL `organization.issueFields` | full refresh |
 | issue_types | GraphQL `organization.issueTypes` | full refresh |
 | workflow_runs | `/repos/{r}/actions/runs` | created_at, weekly step windows |
@@ -45,12 +47,46 @@ identifier resolves to anything an operator can read, and a rename silently
 orphans whatever was bound to the old name. Both are organization-scoped, so
 they cost one paginated query per configured organization per sync.
 
+**Projects V2 boards cost one sweep per board, not per issue.** Both board
+streams partition over the organization's boards, closed ones included: a
+closed board holds history and never changes again. `project_items` must not
+ride the issue cursor — moving a card does not bump the issue's `updated_at`,
+so board movement on an otherwise untouched issue is invisible from the issue
+side.
+
+**Two things about the card filter.** `items(query:)` filters server-side on
+the card's update date, and its granularity is a DAY — a full ISO timestamp
+returns zero rows. Worse, an unparseable qualifier returns zero rows with **no**
+GraphQL error, so a typo reads as "nothing changed": a green sync, an empty
+stream, and no way to tell it from a quiet week. The cursor's `datetime_format`
+is therefore `%Y-%m-%d`, so a timestamp cannot reach the query string, and
+`assert_boards_yield_cards` catches the outcome if one ever does. One day is
+re-read on every sync by design: the row key carries the day the card changed,
+so a re-read rewrites the same row.
+
+**Why a collection day sits in the board keys.** GitHub keeps no history of a
+board field, an option rename, or a non-status card value. `updatedAt` says
+when a value was last touched and never what it was before, so a succession of
+snapshots is the only record — the day in the key makes each sync's view its
+own row while a re-collection inside one day replaces it. Status history is the
+exception: it comes from the issue timeline and is retroactively recoverable.
+
+**Board status is not the issue's state.** An issue is open or closed; a board
+column is a separate field, one per board, and the two are bound separately.
+Nothing in the connector or in silver merges them.
+
 **Re-syncing an existing deployment.** `issues` gained the hoisted
 `issue_field_values_json` column and `issue_timeline_events` gained the field
 and type identifiers. Both are cursored, so an item nobody touches again is
 never re-read and would keep the old, emptier shape forever — clear the state
 of those two streams once the new descriptor is live. The catalogue streams
 have no state and need nothing.
+
+`issue_timeline_events` now also gains `project_id`, `project_number` and
+`was_automated`, and collects the two board-membership event types. Historical
+events carry those columns only after a re-walk — issue timelines are retained
+indefinitely, so clearing that stream's cursor recovers the whole board status
+history. Card field values cannot be backfilled: the snapshot is all there is.
 
 ## What `github_start_date` bounds
 
@@ -168,6 +204,8 @@ no `updatedAfter` argument, so the stream is a newest-first data feed like
 ## Silver Targets
 
 The nine staging models under `dbt/` feed the `class_git_*` classes, plus
-`class_git_item_events` for the lifecycle streams. Issues, projects, CI and
+`class_git_item_events` for the lifecycle streams. Issues feed the
+`class_task_*` classes, and a board's status column reaches them as its own
+field, one per board. Card field values, board field definitions, CI and
 deployments stay bronze-only. Column types must match the other git connectors
 exactly: the classes union positionally.

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -392,6 +392,62 @@ definitions:
         values: "{{ config['github_organizations'] }}"
         cursor_field: org
 
+  # Lightweight board enumerator the Projects V2 substreams partition over.
+  # Closed boards are kept: they hold history and never change again, so
+  # dropping them would lose the record without saving a sync.
+  projects_all_parent: &projects_all_parent
+    type: DeclarativeStream
+    name: projects_all
+    primary_key:
+      - id
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          id: {type: [string, "null"]}
+          number: {type: [integer, "null"]}
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        path: /graphql
+        http_method: POST
+        error_handler: *graphql_error_handler
+        request_body_json:
+          query: |
+            query($org: String!, $cursor: String) {
+              organization(login: $org) {
+                projectsV2(first: 100, after: $cursor) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes { id number }
+                }
+              }
+            }
+          variables:
+            org: "{{ stream_partition.org }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, organization, projectsV2, nodes]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response['data']['organization']['projectsV2']['pageInfo']['endCursor'] }}"
+          stop_condition: "{{ not response['data']['organization']['projectsV2']['pageInfo']['hasNextPage'] }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+      partition_router:
+        type: ListPartitionRouter
+        values: "{{ config['github_organizations'] }}"
+        cursor_field: org
+
 check:
   type: CheckStream
   # branches is the cheapest proxy-backed stream, and it is checked so a wrong
@@ -2380,6 +2436,421 @@ streams:
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.org | replace(':', '%3A') }}:project:{{ (record.get('id') or '') | replace(':', '%3A') }}
 
+  # ── Projects V2 field catalogue (GitHub GraphQL) ─────────────────────────
+  # Every board's own field definitions. A board field is NOT shared: two
+  # projects' same-named `Status` are different fields with different ids, and
+  # `ProjectV2FieldType` has no STATUS member — a status is an ordinary
+  # SINGLE_SELECT. Which select field means the lifecycle is therefore an
+  # operator's binding, and this catalogue is the list of real ids to bind to.
+  #
+  # It is also the bridge history needs: a status change event names its value
+  # by display name only, so resolving that name to an option id happens
+  # through the options of the board's own field.
+  #
+  # `snapshot_date` is part of the key on purpose. GitHub keeps no history of a
+  # field or an option rename, so the only record of one is a succession of
+  # snapshots — a re-collection inside one day replaces its row, a new day adds
+  # one. Without it a rename erases the name every earlier event carries.
+  - type: DeclarativeStream
+    name: project_fields
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          snapshot_date: {type: [string, "null"]}
+          project_id: {type: [string, "null"]}
+          project_number: {type: [integer, "null"]}
+          field_id: {type: [string, "null"]}
+          field_database_id: {type: [string, "null"]}
+          field_name: {type: [string, "null"]}
+          data_type: {type: [string, "null"]}
+          is_multi: {type: [boolean, "null"]}
+          is_mirror: {type: [boolean, "null"]}
+          is_issue_field: {type: [boolean, "null"]}
+          options_json: {type: [string, "null"]}
+          configuration_json: {type: [string, "null"]}
+          field_updated_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        path: /graphql
+        http_method: POST
+        error_handler: *graphql_error_handler
+        request_body_json:
+          query: |
+            query($project: ID!, $cursor: String) {
+              node(id: $project) {
+                ... on ProjectV2 {
+                  fields(first: 100, after: $cursor) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      __typename
+                      ... on ProjectV2Field { id databaseId name dataType updatedAt isIssueField }
+                      ... on ProjectV2SingleSelectField { id databaseId name dataType updatedAt isIssueField options { id name } }
+                      # A multi-select names its options `multiSelectOptions`,
+                      # not `options` — hoisted to `options_json` all the same.
+                      ... on ProjectV2MultiSelectField { id databaseId name dataType updatedAt isIssueField multiSelectOptions { id name } }
+                      ... on ProjectV2IterationField {
+                        id databaseId name dataType updatedAt isIssueField
+                        configuration {
+                          duration startDay
+                          iterations { id title startDate duration }
+                          completedIterations { id title startDate duration }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          variables:
+            project: "{{ stream_partition.project_id }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, node, fields, nodes]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ (((response.get('data') or {}).get('node') or {}).get('fields') or {}).get('pageInfo', {}).get('endCursor') }}"
+          stop_condition: "{{ not (((response.get('data') or {}).get('node') or {}).get('fields') or {}).get('pageInfo', {}).get('hasNextPage') }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: project_id
+            extra_fields:
+              - [number]
+            stream: *projects_all_parent
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [snapshot_date]
+            value: "{{ now_utc().strftime('%Y-%m-%d') }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ stream_partition.project_id }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [project_number]
+            value: "{{ stream_slice.extra_fields['number'] }}"
+          - type: AddedFieldDefinition
+            path: [field_id]
+            value: "{{ record.get('id') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [field_database_id]
+            value: "{{ record.get('databaseId') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [field_name]
+            value: "{{ record.get('name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [data_type]
+            value: "{{ record.get('dataType') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [is_multi]
+            value: "{{ record.get('dataType') == 'MULTI_SELECT' }}"
+            value_type: boolean
+          # A board field is either authored on the board or a projection of an
+          # issue property (TITLE, ASSIGNEES, LABELS, …). Only the authored
+          # types carry board data; a mirror read as a value would compete with
+          # the issue's own field for the same fact. Stated as an allow-list so
+          # a mirror type added later defaults to excluded, not to competing.
+          - type: AddedFieldDefinition
+            path: [is_mirror]
+            value: "{{ record.get('dataType') not in ['TEXT', 'SINGLE_SELECT', 'MULTI_SELECT', 'NUMBER', 'DATE', 'ITERATION'] }}"
+            value_type: boolean
+          - type: AddedFieldDefinition
+            path: [is_issue_field]
+            value: "{{ record.get('isIssueField') or false }}"
+            value_type: boolean
+          - type: AddedFieldDefinition
+            path: [options_json]
+            value: "{{ (record.get('options') or record.get('multiSelectOptions') or []) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [configuration_json]
+            value: "{{ (record.get('configuration') or {}) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [field_updated_at]
+            value: "{{ record.get('updatedAt') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:project:{{ (stream_partition.project_id or '') | replace(':', '%3A') }}:field:{{ (record.get('id') or '') | replace(':', '%3A') }}:{{ now_utc().strftime('%Y-%m-%d') }}
+      - type: RemoveFields
+        # Hoisted above; the camelCase and nested originals stay out of bronze.
+        field_pointers:
+          - [__typename]
+          - [id]
+          - [databaseId]
+          - [name]
+          - [dataType]
+          - [updatedAt]
+          - [isIssueField]
+          - [options]
+          - [multiSelectOptions]
+          - [configuration]
+
+  # ── Projects V2 cards (GitHub GraphQL) ──────────────────────────────────
+  # One row per (card x day the card changed), carrying the card's current
+  # field values. Two reasons this stream exists rather than riding the issue
+  # streams:
+  #
+  # 1. Moving a card does NOT bump the issue's `updated_at`, and the timeline
+  #    stream is a substream of an issue window cursored on exactly that. Board
+  #    movement on an otherwise untouched issue is invisible without a
+  #    board-side cursor.
+  # 2. No API exposes the history of a non-status board field. `updatedAt` says
+  #    when a value was last touched, never what it was before, so the only
+  #    record is a succession of snapshots — hence the day in the key. The day
+  #    comes from the card's own `updatedAt`, so re-reading an unchanged card
+  #    inside the overlap window rewrites its row instead of adding one.
+  #
+  # INVARIANT: the incremental filter is built from a DATE and nothing else.
+  # `items(query:)` filters server-side on the card's update date, but its
+  # granularity is a day: a full ISO timestamp returns zero rows, and an
+  # unparseable qualifier returns zero rows with NO GraphQL error — a green
+  # sync with no data, indistinguishable from a quiet one. `datetime_format`
+  # renders the cursor as a bare date so a timestamp cannot reach the string.
+  - type: DeclarativeStream
+    name: project_items
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          project_id: {type: [string, "null"]}
+          project_number: {type: [integer, "null"]}
+          item_id: {type: [string, "null"]}
+          item_database_id: {type: [string, "null"]}
+          item_type: {type: [string, "null"]}
+          content_type: {type: [string, "null"]}
+          content_number: {type: [integer, "null"]}
+          content_repo_full_name: {type: [string, "null"]}
+          is_archived: {type: [boolean, "null"]}
+          creator_login: {type: [string, "null"]}
+          creator_id: {type: [integer, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+          field_values_json: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        path: /graphql
+        http_method: POST
+        error_handler: *graphql_error_handler
+        request_body_json:
+          query: |
+            query($project: ID!, $q: String!, $cursor: String) {
+              node(id: $project) {
+                ... on ProjectV2 {
+                  items(first: 50, after: $cursor, query: $q) {
+                    totalCount
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      id fullDatabaseId type createdAt updatedAt isArchived
+                      creator { login ... on User { databaseId } }
+                      content {
+                        __typename
+                        ... on Issue { number repository { nameWithOwner } }
+                        ... on PullRequest { number repository { nameWithOwner } }
+                      }
+                      fieldValues(first: 50) {
+                        nodes {
+                          __typename
+                          ... on ProjectV2ItemFieldSingleSelectValue { optionId name updatedAt field { ... on ProjectV2SingleSelectField { id name dataType } } }
+                          ... on ProjectV2ItemFieldMultiSelectValue { value options { id name } updatedAt field { ... on ProjectV2MultiSelectField { id name dataType } } }
+                          ... on ProjectV2ItemFieldTextValue { text updatedAt field { ... on ProjectV2Field { id name dataType } } }
+                          ... on ProjectV2ItemFieldNumberValue { number updatedAt field { ... on ProjectV2Field { id name dataType } } }
+                          ... on ProjectV2ItemFieldDateValue { date updatedAt field { ... on ProjectV2Field { id name dataType } } }
+                          ... on ProjectV2ItemFieldIterationValue { iterationId title startDate duration updatedAt field { ... on ProjectV2IterationField { id name dataType } } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          variables:
+            project: "{{ stream_partition.project_id }}"
+            q: "updated:>={{ stream_interval.start_time }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, node, items, nodes]
+        record_filter:
+          type: RecordFilter
+          # A draft card has no issue behind it and no identity outside the
+          # board, so it can join nothing downstream.
+          #
+          # Only drafts are dropped. A card whose `content` is null is NOT a
+          # draft — it is an item the token cannot see, its issue living in a
+          # repository outside the token's reach. Dropping those two together
+          # would make a coverage gap indistinguishable from a board note; kept,
+          # the row states that a card exists whose content is unknown.
+          condition: "{{ (record.get('content') or {}).get('__typename') != 'DraftIssue' }}"
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ (((response.get('data') or {}).get('node') or {}).get('items') or {}).get('pageInfo', {}).get('endCursor') }}"
+          stop_condition: "{{ not (((response.get('data') or {}).get('node') or {}).get('items') or {}).get('pageInfo', {}).get('hasNextPage') }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: project_id
+            extra_fields:
+              - [number]
+            stream: *projects_all_parent
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      # Day granularity is the API's, not a choice: `updated:>=` rejects a
+      # timestamp by returning nothing.
+      datetime_format: "%Y-%m-%d"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%SZ"
+        - "%Y-%m-%dT%H:%M:%S%z"
+      # The server filter is coarser than the cursor, so a day is re-read on
+      # every sync. That is deliberate rather than tolerated: the row key
+      # carries the day the card changed, so a re-read rewrites the same row.
+      #
+      # A client-side cut is NOT used here. The CDK applies it in the record
+      # selector, before the transformations that rename `updatedAt` to
+      # `updated_at` — so the cursor field it looks for does not exist yet and
+      # every record is silently dropped. State observation runs after the
+      # transformations, which is why the cursor field is the bronze name.
+      lookback_window: P1D
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config['github_start_date'] }}"
+        datetime_format: "%Y-%m-%d"
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ stream_partition.project_id }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [project_number]
+            value: "{{ stream_slice.extra_fields['number'] }}"
+          - type: AddedFieldDefinition
+            path: [item_id]
+            value: "{{ record.get('id') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [item_database_id]
+            value: "{{ record.get('fullDatabaseId') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [item_type]
+            value: "{{ record.get('type') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [content_type]
+            value: "{{ (record.get('content') or {}).get('__typename') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [content_number]
+            value: "{{ (record.get('content') or {}).get('number') or 0 }}"
+            value_type: integer
+          - type: AddedFieldDefinition
+            path: [content_repo_full_name]
+            value: "{{ ((record.get('content') or {}).get('repository') or {}).get('nameWithOwner') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [is_archived]
+            value: "{{ record.get('isArchived') or false }}"
+            value_type: boolean
+          - type: AddedFieldDefinition
+            path: [creator_login]
+            value: "{{ (record.get('creator') or {}).get('login') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [creator_id]
+            value: "{{ (record.get('creator') or {}).get('databaseId') or 0 }}"
+            value_type: integer
+          - type: AddedFieldDefinition
+            path: [created_at]
+            value: "{{ record.get('createdAt') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [updated_at]
+            value: "{{ record.get('updatedAt') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [field_values_json]
+            value: "{{ ((record.get('fieldValues') or {}).get('nodes') or []) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:project:{{ (stream_partition.project_id or '') | replace(':', '%3A') }}:item:{{ (record.get('id') or '') | replace(':', '%3A') }}:{{ (record.get('updatedAt') or '')[:10] }}
+      - type: RemoveFields
+        # Hoisted above; the camelCase and nested originals stay out of bronze.
+        field_pointers:
+          - [id]
+          - [fullDatabaseId]
+          - [type]
+          - [createdAt]
+          - [updatedAt]
+          - [isArchived]
+          - [creator]
+          - [content]
+          - [fieldValues]
+
   # ── Native issue fields (GitHub GraphQL) ────────────────────────────────
   # The organization's own issue-field catalogue: every field an issue can
   # carry, its data type, and — for the select types — the options it admits.
@@ -3348,6 +3819,9 @@ streams:
           new_value_id: {type: [string, "null"]}
           prev_options_json: {type: [string, "null"]}
           new_options_json: {type: [string, "null"]}
+          project_id: {type: [string, "null"]}
+          project_number: {type: [integer, "null"]}
+          was_automated: {type: [boolean, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -3363,7 +3837,7 @@ streams:
             query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
               repository(owner: $owner, name: $name) {
                 issue(number: $number) {
-                  timelineItems(first: 100, after: $cursor, itemTypes: [ASSIGNED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, CLOSED_EVENT, REOPENED_EVENT, ISSUE_TYPE_CHANGED_EVENT, ISSUE_FIELD_CHANGED_EVENT, PROJECT_V2_ITEM_STATUS_CHANGED_EVENT]) {
+                  timelineItems(first: 100, after: $cursor, itemTypes: [ASSIGNED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, CLOSED_EVENT, REOPENED_EVENT, ISSUE_TYPE_CHANGED_EVENT, ISSUE_FIELD_CHANGED_EVENT, PROJECT_V2_ITEM_STATUS_CHANGED_EVENT, ADDED_TO_PROJECT_V2_EVENT, REMOVED_FROM_PROJECT_V2_EVENT]) {
                     pageInfo { hasNextPage endCursor }
                     nodes {
                       __typename
@@ -3385,7 +3859,16 @@ streams:
                           ... on IssueFieldText { id name }
                         }
                       }
-                      ... on ProjectV2ItemStatusChangedEvent { id createdAt actor { login ... on User { databaseId } } previousStatus status }
+                      # `project` is the board discriminator: an issue on
+                      # several boards interleaves all their status events in
+                      # this one timeline, and without it they cannot be told
+                      # apart. `wasAutomated` separates a workflow's move from
+                      # a person's.
+                      ... on ProjectV2ItemStatusChangedEvent { id createdAt actor { login ... on User { databaseId } } previousStatus status project { id number } wasAutomated }
+                      # Board membership: which boards an issue was on, and
+                      # when. The card snapshot states only the present.
+                      ... on AddedToProjectV2Event { id createdAt actor { login ... on User { databaseId } } project { id number } wasAutomated }
+                      ... on RemovedFromProjectV2Event { id createdAt actor { login ... on User { databaseId } } project { id number } wasAutomated }
                     }
                   }
                 }
@@ -3588,6 +4071,21 @@ streams:
             path: [new_options_json]
             value: "{{ (record.get('newOptions') or []) | map(attribute='name') | list | tojson }}"
             value_type: string
+          # Which board the status change or the membership change happened on.
+          # Every project defines its own Status field, so the board is what
+          # makes a status event resolvable at all.
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ (record.get('project') or {}).get('id') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [project_number]
+            value: "{{ (record.get('project') or {}).get('number') or 0 }}"
+            value_type: integer
+          - type: AddedFieldDefinition
+            path: [was_automated]
+            value: "{{ record.get('wasAutomated') or false }}"
+            value_type: boolean
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
@@ -3716,6 +4214,8 @@ metadata:
     pull_request_diff_stats: false
     issues: false
     projects_v2: false
+    project_fields: false
+    project_items: false
     issue_fields: false
     issue_types: false
     workflow_runs: false

--- a/src/ingestion/connectors/git/github/dbt/github__bronze_promoted.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__bronze_promoted.sql
@@ -28,6 +28,8 @@
 {% do promote_bronze_to_rmt(table='bronze_github.issues',                      order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_github.projects_v2',                 order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_github.issue_fields',                order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_github.project_fields',              order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_github.project_items',               order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_github.issue_types',                 order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_github.workflow_runs',               order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_github.deployments',                 order_by='unique_key') %}

--- a/src/ingestion/connectors/git/github/dbt/github__task_field_history.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__task_field_history.sql
@@ -24,6 +24,13 @@
 -- INVARIANT: `field_id` is the vendor's own identifier, never a role. Gold
 -- resolves a role through `config.task_field_roles`; putting a role here would
 -- bake one deployment's interpretation into the record of what happened.
+--
+-- One field identifier is composed rather than quoted: a board's status is
+-- `project_status:<project node id>`. GitHub names no field on a board status
+-- event — it states the board and the two column names — and every board
+-- defines its own status field, so the board is the field's identity. It is
+-- NOT the issue's `state`: an issue's open/closed lifecycle and a board column
+-- are different fields, bound separately, and nothing here merges them.
 
 WITH
 issues AS (
@@ -83,6 +90,13 @@ events AS (
             e.event_type IN ('AssignedEvent', 'UnassignedEvent'),      'assignees',
             e.event_type = 'IssueTypeChangedEvent',                    'type',
             e.event_type = 'IssueFieldChangedEvent',                   COALESCE(e.field_id, ''),
+            -- A board's status is its OWN field, never the issue's `state`.
+            -- Every board defines its own, so the board IS the field identity:
+            -- the event says "on board X, status went A to B" and names no
+            -- field object. Deriving which ProjectV2 field object it was would
+            -- mean guessing; the board is stated and sufficient.
+            e.event_type = 'ProjectV2ItemStatusChangedEvent',
+                if(COALESCE(e.project_id, '') = '', '', concat('project_status:', e.project_id)),
             ''
         )                                                       AS field_id,
         multiIf(
@@ -95,6 +109,15 @@ events AS (
             e.event_type = 'UnassignedEvent', '',
             e.event_type = 'IssueTypeChangedEvent', COALESCE(e.new_value_id, ''),
             e.event_type = 'IssueFieldChangedEvent', COALESCE(e.new_value, ''),
+            -- The value key carries the board too. `class_task_statuses.status_id`
+            -- is unique per source and gold joins it to this column, so a bare
+            -- column name would collapse two boards' same-named columns into
+            -- one dimension row — and board option identifiers are inherited
+            -- from a template, so they collide as well. Lower-cased because a
+            -- board states its own casing and two spellings are one column.
+            e.event_type = 'ProjectV2ItemStatusChangedEvent',
+                if(COALESCE(e.new_value, '') = '', '',
+                   concat(COALESCE(e.project_id, ''), ':', lower(e.new_value))),
             ''
         )                                                       AS value_id,
         multiIf(
@@ -106,13 +129,20 @@ events AS (
             e.event_type = 'ClosedEvent',           'open',
             e.event_type = 'ReopenedEvent',         concat('closed:', lower(COALESCE(e.state_reason, ''))),
             e.event_type = 'IssueTypeChangedEvent', COALESCE(e.prev_value_id, ''),
+            -- The first status event of a card states an empty previous value,
+            -- which must stay empty: `initial_values` reads it as the value at
+            -- creation and a composed key over nothing is not a value.
+            e.event_type = 'ProjectV2ItemStatusChangedEvent',
+                if(COALESCE(e.prev_value, '') = '', '',
+                   concat(COALESCE(e.project_id, ''), ':', lower(e.prev_value))),
             COALESCE(e.prev_value, '')
         )                                                       AS prev_value_id,
         e._airbyte_extracted_at                                 AS _airbyte_extracted_at
     FROM {{ source('bronze_github', 'issue_timeline_events') }} AS e FINAL
     WHERE e.event_type IN (
         'ClosedEvent', 'ReopenedEvent', 'AssignedEvent', 'UnassignedEvent',
-        'IssueTypeChangedEvent', 'IssueFieldChangedEvent'
+        'IssueTypeChangedEvent', 'IssueFieldChangedEvent',
+        'ProjectV2ItemStatusChangedEvent'
     )
 ),
 
@@ -255,7 +285,12 @@ initial_values AS (
         AND s.source_id = e.source_id
         AND s.issue_id = e.issue_id
         AND s.field_id = e.field_id
-    WHERE e.first_prev != ''
+    -- Board status is excluded from initial synthesis on purpose. An initial
+    -- row is dated at the issue's creation, but a card can join a board long
+    -- after — synthesising one would fabricate a span the issue never had.
+    -- Nothing is lost: adding a card emits its own status event, whose
+    -- previous value is empty.
+    WHERE e.first_prev != '' AND NOT startsWith(e.field_id, 'project_status:')
 ),
 
 -- Row 1 of every issue: who created it and when. A sentinel, not a field —
@@ -359,7 +394,14 @@ SELECT
     CAST([value_id] AS Array(String))                           AS value_ids,
     CAST([if(value_display != '', value_display, value_id)] AS Array(String)) AS value_displays,
     CAST(
-        multiIf(field_id = 'assignees', 'account_id', field_id = 'state', 'string_literal', 'opaque_id')
+        multiIf(
+            field_id = 'assignees', 'account_id',
+            field_id = 'state', 'string_literal',
+            -- A board column is named, not identified: history states the
+            -- display name and nothing else.
+            startsWith(field_id, 'project_status:'), 'string_literal',
+            'opaque_id'
+        )
         AS Enum8('opaque_id' = 1, 'account_id' = 2, 'string_literal' = 3, 'path' = 4, 'none' = 5)
     )                                                           AS value_id_type,
     toDateTime64(_airbyte_extracted_at, 3)                      AS collected_at,

--- a/src/ingestion/connectors/git/github/dbt/github__task_field_metadata.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__task_field_metadata.sql
@@ -15,8 +15,11 @@
 -- for them. The organization's native issue fields come from the catalogue
 -- stream, which is also the list an operator reads when authoring a binding.
 --
--- `project_key` stays null: organization issue fields are not project-scoped.
--- The column is where a board field would record its board.
+-- A third group is board-scoped. Every Projects V2 board carries its own
+-- status column, and a status event names the board rather than a field object
+-- — so the bindable field is `project_status:<project node id>`, one per
+-- board, and `project_key` records which board it is. Organization issue
+-- fields stay null there: they are not project-scoped.
 
 WITH issue_properties AS (
     SELECT
@@ -59,17 +62,44 @@ catalogued AS (
     FROM {{ source('bronze_github', 'issue_fields') }} FINAL
 ),
 
+-- One synthetic field per board that actually defines a select column. A board
+-- with no select field can never emit a status event, so declaring one for it
+-- would invite a binding that resolves nothing.
+board_status AS (
+    SELECT
+        tenant_id,
+        source_id,
+        concat('project_status:', COALESCE(project_id, ''))  AS field_id,
+        'Status'                                             AS field_name,
+        'single_select'                                      AS field_type,
+        toUInt8(0)                                           AS is_multi,
+        toUInt8(0)                                           AS has_id,
+        toString(COALESCE(project_number, 0))                AS project_key,
+        max(_airbyte_extracted_at)                           AS observed_at
+    FROM {{ source('bronze_github', 'project_fields') }} FINAL
+    WHERE COALESCE(is_mirror, true) = false
+      AND COALESCE(data_type, '') = 'SINGLE_SELECT'
+      AND COALESCE(project_id, '') != ''
+    GROUP BY tenant_id, source_id, field_id, project_key
+),
+
 every_field AS (
-    SELECT * FROM declared
+    SELECT *, CAST(NULL AS Nullable(String)) AS project_key FROM declared
     UNION ALL
-    SELECT * FROM catalogued
+    SELECT *, CAST(NULL AS Nullable(String)) AS project_key FROM catalogued
+    UNION ALL
+    SELECT
+        tenant_id, source_id, field_id, field_name, field_type,
+        is_multi, has_id, observed_at,
+        CAST(project_key AS Nullable(String)) AS project_key
+    FROM board_status
 )
 
 SELECT
     CAST(concat(tenant_id, ':', source_id, ':github:field:', field_id) AS Nullable(String)) AS unique_key,
     CAST(COALESCE(source_id, '') AS String)                 AS insight_source_id,
     CAST('github' AS String)                                AS data_source,
-    CAST(NULL AS Nullable(String))                          AS project_key,
+    CAST(project_key AS Nullable(String))                   AS project_key,
     CAST(field_id AS String)                                AS field_id,
     CAST(field_name AS String)                              AS field_name,
     is_multi                                                AS is_multi,

--- a/src/ingestion/connectors/git/github/dbt/github__task_statuses.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__task_statuses.sql
@@ -7,10 +7,17 @@
 ) }}
 
 -- Per-source status dimension; unioned into `silver.class_task_statuses` via
--- `union_by_tag`. GitHub has no status field and no lifecycle categories: an
--- issue is open or closed, and a closure states a reason. The pair is the
--- status, and which lifecycle category each pair means is an operator's
--- decision, not the vendor's — so every row here comes from the binding.
+-- `union_by_tag`. GitHub states no lifecycle category anywhere, so which
+-- category a value means is an operator's decision, not the vendor's — every
+-- row here comes from the binding.
+--
+-- Two independent status families, deliberately not merged. The issue's own
+-- lifecycle is open or closed and a closure states a reason: that pair is the
+-- status. A Projects V2 board additionally has its own status column, one
+-- field per board, which is where an `in_progress` category can come from. An
+-- issue can carry both; they are separate fields with separate bindings, and
+-- which one wins for a measure is the `precedence` column's job, not this
+-- model's.
 --
 -- INVARIANT: a value observed in history with no binding must NOT default to a
 -- category. It is left out, the coverage test names it, and the build fails —
@@ -36,7 +43,11 @@ FROM (
         canonical_value
     FROM {{ source('config', 'task_value_map') }} FINAL
     WHERE data_source = 'github'
-      AND field_id = 'state'
+      -- Two field families reach this dimension, and they stay separate: the
+      -- issue's own open/closed `state`, and one status field per Projects V2
+      -- board. A board's value key already carries the board, so both families
+      -- key on `value_id` alone and cannot collide.
+      AND (field_id = 'state' OR startsWith(field_id, 'project_status:'))
       AND is_deleted = 0
       AND valid_from <= now64(3)
     ORDER BY valid_from DESC, recorded_at DESC

--- a/src/ingestion/connectors/git/github/dbt/schema.yml
+++ b/src/ingestion/connectors/git/github/dbt/schema.yml
@@ -23,6 +23,8 @@ sources:
       - name: issues
       - name: projects_v2
       - name: issue_fields
+      - name: project_fields
+      - name: project_items
       - name: issue_types
       - name: workflow_runs
       - name: deployments

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -14,7 +14,16 @@ name: github
 #   staging never re-reads Bronze, so the column heals to NULL on existing
 #   rows, and a NULL identity never folds. Only the one-shot scoped
 #   `dbt --full-refresh` a major bump dispatches re-materializes the history.
-version: "6.0.0"
+# 6.1.0: Projects V2 boards — two new streams (`project_fields`,
+#   `project_items`) and three new columns on `issue_timeline_events`
+#   (`project_id`, `project_number`, `was_automated`) plus two new event types
+#   on it. MINOR: additive everywhere, and the one model that consumes the new
+#   columns is materialized as a table, so it re-reads Bronze on every run and
+#   needs no full refresh. The new columns are only POPULATED for events
+#   collected after the change — recovering them for history means clearing the
+#   `issue_timeline_events` cursor and re-walking, which is a rollout step, not
+#   a version bump.
+version: "6.1.0"
 schedule: "0 */4 * * *"
 workflow: sync
 

--- a/src/ingestion/connectors/git/github/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github/tests/test_github_streams.py
@@ -19,6 +19,7 @@ import json
 
 import freezegun
 import pytest
+from airbyte_cdk.models import SyncMode
 from config import GH_URL, PROXY_URL, GithubConfigBuilder
 from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, assert_records_conform, read_stream
 from connector_tests.source import load_manifest
@@ -1360,3 +1361,461 @@ def test_issue_types_catalogue_gives_the_type_a_stable_key(http_mocker: HttpMock
     assert by_id["IT_bug"]["unique_key"].endswith(":acme:issue_type:IT_bug")
     _no_literal_none(output.records)
     assert_records_conform(output.records, _CONNECTOR, "issue_types", strict=True)
+
+
+def _projects_parent_body(cursor: str | None = None) -> dict:
+    """The board enumerator lives in `definitions`, not `streams` — the two
+    board substreams share it, so its body is built from there."""
+    manifest = load_manifest(_CONNECTOR)
+    parent = manifest["definitions"]["projects_all_parent"]
+    body = dict(parent["retriever"]["requester"]["request_body_json"])
+    body["query"] = body["query"].rstrip("\n")
+    body["variables"] = {"org": "acme"}
+    if cursor is not None:
+        body["variables"]["cursor"] = cursor
+    return body
+
+
+def _mock_projects_parent(http_mocker: HttpMocker, nodes: list[dict]) -> None:
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_projects_parent_body()),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "organization": {
+                            "projectsV2": {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": nodes}
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+
+def _project_fields_body(project_id: str, cursor: str | None = None) -> dict:
+    return _graphql_body("project_fields", {"project": project_id}, cursor)
+
+
+def _project_items_body(project_id: str, q: str, cursor: str | None = None) -> dict:
+    return _graphql_body("project_items", {"project": project_id, "q": q}, cursor)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_project_fields_are_scoped_to_their_own_board(http_mocker: HttpMocker) -> None:
+    """A same-named Status in two boards is two different fields. Collecting
+    the catalogue per board is what keeps a status resolvable at all — and what
+    stops one board's option name being read as another's."""
+    config = GithubConfigBuilder().build()
+    _mock_projects_parent(http_mocker, [{"id": "PVT_1", "number": 40}, {"id": "PVT_2", "number": 41}])
+    for project_id, option_name in (("PVT_1", "In progress"), ("PVT_2", "10%")):
+        http_mocker.post(
+            HttpRequest(f"{GH_URL}/graphql", body=_project_fields_body(project_id)),
+            HttpResponse(
+                body=json.dumps(
+                    {
+                        "data": {
+                            "node": {
+                                "fields": {
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": [
+                                        {
+                                            "__typename": "ProjectV2SingleSelectField",
+                                            "id": f"PVTSSF_{project_id}",
+                                            "databaseId": 1,
+                                            "name": "Status",
+                                            "dataType": "SINGLE_SELECT",
+                                            "updatedAt": "2026-06-02T00:00:00Z",
+                                            "isIssueField": False,
+                                            # Boards created from one template
+                                            # inherit its option ids, then
+                                            # rename the options independently.
+                                            "options": [{"id": "shared-option", "name": option_name}],
+                                        }
+                                    ],
+                                }
+                            }
+                        }
+                    }
+                ),
+                status_code=200,
+            ),
+        )
+
+    output = read_stream(_CONNECTOR, "project_fields", config)
+
+    assert not output.errors
+    by_field = {r.record.data["field_id"]: r.record.data for r in output.records}
+    assert set(by_field) == {"PVTSSF_PVT_1", "PVTSSF_PVT_2"}
+    assert by_field["PVTSSF_PVT_1"]["project_number"] == 40
+    assert by_field["PVTSSF_PVT_2"]["project_number"] == 41
+    one = json.loads(by_field["PVTSSF_PVT_1"]["options_json"])
+    two = json.loads(by_field["PVTSSF_PVT_2"]["options_json"])
+    assert one[0]["id"] == two[0]["id"], "the fixture shares an option id across boards on purpose"
+    assert one[0]["name"] != two[0]["name"], "and the names diverge, so the id alone identifies nothing"
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "project_fields", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_project_fields_mark_the_issue_mirrors(http_mocker: HttpMocker) -> None:
+    """A built-in board field is a projection of the issue. Read as a value it
+    would compete with the issue's own field for the same fact, so the
+    catalogue has to say which is which."""
+    config = GithubConfigBuilder().build()
+    _mock_projects_parent(http_mocker, [{"id": "PVT_1", "number": 40}])
+    nodes = [
+        {"__typename": "ProjectV2Field", "id": "F_title", "name": "Title", "dataType": "TITLE"},
+        {"__typename": "ProjectV2Field", "id": "F_assignees", "name": "Assignees", "dataType": "ASSIGNEES"},
+        {"__typename": "ProjectV2Field", "id": "F_est", "name": "Estimate", "dataType": "NUMBER"},
+        {
+            "__typename": "ProjectV2IterationField",
+            "id": "F_sprint",
+            "name": "Sprint",
+            "dataType": "ITERATION",
+            "configuration": {
+                "duration": 14,
+                "startDay": 1,
+                "iterations": [{"id": "it1", "title": "S1"}],
+                "completedIterations": [],
+            },
+        },
+    ]
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_project_fields_body("PVT_1")),
+        HttpResponse(
+            body=json.dumps(
+                {"data": {"node": {"fields": {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": nodes}}}}
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "project_fields", config)
+
+    assert not output.errors
+    mirror = {r.record.data["field_id"]: r.record.data["is_mirror"] for r in output.records}
+    assert mirror == {"F_title": True, "F_assignees": True, "F_est": False, "F_sprint": False}
+    sprint = next(r.record.data for r in output.records if r.record.data["field_id"] == "F_sprint")
+    assert json.loads(sprint["configuration_json"])["duration"] == 14
+    _no_literal_none(output.records)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_project_fields_key_carries_the_snapshot_day(http_mocker: HttpMocker) -> None:
+    """GitHub keeps no history of an option rename, so a succession of daily
+    snapshots is the only record of one. Without the day in the key a rename
+    erases the name every earlier status event carries."""
+    config = GithubConfigBuilder().build()
+    _mock_projects_parent(http_mocker, [{"id": "PVT_1", "number": 40}])
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_project_fields_body("PVT_1")),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "node": {
+                            "fields": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    {
+                                        "__typename": "ProjectV2Field",
+                                        "id": "F_est",
+                                        "name": "Estimate",
+                                        "dataType": "NUMBER",
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "project_fields", config)
+
+    assert not output.errors
+    key = output.records[0].record.data["unique_key"]
+    assert key.endswith(":project:PVT_1:field:F_est:2026-07-01"), key
+    assert output.records[0].record.data["snapshot_date"] == "2026-07-01"
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_project_items_filter_is_a_bare_date(http_mocker: HttpMocker) -> None:
+    """`items(query:)` filters on a DAY. A full timestamp returns zero rows and
+    an unparseable qualifier returns zero rows with no GraphQL error — a green
+    sync with no data, indistinguishable from a quiet one. The mock matches the
+    exact body, so a rendered timestamp fails this test instead of production.
+    """
+    config = GithubConfigBuilder().build()
+    _mock_projects_parent(http_mocker, [{"id": "PVT_1", "number": 40}])
+    body = _project_items_body("PVT_1", "updated:>=2026-06-01")
+    assert body["variables"]["q"] == "updated:>=2026-06-01", "the start date must render date-only"
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=body),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "node": {
+                            "items": {
+                                "totalCount": 1,
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [_card("PVTI_1", "2026-06-20T10:00:00Z")],
+                            }
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "project_items", config)
+
+    assert not output.errors
+    assert len(output.records) == 1
+    assert output.records[0].record.data["item_id"] == "PVTI_1"
+    assert_records_conform(output.records, _CONNECTOR, "project_items", strict=True)
+
+
+def _card(item_id: str, updated_at: str, content: dict | None = None) -> dict:
+    return {
+        "id": item_id,
+        "fullDatabaseId": 5551,
+        "type": "ISSUE",
+        "createdAt": "2026-06-02T00:00:00Z",
+        "updatedAt": updated_at,
+        "isArchived": False,
+        "creator": {"login": "alice", "databaseId": 1001},
+        "content": content
+        if content is not None
+        else {"__typename": "Issue", "number": 7, "repository": {"nameWithOwner": "acme/app"}},
+        "fieldValues": {
+            "nodes": [
+                {
+                    "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                    "optionId": "shared-option",
+                    "name": "In progress",
+                    "updatedAt": updated_at,
+                    "field": {"id": "PVTSSF_PVT_1", "name": "Status", "dataType": "SINGLE_SELECT"},
+                }
+            ]
+        },
+    }
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_project_items_drop_a_draft_card_but_keep_an_unreadable_one(http_mocker: HttpMocker) -> None:
+    """A draft card has no issue behind it and no identity outside the board, so
+    it can join nothing downstream. A card with null content is a different
+    thing entirely — its issue lives where the token cannot look — and dropping
+    both together would hide a coverage gap behind a board note."""
+    config = GithubConfigBuilder().build()
+    _mock_projects_parent(http_mocker, [{"id": "PVT_1", "number": 40}])
+    nodes = [
+        _card("PVTI_issue", "2026-06-20T10:00:00Z"),
+        _card("PVTI_draft", "2026-06-20T10:00:00Z", content={"__typename": "DraftIssue"}),
+        _card("PVTI_none", "2026-06-20T10:00:00Z", content=None),
+    ]
+    # `None` content is a card whose issue the token cannot see, not a draft.
+    nodes[2]["content"] = None
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_project_items_body("PVT_1", "updated:>=2026-06-01")),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "node": {
+                            "items": {
+                                "totalCount": 3,
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": nodes,
+                            }
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "project_items", config)
+
+    assert not output.errors
+    kept = {r.record.data["item_id"]: r.record.data for r in output.records}
+    assert set(kept) == {"PVTI_issue", "PVTI_none"}, "the draft goes, the unreadable card stays"
+    assert kept["PVTI_issue"]["content_type"] == "Issue"
+    assert kept["PVTI_none"]["content_type"] == "", "unknown content is empty, never a literal None"
+    assert kept["PVTI_none"]["content_number"] == 0
+    assert kept["PVTI_none"]["content_repo_full_name"] == ""
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_project_item_key_carries_the_day_the_card_changed(http_mocker: HttpMocker) -> None:
+    """No API exposes the history of a non-status board field, so the record is
+    a succession of snapshots. The day comes from the card's own updatedAt, so
+    re-reading an unchanged card inside the overlap window rewrites its row
+    instead of adding one."""
+    config = GithubConfigBuilder().build()
+    _mock_projects_parent(http_mocker, [{"id": "PVT_1", "number": 40}])
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_project_items_body("PVT_1", "updated:>=2026-06-01")),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "node": {
+                            "items": {
+                                "totalCount": 2,
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    _card("PVTI_1", "2026-06-20T10:00:00Z"),
+                                    _card("PVTI_1", "2026-06-21T09:00:00Z"),
+                                ],
+                            }
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "project_items", config)
+
+    assert not output.errors
+    keys = [r.record.data["unique_key"] for r in output.records]
+    assert keys[0].endswith(":project:PVT_1:item:PVTI_1:2026-06-20")
+    assert keys[1].endswith(":project:PVT_1:item:PVTI_1:2026-06-21")
+    assert keys[0] != keys[1], "one row per day the card changed, not one row ever"
+    first = output.records[0].record.data
+    assert first["content_number"] == 7
+    assert first["content_repo_full_name"] == "acme/app"
+    assert json.loads(first["field_values_json"])[0]["optionId"] == "shared-option"
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_project_items_state_stays_day_granular(http_mocker: HttpMocker) -> None:
+    """The cursor is stored in the format the filter needs. A stored timestamp
+    would render into the query and silently return nothing."""
+    config = GithubConfigBuilder().build()
+    _mock_projects_parent(http_mocker, [{"id": "PVT_1", "number": 40}])
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_project_items_body("PVT_1", "updated:>=2026-06-01")),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "node": {
+                            "items": {
+                                "totalCount": 1,
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [_card("PVTI_1", "2026-06-20T10:00:00Z")],
+                            }
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "project_items", config, sync_mode=SyncMode.incremental)
+
+    assert not output.errors
+    assert output.state_messages, "an incremental read must emit state"
+    blob = json.dumps([sm.state.stream.stream_state.__dict__ for sm in output.state_messages])
+    assert "2026-06-01T" not in blob and "T00:00:00" not in blob, f"state must not carry a time: {blob}"
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_status_change_names_the_board_it_happened_on(http_mocker: HttpMocker) -> None:
+    """Every board defines its own Status field, so a status event without its
+    board cannot be resolved. An issue on several boards interleaves all their
+    events in this one timeline."""
+    config = GithubConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps([_repo()]), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(f"{GH_URL}/repos/acme/app/issues", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps([{"id": 901, "number": 7, "updated_at": "2026-06-20T00:00:00Z"}]), status_code=200
+        ),
+    )
+    nodes = [
+        {
+            "__typename": "ProjectV2ItemStatusChangedEvent",
+            "id": "E_status_a",
+            "createdAt": "2026-06-10T00:00:00Z",
+            "actor": {"login": "alice", "databaseId": 1001},
+            "previousStatus": "Todo",
+            "status": "In progress",
+            "project": {"id": "PVT_1", "number": 40},
+            "wasAutomated": False,
+        },
+        {
+            "__typename": "ProjectV2ItemStatusChangedEvent",
+            "id": "E_status_b",
+            "createdAt": "2026-06-11T00:00:00Z",
+            "actor": {"login": "bot", "databaseId": None},
+            "previousStatus": "Todo",
+            "status": "In progress",
+            "project": {"id": "PVT_2", "number": 41},
+            "wasAutomated": True,
+        },
+        {
+            "__typename": "AddedToProjectV2Event",
+            "id": "E_added",
+            "createdAt": "2026-06-09T00:00:00Z",
+            "actor": {"login": "alice", "databaseId": 1001},
+            "project": {"id": "PVT_1", "number": 40},
+        },
+        {
+            "__typename": "RemovedFromProjectV2Event",
+            "id": "E_removed",
+            "createdAt": "2026-06-12T00:00:00Z",
+            "actor": {"login": "alice", "databaseId": 1001},
+            "project": {"id": "PVT_2", "number": 41},
+        },
+    ]
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_issue_timeline_body()),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "issue": {
+                                "timelineItems": {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": nodes}
+                            }
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "issue_timeline_events", config)
+
+    assert not output.errors
+    by_event = {r.record.data["event_id"]: r.record.data for r in output.records}
+    assert set(by_event) == {"E_status_a", "E_status_b", "E_added", "E_removed"}
+    # Two boards, one issue: same status name, different boards.
+    assert by_event["E_status_a"]["new_value"] == by_event["E_status_b"]["new_value"] == "In progress"
+    assert by_event["E_status_a"]["project_id"] == "PVT_1"
+    assert by_event["E_status_b"]["project_id"] == "PVT_2"
+    assert by_event["E_status_a"]["project_number"] == 40
+    assert by_event["E_status_a"]["was_automated"] is False
+    assert by_event["E_status_b"]["was_automated"] is True, "a workflow's move is not a person's"
+    # Membership states the board and nothing else — the event type is the fact.
+    assert by_event["E_added"]["project_id"] == "PVT_1"
+    assert by_event["E_removed"]["project_id"] == "PVT_2"
+    assert by_event["E_added"]["new_value"] == ""
+    _no_literal_none(output.records)

--- a/src/ingestion/dbt/dbt_project.yml
+++ b/src/ingestion/dbt/dbt_project.yml
@@ -96,6 +96,18 @@ vars:
   # compared case-insensitively — never a localized name.
   task_issue_type_field_names:
     - type
+  # Whether a Projects V2 board's status field must be bound like any other
+  # field. Boards multiply the field set: every board defines its own status,
+  # so enforcing coverage means one authored binding per board, and there is no
+  # authoring surface for that yet — the tables are written by hand. While this
+  # is false the two coverage tests skip board fields, so collecting boards
+  # cannot turn the build red on its own.
+  #
+  # It does NOT relax the invariant it guards: an unbound or unmapped board
+  # value still produces no dimension row and still reaches no category. It
+  # goes unreported instead of failing the build. Flip this on once binding
+  # boards is something an operator can actually do.
+  task_board_bindings_enforced: false
   task_non_bug_type_names:
     - task
     - sub-task

--- a/src/ingestion/dbt/tests/task/README.md
+++ b/src/ingestion/dbt/tests/task/README.md
@@ -28,6 +28,8 @@ tag, add `config(tags=['task_tracker'])` as a SQL comment at the top of each tes
 | `assert_initial_traceable_to_bronze` | Silver initial row with no matching `bronze_jira.jira_issue` |
 | `assert_initial_is_earliest_per_issue_field` | `event_at` of initial row later than first changelog |
 | `assert_value_id_type_consistent` | Same field_id classified with different `value_id_type`s across runs |
+| `assert_one_field_per_role` | Two vendor fields bound to one metric role — consumers merge them rather than choose, and `precedence` is not read yet |
+| `assert_boards_yield_cards` | Projects V2 boards and board events collected, cards not — the date filter on `items(query:)` is being rejected silently |
 
 ## Not covered (too expensive)
 

--- a/src/ingestion/dbt/tests/task/assert_boards_yield_cards.sql
+++ b/src/ingestion/dbt/tests/task/assert_boards_yield_cards.sql
@@ -1,0 +1,40 @@
+-- The board card stream filters server-side on a date: `items(query: "updated:>=…")`.
+-- That filter fails SILENTLY. An unparseable qualifier — a stray timestamp, a
+-- typo — returns zero rows with no GraphQL error, so the sync is green, the
+-- stream is empty, and nothing distinguishes it from a genuinely quiet week.
+-- The connector guards the input by rendering a bare date; this guards the
+-- outcome.
+--
+-- The condition is deliberately narrow so it cannot fire on a real zero: the
+-- source must have collected board field definitions (boards are visible) AND
+-- board status events (a card existed and moved) while holding no card rows at
+-- all. A new organization with empty boards satisfies neither of the first two.
+
+WITH boards AS (
+    SELECT DISTINCT tenant_id, source_id
+    FROM {{ source('bronze_github', 'project_fields') }} FINAL
+    WHERE COALESCE(project_id, '') != ''
+),
+
+board_events AS (
+    SELECT DISTINCT tenant_id, source_id
+    FROM {{ source('bronze_github', 'issue_timeline_events') }} FINAL
+    WHERE event_type = 'ProjectV2ItemStatusChangedEvent'
+),
+
+cards AS (
+    SELECT DISTINCT tenant_id, source_id
+    FROM {{ source('bronze_github', 'project_items') }} FINAL
+    WHERE COALESCE(item_id, '') != ''
+)
+
+SELECT
+    b.tenant_id  AS tenant_id,
+    b.source_id  AS source_id,
+    'boards and board events are collected, cards are not — the incremental filter is rejected' AS finding
+FROM boards AS b
+INNER JOIN board_events AS e
+    ON e.tenant_id = b.tenant_id AND e.source_id = b.source_id
+LEFT ANTI JOIN cards AS c
+    ON c.tenant_id = b.tenant_id AND c.source_id = b.source_id
+LIMIT 100

--- a/src/ingestion/dbt/tests/task/assert_bound_values_are_mapped.sql
+++ b/src/ingestion/dbt/tests/task/assert_bound_values_are_mapped.sql
@@ -37,6 +37,9 @@ observed AS (
         AND b.data_source = fh.data_source
         AND b.field_id = fh.field_id
     WHERE fh.delta_action = 'set' AND fh.value_ids[1] != ''
+      {% if not var('task_board_bindings_enforced', false) %}
+      AND NOT startsWith(fh.field_id, 'project_status:')
+      {% endif %}
 )
 
 SELECT o.*

--- a/src/ingestion/dbt/tests/task/assert_every_field_is_bound_or_ignored.sql
+++ b/src/ingestion/dbt/tests/task/assert_every_field_is_bound_or_ignored.sql
@@ -27,6 +27,11 @@ carrying_events AS (
         ON c.insight_source_id = fh.insight_source_id
         AND c.data_source = fh.data_source
     WHERE fh.field_id != 'created'
+      {% if not var('task_board_bindings_enforced', false) %}
+      -- Boards are not enforced yet: one authored binding per board, and no
+      -- surface to author them in. See `task_board_bindings_enforced`.
+      AND NOT startsWith(fh.field_id, 'project_status:')
+      {% endif %}
 )
 
 SELECT e.*

--- a/src/ingestion/dbt/tests/task/assert_one_field_per_role.sql
+++ b/src/ingestion/dbt/tests/task/assert_one_field_per_role.sql
@@ -1,0 +1,36 @@
+-- A role names one field. Every consumer joins `task_field_roles_current` by
+-- role and takes what comes back, so two fields bound to the same role in one
+-- source do not compete — they MERGE. For `status` that means two independent
+-- timelines interleaved into one ordered event array, and a span sequence that
+-- belongs to neither field.
+--
+-- This is reachable the moment boards are bindable: an issue's own open/closed
+-- lifecycle and a Projects V2 board column are different fields, and both look
+-- like a status. `config.task_field_roles.precedence` exists to choose between
+-- them and is read by nothing yet, so until it is, binding both is a defect
+-- rather than a configuration.
+--
+-- `ignored` is excluded: it is the explicit "somebody looked and decided not
+-- to use this field" marker, and any number of fields may carry it.
+
+WITH bound AS (
+    SELECT
+        insight_source_id,
+        data_source,
+        field_id,
+        argMax(role, (valid_from, recorded_at)) AS role
+    FROM config.task_field_roles FINAL
+    WHERE is_deleted = 0 AND valid_from <= now64(3)
+    GROUP BY insight_source_id, data_source, field_id
+)
+
+SELECT
+    insight_source_id,
+    data_source,
+    role,
+    groupArray(field_id) AS fields_bound_to_it
+FROM bound
+WHERE role != 'ignored'
+GROUP BY insight_source_id, data_source, role
+HAVING count() > 1
+LIMIT 100

--- a/src/ingestion/scripts/connectors-ddl/github.sql
+++ b/src/ingestion/scripts/connectors-ddl/github.sql
@@ -223,7 +223,10 @@ CREATE TABLE IF NOT EXISTS bronze_github.issue_timeline_events
     `prev_value_id` Nullable(String),
     `new_value_id` Nullable(String),
     `prev_options_json` Nullable(String),
-    `new_options_json` Nullable(String)
+    `new_options_json` Nullable(String),
+    `project_id` Nullable(String),
+    `project_number` Nullable(Int64),
+    `was_automated` Nullable(Bool)
 )
 ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
 ORDER BY unique_key
@@ -290,6 +293,67 @@ CREATE TABLE IF NOT EXISTS bronze_github.issues
     `updated_at` Nullable(String),
     `closed_at` Nullable(String),
     `issue_field_values_json` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github.project_fields
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `snapshot_date` Nullable(String),
+    `project_id` Nullable(String),
+    `project_number` Nullable(Int64),
+    `field_id` Nullable(String),
+    `field_database_id` Nullable(String),
+    `field_name` Nullable(String),
+    `data_type` Nullable(String),
+    `is_multi` Nullable(Bool),
+    `is_mirror` Nullable(Bool),
+    `is_issue_field` Nullable(Bool),
+    `options_json` Nullable(String),
+    `configuration_json` Nullable(String),
+    `field_updated_at` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github.project_items
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `project_id` Nullable(String),
+    `project_number` Nullable(Int64),
+    `item_id` Nullable(String),
+    `item_database_id` Nullable(String),
+    `item_type` Nullable(String),
+    `content_type` Nullable(String),
+    `content_number` Nullable(Int64),
+    `content_repo_full_name` Nullable(String),
+    `is_archived` Nullable(Bool),
+    `creator_login` Nullable(String),
+    `creator_id` Nullable(Int64),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String),
+    `field_values_json` Nullable(String)
 )
 ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
 ORDER BY unique_key

--- a/src/ingestion/tests/e2e/metrics/github_tasks_board_status.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/github_tasks_board_status.test.yaml
@@ -1,0 +1,128 @@
+spec_version: 1
+description: >
+  Task Delivery - dev time, pickup time and flow efficiency for GITHUB, driven
+  by a Projects V2 board column.
+
+  An issue's own lifecycle has no middle: GitHub says open or closed and
+  nothing else. A board column is the only place it says work is in progress,
+  so these three measures exist for GitHub only through a board. This fixture
+  pins that path end to end - a status event that names a board and two column
+  NAMES, resolved through an operator's binding into a lifecycle category.
+
+  The issue is created on the 1st, lands on the board as Todo on the 2nd,
+  enters In progress on the 6th and reaches Done on the 11th. Pickup is
+  therefore five days from creation, active development is five days, and
+  lifetime is ten - so flow efficiency is exactly half. Reading the pickup from
+  the first recorded event instead of from the synthesised creation marker
+  would report four days and look entirely plausible.
+
+  The second board is the control. The same issue also sits on PVT_board2 and
+  moves through it on completely different dates, and that board is bound to
+  nothing. Its events reach silver as their own field and must contribute
+  nothing: a board's status is not the issue's status, and two boards are not
+  one timeline. If the field identity were shared - or if both boards were
+  bound to the same role - the two histories would interleave and every number
+  below would move.
+
+  `state` and `type` are bound to `ignored`, which is the difference between
+  "somebody looked and decided" and silence. Binding `state` to `status` as
+  well would merge two independent timelines into one ordered event array;
+  `assert_one_field_per_role` refuses that, and `precedence` is not read by any
+  consumer yet.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/carol
+
+  bronze_github.commit_authors:
+    - { $ref: templates/github_task.yaml#/templates/commit_author, unique_key: gh-author-1003, _airbyte_raw_id: gh-author-1003, author_id: 1003, author_login: carol, author_email: carol@example.com }
+
+  config.task_field_roles:
+    # The board is the lifecycle source; the issue's own state is not.
+    - $ref: templates/github_task.yaml#/templates/role_board_status
+    - $ref: templates/github_task.yaml#/templates/role_assignees
+    - { $ref: templates/github_task.yaml#/templates/role_state, unique_key: gh-role-state-ignored, role: ignored }
+    - { $ref: templates/github_task.yaml#/templates/role_type, unique_key: gh-role-type-ignored, role: ignored }
+
+  config.task_value_map:
+    - $ref: templates/github_task.yaml#/templates/value_board_todo
+    - $ref: templates/github_task.yaml#/templates/value_board_in_progress
+    - $ref: templates/github_task.yaml#/templates/value_board_done
+
+  bronze_github.issue_types: []
+  bronze_github.issue_fields: []
+
+  bronze_github.project_fields:
+    - $ref: templates/github_task.yaml#/templates/project_field_status
+    - { $ref: templates/github_task.yaml#/templates/project_field_status, unique_key: gh-project-field-status-2, _airbyte_raw_id: gh-project-field-status-2,
+        project_id: PVT_board2, project_number: 41, field_id: PVTSSF_board2_status }
+    # A built-in mirror of an issue property. It must not become a bindable
+    # board field: read as a value it would compete with the issue's own.
+    - { $ref: templates/github_task.yaml#/templates/project_field_status, unique_key: gh-project-field-title, _airbyte_raw_id: gh-project-field-title,
+        field_id: PVTF_board1_title, field_name: Title, data_type: TITLE, is_mirror: true, options_json: "[]" }
+
+  bronze_github.project_items:
+    - $ref: templates/github_task.yaml#/templates/project_item
+    - { $ref: templates/github_task.yaml#/templates/project_item, unique_key: gh-project-item-2, _airbyte_raw_id: gh-project-item-2,
+        project_id: PVT_board2, project_number: 41, item_id: PVTI_card2 }
+
+  bronze_github.issues:
+    - { $ref: templates/github_task.yaml#/templates/issue, id: 1, number: 1, unique_key: gh-issue-1, assignee_logins: carol, assignee_ids: "1003", author_id: 1003,
+        created_at: "2026-03-01T09:00:00Z", closed_at: "2026-03-11T09:00:00Z", updated_at: "2026-03-11T09:00:00Z" }
+
+  bronze_github.issue_timeline_events:
+    # The bound board: Todo on the 2nd, In progress on the 6th, Done on the 11th.
+    - { $ref: templates/github_task.yaml#/templates/board_status_event, unique_key: gh-bev-1, event_id: PSE_1, event_at: "2026-03-02T09:00:00Z", prev_value: "",            new_value: Todo }
+    - { $ref: templates/github_task.yaml#/templates/board_status_event, unique_key: gh-bev-2, event_id: PSE_2, event_at: "2026-03-06T09:00:00Z", prev_value: Todo,          new_value: "In progress" }
+    - { $ref: templates/github_task.yaml#/templates/board_status_event, unique_key: gh-bev-3, event_id: PSE_3, event_at: "2026-03-11T09:00:00Z", prev_value: "In progress", new_value: Done }
+    # The control board, bound to nothing, moving on different dates. Note the
+    # column names are the same strings — only the board differs.
+    - { $ref: templates/github_task.yaml#/templates/board_status_event, unique_key: gh-bev-4, event_id: PSE_4, event_at: "2026-03-03T09:00:00Z", prev_value: "",            new_value: "In progress", project_id: PVT_board2, project_number: 41 }
+    - { $ref: templates/github_task.yaml#/templates/board_status_event, unique_key: gh-bev-5, event_id: PSE_5, event_at: "2026-03-20T09:00:00Z", prev_value: "In progress", new_value: Done,          project_id: PVT_board2, project_number: 41 }
+    # The issue's own closure. Bound to `ignored`, so it reaches silver and
+    # stops there — the board decides when this issue closed.
+    - { $ref: templates/github_task.yaml#/templates/closed_event, unique_key: gh-ev-1, event_id: CE_1, item_number: 1, actor_id: 1003, event_at: "2026-03-11T09:00:00Z" }
+
+cases:
+  - name: a board column supplies the in-progress lifecycle GitHub itself never states
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [carol@example.com] }
+        period: { from: "2026-03-01", to: "2026-03-31" }
+        metrics:
+          - { metric_key: tasks.closed, views: [{ view: period }] }
+          - { metric_key: tasks.dev_time, views: [{ view: period }] }
+          - { metric_key: tasks.pickup_time, views: [{ view: period }] }
+          - { metric_key: tasks.resolution_time, views: [{ view: period }] }
+          - { metric_key: tasks.flow_efficiency, views: [{ view: period }] }
+    expect:
+      - assert: "status == 200"
+      # Closed by the board's Done column, not by the issue's closed state.
+      - metric: tasks.closed
+        view: period
+        find: { entity_id: carol@example.com }
+        equal: { value: 1 }
+      # 6th to 11th: five days in progress. 120 hours, not 408 — which is what
+      # the control board's own In progress to Done span would have produced.
+      - metric: tasks.dev_time
+        view: period
+        find: { entity_id: carol@example.com }
+        equal: { value: 120 }
+      # Creation on the 1st to first In progress on the 6th: five days. Four
+      # would mean the first recorded event was used as the start instead of
+      # the synthesised creation marker.
+      - metric: tasks.pickup_time
+        view: period
+        find: { entity_id: carol@example.com }
+        equal: { value: 5 }
+      - metric: tasks.resolution_time
+        view: period
+        find: { entity_id: carol@example.com }
+        equal: { value: 10 }
+      # Five days of ten.
+      - metric: tasks.flow_efficiency
+        view: period
+        find: { entity_id: carol@example.com }
+        equal: { value: 50 }

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_github.issue_timeline_events.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_github.issue_timeline_events.yaml
@@ -43,3 +43,17 @@ schemas:
       new_value_id: *id001
       prev_options_json: *id001
       new_options_json: *id001
+      # Nullable: only board status and board membership events carry these, so
+      # every other event in a fixture leaves them unset.
+      project_id: &id003
+        type:
+        - string
+        - 'null'
+      project_number:
+        type:
+        - integer
+        - 'null'
+      was_automated:
+        type:
+        - boolean
+        - 'null'

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_github.project_fields.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_github.project_fields.yaml
@@ -1,0 +1,37 @@
+# Mirrors the bronze_github.project_fields DDL in scripts/connectors-ddl/github.sql.
+schemas:
+  bronze_github.project_fields:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      _airbyte_raw_id:
+        type: string
+      _airbyte_extracted_at:
+        type: string
+        format: date-time
+      _airbyte_meta:
+        type: string
+      _airbyte_generation_id:
+        type: integer
+      unique_key: &id001
+        type: string
+      tenant_id: *id001
+      source_id: *id001
+      data_source: *id001
+      collected_at: *id001
+      snapshot_date: *id001
+      project_id: *id001
+      project_number: &id002
+        type: integer
+      field_id: *id001
+      field_database_id: *id001
+      field_name: *id001
+      data_type: *id001
+      is_multi: &id003
+        type: boolean
+      is_mirror: *id003
+      is_issue_field: *id003
+      options_json: *id001
+      configuration_json: *id001
+      field_updated_at: *id001

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_github.project_items.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_github.project_items.yaml
@@ -1,0 +1,38 @@
+# Mirrors the bronze_github.project_items DDL in scripts/connectors-ddl/github.sql.
+schemas:
+  bronze_github.project_items:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      _airbyte_raw_id:
+        type: string
+      _airbyte_extracted_at:
+        type: string
+        format: date-time
+      _airbyte_meta:
+        type: string
+      _airbyte_generation_id:
+        type: integer
+      unique_key: &id001
+        type: string
+      tenant_id: *id001
+      source_id: *id001
+      data_source: *id001
+      collected_at: *id001
+      project_id: *id001
+      project_number: &id002
+        type: integer
+      item_id: *id001
+      item_database_id: *id001
+      item_type: *id001
+      content_type: *id001
+      content_number: *id002
+      content_repo_full_name: *id001
+      is_archived:
+        type: boolean
+      creator_login: *id001
+      creator_id: *id002
+      created_at: *id001
+      updated_at: *id001
+      field_values_json: *id001

--- a/src/ingestion/tests/e2e/metrics/templates/github_task.yaml
+++ b/src/ingestion/tests/e2e/metrics/templates/github_task.yaml
@@ -68,6 +68,45 @@ templates:
     canonical_value: done
     value_display: Not planned
 
+  # A Projects V2 board's status is its OWN field, one per board, never the
+  # issue's `state`. The field identity is the board, because a status event
+  # names the board and no field object; the value key carries the board too,
+  # so two boards' same-named columns stay distinct dimension rows.
+  #
+  # Binding this to `status` INSTEAD of `state` is the point of a board: the
+  # issue's own lifecycle has no middle, and a board column is the only place
+  # GitHub says work is in progress. Binding both is a defect, not a choice —
+  # consumers join by role and merge what they find. `assert_one_field_per_role`
+  # refuses it.
+  role_board_status:
+    $ref: "#/templates/role_state"
+    field_id: "project_status:PVT_board1"
+    unique_key: gh-role-board-status
+    role: status
+    precedence: 1
+
+  value_board_todo:
+    $ref: "#/templates/value_open"
+    field_id: "project_status:PVT_board1"
+    value_id: "PVT_board1:todo"
+    unique_key: gh-value-board-todo
+    canonical_value: new
+    value_display: Todo
+
+  value_board_in_progress:
+    $ref: "#/templates/value_board_todo"
+    value_id: "PVT_board1:in progress"
+    unique_key: gh-value-board-in-progress
+    canonical_value: in_progress
+    value_display: In progress
+
+  value_board_done:
+    $ref: "#/templates/value_board_todo"
+    value_id: "PVT_board1:done"
+    unique_key: gh-value-board-done
+    canonical_value: done
+    value_display: Done
+
   # ── catalogues ─────────────────────────────────────────────────────────
   issue_type_task:
     unique_key: gh-type-task
@@ -142,6 +181,97 @@ templates:
     closed_at: "2026-03-25T09:00:00Z"
     issue_field_values_json: "[]"
     _airbyte_raw_id: gh-issue
+    _airbyte_extracted_at: "2026-03-31T00:00:00Z"
+    _airbyte_meta: '{"changes":[]}'
+    _airbyte_generation_id: 1
+
+  # The board's own field definition. `github__task_field_metadata` declares a
+  # bindable board status only for a board that actually defines a select
+  # column, so without this row the board is not bindable.
+  project_field_status:
+    unique_key: gh-project-field-status
+    tenant_id: "11111111-1111-1111-1111-111111111111"
+    source_id: github-test
+    data_source: github
+    collected_at: "2026-03-01T00:00:00Z"
+    snapshot_date: "2026-03-01"
+    project_id: PVT_board1
+    project_number: 40
+    field_id: PVTSSF_board1_status
+    field_database_id: "1"
+    field_name: Status
+    data_type: SINGLE_SELECT
+    is_multi: false
+    is_mirror: false
+    is_issue_field: false
+    options_json: '[{"id":"opt_todo","name":"Todo"},{"id":"opt_wip","name":"In progress"},{"id":"opt_done","name":"Done"}]'
+    configuration_json: "{}"
+    field_updated_at: "2026-03-01T00:00:00Z"
+    _airbyte_raw_id: gh-project-field-status
+    _airbyte_extracted_at: "2026-03-01T00:00:00Z"
+    _airbyte_meta: '{"changes":[]}'
+    _airbyte_generation_id: 1
+
+  # A board status change. It states the board and the two column NAMES — no
+  # option identifier anywhere, which is why the value key is built from the
+  # name and why casing is normalised downstream.
+  board_status_event:
+    unique_key: gh-board-event
+    tenant_id: "11111111-1111-1111-1111-111111111111"
+    source_id: github-test
+    data_source: github
+    collected_at: "2026-03-31T00:00:00Z"
+    event_id: PSE_1
+    event_type: ProjectV2ItemStatusChangedEvent
+    event_at: "2026-03-05T09:00:00Z"
+    item_number: 1
+    repo_full_name: acme/app
+    actor_login: alice
+    actor_id: 1001
+    target_login: ""
+    target_id: 0
+    label_name: ""
+    state_reason: ""
+    field_id: ""
+    field_name: ""
+    prev_value: ""
+    new_value: Todo
+    prev_value_id: ""
+    new_value_id: ""
+    prev_options_json: "[]"
+    new_options_json: "[]"
+    project_id: PVT_board1
+    project_number: 40
+    was_automated: false
+    _airbyte_raw_id: gh-board-event
+    _airbyte_extracted_at: "2026-03-31T00:00:00Z"
+    _airbyte_meta: '{"changes":[]}'
+    _airbyte_generation_id: 1
+
+  # A card snapshot. Nothing in gold reads it yet, but `assert_boards_yield_cards`
+  # does: boards and board events collected with no cards at all is the shape a
+  # silently rejected incremental filter leaves behind.
+  project_item:
+    unique_key: gh-project-item
+    tenant_id: "11111111-1111-1111-1111-111111111111"
+    source_id: github-test
+    data_source: github
+    collected_at: "2026-03-31T00:00:00Z"
+    project_id: PVT_board1
+    project_number: 40
+    item_id: PVTI_card1
+    item_database_id: "9001"
+    item_type: ISSUE
+    content_type: Issue
+    content_number: 1
+    content_repo_full_name: acme/app
+    is_archived: false
+    creator_login: alice
+    creator_id: 1001
+    created_at: "2026-03-02T09:00:00Z"
+    updated_at: "2026-03-11T09:00:00Z"
+    field_values_json: '[{"__typename":"ProjectV2ItemFieldSingleSelectValue","optionId":"opt_done","name":"Done","field":{"id":"PVTSSF_board1_status","name":"Status","dataType":"SINGLE_SELECT"}}]'
+    _airbyte_raw_id: gh-project-item
     _airbyte_extracted_at: "2026-03-31T00:00:00Z"
     _airbyte_meta: '{"changes":[]}'
     _airbyte_generation_id: 1


### PR DESCRIPTION
Refs #2908.

**Why.** GitHub states no in-progress lifecycle — an issue is open or closed — so dev time, pickup time and flow efficiency cannot exist for GitHub issues unless a board column supplies the middle state.

**What changed.** Two streams collect Projects V2 boards — `project_fields`, and `project_items` incremental on the card's own update date — and `issue_timeline_events` gains the board discriminator and the two membership event types, so a board's status column reaches `class_task_field_history` as its own bindable field. The card filter's day granularity and its silent rejection of a bad qualifier are in `DESIGN.md` §4; the identity it forces, §5.

**Board status is its own field, never the issue's `state`.** Merging them is currently a defect, not a configuration: nothing chooses between two fields bound to one role and `precedence` is read by nothing, so `assert_one_field_per_role` refuses that state.

**Board binding coverage is not enforced yet.** `task_board_bindings_enforced` (default false) keeps board fields out of the two coverage tests — one status field per board, authored by hand, would turn collection into a red build. Reporting relaxes; the invariant does not. One flag to flip back.

**With no binding authored, no gold number moves.** Unbound rows carry no role and never get a synthetic initial row, so `task_issue_state` drops them before its pivot. That exclusion is load-bearing: a card can join a board long after its issue was created, so an initial row would fabricate a span.

**Out of scope.** Honouring `precedence`, an authoring surface for bindings, board views and workflow definitions, membership in silver — recorded in #2908 and `DESIGN.md` §10.

**Verified.** 36 connector mock tests; all three streams read against the live GitHub API, which found two defects the mocks could not model (`ProjectV2MultiSelectField` names its options `multiSelectOptions`, and a client-side incremental cut that silently drops every record); the full e2e metrics suite green locally, 79 of 79 fixtures, including the new `github_tasks_board_status` — a board column supplying the lifecycle while a second, unbound board contributes nothing; the `connectors-ddl` addition derived from a rule reproducing all 22 committed `bronze_github` relations byte-for-byte. Not run: `dbt parse` — the local fusion preview reports 963 pre-existing errors.
