### PR TITLE
fix(ai-cost): re-chain an invoice when the columns its line rows carry change

### DIFF
--- a/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/streams.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/streams.py
@@ -30,6 +30,7 @@ socket.
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from datetime import UTC, datetime
@@ -42,16 +43,21 @@ from source_claude_team_invoices.stripe_chain import (
     CHAIN_OK,
     StripeChainError,
     build_records,
+    line_projection_id,
     read_bootstrap,
     unique_key_parts,
 )
+
+logger = logging.getLogger("airbyte")
 
 STRIPE_VERSION = "2026-06-24.dahlia"
 BOOTSTRAP_HOST = "https://invoicedata.stripe.com"
 STRIPE_API = "https://api.stripe.com/v1"
 
-# The one key in the stream's state blob.
+# The two keys in the stream's state blob: the index of chained invoices, and
+# the shape of the line rows it stands for.
 STATE_ENRICHED = "enriched"
+STATE_PROJECTION = "line_projection"
 
 PER_PAGE = 12
 # Bounds on the two cursor walks, far above any real history. They guard
@@ -171,14 +177,28 @@ class InvoiceLines(Stream, CheckpointMixin):
         invoice's row that the listing cannot supply — it comes from the lines.
         Nothing here is a credential: the ephemeral key and the hosted URL that
         carries it are never written to state.
+
+        The projection marker rides along so the next run can tell whether the
+        rows this index stands for still carry the columns bronze now expects.
         """
-        return {STATE_ENRICHED: {**self._known, **self._learned}}
+        return {STATE_ENRICHED: {**self._known, **self._learned}, STATE_PROJECTION: line_projection_id()}
 
     @state.setter
     def state(self, value: Mapping[str, Any]) -> None:
-        stored = value.get(STATE_ENRICHED) if isinstance(value, Mapping) else None
-        self._known = dict(stored) if isinstance(stored, Mapping) else {}
         self._learned = {}
+        stored = value.get(STATE_ENRICHED) if isinstance(value, Mapping) else None
+        marker = value.get(STATE_PROJECTION) if isinstance(value, Mapping) else None
+        if stored and marker != line_projection_id():
+            # The index says these invoices need no chain, but it was written for
+            # a narrower line row: skipping them would leave the columns added
+            # since empty for good, because only a chain emits a line row.
+            logger.info(
+                "line projection changed since this state was written — chaining %s known invoice(s) once more",
+                len(stored),
+            )
+            self._known = {}
+            return
+        self._known = dict(stored) if isinstance(stored, Mapping) else {}
 
     def _remember(self, record: Mapping[str, Any]) -> None:
         """Record what a completed chain found, so the next sync can skip it.

--- a/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/stripe_chain.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/stripe_chain.py
@@ -11,6 +11,7 @@ rules are exercised without a network call.
 from __future__ import annotations
 
 import base64
+import hashlib
 import logging
 import re
 from collections.abc import Callable, Iterator, Mapping, Sequence
@@ -273,6 +274,17 @@ _EMPTY_LINE: Mapping[str, Any] = {
     "period_start_ts": None,
     "period_end_ts": None,
 }
+
+
+def line_projection_id() -> str:
+    """A digest of the fields a line row carries.
+
+    Derived from the field set rather than declared beside it: a run that skips
+    the chain reuses the line rows an earlier run wrote, so a changed set means
+    those rows are missing a column and only a chain can fill it. Hand-numbering
+    that would put the invalidation one forgotten bump away from silence.
+    """
+    return hashlib.sha256(",".join(sorted(_EMPTY_LINE)).encode()).hexdigest()[:12]
 
 
 class UrlFormatDrift(RuntimeError):

--- a/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stream_over_http.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stream_over_http.py
@@ -18,7 +18,9 @@ from typing import Any
 import pytest
 import requests_mock as rm_module
 from source_claude_team_invoices import streams as streams_module
+from source_claude_team_invoices import stripe_chain as chain_module
 from source_claude_team_invoices.streams import BOOTSTRAP_HOST, STRIPE_API, STRIPE_VERSION, InvoiceLines
