### PR TITLE
fix(analytics): record the syncs the mover reports, and open a connector from its whole row

### DIFF
--- a/docs/components/backend/analytics/specs/connector-health/DESIGN.md
+++ b/docs/components/backend/analytics/specs/connector-health/DESIGN.md
@@ -174,8 +174,18 @@ One table holds three kinds of row, told apart by `event`.
 | Event | Written when | Carries |
 |---|---|---|
 | `sync.completed` | the sweep sees a job in the mover's history | job identity, connector, outcome, timestamps, duration, reported records |
-| `connector.configured` | each tick, one row per managed connector | connector, tick identity |
+| `connector.configured` | each tick, one row per configured connector | connector, tick identity |
 | `sweep.completed` | each tick, last | tick identity — the marker that seals the snapshot |
+
+**Configured is what it means to the reconcile loop: a shipped descriptor that has a
+Kubernetes Secret on this install.** The two differ by most of the list — descriptors are
+every connector the product knows how to run, and reconcile cascade-deletes the mover
+resources of any without a Secret rather than driving it. Recording the descriptor set would
+fill the page with connectors the install never had, each correctly reported as never synced
+and none of them anything an operator can act on. A connector whose Secret lookup fails is
+neither in nor out: the tick records nothing at all, because dropping it would seal a snapshot
+saying it is no longer configured and the read surface takes a sealed snapshot as
+authoritative.
 
 **What each event writes.** One table serving three row classes means every column needs a
 defined value on every one of them. A column left to the implementation's judgement is a
@@ -188,7 +198,7 @@ column the reader and the writer will disagree about.
 | `connector` | the synced connector | the member connector | empty |
 | `status` | the mapped outcome | empty | empty |
 | `started_at` | the job's own start, else its first attempt's; NULL if not started | NULL | NULL |
-| `job_created_at` | always present | NULL | NULL |
+| `job_updated_at` | always present | NULL | NULL |
 | `duration_ms` | between the mover's own two stamps; NULL until terminal | NULL | NULL |
 | `records_reported` | the last attempt's count; NULL if it reported none | NULL | NULL |
 
@@ -200,10 +210,11 @@ them, so an absent-value type would buy nothing and cost a nullable read on the 
 out-of-range one — it clamps a `DateTime64` and wraps a `UInt64`. A year-1000 stamp lands as
 1900 and a count above 2^64 lands as a different number, and the page would label both as
 what the mover reported. A stamp or a count the column cannot hold is therefore treated as
-absent, and a job whose creation stamp is unusable is not recorded at all.
+absent, and a job whose update stamp is unusable is not recorded at all.
 
 **Resolution.** The summary takes, per connector, the newest `sync.completed` by the mover's
-job creation time; the configured set is the membership of the newest *sealed* tick. Sealing
+own last-update stamp for the job; the configured set is the membership of the newest *sealed*
+tick. Sealing
 matters: without keying on the marker, a snapshot still being written would read as the whole
 set, and a connector removed a moment ago would come back for one tick.
 
@@ -219,24 +230,38 @@ page shows it as a state it could not read. It is also not terminal: coverage fa
 a status the sweep could not read is one it keeps re-reading until it becomes one it can.
 
 **Two timestamps, kept apart.** `started_at` is when the mover says the sync began, and is
-absent for a job it has not started. `job_created_at` is when the job was created, which is
-the field the mover's listing is ordered and filtered by — and therefore the axis the sweep's
-own watermark moves along. Substituting one for the other would report a start that never
-happened and still leave the cursor on the wrong axis.
+absent for a job it has not started. `job_updated_at` is the mover's own last-update stamp for
+the job, which is the field the listing is ordered and filtered by — and therefore the axis
+the sweep's own watermark moves along. Substituting one for the other would report a start
+that never happened and still leave the cursor on the wrong axis.
 
-**`job_created_at` is never NULL on a sync row.** The listing is ordered by it, so a job the
+**The listing reports no creation time, and this is load-bearing.** It accepts a creation
+filter, so a creation stamp looks available from the query surface alone; the entries carry a
+start and a last update and nothing else. A sweep that asks by one field and reads back
+another refuses every entry, and the page then reports every connector as never synced —
+which is indistinguishable from a mover that has run no syncs at all. The sort key, the
+filter and the field read off an entry are therefore one stamp, and both halves of that are
+asserted: the request's shape in the mover's tests, the response's shape in the planner's.
+
+The mover also answers `200` and **ignores a query parameter it does not recognise** rather
+than refusing it. A filter renamed by a later release would therefore stop filtering
+silently: the read restarts at the beginning of history and a capped pass never reaches the
+newest jobs. Each tick counts the entries that came back older than the watermark it sent and
+says so — an ignored filter is otherwise only visible as a page that stopped advancing.
+
+**`job_updated_at` is never NULL on a sync row.** The listing is ordered by it, so a job the
 mover returns always carries one; the column is nullable only because snapshot and seal rows
-are not about a job at all. A job the mover returns without a creation time is one the planner
+are not about a job at all. A job the mover returns without an update stamp is one the planner
 cannot place in time, so it is skipped and logged rather than written with a NULL.
 
 **The resolution is one aggregate over an ordering tuple.** Per connector the newest row wins
 by `argMax` over
-`(coalesce(job_created_at, ts), toUInt64OrZero(job_id), status IN (terminal), ts)`.
+`(coalesce(job_updated_at, ts), toUInt64OrZero(job_id), status IN (terminal), ts)`.
 
 Every component earns its place, and each closes a wrong answer that was measured first:
 
-- **`coalesce(job_created_at, ts)`** — NULLs sort last in ClickHouse in BOTH directions, so a
-  job the mover gave no creation stamp for does not merely lose the comparison: a different,
+- **`coalesce(job_updated_at, ts)`** — NULLs sort last in ClickHouse in BOTH directions, so a
+  job the mover gave no update stamp for does not merely lose the comparison: a different,
   older job wins it, and the page presents a stale success as the current state. Falling back
   to when the row was recorded places the job by a real recorded moment instead.
 - **`toUInt64OrZero(job_id)`** — the mover's ids are numbers stored as text, so comparing them
@@ -271,10 +296,10 @@ the reconcile loop already authenticates to the mover and ticks.
 
 ##### Responsibility scope
 
-Each tick: resolve the watermark from the ledger, page the mover's job listing forward from
-it, map each job's connection to a connector, plan one row per job the ledger does not
-already hold with a terminal outcome, plan the configured-set snapshot, write the rows, then
-write the seal.
+Each tick: resolve the configured set, resolve the watermark from the ledger, page the
+mover's job listing forward from it, map each job's connection to a connector, plan one row
+per job the ledger does not already hold with a terminal outcome, plan the configured-set
+snapshot, write the rows, then write the seal.
 
 The planning is a pure function over values — the shell gathers, the planner decides, and the
 planner is what the tests exercise. Its rules are the change's densest logic: which jobs to
@@ -426,9 +451,10 @@ Shape rules that the generated contract enforces:
   instead of implying health.
 - `window` is the largest number of rows the per-connector list can hold, so the page can say
   the list is a window rather than the whole retained history (FR-6).
-- **The summary carries a row cap too.** The set is bounded by the build's descriptor list in
-  practice, so an install cannot reach the cap by configuring connectors — only by accumulating
-  names in the ledger that no build has. It is a backstop rather than a page, and the read logs
+- **The summary carries a row cap too.** The set is bounded in practice by the build's
+  descriptor list — and below it, by the descriptors this install holds a Secret for — so an
+  install cannot reach the cap by configuring connectors, only by accumulating names in the
+  ledger that no build has. It is a backstop rather than a page, and the read logs
   when it truncates, because reaching it should be visible rather than silent.
 
 ### 3.4 Internal Dependencies
@@ -448,19 +474,24 @@ Shape rules that the generated contract enforces:
 #### Data mover job listing
 
 The sweep reads the mover's public job listing, paged, with five query parameters: the job
-type, ascending creation order, the page's size and offset, and a creation-time floor. Per entry it takes the
-job's identity, its connection, its status, its creation and start stamps, its duration and
-its reported record count — all flat on the entry, all as the listing spells them.
+type, ascending update order, the page's size and offset, and an update-time floor. Per entry
+it takes the job's identity, its connection, its status, its start and last-update stamps, its
+duration and its reported record count — all flat on the entry, all as the listing spells
+them. The listing reports no creation time, so nothing here reads one.
 
 Two of those parameters carry the correctness of the whole read. **Ascending order** is what
 makes a capped pass safe: whatever the cap leaves unread is newer than everything collected,
 so the next tick resumes at that edge rather than the watermark stepping over a gap. **The
-creation-time floor** is what keeps a steady tick from re-reading the whole retained history
-to find the handful of jobs it has not seen.
+update-time floor** is what keeps a steady tick from re-reading the whole retained history to
+find the handful of jobs it has not seen. Both name the same stamp as the field read back off
+an entry, which is what makes the second claim true of the first.
 
 The floor is sent in the listing's own stamp format, which differs from the ledger's by a
 separator. Sending the ledger's form is silent rather than loud — the listing does not filter
-on it — so the conversion lives in one named function rather than at the call site.
+on it — so the conversion lives in one named function rather than at the call site. So is
+sending a parameter name the listing does not know: it answers `200` and drops it. Each tick
+therefore counts what came back below the floor it sent, which is the only signal that
+separates an ignored filter from a quiet mover.
 
 Nothing richer is read. Per-job detail exists and is not contract-stable across mover
 upgrades; the value of this ledger is that it keeps saying what a changing source said.
@@ -487,7 +518,7 @@ sequenceDiagram
     R->>L: oldest job still open (floored), or the newest recorded
     L-->>R: watermark (empty ⇒ backfill everything)
     R->>L: jobs already closed at or after the watermark
-    R->>M: list sync jobs from the watermark, oldest first, paged
+    R->>M: list sync jobs updated from the watermark, oldest first, paged
     M-->>R: jobs with status, stamps, duration, reported records
     R->>R: map each job's connection to a connector
     R->>R: plan rows for jobs not already closed
@@ -584,7 +615,7 @@ customer extracts, which must never carry service rows.
 | `event` | `LowCardinality(String)` | `sync.completed` \| `connector.configured` \| `sweep.completed` |
 | `status` | `LowCardinality(String)` | on a sync row, the mover's own word or `unknown`; empty elsewhere |
 | `started_at` | `Nullable(DateTime64(3, 'UTC'))` | when the mover says the sync began; NULL for a job it has not started |