+from source_claude_team_invoices.stripe_chain import line_projection_id
 
 CONFIG = {
     "proxy_url": "https://proxy.example/",
@@ -219,7 +221,8 @@ def test_a_sync_remembers_what_the_chain_found_so_the_next_one_can_skip_it(
 def test_a_remembered_invoice_costs_no_stripe_request(stream: InvoiceLines, http: rm_module.Mocker) -> None:
     """The saving, asserted by request count rather than by how long a run took."""
     stream.state = {
-        "enriched": {f"{ACCT},_entEXAMPLE": {"invoice_id": INVOICE_ID, "period_start_ts": 1, "period_end_ts": 2}}
+        "enriched": {f"{ACCT},_entEXAMPLE": {"invoice_id": INVOICE_ID, "period_start_ts": 1, "period_end_ts": 2}},
+        "line_projection": line_projection_id(),
     }
     listing = http.get(INVOICES_URL, json={"invoices": [wrapper_invoice()], "next_page": None})
 
@@ -232,9 +235,56 @@ def test_a_remembered_invoice_costs_no_stripe_request(stream: InvoiceLines, http
     assert records[0]["invoice_id"] == INVOICE_ID
 
 
+def test_a_state_from_a_narrower_line_row_chains_again(
+    stream: InvoiceLines, http: rm_module.Mocker, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The state a release before the new columns wrote carries no marker at all.
+
+    Its index says these invoices need no chain, and only a chain emits a line
+    row — so honouring it would leave every column added since empty for good.
+    """
+    stream.state = {
+        "enriched": {f"{ACCT},_entEXAMPLE": {"invoice_id": INVOICE_ID, "period_start_ts": 1, "period_end_ts": 2}}
+    }
+    register_chain(http, [{"data": [subscription_line()], "has_more": False}])
+
+    with caplog.at_level(logging.INFO):
+        records = list(stream.read_records(sync_mode="incremental"))
+
+    assert any(r.netloc == "invoicedata.stripe.com" for r in http.request_history), "the chain ran again"
+    assert len(records) == 2, "its own row and its line row"
+    assert "line projection changed" in caplog.text, "an operator can see why a full pass happened"
+
+
+def test_the_extra_pass_happens_once_and_not_on_every_later_sync(stream: InvoiceLines, http: rm_module.Mocker) -> None:
+    """The state a re-chain writes has to carry the marker, or the pass repeats forever."""
+    stream.state = {"enriched": {f"{ACCT},_entEXAMPLE": {"invoice_id": INVOICE_ID}}}
+    register_chain(http, [{"data": [subscription_line()], "has_more": False}])
+    list(stream.read_records(sync_mode="incremental"))
+    carried = stream.state
+
+    assert carried["line_projection"] == line_projection_id()
+
+    next_run = InvoiceLines(CONFIG)
+    next_run.state = carried
+    records = list(next_run.read_records(sync_mode="incremental"))
+
+    stripe_calls = [r for r in http.request_history if r.netloc == "invoicedata.stripe.com"]
+    assert len(stripe_calls) == 1, "the chain ran on the upgrade pass and not again"
+    assert [r["chain_status"] for r in records] == ["ok"], "the second run emits its own row alone"
+
+
+def test_the_marker_follows_the_line_fields_rather_than_a_hand_written_number(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A forgotten bump is the failure this replaces, so nothing is bumped by hand."""
+    before = line_projection_id()
+    monkeypatch.setitem(chain_module._EMPTY_LINE, "a_new_line_column", None)
+
+    assert line_projection_id() != before
+
+
 def test_an_empty_state_chains_everything(stream: InvoiceLines, http: rm_module.Mocker) -> None:
     """The first sync after a deploy carries nothing, so it behaves as before."""
-    assert stream.state == {"enriched": {}}
+    assert stream.state == {"enriched": {}, "line_projection": line_projection_id()}
     register_chain(http, [{"data": [subscription_line()], "has_more": False}])
 
     records = list(stream.read_records(sync_mode="incremental"))
@@ -254,7 +304,7 @@ def test_a_failed_chain_is_not_remembered_and_is_tried_again(
         records = list(stream.read_records(sync_mode="incremental"))
 
     assert [r["chain_status"] for r in records] == ["failed"]
-    assert stream.state == {"enriched": {}}
+    assert stream.state == {"enriched": {}, "line_projection": line_projection_id()}
 
 
 def test_state_carries_no_credential(stream: InvoiceLines, http: rm_module.Mocker) -> None:

--- a/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stripe_chain.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stripe_chain.py
@@ -10,6 +10,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import pytest
+from source_claude_team_invoices import stripe_chain as chain_module
 from source_claude_team_invoices.stripe_chain import (
     CATEGORY_OVERUSAGE,
     CATEGORY_SUBSCRIPTIONS,
@@ -141,6 +142,20 @@ def test_a_line_naming_no_tier_carries_absence_not_an_empty_string(pricing: Mapp
     assert price_details(dict(SUBSCRIPTION_LINE, pricing=pricing)) == PriceRef(None, None), (
         f"should be absent: {pricing!r}"
     )
+
+
+def test_the_projection_digest_covers_every_field_a_line_row_carries() -> None:
+    """`_EMPTY_LINE` is what the digest is taken from, and what an invoice's own row
+    fills in for the fields it has no line for. A column added to `shape_line` and
+    not to it would leave the digest unmoved — so the re-chain that column needs
+    would not happen — and would leave that column off the invoice's own row.
+
+    `invoice_key` is the one field outside the set on purpose: `line_row` pops it
+    before the row is emitted, so it reaches neither bronze nor the digest.
+    """
+    shaped = set(shape_line(SUBSCRIPTION_LINE, "in_1ABC")) - {"invoice_key"}
+
+    assert shaped == set(chain_module._EMPTY_LINE), "one of the two declarations gained a field the other lacks"
 
 
 def test_category_comes_from_the_parent_not_the_description() -> None:


### PR DESCRIPTION
Part of #2620.

**Why.** A column added to an invoice line row stays empty wherever the connector has already synced. The chain that fills it is skipped for invoices the state already indexes, and nothing reports the gap — the sync succeeds and the index is intact, so the operator cannot write the tier binding because the identifier to bind never arrives.

**What changed.** The state carries a digest of the fields a line row holds. A stored index whose digest differs — including one written before the digest existed — is discarded once, so those invoices chain again and their line rows land complete.

**The digest is derived from the field set, not declared beside it.** Hand-numbering it would put the invalidation one forgotten bump away from the silence it exists to prevent. A test changes the field set and asserts the digest moves.

**The extra pass happens once.** The state a re-chain writes carries the current digest, so the next sync skips as before. The test runs two syncs and counts chain calls rather than trusting the state's shape.

**Evidence.** Reverting the invalidation fails the upgrade test. The connector suite goes 111 → 114 tests.

**Verified.** 114 pass, `ruff check` and `ruff format --check` clean at the pinned v0.15.21.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice processing when line-item fields change.
  * Automatically reprocesses previously known invoices once when outdated state is detected.
  * Preserves processing state during normal operation.

* **Tests**
  * Added coverage for state tracking, schema changes, and one-time reprocessing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->