-| `job_created_at` | `Nullable(DateTime64(3, 'UTC'))` | when the job was created — the axis the watermark moves along; never NULL on a sync row |
+| `job_updated_at` | `Nullable(DateTime64(3, 'UTC'))` | the mover's last-update stamp for the job — the axis the watermark moves along, and the field the listing is ordered and filtered by; never NULL on a sync row |
 | `duration_ms` | `Nullable(UInt64)` | between the mover's own start and end stamps; NULL while a job is in flight and where either stamp is missing, which a zero could not express |
 | `records_reported` | `Nullable(UInt64)` | the mover's own count; NULL where it reported none |
 

--- a/docs/components/backend/analytics/specs/connector-health/DESIGN.md
+++ b/docs/components/backend/analytics/specs/connector-health/DESIGN.md
@@ -245,9 +245,13 @@ asserted: the request's shape in the mover's tests, the response's shape in the 
 
 The mover also answers `200` and **ignores a query parameter it does not recognise** rather
 than refusing it. A filter renamed by a later release would therefore stop filtering
-silently: the read restarts at the beginning of history and a capped pass never reaches the
-newest jobs. Each tick counts the entries that came back older than the watermark it sent and
-says so — an ignored filter is otherwise only visible as a page that stopped advancing.
+silently, and the read would restart at the beginning of history. Each tick counts the
+entries that came back older than the watermark it sent, and **treats any as a failed read**
+— it plans nothing and does not seal. Logging it would not be enough: every terminal job
+below the watermark would be recorded again on every tick, because the closed-job read is
+bounded by that same watermark and so cannot filter them out; and a capped pass would stop
+short of the newest jobs while still sealing, leaving the page dated as freshly checked on
+facts it never reached.
 
 **`job_updated_at` is never NULL on a sync row.** The listing is ordered by it, so a job the
 mover returns always carries one; the column is nullable only because snapshot and seal rows
@@ -490,8 +494,8 @@ The floor is sent in the listing's own stamp format, which differs from the ledg
 separator. Sending the ledger's form is silent rather than loud — the listing does not filter
 on it — so the conversion lives in one named function rather than at the call site. So is
 sending a parameter name the listing does not know: it answers `200` and drops it. Each tick
-therefore counts what came back below the floor it sent, which is the only signal that
-separates an ignored filter from a quiet mover.
+therefore counts what came back below the floor it sent and refuses the read if anything did,
+which is the only thing that separates an ignored filter from a quiet mover.
 
 Nothing richer is read. Per-job detail exists and is not contract-stable across mover
 upgrades; the value of this ledger is that it keeps saying what a changing source said.

--- a/docs/components/backend/analytics/specs/connector-health/PRD.md
+++ b/docs/components/backend/analytics/specs/connector-health/PRD.md
@@ -94,8 +94,8 @@ Two failure classes are invisible today even to a diligent operator reading dash
 | **Connector** | one ingestion source type configured on the install; its raw data lands in a per-connector bronze schema |
 | **Sync** | one execution of the data mover for one connector's connection |
 | **Sync ledger** | the append-only record of sync outcomes this PRD introduces |
-| **Sweep** | the periodic reconciliation that copies sync outcomes from the mover's job history into the ledger, and records which connectors it manages |
-| **Configured connector** | a connector present in the controller's newest COMPLETE snapshot of the set it manages; absence from that snapshot means no longer configured. A snapshot still being written is not one |
+| **Sweep** | the periodic reconciliation that copies sync outcomes from the mover's job history into the ledger, and records which connectors the install has configured |
+| **Configured connector** | a connector the install has supplied credentials for — which is the criterion the controller itself acts on — and which is present in its newest COMPLETE snapshot; absence from that snapshot means no longer configured. A snapshot still being written is not one. Every connector the build ships is a wider set and is not this one |
 | **Reported records** | the record count the mover states for a sync. It describes what the mover sent, not what storage kept |
 
 ## 2. Actors

--- a/src/backend/services/analytics/src/domain/connector_health/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/live_tests.rs
@@ -108,7 +108,7 @@ struct Row<'a> {
     event: &'a str,
     status: &'a str,
     started_at: Option<&'a str>,
-    job_created_at: Option<&'a str>,
+    job_updated_at: Option<&'a str>,
     duration_ms: Option<u64>,
     records_reported: Option<u64>,
 }
@@ -132,7 +132,7 @@ impl Row<'_> {
             self.event,
             self.status,
             moment(self.started_at),
-            moment(self.job_created_at),
+            moment(self.job_updated_at),
             number(self.duration_ms),
             number(self.records_reported),
         )
@@ -143,22 +143,22 @@ async fn insert(ch: &insight_clickhouse::Client, rows: &[Row<'_>]) {
     let values: Vec<String> = rows.iter().map(Row::values).collect();
     let sql = format!(
         "INSERT INTO {TABLE} (ts, tick_id, job_id, connector, event, status, \
-         started_at, job_created_at, duration_ms, records_reported) VALUES {}",
+         started_at, job_updated_at, duration_ms, records_reported) VALUES {}",
         values.join(", ")
     );
     ch.query(&sql).execute().await.expect("insert");
 }
 
-fn sync<'a>(job_id: &'a str, connector: &'a str, status: &'a str, created: &'a str) -> Row<'a> {
+fn sync<'a>(job_id: &'a str, connector: &'a str, status: &'a str, updated: &'a str) -> Row<'a> {
     Row {
-        ts: created,
+        ts: updated,
         tick_id: "tick-1",
         job_id,
         connector,
         event: "sync.completed",
         status,
-        started_at: Some(created),
-        job_created_at: Some(created),
+        started_at: Some(updated),
+        job_updated_at: Some(updated),
         duration_ms: Some(1_000),
         records_reported: Some(7),
     }
@@ -173,7 +173,7 @@ fn configured<'a>(connector: &'a str, tick_id: &'a str, at: &'a str) -> Row<'a> 
         event: "connector.configured",
         status: "",
         started_at: None,
-        job_created_at: None,
+        job_updated_at: None,
         duration_ms: None,
         records_reported: None,
     }
@@ -188,7 +188,7 @@ fn seal<'a>(tick_id: &'a str, at: &'a str) -> Row<'a> {
         event: "sweep.completed",
         status: "",
         started_at: None,
-        job_created_at: None,
+        job_updated_at: None,
         duration_ms: None,
         records_reported: None,
     }
@@ -240,7 +240,7 @@ async fn the_ledger_reads_answer_from_real_rows() {
 /// server before the shape was replaced.
 ///
 /// It sorted the relation and read the winner off the top, which meant: job ids
-/// compared as text so `"9"` beat `"10"`; a NULL creation stamp sorting last in
+/// compared as text so `"9"` beat `"10"`; a NULL update stamp sorting last in
 /// BOTH directions so an older job won outright; and two rows of one job
 /// sharing a millisecond decided by physical row order. Each produced a
 /// confident wrong answer rather than an absence.
@@ -251,7 +251,7 @@ async fn the_resolution_survives_every_way_it_used_to_be_wrong(
     insert(
         ch,
         &[
-            // Same creation moment, ids 9 and 10: text order says 9 is newer.
+            // Same update moment, ids 9 and 10: text order says 9 is newer.
             sync("9", "numeric", "succeeded", &at.job_older),
             Row {
                 ts: &at.tick_1,
@@ -264,11 +264,11 @@ async fn the_resolution_survives_every_way_it_used_to_be_wrong(
                 records_reported: Some(0),
                 ..sync("10", "numeric", "failed", &at.job_older)
             },
-            // A newer job the mover gave no creation stamp for.
+            // A newer job the mover gave no update stamp for.
             sync("1", "unplaced", "succeeded", &at.job_older),
             Row {
                 ts: &at.tick_3,
-                job_created_at: None,
+                job_updated_at: None,
                 ..sync("2", "unplaced", "failed", &at.job_newer)
             },
         ],
@@ -298,12 +298,12 @@ async fn the_resolution_survives_every_way_it_used_to_be_wrong(
     let resolved = unplaced.last_sync.as_ref().expect("unplaced has synced");
     assert_eq!(
         resolved.job_id, "2",
-        "a job with no creation stamp must not hand the answer to an older one"
+        "a job with no update stamp must not hand the answer to an older one"
     );
     assert!(
-        resolved.job_created_at.is_none(),
+        resolved.job_updated_at.is_none(),
         "the resolved row must be one real row, not a mix of two: job 2 has no \
-         creation stamp, so this must be absent rather than job 1's stamp"
+         update stamp, so this must be absent rather than job 1's stamp"
     );
     assert_eq!(resolved.status, SyncStatus::Failed);
 }

--- a/src/backend/services/analytics/src/domain/connector_health/model.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/model.rs
@@ -86,9 +86,10 @@ pub(crate) struct LastSync {
     pub job_id: String,
     pub status: SyncStatus,
     pub started_at: Option<DateTime<Utc>>,
-    /// The axis the ledger orders jobs along. Used to sort within a band and
-    /// never serialised — the page has no use for a job's creation time.
-    pub job_created_at: Option<DateTime<Utc>>,
+    /// The axis the ledger orders jobs along — the mover's own last-update
+    /// stamp for the job. Used to sort within a band and never serialised: the
+    /// page states when a sync started, which is a different fact.
+    pub job_updated_at: Option<DateTime<Utc>>,
     pub duration_ms: Option<u64>,
     pub records_reported: Option<u64>,
 }
@@ -125,7 +126,7 @@ impl ConnectorSummary {
     /// When this connector was last heard from, for ordering inside a band.
     fn last_activity(&self) -> Option<DateTime<Utc>> {
         let sync = self.last_sync.as_ref()?;
-        sync.started_at.or(sync.job_created_at)
+        sync.started_at.or(sync.job_updated_at)
     }
 }
 

--- a/src/backend/services/analytics/src/domain/connector_health/read.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/read.rs
@@ -80,10 +80,10 @@ static READ_INTERVAL_SQL: LazyLock<String> = LazyLock::new(|| {
 ///
 /// Four components, each earning its place:
 ///
-/// * `coalesce(job_created_at, ts)` — the axis the ledger places jobs along,
+/// * `coalesce(job_updated_at, ts)` — the axis the ledger places jobs along,
 ///   falling back to when the row was recorded. A NULL here would be worse than
 ///   a fallback: ClickHouse sorts NULLs last in BOTH directions, so a job the
-///   mover gave no creation time would not merely lose the comparison — a
+///   mover gave no update stamp for would not merely lose the comparison — a
 ///   different, older job would win it, and the page would present a stale
 ///   success as the current state.
 /// * `toUInt64OrZero(job_id)` — the mover's ids are numbers stored as text, so
@@ -99,7 +99,7 @@ static ROW_ORDER: LazyLock<String> = LazyLock::new(|| {
         .collect::<Vec<_>>()
         .join(", ");
     format!(
-        "(coalesce(job_created_at, ts), toUInt64OrZero(job_id), \
+        "(coalesce(job_updated_at, ts), toUInt64OrZero(job_id), \
           status IN ({terminal}), ts)"
     )
 });
@@ -111,7 +111,7 @@ static ROW_ORDER: LazyLock<String> = LazyLock::new(|| {
 /// calls answer from six independently-chosen rows — one column taken from
 /// the newest job and another from an older one whose value happened not to
 /// be NULL, producing a row that never existed.
-const SYNC_COLUMNS: &str = "job_id, status, started_at, job_created_at, \
+const SYNC_COLUMNS: &str = "job_id, status, started_at, job_updated_at, \
      duration_ms, records_reported";
 
 /// The unpacked tuple, under names no ledger column carries.
@@ -122,7 +122,7 @@ const SYNC_COLUMNS: &str = "job_id, status, started_at, job_created_at, \
 /// with an exception. This keeps the rule absolute.
 const UNPACK_WINNER: &str = "winner.1 AS resolved_job_id, \
      winner.2 AS resolved_status, winner.3 AS resolved_started_at, \
-     winner.4 AS resolved_job_created_at, winner.5 AS resolved_duration_ms, \
+     winner.4 AS resolved_job_updated_at, winner.5 AS resolved_duration_ms, \
      winner.6 AS resolved_records_reported";
 
 /// The newest sync per connector.
@@ -216,10 +216,10 @@ struct SyncRow {
     )]
     started_at: Option<DateTime<Utc>>,
     #[serde(
-        rename = "resolved_job_created_at",
+        rename = "resolved_job_updated_at",
         with = "clickhouse::serde::chrono::datetime64::millis::option"
     )]
-    job_created_at: Option<DateTime<Utc>>,
+    job_updated_at: Option<DateTime<Utc>>,
     #[serde(rename = "resolved_duration_ms")]
     duration_ms: Option<u64>,
     #[serde(rename = "resolved_records_reported")]
@@ -238,10 +238,10 @@ struct HistoryRow {
     )]
     started_at: Option<DateTime<Utc>>,
     #[serde(
-        rename = "resolved_job_created_at",
+        rename = "resolved_job_updated_at",
         with = "clickhouse::serde::chrono::datetime64::millis::option"
     )]
-    job_created_at: Option<DateTime<Utc>>,
+    job_updated_at: Option<DateTime<Utc>>,
     #[serde(rename = "resolved_duration_ms")]
     duration_ms: Option<u64>,
     #[serde(rename = "resolved_records_reported")]
@@ -341,7 +341,7 @@ impl HistoryRow {
             job_id: self.job_id,
             status: SyncStatus::parse(&self.status),
             started_at: self.started_at,
-            job_created_at: self.job_created_at,
+            job_updated_at: self.job_updated_at,
             duration_ms: self.duration_ms,
             records_reported: self.records_reported,
         }
@@ -364,7 +364,7 @@ fn merge(syncs: Vec<SyncRow>, configured: &HashSet<String>) -> Vec<ConnectorSumm
             job_id: row.job_id,
             status: SyncStatus::parse(&row.status),
             started_at: row.started_at,
-            job_created_at: row.job_created_at,
+            job_updated_at: row.job_updated_at,
             duration_ms: row.duration_ms,
             records_reported: row.records_reported,
         };
@@ -543,7 +543,7 @@ mod guards {
         // A NULL sort key does not lose a comparison in ClickHouse — it wins a
         // different one, because NULLs sort last in both directions.
         let order = normalised(&ROW_ORDER);
-        assert!(order.contains("coalesce(job_created_at, ts)"), "{order}");
+        assert!(order.contains("coalesce(job_updated_at, ts)"), "{order}");
         assert!(order.contains("touint64orzero(job_id)"), "{order}");
         assert!(order.contains("status in ("), "{order}");
     }

--- a/src/backend/services/analytics/src/domain/connector_health/tests.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/tests.rs
@@ -23,7 +23,7 @@ fn sync(status: SyncStatus, started: Option<i64>) -> LastSync {
         job_id: "8412".to_owned(),
         status,
         started_at: started.map(moment),
-        job_created_at: started.map(|at| moment(at - 10)),
+        job_updated_at: started.map(|at| moment(at - 10)),
         duration_ms: Some(142_000),
         records_reported: Some(12_400),
     }
@@ -175,7 +175,7 @@ fn absence_crosses_the_wire_as_absence() {
         job_id: "1".to_owned(),
         status: SyncStatus::Pending,
         started_at: None,
-        job_created_at: Some(moment(0)),
+        job_updated_at: Some(moment(0)),
         duration_ms: None,
         records_reported: None,
     });
@@ -197,13 +197,13 @@ fn a_reported_zero_crosses_the_wire_as_zero() {
 }
 
 #[test]
-fn the_creation_time_is_not_serialised() {
-    // It exists to order rows, and a job's creation time is not something the
+fn the_ordering_stamp_is_not_serialised() {
+    // It exists to order rows, and the mover's update stamp is not something the
     // page has any use for. Serialising it would invite a client to read it as
     // the start.
     let json = serde_json::to_string(&SyncFact::from(sync(SyncStatus::Succeeded, Some(0))))
         .expect("serialisable");
-    assert!(!json.contains("job_created_at"), "{json}");
+    assert!(!json.contains("job_updated_at"), "{json}");
 }
 
 #[test]

--- a/src/frontend/src/components/portal/connector-health.test.tsx
+++ b/src/frontend/src/components/portal/connector-health.test.tsx
@@ -6,7 +6,7 @@
  * number renders as absence rather than a zero, and that a stopped recorder
  * reaches a screen reader as an alert rather than as ordinary prose.
  */
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -14,6 +14,16 @@ import type {
   ConnectorHealthSummary,
   ConnectorSyncHistory,
 } from "@/api/connector-health-client";
+
+/**
+ * A connector's row. The whole row is the disclosure control — the same rule
+ * every console listing follows — so there is no button inside it to aim at.
+ */
+function rowFor(connector: string): HTMLElement {
+  const row = screen.getByRole("cell", { name: connector }).closest("tr");
+  if (row === null) throw new Error(`no row for ${connector}`);
+  return row;
+}
 
 const mocks = vi.hoisted(() => ({
   summary: {
@@ -88,8 +98,8 @@ describe("the pane prints what it was served", () => {
     render(<ConnectorHealthPane />);
 
     const names = screen
-      .getAllByRole("button", { expanded: false })
-      .map((button) => button.textContent);
+      .getAllByRole("row", { expanded: false })
+      .map((row) => row.querySelector("td")?.textContent);
     expect(names).toEqual(["zulu", "alpha", "mike"]);
   });
 
@@ -109,23 +119,14 @@ describe("the pane prints what it was served", () => {
     mocks.summary.data = summary({ connectors: [alpha, bravo] });
     const { rerender } = render(<ConnectorHealthPane />);
 
-    await userEvent.click(screen.getByRole("button", { name: "alpha" }));
-    expect(screen.getByRole("button", { name: "alpha" })).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
+    await userEvent.click(rowFor("alpha"));
+    expect(rowFor("alpha")).toHaveAttribute("aria-expanded", "true");
 
     mocks.summary.data = summary({ connectors: [bravo, alpha] });
     rerender(<ConnectorHealthPane />);
 
-    expect(screen.getByRole("button", { name: "alpha" })).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-    expect(screen.getByRole("button", { name: "bravo" })).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
+    expect(rowFor("alpha")).toHaveAttribute("aria-expanded", "true");
+    expect(rowFor("bravo")).toHaveAttribute("aria-expanded", "false");
   });
 
   it("prints an unmeasured number as absence, not as a zero", () => {
@@ -146,10 +147,9 @@ describe("the pane prints what it was served", () => {
     });
     render(<ConnectorHealthPane />);
 
-    const row = screen.getByRole("button", { name: "alpha" }).closest("tr");
-    expect(row).not.toBeNull();
-    expect(within(row as HTMLElement).getAllByText("—")).toHaveLength(3);
-    expect(within(row as HTMLElement).queryByText("0")).not.toBeInTheDocument();
+    const row = rowFor("alpha");
+    expect(within(row).getAllByText("—")).toHaveLength(3);
+    expect(within(row).queryByText("0")).not.toBeInTheDocument();
   });
 
   it("says a reported zero is a zero", () => {
@@ -170,8 +170,7 @@ describe("the pane prints what it was served", () => {
     });
     render(<ConnectorHealthPane />);
 
-    const row = screen.getByRole("button", { name: "alpha" }).closest("tr");
-    expect(within(row as HTMLElement).getByText("0")).toBeInTheDocument();
+    expect(within(rowFor("alpha")).getByText("0")).toBeInTheDocument();
   });
 
   it("says nothing has been recorded instead of implying health", () => {
@@ -259,7 +258,7 @@ describe("a read that failed says so", () => {
     mocks.syncs.data = undefined;
     render(<ConnectorHealthPane />);
 
-    await userEvent.click(screen.getByRole("button", { name: "alpha" }));
+    await userEvent.click(rowFor("alpha"));
 
     // The summary above it is still readable — one connector's unreadable
     // history must not take the page down with it.
@@ -275,7 +274,7 @@ describe("a read that failed says so", () => {
     mocks.syncs.data = { connector: "alpha", syncs: [], window: 50 };
     render(<ConnectorHealthPane />);
 
-    await userEvent.click(screen.getByRole("button", { name: "alpha" }));
+    await userEvent.click(rowFor("alpha"));
 
     expect(
       screen.getByText(/no sync has been recorded for this connector/i),
@@ -315,12 +314,11 @@ describe("a row expands to its recent syncs", () => {
     };
     render(<ConnectorHealthPane />);
 
-    const toggle = screen.getByRole("button", { name: "alpha" });
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(rowFor("alpha")).toHaveAttribute("aria-expanded", "false");
 
-    await userEvent.click(toggle);
+    await userEvent.click(rowFor("alpha"));
 
-    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(rowFor("alpha")).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByText(/recent syncs/i)).toBeInTheDocument();
   });
 
@@ -345,7 +343,7 @@ describe("a row expands to its recent syncs", () => {
     };
     render(<ConnectorHealthPane />);
 
-    await userEvent.click(screen.getByRole("button", { name: "alpha" }));
+    await userEvent.click(rowFor("alpha"));
 
     expect(
       screen.getByText(/the most recent 50, not the full history/i),
@@ -360,9 +358,68 @@ describe("a row expands to its recent syncs", () => {
     });
     render(<ConnectorHealthPane />);
 
-    // One header row plus one body row. A `role="button"` on a `<tr>` would
-    // remove it from the table for a screen reader, which is why the toggle is
-    // a real button inside the row instead.
+    // One header row plus one body row: the gesture is on the `<tr>` and the
+    // role is not overridden, so the row stays in its table for a screen
+    // reader and still announces itself as a disclosure.
     expect(screen.getAllByRole("row")).toHaveLength(2);
+    expect(rowFor("alpha")).toHaveAttribute("aria-expanded");
+  });
+
+  it("opens the connector from anywhere in the row, not just its name", async () => {
+    // The complaint this answers: only the name was clickable, so the rest of
+    // a wide row looked interactive and did nothing.
+    mocks.summary.data = summary({
+      connectors: [
+        {
+          connector: "alpha",
+          configured: true,
+          last_sync: { job_id: "1", status: "succeeded", started_at: NOW },
+        },
+      ],
+    });
+    render(<ConnectorHealthPane />);
+
+    await userEvent.click(screen.getByText("sync ok"));
+
+    expect(rowFor("alpha")).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("opens the connector from the keyboard", async () => {
+    mocks.summary.data = summary({
+      connectors: [
+        { connector: "alpha", configured: true, last_sync: null },
+      ],
+    });
+    render(<ConnectorHealthPane />);
+
+    rowFor("alpha").focus();
+    await userEvent.keyboard("{Enter}");
+
+    expect(rowFor("alpha")).toHaveAttribute("aria-expanded", "true");
+
+    await userEvent.keyboard(" ");
+
+    expect(rowFor("alpha")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("does not open the connector when a selection was dragged across it", async () => {
+    // Copying a connector name out of the table must not open it. The rule is
+    // shared with every other console listing, which is the point.
+    mocks.summary.data = summary({
+      connectors: [
+        { connector: "alpha", configured: true, last_sync: null },
+      ],
+    });
+    render(<ConnectorHealthPane />);
+
+    const selection = window.getSelection();
+    selection?.selectAllChildren(screen.getByRole("cell", { name: "alpha" }));
+
+    // Dispatched rather than driven through userEvent: a real pointer press
+    // collapses the selection before the handler sees it, so the one state
+    // this guard exists for cannot be reached that way.
+    fireEvent.click(rowFor("alpha"));
+
+    expect(rowFor("alpha")).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/src/frontend/src/components/portal/connector-health.tsx
+++ b/src/frontend/src/components/portal/connector-health.tsx
@@ -23,6 +23,7 @@ import {
   type ConnectorTone,
 } from "@/lib/portal/connector-health";
 import { useConnectorHealth, useConnectorSyncs } from "@/queries/connector-health";
+import { activatesRow, activatesRowByKey } from "@/lib/identities/row-activation";
 import { TEXT_LABEL } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 
@@ -53,7 +54,7 @@ export function ConnectorHealthPane() {
   const recording = describeRecording(data);
 
   return (
-    <div className="flex flex-col gap-4 p-4 md:p-6">
+    <div className="flex flex-col gap-3 p-4 md:p-6">
       <div>
         <h1 className="text-lg font-semibold tracking-tight">
           Connector health
@@ -103,34 +104,51 @@ export function ConnectorHealthPane() {
                 // cannot carry two rows sharing one.
                 const open = expanded === row.connector;
                 const panelId = `connector-syncs-${row.connector}`;
+                const toggle = () => setExpanded(open ? null : row.connector);
                 return [
-                  <TableRow key={row.connector} data-state-name={state.state}>
+                  // The whole row opens the connector, by the same rule every
+                  // console listing follows — `activatesRow` is shared with
+                  // them, so a press on a control and the end of a text
+                  // selection are told apart here exactly as they are there.
+                  //
+                  // The gesture goes on the row and the role does not: a `<tr>`
+                  // keeps `role="row"`, which supports `aria-expanded`, so the
+                  // disclosure is announced without taking the row out of its
+                  // table. An inner button would be a second focus stop for the
+                  // one thing the row already does.
+                  <TableRow
+                    key={row.connector}
+                    data-state-name={state.state}
+                    data-state={open ? "selected" : undefined}
+                    tabIndex={0}
+                    aria-expanded={open}
+                    aria-controls={panelId}
+                    onClick={(event) => {
+                      if (activatesRow(event)) toggle();
+                    }}
+                    onKeyDown={(event) => {
+                      if (!activatesRowByKey(event)) return;
+                      event.preventDefault();
+                      toggle();
+                    }}
+                    className="cursor-pointer select-text"
+                  >
+                    <TableCell className="font-medium">{row.connector}</TableCell>
                     <TableCell>
-                      {/* A real button rather than a role on the row: an
-                          overridden role takes the row out of the table for a
-                          screen reader, which costs more than it buys. */}
-                      <button
-                        type="button"
-                        className="text-left font-medium underline-offset-2 hover:underline"
-                        aria-expanded={open}
-                        aria-controls={panelId}
-                        onClick={() => setExpanded(open ? null : row.connector)}
+                      <Badge
+                        variant="secondary"
+                        className={cn("font-medium", TONE_STYLE[state.tone])}
                       >
-                        {row.connector}
-                      </button>
-                    </TableCell>
-                    <TableCell>
-                      <Badge className={cn("font-medium", TONE_STYLE[state.tone])}>
                         {state.label}
                       </Badge>
                     </TableCell>
-                    <TableCell className="tabular-nums">
+                    <TableCell className="tabular-nums text-muted-foreground">
                       {formatStarted(row.last_sync?.started_at ?? null)}
                     </TableCell>
-                    <TableCell className="text-right tabular-nums">
+                    <TableCell className="text-right tabular-nums text-muted-foreground">
                       {formatDuration(row.last_sync?.duration_ms ?? null)}
                     </TableCell>
-                    <TableCell className="text-right tabular-nums">
+                    <TableCell className="text-right tabular-nums text-muted-foreground">
                       {formatRecords(row.last_sync?.records_reported ?? null)}
                     </TableCell>
                   </TableRow>,

--- a/src/ingestion/reconcile-connectors/lib/sweep.sh
+++ b/src/ingestion/reconcile-connectors/lib/sweep.sh
@@ -82,6 +82,12 @@ sweep_run() {
 # Emits the JSON the sweep reads on stdin:
 #   {"tick_id": "...", "connectors": [{"name": ..., "connection_id": ...}]}
 #
+# Configured means what it means to the reconcile loop: a descriptor WITH a
+# Kubernetes Secret. Descriptors are every connector the product ships, and a
+# descriptor without a Secret is not installed here — reconcile cascade-deletes
+# its source and connection rather than driving it — so reporting the descriptor
+# set would fill the page with connectors this install does not have.
+#
 # A connector the mover has no connection for yet is reported WITHOUT a
 # connection id rather than dropped. It is configured — which is the first thing
 # the page answers — and simply has nothing to read yet; dropping it would make
@@ -96,9 +102,28 @@ sweep__build_work() {
   # Re-delimited on US for the same reason reconcile_run does it: TAB is
   # IFS-whitespace, so empty descriptor fields would collapse and shift. Only
   # the name is read here; `rest` absorbs the columns this sweep has no use for.
+  local missing_rc
   while IFS=$'\037' read -r name rest; do
     [[ -n "${name}" ]] || continue
     : "${rest}"  # read into it deliberately; nothing here needs the other columns
+    # Exit codes are the gate's contract: 0=missing, 1=exists, 2=API blip.
+    # A blip may not be read as "missing" here for the same reason it may not
+    # in the reconcile loop — there it would cascade-delete a live source, and
+    # here it would seal a snapshot claiming the connector is no longer
+    # configured, which the read surface takes as authoritative.
+    # SAFETY: stdout is this function's JSON contract, so the gate's is
+    # discarded rather than allowed to land in the middle of it. stderr is left
+    # alone — it is where the reason for a failed lookup reaches the pod log.
+    valsec_secret_missing_p "${name}" >/dev/null
+    missing_rc=$?
+    case ${missing_rc} in
+      0) continue ;;
+      1) ;;
+      *)
+        log_line WARN "sweep: secret lookup failed for ${name}; recording nothing this tick"
+        return 1
+        ;;
+    esac
     conn_name="$(reconcile_compute_connection_name "${name}")"
     # Not piped into `head`: without `pipefail` that hides a nonzero exit from
     # the filter, and a failed lookup would read as "no connection yet" — which

--- a/src/ingestion/reconcile-connectors/python/sweep/__main__.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/__main__.py
@@ -110,6 +110,16 @@ def run(stream: Any) -> int:
         watermark = ledger.watermark()
         closed = ledger.closed_job_ids(watermark)
         entries, truncated = mover.sync_jobs(plan.as_listing_stamp(watermark))
+
+        # The mover ignores a filter it does not recognise rather than refusing
+        # it, so this is the only place an unsupported one shows up as anything
+        # but a page that quietly stops advancing.
+        unfiltered = plan.unfiltered_count(entries, watermark)
+        if unfiltered:
+            _log(
+                f"the listing returned {unfiltered} entry(ies) older than the "
+                "watermark it was handed; the mover is not filtering on it"
+            )
         if truncated:
             incomplete = True
             _log(

--- a/src/ingestion/reconcile-connectors/python/sweep/__main__.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/__main__.py
@@ -26,6 +26,10 @@ class UnreadableWork(ValueError):
     """The tick's own instructions could not be read."""
 
 
+class UnfilteredListing(RuntimeError):
+    """The mover served a listing it did not apply the watermark to."""
+
+
 class Connector(NamedTuple):
     name: str
     #: Absent for a connector the controller manages but the mover has no
@@ -111,14 +115,19 @@ def run(stream: Any) -> int:
         closed = ledger.closed_job_ids(watermark)
         entries, truncated = mover.sync_jobs(plan.as_listing_stamp(watermark))
 
-        # The mover ignores a filter it does not recognise rather than refusing
-        # it, so this is the only place an unsupported one shows up as anything
-        # but a page that quietly stops advancing.
+        # INVARIANT: an ignored filter is a failed read, not a noisy one. The
+        # mover answers 200 and drops a parameter it does not recognise, so the
+        # listing restarts at the beginning of history — and neither of the two
+        # things that follow is survivable. Every terminal job below the
+        # watermark would be recorded again every tick, because the closed-job
+        # read is bounded by that same watermark and so cannot filter them out.
+        # And a capped pass would stop short of current jobs while still
+        # sealing, leaving the page dated as freshly checked on stale facts.
         unfiltered = plan.unfiltered_count(entries, watermark)
         if unfiltered:
-            _log(
-                f"the listing returned {unfiltered} entry(ies) older than the "
-                "watermark it was handed; the mover is not filtering on it"
+            raise UnfilteredListing(
+                f"{unfiltered} entry(ies) came back older than the watermark "
+                "the listing was handed; it is not filtering on it"
             )
         if truncated:
             incomplete = True

--- a/src/ingestion/reconcile-connectors/python/sweep/ledger.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/ledger.py
@@ -118,7 +118,7 @@ class Ledger:
         ever — and three inputs produce one: a connection deleted while a job
         was running (the mover drops the job, so its last recorded word stays
         provisional), a status word a later mover release adds (stored as
-        `unknown`, which is deliberately non-terminal), and a creation stamp the
+        `unknown`, which is deliberately non-terminal), and an update stamp the
         column cannot hold. Once the start is pinned and more jobs than one tick
         may read sit above it, the newest syncs stop being read at all and the
         page freezes on stale data with only a log line to say so.
@@ -131,12 +131,12 @@ class Ledger:
             f"    greatest(oldest_open, newest - INTERVAL {LOOKBACK_DAYS} DAY), "
             "    newest)) AS watermark "
             "FROM (SELECT countIf(open) AS open_count, "
-            "             min(if(open, job_created_at, NULL)) AS oldest_open, "
-            "             max(job_created_at) AS newest "
-            "      FROM (SELECT job_created_at, "
+            "             min(if(open, job_updated_at, NULL)) AS oldest_open, "
+            "             max(job_updated_at) AS newest "
+            "      FROM (SELECT job_updated_at, "
             f"                   status NOT IN ({_OPEN_EXCLUDED}) AS open "
             f"            FROM {TABLE} WHERE event = '{SYNC_COMPLETED}' "
-            "              AND job_created_at IS NOT NULL "
+            "              AND job_updated_at IS NOT NULL "
             "            ORDER BY job_id, ts DESC LIMIT 1 BY job_id))"
         )
         if not rows:
@@ -153,7 +153,7 @@ class Ledger:
         """
         window = ""
         if since is not None:
-            window = f" AND job_created_at >= {_quote(since)}"
+            window = f" AND job_updated_at >= {_quote(since)}"
         rows = self._select(
             f"SELECT DISTINCT job_id FROM {TABLE} "
             f"WHERE event = '{SYNC_COMPLETED}' "
@@ -176,13 +176,13 @@ class Ledger:
         if watermark is None:
             return []
         return self._select(
-            "SELECT job_id, connector, toString(job_created_at) AS created FROM ("
-            "  SELECT job_id, connector, job_created_at, status "
+            "SELECT job_id, connector, toString(job_updated_at) AS updated FROM ("
+            "  SELECT job_id, connector, job_updated_at, status "
             f"  FROM {TABLE} WHERE event = '{SYNC_COMPLETED}' "
-            "    AND job_created_at IS NOT NULL "
+            "    AND job_updated_at IS NOT NULL "
             "  ORDER BY job_id, ts DESC LIMIT 1 BY job_id) "
             f"WHERE status NOT IN ({_OPEN_EXCLUDED}) "
-            f"  AND job_created_at < {_quote(watermark)}"
+            f"  AND job_updated_at < {_quote(watermark)}"
         )
 
     def insert(self, rows: Iterable[dict[str, Any]]) -> int:

--- a/src/ingestion/reconcile-connectors/python/sweep/mover.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/mover.py
@@ -6,10 +6,15 @@ contract-stable across mover upgrades, and the whole point of copying this
 account is to keep a durable record of what a changing source said.
 
 Two of those parameters do the work that would otherwise be ours: the listing is
-asked for in ascending creation order and filtered from a watermark. Ascending
+asked for in ascending update order and filtered from a watermark. Ascending
 order is what makes a capped read safe — whatever the cap leaves unread is NEWER
 than everything collected, so the next tick resumes at that edge instead of the
 watermark jumping over a gap.
+
+INVARIANT: the sort key, the filter and the field read back off each entry are
+all the job's last-update stamp. The listing offers a creation filter too but
+reports no creation time, so a read filtered one way and ordered or recorded
+another cannot be told apart from a read that simply found nothing.
 """
 
 from __future__ import annotations
@@ -69,8 +74,8 @@ class Mover:
             raise MoverError("AIRBYTE_TOKEN is not set")
         return cls(url, token)
 
-    def sync_jobs(self, created_at_start: str | None) -> tuple[list[dict[str, Any]], bool]:
-        """Every sync job created at or after the watermark, oldest first.
+    def sync_jobs(self, updated_at_start: str | None) -> tuple[list[dict[str, Any]], bool]:
+        """Every sync job updated at or after the watermark, oldest update first.
 
         Returns the entries and whether the read stopped short — of the page cap
         or of the time budget. Either way what was collected is contiguous from
@@ -85,7 +90,7 @@ class Mover:
             # seal that dates the page.
             if page > 0 and time.monotonic() >= deadline:
                 return collected, True
-            entries, served = self._page(page * PAGE_SIZE, created_at_start)
+            entries, served = self._page(page * PAGE_SIZE, updated_at_start)
             collected.extend(entries)
             # INVARIANT: measured against what the server SERVED, not what
             # survived filtering. A full page carrying one unusable element
@@ -96,16 +101,16 @@ class Mover:
         return collected, True
 
     def _page(
-        self, offset: int, created_at_start: str | None
+        self, offset: int, updated_at_start: str | None
     ) -> tuple[list[dict[str, Any]], int]:
         query = {
             "jobType": "sync",
-            "orderBy": "createdAt|ASC",
+            "orderBy": "updatedAt|ASC",
             "limit": str(PAGE_SIZE),
             "offset": str(offset),
         }
-        if created_at_start:
-            query["createdAtStart"] = created_at_start
+        if updated_at_start:
+            query["updatedAtStart"] = updated_at_start
         path = "/api/public/v1/jobs?" + urllib.parse.urlencode(query)
 
         payload = self._get(path)

--- a/src/ingestion/reconcile-connectors/python/sweep/plan.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/plan.py
@@ -5,9 +5,14 @@ exercise. Its rules are this change's densest logic: which jobs to cover, which
 already-recorded rows close a job, and which jobs cannot be placed at all.
 
 Every field read here comes from the mover's own listing entry, whose shape is
-flat: `jobId`, `connectionId`, `status`, `createdAt`, `startTime`, `duration`,
-`rowsSynced`. The stamps are ISO-8601 strings and the duration is an ISO-8601
-duration, so both are parsed rather than cast.
+flat: `jobId`, `connectionId`, `status`, `lastUpdatedAt`, `startTime`,
+`duration`, `rowsSynced`. The stamps are ISO-8601 strings and the duration is an
+ISO-8601 duration, so both are parsed rather than cast.
+
+INVARIANT: the entry carries no creation time. The listing accepts a creation
+filter but never reports one, so reading a job's moment from anything other
+than its last-update stamp refuses every entry — indistinguishable, from the
+page, from a mover that has run no syncs at all.
 """
 
 from __future__ import annotations
@@ -91,13 +96,13 @@ def moment(stamp: object) -> str | None:
 
 
 def entry_moment(entry: Mapping[str, Any]) -> str | None:
-    """One listing entry's creation moment, in the ledger's own form.
+    """One listing entry's last-update moment, in the ledger's own form.
 
-    The single reader of that field: the watermark is compared against it and
-    the planner records it, and the two must never disagree about what an
-    entry's creation time is.
+    The single reader of that field: the watermark is compared against it, the
+    listing is filtered by it and the planner records it, and the three must
+    never disagree about which of an entry's stamps places it.
     """
-    return moment(entry.get("createdAt"))
+    return moment(entry.get("lastUpdatedAt"))
 
 
 def as_listing_stamp(recorded: str | None) -> str | None:
@@ -107,10 +112,35 @@ def as_listing_stamp(recorded: str | None) -> str | None:
     silent: a listing handed `2026-08-27 16:00:00.000` does not filter on it, so
     the sweep would re-read the whole history every tick and think it had
     filtered. Converting in one named place is the only way that stays visible.
+
+    `unfiltered_count` is the other half of that guard — this one shapes the
+    request, and that one checks the answer.
     """
     if recorded is None:
         return None
     return recorded.strip().replace(" ", "T") + "Z"
+
+
+def unfiltered_count(entries: Iterable[Mapping[str, Any]], watermark: str | None) -> int:
+    """How many entries came back older than the watermark the listing was handed.
+
+    The mover ignores a query parameter it does not recognise instead of
+    refusing it, so a filter a later release renames stops filtering silently:
+    the read restarts at the beginning of history, a capped pass never reaches
+    the newest jobs, and the page stops advancing with nothing to say why. Any
+    entry older than what was asked for proves the filter did not apply.
+
+    Compared as strings deliberately — both sides are the ledger's own
+    fixed-width form, where lexicographic order is chronological order.
+    """
+    if watermark is None:
+        return 0
+    older = 0
+    for entry in entries:
+        placed = entry_moment(entry)
+        if placed is not None and placed < watermark:
+            older += 1
+    return older
 
 
 def duration_ms(duration: object) -> int | None:
@@ -203,9 +233,9 @@ def sync_row(
     # SAFETY: the summary resolves the newest sync per connector along this
     # column, and a row without it can never win that comparison. Recording it
     # anyway would hide the connector rather than the row.
-    created = entry_moment(entry)
-    if created is None:
-        return Skipped(job_id, "job carries no readable creation time")
+    updated = entry_moment(entry)
+    if updated is None:
+        return Skipped(job_id, "job carries no readable update time")
 
     return {
         "tick_id": tick_id,
@@ -214,7 +244,7 @@ def sync_row(
         "event": SYNC_COMPLETED,
         "status": vocab.normalise(entry.get("status")),
         "started_at": moment(entry.get("startTime")),
-        "job_created_at": created,
+        "job_updated_at": updated,
         "duration_ms": duration_ms(entry.get("duration")),
         "records_reported": records_reported(entry),
     }
@@ -260,8 +290,8 @@ def plan_abandoned(
     for job in jobs:
         job_id = str(job.get("job_id", ""))
         connector = str(job.get("connector", ""))
-        created = str(job.get("created", ""))
-        if not job_id or not connector or not created:
+        updated = str(job.get("updated", ""))
+        if not job_id or not connector or not updated:
             continue
         rows.append(
             {
@@ -271,7 +301,7 @@ def plan_abandoned(
                 "event": SYNC_COMPLETED,
                 "status": vocab.UNKNOWN,
                 "started_at": None,
-                "job_created_at": created,
+                "job_updated_at": updated,
                 "duration_ms": None,
                 "records_reported": None,
             }
@@ -287,7 +317,7 @@ def _bare_row(tick_id: str, event: str, connector: str) -> dict[str, Any]:
         "event": event,
         "status": _ABSENT,
         "started_at": None,
-        "job_created_at": None,
+        "job_updated_at": None,
         "duration_ms": None,
         "records_reported": None,
     }

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
@@ -64,6 +64,13 @@ def _ch_stamp(iso: str) -> str:
     return iso.replace("T", " ").replace("Z", "") + ".000"
 
 
+#: Every parameter the sweep is allowed to send. A name outside it is a filter
+#: the real listing would silently ignore.
+_LISTING_PARAMETERS = frozenset(
+    {"jobType", "orderBy", "limit", "offset", "updatedAtStart"}
+)
+
+
 def _parse_iso(stamp: str) -> datetime:
     """Refuses anything that is not ISO-8601, so a mis-sent watermark fails the
     test rather than quietly matching every entry."""
@@ -75,7 +82,7 @@ def _closed_job(index: int) -> dict:
         "jobId": 500 + index,
         "connectionId": CONNECTION,
         "status": "succeeded",
-        "createdAt": _stamp(index),
+        "lastUpdatedAt": _stamp(index),
         "startTime": _stamp(index),
         "duration": "PT3M10S",
         "rowsSynced": 100 * index,
@@ -88,7 +95,7 @@ def _running_job() -> dict:
         "jobId": 999,
         "connectionId": CONNECTION,
         "status": "running",
-        "createdAt": _stamp(8),
+        "lastUpdatedAt": _stamp(8),
     }
 
 
@@ -97,7 +104,7 @@ def _finished_job() -> dict:
         "jobId": 999,
         "connectionId": CONNECTION,
         "status": "failed",
-        "createdAt": _stamp(8),
+        "lastUpdatedAt": _stamp(8),
         "startTime": _stamp(8),
         "duration": "PT5M",
         "rowsSynced": 0,
@@ -108,8 +115,13 @@ class _StubMover:
     """The public job listing, serving only what the sweep asks it for.
 
     Asserts the two query parameters the sweep's correctness rests on: ascending
-    creation order, so a capped read leaves only NEWER jobs unread, and the
+    update order, so a capped read leaves only NEWER jobs unread, and the
     watermark filter, so a steady tick does not re-read the whole history.
+
+    Stricter than the real listing on one point, deliberately: the real one
+    answers 200 and drops a parameter it does not recognise, so a filter under
+    the wrong name reads here as a filter that works and there as no filter at
+    all. This stub refuses the unknown name instead.
     """
 
     def __init__(self, page_size: int = 100) -> None:
@@ -127,17 +139,20 @@ class _StubMover:
                 flat = {key: value[0] for key, value in query.items()}
                 stub.requests.append(flat)
 
-                assert flat.get("orderBy") == "createdAt|ASC", flat
+                assert flat.get("orderBy") == "updatedAt|ASC", flat
                 assert flat.get("jobType") == "sync", flat
+                assert set(flat) <= _LISTING_PARAMETERS, flat
 
                 entries = stub.oldest_first
-                since = flat.get("createdAtStart")
+                since = flat.get("updatedAtStart")
                 if since is not None:
                     # A real listing parses this. Comparing the two stamp forms
                     # as raw strings is what let a wrongly-formatted watermark
                     # look like a working filter.
                     edge = _parse_iso(since)
-                    entries = [e for e in entries if _parse_iso(e["createdAt"]) >= edge]
+                    entries = [
+                        e for e in entries if _parse_iso(e["lastUpdatedAt"]) >= edge
+                    ]
                 offset = int(flat.get("offset", "0"))
                 window = entries[offset : offset + stub.page_size]
 
@@ -227,7 +242,7 @@ class SweptRowsLandAndResolve(unittest.TestCase):
         with _StubMover() as mover:
             self.assertEqual(self._tick("tick-a"), 0)
             self.assertIsNone(
-                mover.requests[0].get("createdAtStart"),
+                mover.requests[0].get("updatedAtStart"),
                 "an empty ledger reads everything, unfiltered",
             )
 
@@ -242,7 +257,7 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             mover.requests.clear()
             self._tick("tick-b")
 
-            since = mover.requests[0].get("createdAtStart")
+            since = mover.requests[0].get("updatedAtStart")
             self.assertIsNotNone(since, "a populated ledger must filter")
             # Not merely "a stamp": one the listing can parse. The ledger's own
             # form differs by a space, and a listing handed that form filters on
@@ -261,7 +276,7 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             mover.requests.clear()
             self._tick("tick-b")
 
-        since = mover.requests[0]["createdAtStart"]
+        since = mover.requests[0]["updatedAtStart"]
         self.assertLessEqual(
             _parse_iso(since),
             _parse_iso(_stamp(8)),
@@ -324,10 +339,10 @@ class SweptRowsLandAndResolve(unittest.TestCase):
 
         summary = _rows(
             "SELECT connector, job_id, status FROM ("
-            f"  SELECT connector, job_id, status, job_created_at FROM {TABLE}"
+            f"  SELECT connector, job_id, status, job_updated_at FROM {TABLE}"
             "   WHERE event = 'sync.completed'"
             "   ORDER BY job_id, ts DESC LIMIT 1 BY job_id"
-            ") ORDER BY connector, job_created_at DESC, job_id DESC LIMIT 1 BY connector"
+            ") ORDER BY connector, job_updated_at DESC, job_id DESC LIMIT 1 BY connector"
         )
         self.assertEqual(len(summary), 1)
         self.assertEqual(summary[0]["job_id"], "999")
@@ -408,7 +423,7 @@ class SweptRowsLandAndResolve(unittest.TestCase):
         stale = _stamp(-24 * 60)
         _query(
             f"INSERT INTO {TABLE} (ts, tick_id, job_id, connector, event, status, "
-            "started_at, job_created_at, duration_ms, records_reported) VALUES "
+            "started_at, job_updated_at, duration_ms, records_reported) VALUES "
             f"(now64(3), 'old', 'stranded', '{CONNECTOR}', 'sync.completed', 'running', "
             f"NULL, toDateTime64('{_ch_stamp(stale)}', 3, 'UTC'), NULL, NULL)"
         )
@@ -441,7 +456,7 @@ class SweptRowsLandAndResolve(unittest.TestCase):
         stale = _stamp(-24 * 60)
         _query(
             f"INSERT INTO {TABLE} (ts, tick_id, job_id, connector, event, status, "
-            "started_at, job_created_at, duration_ms, records_reported) VALUES "
+            "started_at, job_updated_at, duration_ms, records_reported) VALUES "
             f"(now64(3), 'old', 'stranded', '{CONNECTOR}', 'sync.completed', 'running', "
             f"NULL, toDateTime64('{_ch_stamp(stale)}', 3, 'UTC'), NULL, NULL)"
         )
@@ -463,7 +478,7 @@ class SweptRowsLandAndResolve(unittest.TestCase):
         stale = _stamp(-24 * 60)  # a month back, in the same shape the mover sends
         _query(
             f"INSERT INTO {TABLE} (ts, tick_id, job_id, connector, event, status, "
-            "started_at, job_created_at, duration_ms, records_reported) VALUES "
+            "started_at, job_updated_at, duration_ms, records_reported) VALUES "
             f"(now64(3), 'old', 'stuck', '{CONNECTOR}', 'sync.completed', 'running', "
             f"NULL, toDateTime64('{_ch_stamp(stale)}', 3, 'UTC'), NULL, NULL)"
         )
@@ -472,7 +487,7 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             mover.requests.clear()
             self._tick("tick-b")
 
-        since = _parse_iso(mover.requests[0]["createdAtStart"])
+        since = _parse_iso(mover.requests[0]["updatedAtStart"])
         self.assertGreater(
             since,
             _parse_iso(stale),

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
@@ -124,9 +124,12 @@ class _StubMover:
     all. This stub refuses the unknown name instead.
     """
 
-    def __init__(self, page_size: int = 100) -> None:
+    def __init__(self, page_size: int = 100, *, honours_filter: bool = True) -> None:
         self.oldest_first = [_closed_job(i) for i in range(7)] + [_running_job()]
         self.page_size = page_size
+        #: False imitates the real listing meeting a parameter name it does not
+        #: know: it answers 200 and serves the whole history unfiltered.
+        self.honours_filter = honours_filter
         self.requests: list[dict[str, str]] = []
         stub = self
 
@@ -144,7 +147,7 @@ class _StubMover:
                 assert set(flat) <= _LISTING_PARAMETERS, flat
 
                 entries = stub.oldest_first
-                since = flat.get("updatedAtStart")
+                since = flat.get("updatedAtStart") if stub.honours_filter else None
                 if since is not None:
                     # A real listing parses this. Comparing the two stamp forms
                     # as raw strings is what let a wrongly-formatted watermark
@@ -387,6 +390,40 @@ class SweptRowsLandAndResolve(unittest.TestCase):
                 0,
                 f"an unread tick must write no {event} row",
             )
+
+    def test_a_listing_that_ignores_the_watermark_records_nothing(self) -> None:
+        """An unapplied filter is a failed read, not a noisy one.
+
+        Two things follow from serving the whole history, and neither survives
+        a log line. Every terminal job below the watermark would be recorded
+        again on every tick — the closed-job read is bounded by that same
+        watermark, so it cannot filter them out. And a capped pass would stop
+        short of current jobs while still sealing, dating the page as freshly
+        checked on facts it never reached.
+        """
+        with _StubMover():
+            self._tick("tick-a")
+        before = _count(f"SELECT count() AS n FROM {TABLE}")
+        seals = _count(
+            f"SELECT count() AS n FROM {TABLE} WHERE event = 'sweep.completed'"
+        )
+
+        with _StubMover(honours_filter=False):
+            code = self._tick("tick-b")
+
+        self.assertEqual(code, 1, "the caller learns the tick was incomplete")
+        self.assertEqual(
+            _count(f"SELECT count() AS n FROM {TABLE}"),
+            before,
+            "an unfiltered listing must not re-record the history it served",
+        )
+        self.assertEqual(
+            _count(
+                f"SELECT count() AS n FROM {TABLE} WHERE event = 'sweep.completed'"
+            ),
+            seals,
+            "and must not seal, or the page reports itself freshly checked",
+        )
 
     def test_a_connector_awaiting_its_first_connection_is_still_configured(self) -> None:
         """Configured is the first thing the page answers, and it does not

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_mover.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_mover.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import sys
 import unittest
+import urllib.parse
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
@@ -33,7 +34,7 @@ class _Listing(Mover):
         self._pages = pages
         self.requested: list[int] = []
 
-    def _page(self, offset: int, created_at_start: str | None):
+    def _page(self, offset: int, updated_at_start: str | None):
         self.requested.append(offset)
         index = len(self.requested) - 1
         usable, served = self._pages[index] if index < len(self._pages) else (0, 0)
@@ -105,3 +106,43 @@ class TheReadHasATimeBudget(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TheRequestNamesTheFieldItReadsBack(unittest.TestCase):
+    """The sort key, the filter and the field read off an entry are one stamp.
+
+    The mover answers 200 and ignores a query parameter it does not recognise,
+    so a filter under the wrong name does not fail — it stops filtering, the
+    read restarts at the beginning of history, and a capped pass never reaches
+    the newest jobs. Nothing downstream can tell that apart from a quiet page,
+    which is why the request's own shape is asserted here.
+    """
+
+    def _query(self, updated_at_start: str | None) -> dict[str, str]:
+        asked: list[str] = []
+
+        class _Transport(Mover):
+            def _get(self, path: str) -> dict:
+                asked.append(path)
+                return {"data": []}
+
+        _Transport("http://mover.invalid", "token").sync_jobs(updated_at_start)
+        self.assertEqual(len(asked), 1)
+        query = urllib.parse.urlparse(asked[0]).query
+        return dict(urllib.parse.parse_qsl(query))
+
+    def test_the_listing_is_ordered_by_the_stamp_the_planner_records(self) -> None:
+        self.assertEqual(self._query(None)["orderBy"], "updatedAt|ASC")
+
+    def test_the_watermark_is_sent_as_the_update_filter(self) -> None:
+        query = self._query("2026-08-27T08:02:52Z")
+
+        self.assertEqual(query["updatedAtStart"], "2026-08-27T08:02:52Z")
+        self.assertNotIn("createdAtStart", query)
+
+    def test_a_first_sweep_sends_no_filter_at_all(self) -> None:
+        """None is "read the whole retained history", not "read from now"."""
+        query = self._query(None)
+
+        self.assertNotIn("updatedAtStart", query)
+        self.assertNotIn("createdAtStart", query)

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
@@ -42,7 +42,7 @@ SERVED_KEYS = frozenset(
 )
 
 
-def entry(**overrides) -> dict:
+def entry(**overrides: object) -> dict[str, object]:
     """One entry of the mover's job listing, in the shape it serves.
 
     Flat, ISO-8601 stamps, an ISO-8601 duration, and the record count on the
@@ -65,7 +65,7 @@ def entry(**overrides) -> dict:
     return listing_entry
 
 
-def row(**overrides) -> dict:
+def row(**overrides: object) -> dict[str, object]:
     planned = plan.sync_row(entry(**overrides), CONNECTORS, TICK)
     assert not isinstance(planned, plan.Skipped), planned
     return planned

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
@@ -20,23 +20,45 @@ TICK = "tick-1"
 CONNECTION = "connection-under-test"
 CONNECTORS = {CONNECTION: CONNECTOR}
 
-CREATED = "2026-08-27T08:00:00Z"
 STARTED = "2026-08-27T08:00:30Z"
+UPDATED = "2026-08-27T08:02:52Z"
+
+#: Every key the listing serves, and nothing it does not. Kept as data because a
+#: fixture that invents a field name is how a planner comes to read one the
+#: mover never sends: every entry is then refused, and a page reporting every
+#: connector as never synced cannot be told apart from a mover that ran nothing.
+SERVED_KEYS = frozenset(
+    {
+        "jobId",
+        "connectionId",
+        "jobType",
+        "status",
+        "startTime",
+        "lastUpdatedAt",
+        "duration",
+        "bytesSynced",
+        "rowsSynced",
+    }
+)
 
 
 def entry(**overrides) -> dict:
     """One entry of the mover's job listing, in the shape it serves.
 
     Flat, ISO-8601 stamps, an ISO-8601 duration, and the record count on the
-    entry itself — there is no nested job or attempts array on this listing.
+    entry itself — there is no nested job or attempts array on this listing, and
+    no creation stamp: the listing accepts a creation filter but reports only
+    when a job started and when it was last updated.
     """
     listing_entry = {
         "jobId": 8412,
         "connectionId": CONNECTION,
+        "jobType": "sync",
         "status": "succeeded",
-        "createdAt": CREATED,
         "startTime": STARTED,
+        "lastUpdatedAt": UPDATED,
         "duration": "PT2M22S",
+        "bytesSynced": 3_100_000,
         "rowsSynced": 12_400,
     }
     listing_entry.update(overrides)
@@ -78,14 +100,14 @@ class StatusKeepsTheMoversWord(unittest.TestCase):
 
 
 class AJobMustBePlaceable(unittest.TestCase):
-    def test_a_job_with_no_creation_time_is_refused(self) -> None:
+    def test_a_job_with_no_update_time_is_refused(self) -> None:
         for absent in (None, 0, -1, "yesterday", True):
             with self.subTest(absent=absent):
                 planned = plan.sync_row(
-                    entry(createdAt=absent), CONNECTORS, TICK
+                    entry(lastUpdatedAt=absent), CONNECTORS, TICK
                 )
                 self.assertIsInstance(
-                    planned, plan.Skipped, f"should refuse createdAt={absent!r}"
+                    planned, plan.Skipped, f"should refuse lastUpdatedAt={absent!r}"
                 )
 
     def test_a_job_with_no_identity_is_refused(self) -> None:
@@ -97,8 +119,8 @@ class AJobMustBePlaceable(unittest.TestCase):
         self.assertIsInstance(planned, plan.Skipped)
 
     def test_a_refusal_carries_its_reason(self) -> None:
-        planned = plan.sync_row(entry(createdAt=None), CONNECTORS, TICK)
-        self.assertIn("creation time", planned.reason)
+        planned = plan.sync_row(entry(lastUpdatedAt=None), CONNECTORS, TICK)
+        self.assertIn("update time", planned.reason)
 
 
 class AbsenceIsNotZero(unittest.TestCase):
@@ -107,7 +129,7 @@ class AbsenceIsNotZero(unittest.TestCase):
             "jobId": 1,
             "connectionId": CONNECTION,
             "status": "pending",
-            "createdAt": CREATED,
+            "lastUpdatedAt": UPDATED,
         }
         planned = plan.sync_row(bare, CONNECTORS, TICK)
         self.assertIsNone(planned["started_at"])
@@ -153,17 +175,27 @@ class AbsenceIsNotZero(unittest.TestCase):
 class WhatIsRead(unittest.TestCase):
     def test_the_stamps_are_read_as_iso_8601(self) -> None:
         planned = row()
-        self.assertEqual(planned["job_created_at"], "2026-08-27 08:00:00.000")
+        self.assertEqual(planned["job_updated_at"], "2026-08-27 08:02:52.000")
         self.assertEqual(planned["started_at"], "2026-08-27 08:00:30.000")
 
     def test_a_stamp_with_an_offset_is_normalised_to_utc(self) -> None:
-        planned = row(createdAt="2026-08-27T11:00:00+03:00")
-        self.assertEqual(planned["job_created_at"], "2026-08-27 08:00:00.000")
+        planned = row(lastUpdatedAt="2026-08-27T11:00:00+03:00")
+        self.assertEqual(planned["job_updated_at"], "2026-08-27 08:00:00.000")
+
+    def test_the_placing_stamp_is_the_last_update_not_the_start(self) -> None:
+        """Two stamps arrive and only one places the job.
+
+        Reading the other would still produce a row, so nothing but naming the
+        expected value catches a planner that took `startTime` for the axis the
+        watermark moves along.
+        """
+        self.assertEqual(row()["job_updated_at"], "2026-08-27 08:02:52.000")
+        self.assertNotEqual(row()["job_updated_at"], row()["started_at"])
 
     def test_an_epoch_number_is_not_a_stamp(self) -> None:
         """The listing sends strings. A number here would be a different
         endpoint's shape, and guessing at it would date every job to 1970."""
-        planned = plan.sync_row(entry(createdAt=1_700_000_000), CONNECTORS, TICK)
+        planned = plan.sync_row(entry(lastUpdatedAt=1_700_000_000), CONNECTORS, TICK)
         self.assertIsInstance(planned, plan.Skipped)
 
     def test_the_duration_is_read_as_an_iso_8601_duration(self) -> None:
@@ -212,7 +244,7 @@ class CoverageSkipsWhatIsClosed(unittest.TestCase):
 
     def test_refusals_are_reported_beside_the_rows(self) -> None:
         planned = plan.plan_syncs(
-            [entry(), entry(jobId=7, createdAt=None)], CONNECTORS, TICK, frozenset()
+            [entry(), entry(jobId=7, lastUpdatedAt=None)], CONNECTORS, TICK, frozenset()
         )
         self.assertEqual(len(planned.rows), 1)
         self.assertEqual(len(planned.skipped), 1)
@@ -236,7 +268,7 @@ class EveryRowClassFillsEveryColumn(unittest.TestCase):
         self.assertEqual(snapshot["event"], plan.CONNECTOR_CONFIGURED)
         self.assertEqual(snapshot["job_id"], "")
         self.assertEqual(snapshot["status"], "")
-        self.assertIsNone(snapshot["job_created_at"])
+        self.assertIsNone(snapshot["job_updated_at"])
 
     def test_the_seal_names_no_connector(self) -> None:
         seal = plan.plan_seal(TICK)
@@ -251,3 +283,61 @@ class EveryRowClassFillsEveryColumn(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TheListingsOwnShape(unittest.TestCase):
+    """The fixture above is the mover's shape, not a convenient stand-in for it.
+
+    A field the mover never sends refuses every real entry while every test
+    passes, and the page then reports every connector as never synced — which
+    reads exactly like a mover that has run no syncs at all.
+    """
+
+    def test_the_fixture_carries_exactly_the_keys_the_listing_serves(self) -> None:
+        self.assertEqual(frozenset(entry()), SERVED_KEYS)
+
+    def test_a_creation_stamp_does_not_place_a_job(self) -> None:
+        """The listing filters on creation and reports none, so an entry
+        carrying only a creation stamp is one the mover cannot have sent."""
+        invented = {k: v for k, v in entry().items() if k != "lastUpdatedAt"}
+        invented["createdAt"] = "2026-08-27T08:00:00Z"
+
+        planned = plan.sync_row(invented, CONNECTORS, TICK)
+
+        self.assertIsInstance(planned, plan.Skipped)
+
+
+class AnIgnoredFilterIsVisible(unittest.TestCase):
+    """The mover answers 200 and drops a parameter it does not recognise.
+
+    So a filter renamed by a later release stops filtering rather than failing:
+    the read restarts at the beginning of history and a capped pass never
+    reaches the newest jobs. Counting what came back below the watermark is the
+    only signal that separates that from a page with nothing new to say.
+    """
+
+    WATERMARK = "2026-08-27 08:00:00.000"
+
+    def test_entries_below_the_watermark_are_counted(self) -> None:
+        older = entry(jobId=1, lastUpdatedAt="2026-08-26T23:59:59Z")
+        at_the_mark = entry(jobId=2, lastUpdatedAt="2026-08-27T08:00:00Z")
+        newer = entry(jobId=3, lastUpdatedAt="2026-08-27T09:00:00Z")
+
+        self.assertEqual(
+            plan.unfiltered_count([older, at_the_mark, newer], self.WATERMARK), 1
+        )
+
+    def test_a_filtered_listing_counts_nothing(self) -> None:
+        self.assertEqual(plan.unfiltered_count([entry()], self.WATERMARK), 0)
+
+    def test_the_first_sweep_sent_no_watermark_so_nothing_is_out_of_place(self) -> None:
+        older = entry(lastUpdatedAt="2020-01-01T00:00:00Z")
+
+        self.assertEqual(plan.unfiltered_count([older], None), 0)
+
+    def test_an_unplaceable_entry_is_not_evidence_of_an_ignored_filter(self) -> None:
+        """It is refused for its own reason; counting it here would report a
+        working filter as broken on every tick that meets one."""
+        self.assertEqual(
+            plan.unfiltered_count([entry(lastUpdatedAt=None)], self.WATERMARK), 0
+        )

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_work.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_work.py
@@ -1,0 +1,105 @@
+"""Which connectors a tick calls configured.
+
+The sweep's snapshot is what the page prints as "these are your connectors", and
+the read surface treats a sealed snapshot as authoritative. So the set is worth
+a test of its own: too wide and the page lists connectors the install does not
+have, too narrow and a configured one reads as removed.
+
+Drives the real bash rather than a transcription of it — the gate's three exit
+codes are the whole point, and a rewrite in Python would test the rewrite.
+
+Run: python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CONNECTIONS = json.dumps(
+    [
+        {"name": "alpha-main-default-conn", "connectionId": "conn-alpha"},
+        {"name": "bravo-main-default-conn", "connectionId": "conn-bravo"},
+    ]
+)
+
+#: `disc_load_descriptors` emits TSV; only the first field is read here. Written
+#: with escapes because the stub renders it through `printf '%b'` — a literal tab
+#: in this string would be indistinguishable from the padding around it.
+DESCRIPTORS = "\\n".join(
+    f"{name}\\tdir\\t1\\tnocode\\t\\t\\t" for name in ("alpha", "bravo", "charlie")
+)
+
+
+def build_work(gate: str, descriptors: str = DESCRIPTORS) -> subprocess.CompletedProcess:
+    """Call `sweep__build_work` with its collaborators replaced.
+
+    `gate` is the body of `valsec_secret_missing_p`, which is the one thing each
+    case varies. Everything else is stubbed to a fixed answer so a failure can
+    only be the function under test.
+    """
+    script = f"""
+    set -uo pipefail
+    source "{ROOT}/lib/sweep.sh"
+    log_line() {{ printf '%s\\n' "$*" >&2; }}
+    disc_load_descriptors() {{ printf '%b\\n' {json.dumps(descriptors)}; }}
+    reconcile_compute_connection_name() {{ printf '%s-main-default-conn' "$1"; }}
+    valsec_secret_missing_p() {{ {gate}; }}
+    sweep__build_work "tick-1" {json.dumps(CONNECTIONS)}
+    """
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False
+    )
+
+
+def names(result: subprocess.CompletedProcess) -> list[str]:
+    work = json.loads(result.stdout)
+    return [c["name"] for c in work["connectors"]]
+
+
+class ConfiguredMeansTheInstallHasIt(unittest.TestCase):
+    def test_a_descriptor_without_a_secret_is_not_configured(self) -> None:
+        """Descriptors are every connector the product ships. Reporting them all
+        fills the page with connectors this install never had — and reconcile
+        agrees: without a Secret it deletes the source rather than driving it."""
+        result = build_work('[[ "$1" == "charlie" ]] && return 0; return 1')
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(names(result), ["alpha", "bravo"])
+
+    def test_a_connector_with_a_secret_is_configured_even_with_no_connection(self) -> None:
+        """A configured connector that never ran is a state the page must be
+        able to show, so it is reported without a connection id, not dropped."""
+        result = build_work("return 1")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        work = json.loads(result.stdout)
+        by_name = {c["name"]: c for c in work["connectors"]}
+        self.assertEqual(by_name["alpha"]["connection_id"], "conn-alpha")
+        self.assertNotIn("connection_id", by_name["charlie"])
+
+    def test_a_failed_secret_lookup_records_nothing_at_all(self) -> None:
+        """Exit 2 is "the API blipped", not "the Secret is gone". Dropping the
+        connector on it would seal a snapshot saying it is no longer configured,
+        which the read surface takes at face value — so no snapshot is built."""
+        result = build_work('[[ "$1" == "bravo" ]] && return 2; return 1')
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout.strip(), "")
+        self.assertIn("bravo", result.stderr)
+
+    def test_no_descriptor_carries_a_secret_and_the_set_is_empty(self) -> None:
+        """An empty set is not an error here. The caller refuses to seal it —
+        an empty snapshot and "everything was removed" are the same rows."""
+        result = build_work("return 0")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(names(result), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/ingestion/scripts/migrations/20260827000000_connector-sync-history.sql
+++ b/src/ingestion/scripts/migrations/20260827000000_connector-sync-history.sql
@@ -7,9 +7,14 @@
 -- Three row classes share the table, told apart by `event`. Every column has a
 -- defined value on every class — see the design's domain model. Columns are
 -- nullable only where "nobody measured" and "measured zero" are different
--- answers; `job_created_at` is nullable because snapshot rows are not about a
+-- answers; `job_updated_at` is nullable because snapshot rows are not about a
 -- job at all, and is never NULL on a sync row — the read surface orders jobs
 -- along it, and a row without it cannot be placed among them.
+--
+-- `job_updated_at` is the mover's own last-update stamp for the job, not a
+-- creation time: the listing does not report when a job was created, and it is
+-- also the field the listing filters on, so the sweep reads back exactly the
+-- field it asks by.
 --
 -- Spec: docs/components/backend/analytics/specs/connector-health.
 
@@ -24,7 +29,7 @@ CREATE TABLE IF NOT EXISTS ingestion_history.sync_events (
     event            LowCardinality(String),
     status           LowCardinality(String),
     started_at       Nullable(DateTime64(3, 'UTC')),
-    job_created_at   Nullable(DateTime64(3, 'UTC')),
+    job_updated_at   Nullable(DateTime64(3, 'UTC')),
     duration_ms      Nullable(UInt64),
     records_reported Nullable(UInt64)
 ) ENGINE = MergeTree

--- a/src/ingestion/scripts/migrations/20260827010000_connector-sync-history-updated-at.sql
+++ b/src/ingestion/scripts/migrations/20260827010000_connector-sync-history-updated-at.sql
@@ -1,0 +1,18 @@
+-- Heal a sync ledger created with `job_created_at`.
+--
+-- The column was named for a field the mover's job listing does not report:
+-- entries carry a last-update stamp, not a creation time, so every job was
+-- refused for having no readable creation time and the page showed every
+-- connector as never synced. The sweep now reads and filters by the stamp the
+-- listing does report, and the column carries that name.
+--
+-- `CREATE TABLE IF NOT EXISTS` never renames a column of a table that already
+-- exists, and this channel keeps no ledger — it re-runs on every deploy — so
+-- the rename is guarded and a second run is a no-op. Only sync rows ever
+-- carried the column, so an install that has recorded none loses nothing; one
+-- that has keeps its stamps under the truthful name.
+--
+-- Spec: docs/components/backend/analytics/specs/connector-health.
+
+ALTER TABLE ingestion_history.sync_events
+    RENAME COLUMN IF EXISTS job_created_at TO job_updated_at;


### PR DESCRIPTION
**Why.** The page reported every connector as never synced, and listed every connector the build ships rather than the ones this install configured.

**What changed.** The sweep read a job's moment from `createdAt`. The mover's public job listing accepts a creation filter but reports no creation time, so every job was refused for having none — and a page saying "never synced" everywhere is indistinguishable from a mover that has run nothing. The sort key, the filter and the field read back off an entry are now one stamp, the job's last update, and the ledger column is renamed to say so. The configured set now comes from the descriptors this install holds a Secret for, which is the criterion the reconcile loop itself acts on. And the whole table row opens a connector, not just its name.

**A failed Secret lookup records nothing rather than dropping the connector.** Exit 2 means the API blipped, not that the Secret is gone, and a sealed snapshot is authoritative to the reader — the same reasoning the reconcile loop applies before it cascade-deletes.

**The row keeps `role="row"`.** That role supports `aria-expanded`, so the disclosure is announced without taking the row out of its table — the objection that put a button inside it originally. Reverting is one attribute.

Fed the real listing from a stand through the fixed planner: **38 rows planned where it planned 0**, every previous refusal reading `job carries no readable creation time`.

The interaction is not photographable, so the accessibility tree is the evidence. Clicking the Duration cell:

| | Before | After |
|---|---|---|
| the row | `row` | `row [cursor=pointer]` → `row [expanded]` |
| the name | `button "example-tracker"` | `cell "example-tracker"` |

The visible change is the trailing columns, now muted to match the roster table beside it:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/constructorfabric/insight/pr-2921-assets/before.png) | ![after](https://raw.githubusercontent.com/constructorfabric/insight/pr-2921-assets/after.png) |

**Out of scope.** Two, both untracked and happy to file either. A connection disabled in the mover still reads as configured — nothing reads connection status. And the sweep's boundary values are still `Mapping[str, Any]` rather than a frozen `ListingEntry`, which the repo's typing rule wants; converting one function while its neighbours stay dicts would read worse than either end state, so it belongs in its own change.

**Verified.** 70 ingestion tests (14 e2e against a throwaway ClickHouse), 698 backend (2 live), 2264 frontend, `clippy -D warnings`, typecheck, lint, `ruff check`, no OpenAPI drift. The guarded rename ran against a live ClickHouse: renames, preserves rows, idempotent. `ruff format` was not run — the repo config is 120 columns while this tree is written at 88, so it would rewrite unrelated files. A `pending` job's shape is covered only by the stub; every sampled job was terminal.
