### PR TITLE
feat(frontend): make every Repositories figure drillable, down to one repository

### DIFF
--- a/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
+++ b/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
@@ -1021,6 +1021,7 @@ metrics:
       - input_role: value
         measure_key: non_default_commit_count
     dimensions:
+      - hour_block
       - project
       - repository
       - source

--- a/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
+++ b/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
@@ -178,6 +178,7 @@ sources:
       - comment_target
       - destination_branch
       - file_extension
+      - hour_block
       - project
       - repository
       - source
@@ -968,6 +969,7 @@ metrics:
         measure_key: commit_count
     dimensions:
       - branch_scope
+      - hour_block
       - project
       - repository
       - source
@@ -993,6 +995,7 @@ metrics:
       - input_role: value
         measure_key: default_commit_count
     dimensions:
+      - hour_block
       - project
       - repository
       - source

--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -718,6 +718,85 @@ describe("composition (rule 7: only real server dimensions)", () => {
     ]);
   });
 
+  it("leaves a segment the response never named inert", async () => {
+    const openEvidenceTargets = vi.fn();
+    const comp = emptyCollection();
+    comp.byKey.set("t.commits", {
+      ...metric("t.commits", []),
+      breakdown: {
+        view: "breakdown",
+        values: IDS.flatMap((id) => [
+          {
+            entity_id: id,
+            dimensions: [
+              { key: "repository", value: "src:acme/api", label: "acme/api" },
+              { key: "branch_scope", value: "default", label: "Default branch" },
+            ],
+            value: 30,
+          },
+          // No `branch_scope` at all: the row lands in the synthetic segment.
+          {
+            entity_id: id,
+            dimensions: [
+              { key: "repository", value: "src:acme/web", label: "acme/web" },
+            ],
+            value: 10,
+          },
+        ]),
+      },
+    } as never);
+    mocks.collections = [emptyCollection(), comp, emptyCollection()];
+    mocks.grid.byKey = new Map([
+      [
+        "t.commits",
+        metric("t.commits", IDS.map((id) => [id, 10] as [string, number]), {
+          label: "Commits",
+          drilldown: { granularity: ["event"] },
+          selection: {
+            metric_key: "t.commits",
+            entity: { type: "person", ids: IDS },
+            period: { from: "2026-07-20", to: "2026-07-26" },
+            filters: [],
+          },
+        } as Partial<NormalizedMetricResult>),
+      ],
+    ]);
+
+    render(
+      <EvidenceDialogContext.Provider
+        value={{
+          openEvidence: vi.fn(),
+          openEvidenceTargets,
+          openEvidencePeople: vi.fn(),
+        }}
+      >
+        <DomainLensView
+          config={{
+            title: "T",
+            sections: [
+              {
+                kind: "composition",
+                metric: "t.commits",
+                dimension: "repository",
+                splitBy: "branch_scope",
+                title: "Lines by repository",
+              },
+            ],
+          }}
+        />
+      </EvidenceDialogContext.Provider>,
+    );
+
+    // The named segment offers its records; the unnamed one has no value to
+    // filter on, so it must not offer a dialog that would come back empty.
+    expect(
+      screen.getByRole("button", { name: /acme\/api · Default branch/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /acme\/web · unsplit/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("leaves the bars inert when the carrier's records cannot be read", () => {
     const comp = emptyCollection();
     comp.byKey.set("t.commits", {
@@ -1419,6 +1498,76 @@ describe("descending into one dimension value", () => {
         { dimension: "repository", values: ["src:acme/api"] },
       ]);
     }
+  });
+
+  it("opens an hour block from its column, and leaves the cells inert", async () => {
+    const user = userEvent.setup();
+    const openEvidenceTargets = vi.fn();
+    const hours = emptyCollection();
+    hours.byKey.set("t.commits", {
+      ...metric("t.commits", []),
+      timeseries: {
+        view: "timeseries",
+        bucket: "day",
+        dimensions: ["hour_block"],
+        series: IDS.map((id) => ({
+          entity_id: id,
+          dimensions: [{ key: "hour_block", value: "08", label: "08–10" }],
+          points: [{ bucket_start: "2026-10-05", value: 3 }],
+        })),
+      },
+    } as never);
+    mocks.collections = [
+      emptyCollection(),
+      emptyCollection(),
+      emptyCollection(),
+      emptyCollection(),
+      hours,
+    ];
+    mocks.grid.byKey = new Map([
+      [
+        "t.commits",
+        metric("t.commits", IDS.map((id) => [id, 10] as [string, number]), {
+          label: "Commits",
+          drilldown: { granularity: ["event"] },
+          selection: {
+            metric_key: "t.commits",
+            entity: { type: "person", ids: IDS },
+            period: { from: "2026-07-20", to: "2026-07-26" },
+            filters: [],
+          },
+        } as Partial<NormalizedMetricResult>),
+      ],
+    ]);
+    act(() => portalRouter.set({ repo: "src:acme/api" }));
+
+    render(
+      <EvidenceDialogContext.Provider
+        value={{
+          openEvidence: vi.fn(),
+          openEvidenceTargets,
+          openEvidencePeople: vi.fn(),
+        }}
+      >
+        <DomainLensView config={SCOPED_CONFIG} />
+      </EvidenceDialogContext.Provider>,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Open the records from the 08:00 block",
+      }),
+    );
+
+    const [targets] = openEvidenceTargets.mock.calls[0]!;
+    // The block across the period, and still inside the repository. A CELL is
+    // that block on ONE weekday, which the request has no predicate for — so
+    // the cells stay inert rather than answering a wider question.
+    expect(targets[0].selection.filters).toEqual([
+      { dimension: "repository", values: ["src:acme/api"] },
+      { dimension: "hour_block", values: ["08"] },
+    ]);
+    expect(screen.getByTitle(/^Mon 08:00/).tagName).toBe("DIV");
   });
 
   it("ignores a value the lens has no screen for", () => {

--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -37,6 +37,14 @@ const mocks = vi.hoisted(() => ({
     refetch: vi.fn(),
   },
   call: 0,
+  /** Every collection the view asked for, in call order. */
+  requested: [] as Array<{
+    metrics: Array<{
+      key: string;
+      filters?: Array<{ dimension: string; values: string[] }>;
+      views: unknown[];
+    }>;
+  }>,
   collectionSet: new Map<string, unknown>(),
   definitions: [] as unknown[],
   collections: [] as Array<{
@@ -80,13 +88,18 @@ vi.mock("@/queries/visible-roster", () => ({
 vi.mock("@/queries/member-grid", () => ({
   useMemberGridData: () => mocks.grid,
 }));
-// DomainLensView calls useMetricCollection four times (trend, composition,
-// event-histogram, dimension-table rollup) in that order on every render. The
-// counter is reset per test (see beforeEach): left running, each caller's slot
-// would depend on how many renders every earlier test happened to do.
+// DomainLensView calls useMetricCollection five times (trend, composition,
+// event-histogram, dimension-table rollup, hour-block heatmap) in that order on
+// every render. The counter is reset per test (see beforeEach): left running,
+// each caller's slot would depend on how many renders every earlier test
+// happened to do.
+const COLLECTION_CALLS = 5;
 vi.mock("@/queries/metric-results", () => ({
-  useMetricCollection: () => {
-    const r = mocks.collections[mocks.call % 4] ?? emptyCollection();
+  useMetricCollection: (collection: unknown) => {
+    mocks.requested.push(
+      collection as (typeof mocks.requested)[number],
+    );
+    const r = mocks.collections[mocks.call % COLLECTION_CALLS] ?? emptyCollection();
     mocks.call += 1;
     return r;
   },
@@ -202,11 +215,12 @@ const HEADLINE_CONFIG: LensConfig = {
 
 beforeEach(() => {
   mocks.call = 0;
+  mocks.requested = [];
   seedHappyOrg();
   mocks.grid.isPending = false;
   mocks.grid.isError = false;
   act(() => {
-    portalRouter.set({ slice: undefined });
+    portalRouter.set({ slice: undefined, repo: undefined });
     portalRouter.set({ scope: undefined, direct: false });
   });
 });
@@ -1305,5 +1319,160 @@ describe("ownership (concentration risk per dimension value)", () => {
     mocks.collections = [emptyCollection(), comp, emptyCollection(), emptyCollection()];
     render(<DomainLensView config={OWNERSHIP_CONFIG} />);
     expect(screen.queryByText("Ownership concentration")).not.toBeInTheDocument();
+  });
+});
+
+describe("descending into one dimension value", () => {
+  const SCOPED_CONFIG: LensConfig = {
+    title: "Dev · Repositories",
+    tagline: "activity, reach & risk",
+    sections: [
+      { kind: "headline", metrics: ["t.commits"] },
+      {
+        kind: "dimension-table",
+        title: "Repositories ranked",
+        dimension: "repository",
+        noun: "repositories",
+        limit: 2,
+        metrics: ["t.commits"],
+      },
+    ],
+    drilldown: {
+      dimension: "repository",
+      tagline: "one repository",
+      sections: [
+        { kind: "headline", metrics: ["t.commits"] },
+        {
+          kind: "contributors",
+          metric: "t.commits",
+          title: "Top contributors",
+        },
+        {
+          kind: "heatmap-hours",
+          metric: "t.commits",
+          title: "When commits land",
+          caption: "Weekday × two-hour block, in UTC.",
+        },
+      ],
+    },
+  };
+
+  function rollupOf(values: Array<[string, string, number, number]>) {
+    const table = emptyCollection();
+    table.byKey.set("t.commits", {
+      ...metric("t.commits", []),
+      rollup: {
+        view: "rollup",
+        dimensions: ["repository"],
+        values: values.map(([value, label, v, persons]) => ({
+          dimensions: [{ key: "repository", value, label }],
+          value: v,
+          contributing_entity_count: persons,
+        })),
+      },
+    } as never);
+    return table;
+  }
+
+  it("opens the value from a table row and comes back through the breadcrumb", async () => {
+    const user = userEvent.setup();
+    mocks.collections = [
+      emptyCollection(),
+      emptyCollection(),
+      emptyCollection(),
+      rollupOf([
+        ["src:acme/api", "acme/api", 60, 3],
+        ["src:acme/web", "acme/web", 40, 2],
+      ]),
+      emptyCollection(),
+    ];
+    render(<DomainLensView config={SCOPED_CONFIG} />);
+
+    await user.click(screen.getByRole("button", { name: "acme/api" }));
+    expect(portalRouter.search.repo).toBe("src:acme/api");
+
+    // The URL is what makes a shared link reproduce this screen, so the id and
+    // not the label is what it carries — the heading shows the label.
+    expect(
+      screen.getByRole("heading", { level: 1, name: "acme/api" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Repositories ranked · 2 repositories"),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Dev · Repositories" }),
+    );
+    expect(portalRouter.search.repo).toBeUndefined();
+  });
+
+  it("filters every request it makes to the value under inspection", () => {
+    act(() => portalRouter.set({ repo: "src:acme/api" }));
+    render(<DomainLensView config={SCOPED_CONFIG} />);
+
+    const asked = mocks.requested.flatMap((c) => c.metrics);
+    expect(asked.length).toBeGreaterThan(0);
+    // Not one request may answer about the whole tenant: a section that
+    // forgot the filter would read as this repository carrying everyone's work.
+    for (const metric of asked) {
+      expect(metric.filters, metric.key).toEqual([
+        { dimension: "repository", values: ["src:acme/api"] },
+      ]);
+    }
+  });
+
+  it("ignores a value the lens has no screen for", () => {
+    act(() => portalRouter.set({ repo: "src:acme/api" }));
+    render(
+      <DomainLensView
+        config={{
+          title: "Dev · Test",
+          sections: [{ kind: "headline", metrics: ["t.commits"] }],
+        }}
+      />,
+    );
+
+    // A `repo` left over from another lens must not turn this one into a
+    // screen about a value it does not group by.
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Dev · Test" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
+    for (const metric of mocks.requested.flatMap((c) => c.metrics)) {
+      expect(metric.filters, metric.key).toBeUndefined();
+    }
+  });
+
+  it("draws the heatmap from the hour blocks the metric reported", () => {
+    const hours = emptyCollection();
+    hours.byKey.set("t.commits", {
+      ...metric("t.commits", []),
+      timeseries: {
+        view: "timeseries",
+        bucket: "day",
+        dimensions: ["hour_block"],
+        series: IDS.map((id) => ({
+          entity_id: id,
+          dimensions: [{ key: "hour_block", value: "08", label: "08–10" }],
+          // 2026-10-05 is a Monday.
+          points: [{ bucket_start: "2026-10-05", value: 3 }],
+        })),
+      },
+    } as never);
+    mocks.collections = [
+      emptyCollection(),
+      emptyCollection(),
+      emptyCollection(),
+      emptyCollection(),
+      hours,
+    ];
+    act(() => portalRouter.set({ repo: "src:acme/api" }));
+    render(<DomainLensView config={SCOPED_CONFIG} />);
+
+    // 4 members × 3 = 12, all in Monday's 08 block.
+    expect(screen.getByText(/When commits land · 12/)).toBeInTheDocument();
+    expect(screen.getByTitle(/^Mon 08:00 · 12/)).toBeInTheDocument();
+    // A block nobody committed in stays empty rather than borrowing a number.
+    expect(screen.getByTitle(/^Tue 08:00 · 0/)).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -216,11 +216,12 @@ afterEach(() => vi.clearAllMocks());
 /* ── tests ───────────────────────────────────────────────────────────── */
 
 describe("headline (rules 1–2: per-capita + PoP delta)", () => {
-  it("shows the per-active-person value, the team total and the delta", () => {
+  it("leads with the team total the dialog explains, and keeps the per-person read", () => {
     render(<DomainLensView config={HEADLINE_CONFIG} />);
-    // 100 commits over 4 active people = 25/person; halved from last period.
-    expect(screen.getByText("25 commits")).toBeInTheDocument();
-    expect(screen.getByText(/100 commits team total/)).toBeInTheDocument();
+    // The figure is the roster's, because that is the set the evidence dialog
+    // lists; 100 commits over 4 active people = 25/person underneath.
+    expect(screen.getByText("100 commits")).toBeInTheDocument();
+    expect(screen.getByText(/25 commits per active person/)).toBeInTheDocument();
     expect(screen.getByText("-50%")).toBeInTheDocument();
     // header carries the scope size + tagline
     expect(screen.getByText(/4 people · test lens/)).toBeInTheDocument();
@@ -232,8 +233,8 @@ describe("headline (rules 1–2: per-capita + PoP delta)", () => {
     ]);
     mocks.grid.previousByKey = new Map();
     render(<DomainLensView config={HEADLINE_CONFIG} />);
-    // 100 total / 2 active = 50, not 25
-    expect(screen.getByText("50 commits")).toBeInTheDocument();
+    // 100 total / 2 active = 50 per person, not 25
+    expect(screen.getByText(/50 commits per active person/)).toBeInTheDocument();
   });
 });
 
@@ -600,6 +601,150 @@ describe("composition (rule 7: only real server dimensions)", () => {
       screen.getByText("First rule that matches wins."),
     ).toBeInTheDocument();
     expect(screen.getByText("Code — everything else.")).toBeInTheDocument();
+  });
+
+  it("opens the records the clicked bar stands for, filtered to it", async () => {
+    const user = userEvent.setup();
+    const openEvidenceTargets = vi.fn();
+    const comp = emptyCollection();
+    comp.byKey.set("t.commits", {
+      ...metric("t.commits", []),
+      breakdown: {
+        view: "breakdown",
+        values: IDS.flatMap((id) => [
+          {
+            entity_id: id,
+            dimensions: [
+              { key: "repository", value: "src:acme/api", label: "acme/api" },
+              {
+                key: "branch_scope",
+                value: "default",
+                label: "Default branch",
+              },
+            ],
+            value: 30,
+          },
+          {
+            entity_id: id,
+            dimensions: [
+              { key: "repository", value: "src:acme/web", label: "acme/web" },
+              {
+                key: "branch_scope",
+                value: "non_default",
+                label: "Other branches",
+              },
+            ],
+            value: 10,
+          },
+        ]),
+      },
+    } as never);
+    mocks.collections = [emptyCollection(), comp, emptyCollection()];
+    mocks.grid.byKey = new Map([
+      [
+        "t.commits",
+        metric(
+          "t.commits",
+          IDS.map((id) => [id, 10] as [string, number]),
+          {
+            label: "Commits",
+            drilldown: { granularity: ["event"] },
+            selection: {
+              metric_key: "t.commits",
+              entity: { type: "person", ids: IDS },
+              period: { from: "2026-07-20", to: "2026-07-26" },
+              filters: [],
+            },
+          } as Partial<NormalizedMetricResult>
+        ),
+      ],
+    ]);
+
+    render(
+      <EvidenceDialogContext.Provider
+        value={{
+          openEvidence: vi.fn(),
+          openEvidenceTargets,
+          openEvidencePeople: vi.fn(),
+        }}
+      >
+        <DomainLensView
+          config={{
+            title: "T",
+            sections: [
+              {
+                kind: "composition",
+                metric: "t.commits",
+                dimension: "repository",
+                splitBy: "branch_scope",
+                title: "Lines by repository",
+              },
+            ],
+          }}
+        />
+      </EvidenceDialogContext.Provider>
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /acme\/api · Default branch/ })
+    );
+
+    expect(openEvidenceTargets).toHaveBeenCalledTimes(1);
+    const [targets] = openEvidenceTargets.mock.calls[0]!;
+    // Narrowed to the repository AND the segment: a bar that opened the
+    // unfiltered metric would answer a different question from the one asked.
+    expect(targets[0].selection.filters).toEqual([
+      { dimension: "repository", values: ["src:acme/api"] },
+      { dimension: "branch_scope", values: ["default"] },
+    ]);
+    // And the row says which slice it belongs to.
+    expect(targets[0].selection.display_dimensions).toEqual([
+      "branch_scope",
+      "repository",
+    ]);
+  });
+
+  it("leaves the bars inert when the carrier's records cannot be read", () => {
+    const comp = emptyCollection();
+    comp.byKey.set("t.commits", {
+      ...metric("t.commits", []),
+      breakdown: {
+        view: "breakdown",
+        values: IDS.flatMap((id) => [
+          {
+            entity_id: id,
+            dimensions: [{ key: "category", value: "docs" }],
+            value: 30,
+          },
+          {
+            entity_id: id,
+            dimensions: [{ key: "category", value: "code" }],
+            value: 10,
+          },
+        ]),
+      },
+    } as never);
+    mocks.collections = [emptyCollection(), comp, emptyCollection()];
+    render(
+      <DomainLensView
+        config={{
+          title: "T",
+          sections: [
+            {
+              kind: "composition",
+              metric: "t.commits",
+              dimension: "category",
+              title: "By category",
+            },
+          ],
+        }}
+      />
+    );
+
+    // An affordance that opens an empty dialog is worse than none.
+    expect(
+      screen.queryByRole("button", { name: /Open the records behind/ })
+    ).not.toBeInTheDocument();
   });
 
   it("shows a retryable error card when the breakdown request fails", () => {
@@ -989,6 +1134,35 @@ describe("dimension-table (rollup: one row per dimension value)", () => {
     expect(screen.queryByText(/Repositories ranked/)).not.toBeInTheDocument();
   });
 
+  it("opens the tail from the remainder row, and folds it back", async () => {
+    const user = userEvent.setup();
+    const table = emptyCollection();
+    table.byKey.set(
+      "t.commits",
+      rollup("t.commits", [
+        ["r1", "org/one", 40, 3],
+        ["r2", "org/two", 60, 2],
+        ["r3", "org/three", 10, 1],
+      ])
+    );
+    mocks.collections = [
+      emptyCollection(),
+      emptyCollection(),
+      emptyCollection(),
+      table,
+    ];
+    render(<DomainLensView config={TABLE_CONFIG} />);
+
+    // The limit is 2, so org/three is inside the remainder and nowhere else:
+    // without this control the tail is unreachable.
+    expect(screen.queryByText("org/three")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Other (1)" }));
+    expect(screen.getByText("org/three")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show top 2" }));
+    expect(screen.queryByText("org/three")).not.toBeInTheDocument();
+  });
+
   it("shows a retryable error card when the rollup request fails", () => {
     const table = emptyCollection();
     table.isError = true;
@@ -1051,6 +1225,72 @@ describe("ownership (concentration risk per dimension value)", () => {
     ).toBeInTheDocument();
     // No member names anywhere on the section.
     expect(screen.queryByText("a")).not.toBeInTheDocument();
+  });
+
+  it("keeps the names out of the row and puts them on the segment", async () => {
+    const user = userEvent.setup();
+    const comp = emptyCollection();
+    comp.byKey.set("t.commits", {
+      ...metric("t.commits", []),
+      breakdown: {
+        view: "breakdown",
+        values: [
+          breakdownRow(pid("a"), "alpha", 70),
+          breakdownRow(pid("b"), "alpha", 20),
+          breakdownRow(pid("c"), "alpha", 10),
+          breakdownRow(pid("a"), "beta", 30),
+          breakdownRow(pid("b"), "beta", 40),
+        ],
+      },
+    } as never);
+    mocks.collections = [
+      emptyCollection(),
+      comp,
+      emptyCollection(),
+      emptyCollection(),
+    ];
+    render(<DomainLensView config={OWNERSHIP_CONFIG} />);
+
+    // Nothing on the row names anyone, which is the section's standing rule.
+    expect(screen.queryByText(/Top person ·/)).not.toBeInTheDocument();
+
+    // Hovering is the reader asking who, and the answer names the leader of
+    // that value — a section that withheld it could not inform the decision
+    // it exists for.
+    const bar = screen.getByRole("img", { name: /alpha: top person 70%/ });
+    await user.hover(bar.firstElementChild as Element);
+    expect(await screen.findByText(/Top person · 70% · a/)).toBeInTheDocument();
+  });
+
+  it("reaches the rows beyond the first few, and folds them back", async () => {
+    const user = userEvent.setup();
+    const comp = emptyCollection();
+    // One value more than the section shows, so the control is the only way in.
+    const repos = Array.from({ length: 13 }, (_, i) => `repo-${i}`);
+    comp.byKey.set("t.commits", {
+      ...metric("t.commits", []),
+      breakdown: {
+        view: "breakdown",
+        values: repos.flatMap((repo, i) => [
+          breakdownRow(pid("a"), repo, 100 - i),
+          breakdownRow(pid("b"), repo, 10),
+        ]),
+      },
+    } as never);
+    mocks.collections = [
+      emptyCollection(),
+      comp,
+      emptyCollection(),
+      emptyCollection(),
+    ];
+    render(<DomainLensView config={OWNERSHIP_CONFIG} />);
+
+    const hidden = repos[repos.length - 1]!;
+    expect(screen.queryByText(hidden)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^\+\d+ more$/ }));
+    expect(screen.getByText(hidden)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^Show top \d+$/ }));
+    expect(screen.queryByText(hidden)).not.toBeInTheDocument();
   });
 
   it("renders nothing with fewer than two values", () => {

--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -1553,6 +1553,12 @@ describe("descending into one dimension value", () => {
       </EvidenceDialogContext.Provider>,
     );
 
+    // Every block is openable, not only the labelled ones: the density choice
+    // must not take six of twelve drilldowns with it.
+    expect(
+      screen.getAllByRole("button", { name: /Open the records from the/ }),
+    ).toHaveLength(12);
+
     await user.click(
       screen.getByRole("button", {
         name: "Open the records from the 08:00 block",

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -2152,20 +2152,24 @@ function HeatmapHoursSection({
             <div />
             {HOUR_BLOCKS.map((block, index) => (
               <div key={block} className="text-center text-muted-foreground">
-                {index % 2 !== 0 ? (
-                  ""
-                ) : onOpenBlock ? (
+                {onOpenBlock ? (
+                  // Every block is openable, including the ones whose label is
+                  // suppressed for density: the button fills its column, so an
+                  // unlabelled one is still a target for a mouse and a
+                  // screen reader both.
                   <button
                     type="button"
                     aria-haspopup="dialog"
                     aria-label={`Open the records from the ${block}:00 block`}
                     onClick={() => onOpenBlock(block)}
-                    className="cursor-pointer underline-offset-2 hover:text-foreground hover:underline"
+                    className="w-full cursor-pointer underline-offset-2 hover:text-foreground hover:underline"
                   >
-                    {block}
+                    <span aria-hidden={index % 2 !== 0}>
+                      {index % 2 === 0 ? block : "·"}
+                    </span>
                   </button>
                 ) : (
-                  block
+                  <span>{index % 2 === 0 ? block : ""}</span>
                 )}
               </div>
             ))}

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -1,7 +1,7 @@
 import { ExplainWithAi } from "@/components/widgets/dashboard/explain-with-ai";
 import { trendSnapshot } from "@/lib/insight/explain-snapshot";
 import { Link } from "@tanstack/react-router";
-import { useMemo, useState, type CSSProperties } from "react";
+import { Fragment, useMemo, useState, type CSSProperties } from "react";
 import { MetricName } from "@/components/widgets/metric-help-tooltip";
 import { ArrowDownRight, ArrowUpRight } from "lucide-react";
 import { AttentionList } from "@/components/portal/attention-list";
@@ -77,6 +77,7 @@ import { peopleEvidenceView } from "@/lib/portal/evidence-people";
 import { formatMetricValue } from "@/lib/format";
 import { seriesColors } from "@/lib/series-colors";
 import {
+  labelForDimensionValue,
   toBarRows,
   UNSPLIT_SEGMENT,
   type BarEntry,
@@ -85,6 +86,11 @@ import {
 } from "@/lib/portal/bar-rows";
 import { narrowedEvidenceSelection } from "@/lib/metrics/evidence-targets";
 import { evidenceMetricFor } from "@/lib/metrics/evidence-via";
+import {
+  dayHourMatrix,
+  HOUR_BLOCKS,
+  WEEKDAY_LABELS,
+} from "@/lib/portal/day-hour-matrix";
 import { mergeEventHistogram } from "@/lib/portal/event-histogram";
 import { peerPopulationLabel } from "@/lib/portal/use-cohort-label";
 import {
@@ -119,6 +125,7 @@ import {
   type TrendDrilldownState,
 } from "@/components/portal/trend-drilldown-dialog";
 import { usePortalNavActions, usePortalSlice } from "@/lib/portal/portal-nav";
+import { usePortalSearch } from "@/lib/portal/portal-search";
 import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 import type { TeamMember } from "@/types/insight";
 import { useOrgScope } from "@/lib/portal/use-org-scope";
@@ -159,9 +166,36 @@ export function DomainLensView({
   // takes its tile with it, and a section left with none of its own is gone
   // rather than drawn empty (`visibleSections`).
   const showPlanned = usePortalShowPlanned();
+  // One repository under inspection turns the lens into that repository's
+  // screen: the drilldown's own sections, every request filtered to the value,
+  // and a breadcrumb back. A `repo` that outlives its lens is ignored rather
+  // than rendering a screen about a value this lens does not group by.
+  const { repo } = usePortalSearch();
+  const { openRepository } = usePortalNavActions();
+  const scoped = repo && declared.drilldown ? repo : null;
+  const scopeDimension = scoped ? (declared.drilldown?.dimension ?? null) : null;
   const config = useMemo(
-    () => visibleSections(declared, showPlanned),
-    [declared, showPlanned]
+    () =>
+      visibleSections(
+        scoped && declared.drilldown
+          ? {
+              ...declared,
+              tagline: declared.drilldown.tagline ?? declared.tagline,
+              sections: declared.drilldown.sections,
+            }
+          : declared,
+        showPlanned
+      ),
+    [declared, showPlanned, scoped]
+  );
+  // Every request the screen makes carries this, so no section can forget it
+  // and quietly answer about the whole tenant instead.
+  const scopeFilters = useMemo(
+    () =>
+      scopeDimension && scoped
+        ? [{ dimension: scopeDimension, values: [scoped] }]
+        : undefined,
+    [scopeDimension, scoped]
   );
 
 
@@ -208,10 +242,11 @@ export function DomainLensView({
     () => ({
       metrics: fetchKeys.map((key) => ({
         key,
+        ...(scopeFilters ? { filters: scopeFilters } : {}),
         views: [{ view: "period" as const }, { view: "peer" as const }],
       })),
     }),
-    [fetchKeys]
+    [fetchKeys, scopeFilters]
   );
   const grid = useMemberGridData(
     gridCollection.metrics.length ? gridCollection : EMPTY_COLLECTION,
@@ -243,11 +278,12 @@ export function DomainLensView({
       metrics: trendBucket
         ? trendKeys.map((key) => ({
             key,
+            ...(scopeFilters ? { filters: scopeFilters } : {}),
             views: [{ view: "timeseries" as const, bucket: trendBucket }],
           }))
         : [],
     }),
-    [trendKeys, trendBucket]
+    [trendKeys, trendBucket, scopeFilters]
   );
   const trend = useMetricCollection(
     trendCollection.metrics.length && memberIds.length
@@ -283,10 +319,11 @@ export function DomainLensView({
     return {
       metrics: [...dims].map(([key, set]) => ({
         key,
+        ...(scopeFilters ? { filters: scopeFilters } : {}),
         views: [{ view: "breakdown" as const, dimensions: [...set] }],
       })),
     };
-  }, [breakdownSections]);
+  }, [breakdownSections, scopeFilters]);
   const compData = useMetricCollection(
     breakdownSections.length && memberIds.length
       ? compCollection
@@ -311,10 +348,11 @@ export function DomainLensView({
     () => ({
       metrics: eventSections.map((s) => ({
         key: s.metric,
+        ...(scopeFilters ? { filters: scopeFilters } : {}),
         views: [{ view: "histogram" as const }],
       })),
     }),
-    [eventSections]
+    [eventSections, scopeFilters]
   );
   const eventData = useMetricCollection(
     eventSections.length && memberIds.length
@@ -347,15 +385,53 @@ export function DomainLensView({
     return {
       metrics: [...dimensionByMetric].map(([key, dimension]) => ({
         key,
+        ...(scopeFilters ? { filters: scopeFilters } : {}),
         views: [{ view: "rollup" as const, dimensions: [dimension] }],
       })),
     };
-  }, [tableSections]);
+  }, [tableSections, scopeFilters]);
   const tableData = useMetricCollection(
     tableSections.length && memberIds.length
       ? tableCollection
       : EMPTY_COLLECTION,
     tableSections.length && memberIds.length
+      ? { type: "person", ids: memberIds }
+      : { type: "person", ids: [] },
+    dateRange
+  );
+
+  // Heatmap: a timeseries of its own, because the same metric cannot carry two
+  // timeseries views in one request — and the trend already claims that view
+  // for the metrics it charts. Bucketed by DAY whatever the trend chose: the
+  // matrix reads the weekday off each bucket, so a week-sized bucket would
+  // collapse five weekdays into one cell.
+  const hourSections = useMemo(
+    () =>
+      config.sections.filter(
+        (s): s is Extract<SectionSpec, { kind: "heatmap-hours" }> =>
+          s.kind === "heatmap-hours"
+      ),
+    [config]
+  );
+  const hourCollection = useMemo<MetricCollectionConfig>(
+    () => ({
+      metrics: hourSections.map((s) => ({
+        key: s.metric,
+        ...(scopeFilters ? { filters: scopeFilters } : {}),
+        views: [
+          {
+            view: "timeseries" as const,
+            bucket: "day" as const,
+            dimensions: [HOUR_BLOCK_DIMENSION],
+          },
+        ],
+      })),
+    }),
+    [hourSections, scopeFilters]
+  );
+  const hourData = useMetricCollection(
+    hourSections.length && memberIds.length ? hourCollection : EMPTY_COLLECTION,
+    hourSections.length && memberIds.length
       ? { type: "person", ids: memberIds }
       : { type: "person", ids: [] },
     dateRange
@@ -431,6 +507,18 @@ export function DomainLensView({
     );
   }
 
+  // The value's own label, found wherever the responses named it. The URL
+  // carries the id, which is `<source>:<owner>/<repo>` and not what a reader
+  // recognises; the id stands in until a row arrives that knows better.
+  const scopedLabel = scoped
+    ? (labelForDimensionValue(
+        scopeDimension,
+        scoped,
+        compData.byKey,
+        tableData.byKey
+      ) ?? null)
+    : null;
+
   // The affordance sits with the page title, not on the chart: it explains the
   // view, and a chart that grows a second card would carry two of them.
   const trendSpec = config.sections.find(
@@ -462,9 +550,26 @@ export function DomainLensView({
 
   return (
     <div className="flex flex-col gap-6 p-4 md:p-6">
+      {scoped ? (
+        <nav aria-label="Breadcrumb" className="flex items-center gap-2 text-sm">
+          <button
+            type="button"
+            onClick={() => openRepository("")}
+            className="cursor-pointer text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            {declared.title}
+          </button>
+          <span aria-hidden className="text-muted-foreground">
+            ›
+          </span>
+          <span className="font-medium">{scopedLabel ?? scoped}</span>
+        </nav>
+      ) : null}
       <div className="relative flex items-start justify-between gap-3">
         <div>
-          <h1 className="text-lg font-semibold tracking-tight">{config.title}</h1>
+          <h1 className="text-lg font-semibold tracking-tight">
+            {scoped ? (scopedLabel ?? scoped) : config.title}
+          </h1>
           <p className="text-sm text-muted-foreground">
             {orgScope.count} {orgScope.count === 1 ? "person" : "people"} ·{" "}
             {config.tagline ?? "trend & balance"}
@@ -496,6 +601,8 @@ export function DomainLensView({
           compRefetch={compData.refetch}
           eventByKey={eventData.byKey}
           eventIsError={eventData.isError}
+          hourByKey={hourData.byKey}
+          hourIsError={hourData.isError}
           tableByKey={tableData.byKey}
           tableIsError={tableData.isError}
           tableRefetch={tableData.refetch}
@@ -505,6 +612,13 @@ export function DomainLensView({
           nameByEntity={nameByEntity}
           personIdByEntity={personIdByEntity}
           onOpenChart={openTrendDrilldown}
+          onOpenValue={
+            // Only from the listing screen: a table INSIDE the drilldown is
+            // already about one value, so descending again means nothing.
+            !scoped && declared.drilldown
+              ? (value) => openRepository(value)
+              : undefined
+          }
         />
       ))}
 
@@ -550,6 +664,8 @@ function Section({
   compRefetch,
   eventByKey,
   eventIsError,
+  hourByKey,
+  hourIsError,
   tableByKey,
   tableIsError,
   tableRefetch,
@@ -559,6 +675,7 @@ function Section({
   nameByEntity,
   personIdByEntity,
   onOpenChart,
+  onOpenValue,
 }: {
   spec: SectionSpec;
   grid: GridData;
@@ -569,6 +686,8 @@ function Section({
   compRefetch: () => void;
   eventByKey: Map<string, NormalizedMetricResult>;
   eventIsError: boolean;
+  hourByKey: Map<string, NormalizedMetricResult>;
+  hourIsError: boolean;
   tableByKey: Map<string, NormalizedMetricResult>;
   tableIsError: boolean;
   tableRefetch: () => void;
@@ -578,6 +697,8 @@ function Section({
   cohortOf: (id: string) => string | null;
   cohortLabel: string;
   onOpenChart: (chart: TrendChart, bucketStart?: string) => void;
+  /** Descend into one dimension value; absent when the lens has no screen for one. */
+  onOpenValue?: (value: string) => void;
 }) {
   switch (spec.kind) {
     case "headline":
@@ -662,6 +783,25 @@ function Section({
           memberIds={memberIds}
         />
       );
+    case "contributors":
+      return (
+        <ContributorsSection
+          spec={spec}
+          grid={grid}
+          memberIds={memberIds}
+          nameByEntity={nameByEntity}
+        />
+      );
+    case "heatmap-hours":
+      return (
+        <HeatmapHoursSection
+          spec={spec}
+          grid={grid}
+          hourByKey={hourByKey}
+          hourIsError={hourIsError}
+          memberIds={memberIds}
+        />
+      );
     case "dimension-table":
       return (
         <DimensionTableSection
@@ -669,6 +809,7 @@ function Section({
           tableByKey={tableByKey}
           tableIsError={tableIsError}
           tableRefetch={tableRefetch}
+          onOpenValue={onOpenValue}
         />
       );
     case "ownership":
@@ -1872,9 +2013,146 @@ function CompositionSection({
   );
 }
 
+/* ── contributors + heatmap-hours (inside a drilldown) ───────────────── */
+
+const CONTRIBUTOR_ROWS = 8;
+
+/**
+ * The people who carried this one value, ranked.
+ *
+ * Named, unlike every roster-wide section: the subject is already one
+ * repository, and "who works on this" is the question a reader descends to ask.
+ * The roster-wide screens stay anonymous — see `AttentionSection` for the only
+ * other place a name appears.
+ */
+function ContributorsSection({
+  spec,
+  grid,
+  memberIds,
+  nameByEntity,
+}: {
+  spec: Extract<SectionSpec, { kind: "contributors" }>;
+  grid: GridData;
+  memberIds: readonly string[];
+  nameByEntity: Map<string, string>;
+}) {
+  const r = grid.byKey.get(spec.metric);
+  if (!r) return null;
+
+  const ranked = entityValues(r, memberIds)
+    .filter((e) => e.value > 0)
+    .sort((a, b) => b.value - a.value);
+  if (ranked.length < 2) return null;
+
+  const limit = spec.limit ?? CONTRIBUTOR_ROWS;
+  const bucket = new Map<string, BarEntry>();
+  for (const entry of ranked.slice(0, limit)) {
+    bucket.set(entry.id, {
+      label: nameByEntity.get(entry.id) ?? entry.id,
+      value: entry.value,
+    });
+  }
+  const rest = ranked.slice(limit);
+  if (rest.length) {
+    bucket.set("__rest__", {
+      label: `${rest.length} more ${rest.length === 1 ? "person" : "people"}`,
+      value: rest.reduce((sum, e) => sum + e.value, 0),
+    });
+  }
+
+  return (
+    <BarList
+      title={spec.title}
+      rows={toBarRows(bucket)}
+      format={r.format}
+      unit={r.unit}
+    />
+  );
+}
+
+/**
+ * Weekday × two-hour block: when the work lands.
+ *
+ * The weekday comes from each bucket's own date and the block from the
+ * metric's `hour_block` dimension, which is why the request behind this is
+ * bucketed by DAY — a week-sized bucket has no weekday to read.
+ */
+function HeatmapHoursSection({
+  spec,
+  grid,
+  hourByKey,
+  hourIsError,
+  memberIds,
+}: {
+  spec: Extract<SectionSpec, { kind: "heatmap-hours" }>;
+  grid: GridData;
+  hourByKey: Map<string, NormalizedMetricResult>;
+  hourIsError: boolean;
+  memberIds: readonly string[];
+}) {
+  if (hourIsError) return null;
+  const r = hourByKey.get(spec.metric);
+  if (!r) return null;
+
+  const { cells, max, total } = dayHourMatrix(
+    memberIds.flatMap((id) => forEntity(r, id).series)
+  );
+  if (total <= 0 || max <= 0) return null;
+
+  const unit = grid.byKey.get(spec.metric)?.unit ?? null;
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        {spec.title} · {fmtCompact(total)}
+      </p>
+      <Card>
+        <CardContent className="flex flex-col gap-3 p-4">
+          <div
+            className="grid gap-px text-xs"
+            style={{
+              gridTemplateColumns: `3rem repeat(${HOUR_BLOCKS.length}, 1fr)`,
+            }}
+          >
+            <div />
+            {HOUR_BLOCKS.map((block, index) => (
+              <div key={block} className="text-center text-muted-foreground">
+                {index % 2 === 0 ? block : ""}
+              </div>
+            ))}
+            {WEEKDAY_LABELS.map((day, dayIndex) => (
+              <Fragment key={day}>
+                <div className="self-center text-muted-foreground">{day}</div>
+                {HOUR_BLOCKS.map((block, blockIndex) => {
+                  const value = cells[dayIndex]?.[blockIndex] ?? 0;
+                  return (
+                    <div
+                      key={block}
+                      title={`${day} ${block}:00 · ${formatMetricValue(value, "integer", unit)}`}
+                      className="aspect-square rounded-[3px]"
+                      style={{
+                        backgroundColor: value
+                          ? `color-mix(in oklab, var(--primary) ${Math.round((value / max) * 100)}%, var(--muted))`
+                          : "var(--muted)",
+                      }}
+                    />
+                  );
+                })}
+              </Fragment>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">{spec.caption}</p>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
 /* ── dimension-table (rollup: one row per dimension value) ───────────── */
 
 const DIMENSION_TABLE_ROWS = 12;
+
+/** The dimension a `heatmap-hours` section reads. */
+const HOUR_BLOCK_DIMENSION = "hour_block";
 
 function tableCellText(
   value: number | null | undefined,
@@ -1888,11 +2166,14 @@ function DimensionTableSection({
   tableByKey,
   tableIsError,
   tableRefetch,
+  onOpenValue,
 }: {
   spec: Extract<SectionSpec, { kind: "dimension-table" }>;
   tableByKey: Map<string, NormalizedMetricResult>;
   tableIsError: boolean;
   tableRefetch: () => void;
+  /** Descend into one row; absent when the lens has no screen for a value. */
+  onOpenValue?: (value: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   if (tableIsError) {
@@ -2016,7 +2297,17 @@ function DimensionTableSection({
                     className="max-w-64 truncate text-sm font-medium"
                     title={row.label}
                   >
-                    {row.label}
+                    {onOpenValue ? (
+                      <button
+                        type="button"
+                        onClick={() => onOpenValue(row.value)}
+                        className="max-w-full cursor-pointer truncate underline-offset-2 hover:underline"
+                      >
+                        {row.label}
+                      </button>
+                    ) : (
+                      row.label
+                    )}
                   </TableCell>
                   {results.map((r) => (
                     <TableCell

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -1,7 +1,7 @@
 import { ExplainWithAi } from "@/components/widgets/dashboard/explain-with-ai";
 import { trendSnapshot } from "@/lib/insight/explain-snapshot";
 import { Link } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useMemo, useState, type CSSProperties } from "react";
 import { MetricName } from "@/components/widgets/metric-help-tooltip";
 import { ArrowDownRight, ArrowUpRight } from "lucide-react";
 import { AttentionList } from "@/components/portal/attention-list";
@@ -81,7 +81,10 @@ import {
   UNSPLIT_SEGMENT,
   type BarEntry,
   type BarRow,
+  type BarSegment,
 } from "@/lib/portal/bar-rows";
+import { narrowedEvidenceSelection } from "@/lib/metrics/evidence-targets";
+import { evidenceMetricFor } from "@/lib/metrics/evidence-via";
 import { mergeEventHistogram } from "@/lib/portal/event-histogram";
 import { peerPopulationLabel } from "@/lib/portal/use-cohort-label";
 import {
@@ -110,7 +113,7 @@ import {
   buildTrendData,
   pickTrendBucket,
 } from "@/lib/portal/trend-data";
-import { bucketBreakdown } from "@/lib/portal/trend-drilldown";
+import { bucketBreakdown, bucketRange } from "@/lib/portal/trend-drilldown";
 import {
   TrendDrilldownDialog,
   type TrendDrilldownState,
@@ -441,12 +444,17 @@ export function DomainLensView({
   // disagree: under a flat policy that roster is the whole organisation, and
   // under an org chart it is the viewer's own subtree — the permission
   // boundary identity already enforces.
-  const openTrendDrilldown = (chart: TrendChart) => {
+  const openTrendDrilldown = (chart: TrendChart, bucketStart?: string) => {
+    // A clicked point asks about its own bucket; the card asks about the
+    // period. The label says which, so the dialog never looks like the other.
+    const range = bucketStart
+      ? bucketRange(bucketStart, trendBucket ?? "day")
+      : { from: dateRange.from, to: dateRange.to };
     setDrilldown({
       metricKey: chart.derived ? null : chart.drilldownKey,
-      label: chart.title,
+      label: bucketStart ? `${chart.title} · ${bucketStart}` : chart.title,
       bucketLabel: trendBucket ?? "period",
-      period: { from: dateRange.from, to: dateRange.to },
+      period: range,
       members: scopedMembers,
       breakdown: bucketBreakdown(chart.drilldownKey, trend.byKey, scopedMembers),
     });
@@ -569,7 +577,7 @@ function Section({
   personIdByEntity: Map<string, string>;
   cohortOf: (id: string) => string | null;
   cohortLabel: string;
-  onOpenChart: (chart: TrendChart) => void;
+  onOpenChart: (chart: TrendChart, bucketStart?: string) => void;
 }) {
   switch (spec.kind) {
     case "headline":
@@ -671,6 +679,7 @@ function Section({
           compIsError={compIsError}
           compRefetch={compRefetch}
           memberIds={memberIds}
+          nameByEntity={nameByEntity}
         />
       );
     case "attention":
@@ -1066,18 +1075,25 @@ function HeadlineSection({
       if (now == null) return null;
       const prev = representative(grid.previousByKey.get(key), memberIds);
       const isSum = r.computation === "sum";
-      return { key, r, now, prev, isSum };
+      // The records that carry the figure: its own, unless the family says
+      // another metric holds them (a line count is carried by commits).
+      const carrier = grid.byKey.get(evidenceMetricFor(key));
+      return { key, r, now, prev, isSum, carrier };
     })
     .filter((x): x is NonNullable<typeof x> => x != null);
   if (!cards.length) return null;
 
   // Every drillable card of the row, so the dialog a reader opens on one of
   // them lists its neighbours — the same set the members grid offers from a
-  // row of cells.
+  // row of cells. Deduplicated by metric: two tiles carried by one metric
+  // would otherwise name the same key twice, which the request refuses.
+  const seen = new Set<string>();
   const targets = cards.flatMap((c) => {
-    if (!c.r.drilldown) return [];
-    const selection = personsEvidenceSelection(c.r.selection, memberIds);
-    return selection ? [{ selection, label: c.r.label }] : [];
+    if (!c.carrier?.drilldown || seen.has(c.carrier.metric_key)) return [];
+    const selection = personsEvidenceSelection(c.carrier.selection, memberIds);
+    if (!selection) return [];
+    seen.add(c.carrier.metric_key);
+    return [{ selection, label: c.carrier.label }];
   });
 
   return (
@@ -1120,14 +1136,15 @@ function HeadlineCard({
     now: number;
     prev: number | null;
     isSum: boolean;
+    carrier: NormalizedMetricResult | undefined;
   };
   targets: readonly { selection: MetricEvidenceSelection; label: string }[];
   memberIds: readonly string[];
 }) {
   const evidence = useMetricEvidenceOptional();
   const c = card;
-  const selection = c.r.drilldown
-    ? personsEvidenceSelection(c.r.selection, memberIds)
+  const selection = c.carrier?.drilldown
+    ? personsEvidenceSelection(c.carrier.selection, memberIds)
     : null;
   const body = (
     <CardContent className="p-4">
@@ -1143,15 +1160,15 @@ function HeadlineCard({
         <Delta now={c.now} prev={c.prev} direction={c.r.direction} />
       </div>
       <div className={cn("mt-1", TEXT_FIGURE)}>
-        {formatMetricValue(
-          c.isSum ? perCapita(c.r, memberIds) : c.now,
-          c.r.format,
-          c.r.unit
-        )}
+        {formatMetricValue(c.now, c.r.format, c.r.unit)}
       </div>
+      {/* The team total leads, because the dialog this card opens lists the
+        roster's records — a per-person figure on the face and a roster-sized
+        table behind it read as a contradiction. The per-person figure keeps
+        its place underneath, where the comparison it serves still works. */}
       <div className="text-xs text-muted-foreground">
         {c.isSum
-          ? `per active person · ${formatMetricValue(c.now, c.r.format, c.r.unit)} team total`
+          ? `team total · ${formatMetricValue(perCapita(c.r, memberIds), c.r.format, c.r.unit)} per active person`
           : "median / person"}
       </div>
     </CardContent>
@@ -1323,7 +1340,7 @@ function TrendSection({
   trend: TrendData;
   bucket: MetricBucket;
   memberIds: readonly string[];
-  onOpenChart: (chart: TrendChart) => void;
+  onOpenChart: (chart: TrendChart, bucketStart?: string) => void;
 }) {
   const charts = trendCharts(spec, grid, trend, memberIds);
 
@@ -1361,6 +1378,7 @@ function TrendSection({
             series={chart.series}
             data={chart.data}
             isPending={trend.isPending}
+            onBucketClick={(bucketStart) => onOpenChart(chart, bucketStart)}
           />
         </button>
       ))}
@@ -1760,6 +1778,7 @@ function CompositionSection({
   grid: GridData;
   memberIds: readonly string[];
 }) {
+  const evidence = useMetricEvidenceOptional();
   if (compIsError) {
     return (
       <section className="flex flex-col gap-3">
@@ -1814,9 +1833,32 @@ function CompositionSection({
       }
     }
   }
-  const rows = toBarRows(bucket);
+  const rows = toBarRows(bucket, spec.splitBy);
   // A single 100%-share bar is an empty shell (rule 11), same as ByUnitSection.
   if (rows.length < 2) return null;
+
+  // The records behind a bar are the ones that carry the figure, which for a
+  // line count is its commits rather than its own per-day summary.
+  const carrier = grid.byKey.get(evidenceMetricFor(spec.metric));
+  const openBar =
+    evidence && carrier?.drilldown
+      ? (row: BarRow, segment?: BarSegment) => {
+          const selection = narrowedEvidenceSelection(carrier, memberIds, {
+            filters: [
+              { dimension: spec.dimension, value: row.key },
+              ...(segment && spec.splitBy
+                ? [{ dimension: spec.splitBy, value: segment.seed }]
+                : []),
+            ],
+          });
+          if (selection) {
+            evidence.openEvidenceTargets(
+              [{ selection, label: carrier.label }],
+              { activeMetricKey: selection.metric_key }
+            );
+          }
+        }
+      : undefined;
 
   return (
     <BarList
@@ -1825,6 +1867,7 @@ function CompositionSection({
       format={r?.format ?? "integer"}
       unit={r?.unit ?? null}
       notes={spec.notes}
+      onOpen={openBar}
     />
   );
 }
@@ -1851,6 +1894,7 @@ function DimensionTableSection({
   tableIsError: boolean;
   tableRefetch: () => void;
 }) {
+  const [expanded, setExpanded] = useState(false);
   if (tableIsError) {
     return (
       <section className="flex flex-col gap-3">
@@ -1914,8 +1958,8 @@ function DimensionTableSection({
   if (ranked.length < 2) return null;
 
   const limit = spec.limit ?? DIMENSION_TABLE_ROWS;
-  const visible = ranked.slice(0, limit);
-  const rest = ranked.slice(limit);
+  const visible = expanded ? ranked : ranked.slice(0, limit);
+  const rest = expanded ? [] : ranked.slice(limit);
   // A remainder only for what still adds up: sums add; a median or a ratio
   // over "everything else" is not derivable from the shown rows.
   const remainder = rest.length
@@ -1937,9 +1981,20 @@ function DimensionTableSection({
 
   return (
     <section className="flex flex-col gap-3">
-      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
-        {spec.title} · {ranked.length} {spec.noun}
-      </p>
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+          {spec.title} · {ranked.length} {spec.noun}
+        </p>
+        {expanded && ranked.length > limit ? (
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            className="cursor-pointer text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            Show top {limit}
+          </button>
+        ) : null}
+      </div>
       <Card>
         <CardContent className="p-0">
           <Table>
@@ -1978,7 +2033,18 @@ function DimensionTableSection({
               ))}
               {remainder ? (
                 <TableRow className="text-muted-foreground">
-                  <TableCell className="text-sm">{remainder.label}</TableCell>
+                  <TableCell className="text-sm">
+                    {/* The remainder is the way into the rows it hides, not a
+                      dead summary line: a reader who wants the long tail has
+                      nowhere else to ask for it. */}
+                    <button
+                      type="button"
+                      onClick={() => setExpanded(true)}
+                      className="cursor-pointer underline-offset-2 hover:text-foreground hover:underline"
+                    >
+                      {remainder.label}
+                    </button>
+                  </TableCell>
                   {results.map((r) => (
                     <TableCell
                       key={r.metric_key}
@@ -2015,13 +2081,16 @@ function OwnershipSection({
   compIsError,
   compRefetch,
   memberIds,
+  nameByEntity,
 }: {
   spec: Extract<SectionSpec, { kind: "ownership" }>;
   compData: Map<string, NormalizedMetricResult>;
   compIsError: boolean;
   compRefetch: () => void;
   memberIds: readonly string[];
+  nameByEntity: Map<string, string>;
 }) {
+  const [expanded, setExpanded] = useState(false);
   if (compIsError) {
     return (
       <section className="flex flex-col gap-3">
@@ -2062,15 +2131,27 @@ function OwnershipSection({
   }
   const rows = [...byValue.entries()]
     .map(([value, bucket]) => {
-      const shares = [...bucket.byEntity.values()].sort((a, b) => b - a);
+      const ranked = [...bucket.byEntity.entries()].sort((a, b) => b[1] - a[1]);
+      const shares = ranked.map(([, share]) => share);
       const top1 = (shares[0] ?? 0) / bucket.total;
       const top3 =
         shares.slice(0, 3).reduce((sum, v) => sum + v, 0) / bucket.total;
-      return { value, label: bucket.label, total: bucket.total, top1, top3 };
+      const nameOf = ([id]: [string, number]) => nameByEntity.get(id) ?? id;
+      return {
+        value,
+        label: bucket.label,
+        total: bucket.total,
+        top1,
+        top3,
+        // The bar stays anonymous; hovering a segment is the reader asking.
+        topName: ranked[0] ? nameOf(ranked[0]) : null,
+        nextNames: ranked.slice(1, 3).map(nameOf),
+        othersCount: Math.max(0, ranked.length - 3),
+      };
     })
     .sort((a, b) => b.total - a.total);
   if (rows.length < 2) return null;
-  const visible = rows.slice(0, OWNERSHIP_ROWS);
+  const visible = expanded ? rows : rows.slice(0, OWNERSHIP_ROWS);
 
   return (
     <section className="flex flex-col gap-3">
@@ -2079,6 +2160,7 @@ function OwnershipSection({
       </p>
       <Card>
         <CardContent className="flex flex-col gap-2 p-4">
+         <TooltipProvider delay={HOVER_DELAY_MS}>
           <ul
             className="flex flex-wrap items-center gap-x-4 gap-y-1 pb-1"
             aria-label="What each colour in a bar means"
@@ -2109,20 +2191,33 @@ function OwnershipSection({
                 role="img"
                 aria-label={`${row.label}: top person ${ownershipPct(row.top1)}, top three ${ownershipPct(row.top3)}`}
               >
-                <span
+                <OwnershipSegment
                   className="rounded-[3px] bg-primary"
-                  style={{ width: `${row.top1 * 100}%` }}
+                  width={row.top1 * 100}
+                  who={row.topName ? [row.topName] : []}
+                  share={ownershipPct(row.top1)}
+                  role="Top person"
                 />
                 {row.top3 > row.top1 ? (
-                  <span
+                  <OwnershipSegment
                     className="rounded-[3px] bg-primary/50"
-                    style={{ width: `${(row.top3 - row.top1) * 100}%` }}
+                    width={(row.top3 - row.top1) * 100}
+                    who={row.nextNames}
+                    share={ownershipPct(row.top3 - row.top1)}
+                    role="Next 2"
                   />
                 ) : null}
                 {row.top3 < 1 ? (
-                  <span
+                  <OwnershipSegment
                     className="rounded-[3px] border border-border bg-muted"
-                    style={{ width: `${(1 - row.top3) * 100}%` }}
+                    width={(1 - row.top3) * 100}
+                    who={[]}
+                    share={ownershipPct(1 - row.top3)}
+                    role={
+                      row.othersCount
+                        ? `Everyone else · ${row.othersCount} ${row.othersCount === 1 ? "person" : "people"}`
+                        : "Everyone else"
+                    }
                   />
                 ) : null}
               </div>
@@ -2140,14 +2235,54 @@ function OwnershipSection({
               </div>
             </div>
           ))}
-          {rows.length > visible.length ? (
-            <p className="text-xs text-muted-foreground">
-              +{rows.length - visible.length} more
-            </p>
+          {rows.length > visible.length || expanded ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="cursor-pointer self-start pt-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+            >
+              {expanded
+                ? `Show top ${OWNERSHIP_ROWS}`
+                : `+${rows.length - visible.length} more`}
+            </button>
           ) : null}
+         </TooltipProvider>
         </CardContent>
       </Card>
     </section>
+  );
+}
+
+/**
+ * One share of an ownership bar, named only when hovered.
+ *
+ * The bar's job is the shape of the concentration, which is why the row itself
+ * says no names. A reader who hovers is asking who, and withholding it there
+ * makes the section unusable for the decision it exists to inform.
+ */
+function OwnershipSegment({
+  className,
+  width,
+  who,
+  share,
+  role,
+}: {
+  className: string;
+  width: number;
+  who: readonly string[];
+  share: string;
+  role: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={<span className={className} style={{ width: `${width}%` }} />}
+      />
+      <TooltipContent side="top">
+        {role} · {share}
+        {who.length ? ` · ${who.join(", ")}` : ""}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -2394,6 +2529,38 @@ const HOVER_DELAY_MS = 400;
 /** Rows shown before the reader opts into the full list. */
 const BAR_LIST_COLLAPSED = 12;
 
+/**
+ * One fill inside a bar — a button when its records can be opened, a plain
+ * span when they cannot. Same geometry either way, so a list where only some
+ * rows are drillable still draws one row of bars.
+ */
+function BarPiece({
+  className,
+  style,
+  onOpen,
+  label,
+}: {
+  className: string;
+  style?: CSSProperties;
+  onOpen?: () => void;
+  label: string;
+}) {
+  if (!onOpen) return <span className={className} style={style} />;
+  return (
+    <button
+      type="button"
+      aria-haspopup="dialog"
+      aria-label={`Open the records behind ${label}`}
+      onClick={onOpen}
+      className={cn(
+        className,
+        "cursor-pointer transition-opacity hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring"
+      )}
+      style={style}
+    />
+  );
+}
+
 export function BarList({
   title,
   rows,
@@ -2401,6 +2568,7 @@ export function BarList({
   unit,
   showShare = true,
   notes,
+  onOpen,
 }: {
   title: string;
   rows: BarRow[];
@@ -2410,6 +2578,12 @@ export function BarList({
   showShare?: boolean;
   /** Below the bars, not above: it explains what was read, not what to read. */
   notes?: readonly string[];
+  /**
+   * The records behind one bar, or behind one of its segments. Omitted where
+   * the caller cannot narrow the figure — the bars then stay inert rather
+   * than offering a dialog that would answer a different question.
+   */
+  onOpen?: (row: BarRow, segment?: BarSegment) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const visible = expanded ? rows : rows.slice(0, BAR_LIST_COLLAPSED);
@@ -2461,7 +2635,7 @@ export function BarList({
               </ul>
             ) : null}
             {visible.map((row) => (
-              <div key={row.label} className="flex items-center gap-3">
+              <div key={row.key} className="flex items-center gap-3">
                 {/* A dimension value is often a path (`owner/repo`), and the part
                   that tells two rows apart is at the END — so the column grows
                   with the viewport and the full value stays on hover. */}
@@ -2495,12 +2669,16 @@ export function BarList({
                         <Tooltip key={segment.seed}>
                           <TooltipTrigger
                             render={
-                              <span
+                              <BarPiece
                                 className="h-full first:rounded-s last:rounded-e"
                                 style={{
                                   width: `${(segment.value / row.value) * 100}%`,
                                   backgroundColor: colors[segment.seed],
                                 }}
+                                onOpen={
+                                  onOpen ? () => onOpen(row, segment) : undefined
+                                }
+                                label={`${row.label} · ${segment.label}`}
                               />
                             }
                           />
@@ -2508,11 +2686,16 @@ export function BarList({
                             {segment.label} ·{" "}
                             {formatMetricValue(segment.value, format, unit)} ·{" "}
                             {shareLabel((segment.value / row.value) * 100)}
+                            {onOpen ? " · click to open the records" : ""}
                           </TooltipContent>
                         </Tooltip>
                       ))
                     ) : (
-                      <span className="h-full w-full rounded bg-primary/25" />
+                      <BarPiece
+                        className="h-full w-full rounded bg-primary/25"
+                        onOpen={onOpen ? () => onOpen(row) : undefined}
+                        label={row.label}
+                      />
                     )}
                   </div>
                 </div>

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -172,6 +172,7 @@ export function DomainLensView({
   // than rendering a screen about a value this lens does not group by.
   const { repo } = usePortalSearch();
   const { openRepository } = usePortalNavActions();
+  const evidence = useMetricEvidenceOptional();
   const scoped = repo && declared.drilldown ? repo : null;
   const scopeDimension = scoped ? (declared.drilldown?.dimension ?? null) : null;
   const config = useMemo(
@@ -532,6 +533,31 @@ export function DomainLensView({
   // disagree: under a flat policy that roster is the whole organisation, and
   // under an org chart it is the viewer's own subtree — the permission
   // boundary identity already enforces.
+  // One hour block over the whole period — the narrowest slice of a heatmap the
+  // evidence request can express. A single cell is that block on ONE weekday,
+  // and there is no weekday predicate to ask for.
+  const openHourBlock = (block: string) => {
+    const heat = config.sections.find(
+      (section): section is Extract<SectionSpec, { kind: "heatmap-hours" }> =>
+        section.kind === "heatmap-hours"
+    );
+    const carrier = heat && grid.byKey.get(evidenceMetricFor(heat.metric));
+    if (!evidence || !carrier?.drilldown) return;
+    const selection = narrowedEvidenceSelection(carrier, memberIds, {
+      filters: [
+        ...(scopeDimension && scoped
+          ? [{ dimension: scopeDimension, value: scoped }]
+          : []),
+        { dimension: HOUR_BLOCK_DIMENSION, value: block },
+      ],
+    });
+    if (selection) {
+      evidence.openEvidenceTargets([{ selection, label: carrier.label }], {
+        activeMetricKey: selection.metric_key,
+      });
+    }
+  };
+
   const openTrendDrilldown = (chart: TrendChart, bucketStart?: string) => {
     // A clicked point asks about its own bucket; the card asks about the
     // period. The label says which, so the dialog never looks like the other.
@@ -619,6 +645,7 @@ export function DomainLensView({
               ? (value) => openRepository(value)
               : undefined
           }
+          onOpenBlock={openHourBlock}
         />
       ))}
 
@@ -676,6 +703,7 @@ function Section({
   personIdByEntity,
   onOpenChart,
   onOpenValue,
+  onOpenBlock,
 }: {
   spec: SectionSpec;
   grid: GridData;
@@ -699,6 +727,8 @@ function Section({
   onOpenChart: (chart: TrendChart, bucketStart?: string) => void;
   /** Descend into one dimension value; absent when the lens has no screen for one. */
   onOpenValue?: (value: string) => void;
+  /** The records of one hour block of a heatmap. */
+  onOpenBlock?: (block: string) => void;
 }) {
   switch (spec.kind) {
     case "headline":
@@ -796,10 +826,10 @@ function Section({
       return (
         <HeatmapHoursSection
           spec={spec}
-          grid={grid}
           hourByKey={hourByKey}
           hourIsError={hourIsError}
           memberIds={memberIds}
+          onOpenBlock={onOpenBlock}
         />
       );
     case "dimension-table":
@@ -2009,6 +2039,7 @@ function CompositionSection({
       unit={r?.unit ?? null}
       notes={spec.notes}
       onOpen={openBar}
+      canOpen={(_row, segment) => segment?.seed !== UNSPLIT_SEGMENT}
     />
   );
 }
@@ -2079,16 +2110,22 @@ function ContributorsSection({
  */
 function HeatmapHoursSection({
   spec,
-  grid,
   hourByKey,
   hourIsError,
   memberIds,
+  onOpenBlock,
 }: {
   spec: Extract<SectionSpec, { kind: "heatmap-hours" }>;
-  grid: GridData;
   hourByKey: Map<string, NormalizedMetricResult>;
   hourIsError: boolean;
   memberIds: readonly string[];
+  /**
+   * The records of one hour block, across the whole period. A CELL cannot be
+   * opened: it is one weekday of one block, and the evidence request has no
+   * weekday predicate to express that — a dialog for the block alone would
+   * answer a wider question than the cell asks.
+   */
+  onOpenBlock?: (block: string) => void;
 }) {
   if (hourIsError) return null;
   const r = hourByKey.get(spec.metric);
@@ -2099,11 +2136,10 @@ function HeatmapHoursSection({
   );
   if (total <= 0 || max <= 0) return null;
 
-  const unit = grid.byKey.get(spec.metric)?.unit ?? null;
   return (
     <section className="flex flex-col gap-3">
       <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
-        {spec.title} · {fmtCompact(total)}
+        {spec.title} · {formatMetricValue(total, r.format, r.unit)}
       </p>
       <Card>
         <CardContent className="flex flex-col gap-3 p-4">
@@ -2116,7 +2152,21 @@ function HeatmapHoursSection({
             <div />
             {HOUR_BLOCKS.map((block, index) => (
               <div key={block} className="text-center text-muted-foreground">
-                {index % 2 === 0 ? block : ""}
+                {index % 2 !== 0 ? (
+                  ""
+                ) : onOpenBlock ? (
+                  <button
+                    type="button"
+                    aria-haspopup="dialog"
+                    aria-label={`Open the records from the ${block}:00 block`}
+                    onClick={() => onOpenBlock(block)}
+                    className="cursor-pointer underline-offset-2 hover:text-foreground hover:underline"
+                  >
+                    {block}
+                  </button>
+                ) : (
+                  block
+                )}
               </div>
             ))}
             {WEEKDAY_LABELS.map((day, dayIndex) => (
@@ -2127,7 +2177,7 @@ function HeatmapHoursSection({
                   return (
                     <div
                       key={block}
-                      title={`${day} ${block}:00 · ${formatMetricValue(value, "integer", unit)}`}
+                      title={`${day} ${block}:00 · ${formatMetricValue(value, r.format, r.unit)}`}
                       className="aspect-square rounded-[3px]"
                       style={{
                         backgroundColor: value
@@ -2860,6 +2910,7 @@ export function BarList({
   showShare = true,
   notes,
   onOpen,
+  canOpen,
 }: {
   title: string;
   rows: BarRow[];
@@ -2875,6 +2926,12 @@ export function BarList({
    * than offering a dialog that would answer a different question.
    */
   onOpen?: (row: BarRow, segment?: BarSegment) => void;
+  /**
+   * Whether ONE piece can be narrowed, when the list as a whole can. A
+   * segment the response did not name has no value to filter on, and an
+   * affordance that opens an empty dialog is worse than none.
+   */
+  canOpen?: (row: BarRow, segment?: BarSegment) => boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const visible = expanded ? rows : rows.slice(0, BAR_LIST_COLLAPSED);
@@ -2967,7 +3024,10 @@ export function BarList({
                                   backgroundColor: colors[segment.seed],
                                 }}
                                 onOpen={
-                                  onOpen ? () => onOpen(row, segment) : undefined
+                                  onOpen &&
+                                  (canOpen?.(row, segment) ?? true)
+                                    ? () => onOpen(row, segment)
+                                    : undefined
                                 }
                                 label={`${row.label} · ${segment.label}`}
                               />
@@ -2984,7 +3044,11 @@ export function BarList({
                     ) : (
                       <BarPiece
                         className="h-full w-full rounded bg-primary/25"
-                        onOpen={onOpen ? () => onOpen(row) : undefined}
+                        onOpen={
+                          onOpen && (canOpen?.(row) ?? true)
+                            ? () => onOpen(row)
+                            : undefined
+                        }
                         label={row.label}
                       />
                     )}

--- a/src/frontend/src/components/portal/section-trend.tsx
+++ b/src/frontend/src/components/portal/section-trend.tsx
@@ -57,6 +57,12 @@ export interface SectionTrendProps {
   isPending?: boolean;
   isError?: boolean;
   onRetry?: () => void;
+  /**
+   * The bucket a reader clicked, by its own label — what the axis shows and
+   * what the trend rows are keyed by. A card that also opens as a whole must
+   * stop this event, or one click answers two questions at once.
+   */
+  onBucketClick?: (bucket: string) => void;
 }
 
 const DEFAULT_CHART_KEYS = ["chart-1", "chart-2", "chart-3", "chart-4", "chart-5"];
@@ -73,6 +79,7 @@ export function SectionTrend({
   isPending,
   isError,
   onRetry,
+  onBucketClick,
 }: SectionTrendProps) {
   if (isPending) {
     return <Skeleton className="h-48 w-full rounded-lg" />;
@@ -138,7 +145,25 @@ export function SectionTrend({
           className="w-full"
           style={{ height }}
         >
-          <ComposedChart data={safeData} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+          <ComposedChart
+            data={safeData}
+            margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+            className={onBucketClick ? "cursor-pointer" : undefined}
+            onClick={
+              onBucketClick
+                ? (next, event) => {
+                    const bucket = next?.activeLabel;
+                    if (typeof bucket !== "string") return;
+                    // The card around this chart opens the whole period; a
+                    // point is a narrower question, so it must not also fire.
+                    (
+                      event as { stopPropagation?: () => void }
+                    )?.stopPropagation?.();
+                    onBucketClick(bucket);
+                  }
+                : undefined
+            }
+          >
             <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
             <XAxis
               dataKey="date"

--- a/src/frontend/src/components/portal/tenant-lens-view/derived.ts
+++ b/src/frontend/src/components/portal/tenant-lens-view/derived.ts
@@ -32,6 +32,13 @@ export interface DimRow {
 }
 
 /** One dimensioned timeseries entry scoped to the tenant entity. */
+export {
+  dayHourMatrix,
+  HOUR_BLOCKS,
+  WEEKDAY_LABELS,
+  type DayHourMatrix,
+} from "@/lib/portal/day-hour-matrix";
+
 export interface DimSeries {
   dimensions: MetricDimension[];
   label?: string;
@@ -364,45 +371,6 @@ export function smallMultiples(
     ...multiples.flatMap((m) => m.points.map((p) => p.value))
   );
   return { multiples, max };
-}
-
-export const HOUR_BLOCKS = Array.from({ length: 12 }, (_, i) =>
-  String(i * 2).padStart(2, "0")
-);
-
-export const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-
-export interface DayHourMatrix {
-  /** cells[weekday (Mon=0)][hour-block index] — summed values. */
-  cells: number[][];
-  max: number;
-  total: number;
-}
-
-/**
- * Day-of-week × two-hour-block magnitudes from a DAY-bucketed series
- * dimensioned by hour_block. Weekday from the bucket date, UTC — the same
- * clock the hour_block dimension is derived in.
- */
-export function dayHourMatrix(series: readonly DimSeries[]): DayHourMatrix {
-  const cells = WEEKDAY_LABELS.map(() => HOUR_BLOCKS.map(() => 0));
-  let max = 0;
-  let total = 0;
-  for (const entry of series) {
-    const block = dimValue(entry, "hour_block");
-    const blockIndex = block == null ? -1 : HOUR_BLOCKS.indexOf(block);
-    if (blockIndex < 0) continue;
-    for (const point of entry.points) {
-      if (point.value == null || point.value <= 0) continue;
-      const day = new Date(`${point.bucket_start}T00:00:00Z`);
-      if (Number.isNaN(day.getTime())) continue;
-      const weekday = (day.getUTCDay() + 6) % 7;
-      cells[weekday][blockIndex] += point.value;
-      max = Math.max(max, cells[weekday][blockIndex]);
-      total += point.value;
-    }
-  }
-  return { cells, max, total };
 }
 
 export interface HourColumn {

--- a/src/frontend/src/components/portal/trend-drilldown-dialog.tsx
+++ b/src/frontend/src/components/portal/trend-drilldown-dialog.tsx
@@ -242,20 +242,32 @@ function PeriodTable({ state }: { state: TrendDrilldownState }) {
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead className="w-36 capitalize">{state.bucketLabel}</TableHead>
-          <TableHead className="w-28 text-right">Total</TableHead>
-          <TableHead className="w-28 text-right">Active</TableHead>
+          {/* INVARIANT: the fixed columns must not wrap. `table-layout` is auto
+            here, so the unbounded "Who" column can squeeze them below their
+            content width — and a date breaks at its own hyphens, landing
+            "2026-" above "08-26". */}
+          <TableHead className="w-36 whitespace-nowrap capitalize">
+            {state.bucketLabel}
+          </TableHead>
+          <TableHead className="w-28 text-right whitespace-nowrap">
+            Total
+          </TableHead>
+          <TableHead className="w-28 text-right whitespace-nowrap">
+            Active
+          </TableHead>
           <TableHead>Who</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {state.breakdown.map((row) => (
           <TableRow key={row.date}>
-            <TableCell className="tabular-nums">{row.date}</TableCell>
-            <TableCell className="text-right tabular-nums">
+            <TableCell className="whitespace-nowrap tabular-nums">
+              {row.date}
+            </TableCell>
+            <TableCell className="text-right whitespace-nowrap tabular-nums">
               {formatMetricNumber(row.total, "decimal")}
             </TableCell>
-            <TableCell className="text-right tabular-nums">
+            <TableCell className="text-right whitespace-nowrap tabular-nums">
               {row.contributors.length}
             </TableCell>
             <TableCell className="text-muted-foreground">

--- a/src/frontend/src/lib/metrics/evidence-targets.test.ts
+++ b/src/frontend/src/lib/metrics/evidence-targets.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from "vitest";
 
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
-import { collectionEvidenceTargets } from "@/lib/metrics/evidence-targets";
+import {
+  collectionEvidenceTargets,
+  narrowedEvidenceSelection,
+} from "@/lib/metrics/evidence-targets";
 
 function metric(
   metricKey: string,
-  options: { drillable?: boolean; selection?: boolean } = {}
+  options: {
+    drillable?: boolean;
+    selection?: boolean;
+    filters?: { dimension: string; values: string[] }[];
+  } = {}
 ): NormalizedMetricResult {
-  const { drillable = true, selection = true } = options;
+  const { drillable = true, selection = true, filters = [] } = options;
   return {
     metric_key: metricKey,
     label: metricKey.toUpperCase(),
@@ -17,7 +24,7 @@ function metric(
           metric_key: metricKey,
           entity: { type: "person", ids: ["person-1"] },
           period: { from: "2026-07-01", to: "2026-07-31" },
-          filters: [],
+          filters,
         }
       : undefined,
   } as unknown as NormalizedMetricResult;
@@ -76,5 +83,92 @@ describe("collectionEvidenceTargets", () => {
       range
     );
     expect(out[0]?.selection.period).toEqual(range);
+  });
+});
+
+describe("narrowedEvidenceSelection", () => {
+  const roster = ["person-1", "person-2"];
+
+  it("adds the clicked value to the filters the figure already carries", () => {
+    const selection = narrowedEvidenceSelection(
+      metric("git.commits", {
+        filters: [{ dimension: "category", values: ["code"] }],
+      }),
+      roster,
+      { filters: [{ dimension: "repository", value: "src-a:acme/api" }] }
+    );
+
+    expect(selection?.filters).toEqual([
+      { dimension: "category", values: ["code"] },
+      { dimension: "repository", values: ["src-a:acme/api"] },
+    ]);
+  });
+
+  it("replaces a filter on the dimension the reader just picked", () => {
+    const selection = narrowedEvidenceSelection(
+      metric("git.commits", {
+        filters: [{ dimension: "repository", values: ["src-a:acme/web"] }],
+      }),
+      roster,
+      { filters: [{ dimension: "repository", value: "src-a:acme/api" }] }
+    );
+
+    expect(selection?.filters).toEqual([
+      { dimension: "repository", values: ["src-a:acme/api"] },
+    ]);
+  });
+
+  it("shows the narrowed dimension, so a row says which one it belongs to", () => {
+    const selection = narrowedEvidenceSelection(metric("git.commits"), roster, {
+      filters: [
+        { dimension: "repository", value: "src-a:acme/api" },
+        { dimension: "branch_scope", value: "default" },
+      ],
+    });
+
+    expect(selection?.display_dimensions).toEqual([
+      "branch_scope",
+      "repository",
+    ]);
+  });
+
+  it("makes a clicked day the whole period", () => {
+    const selection = narrowedEvidenceSelection(metric("git.commits"), roster, {
+      day: "2026-07-14",
+    });
+
+    expect(selection?.period).toEqual({ from: "2026-07-14", to: "2026-07-14" });
+  });
+
+  it("keeps the figure's own period when nothing narrowed it", () => {
+    const selection = narrowedEvidenceSelection(
+      metric("git.commits"),
+      roster,
+      {}
+    );
+
+    expect(selection?.period).toEqual({ from: "2026-07-01", to: "2026-07-31" });
+  });
+
+  it("answers null for a metric whose records cannot be read", () => {
+    expect(
+      narrowedEvidenceSelection(
+        metric("git.commits", { drillable: false }),
+        roster,
+        {
+          filters: [{ dimension: "repository", value: "src-a:acme/api" }],
+        }
+      )
+    ).toBeNull();
+    expect(narrowedEvidenceSelection(undefined, roster, {})).toBeNull();
+  });
+
+  it("ignores a narrowing with no value — a bar with no dimension is not a filter", () => {
+    const selection = narrowedEvidenceSelection(metric("git.commits"), roster, {
+      filters: [{ dimension: "repository", value: "" }],
+    });
+
+    expect(selection?.filters).toEqual([]);
+    expect(selection?.display_dimensions).toEqual([]);
   });
 });

--- a/src/frontend/src/lib/metrics/evidence-targets.ts
+++ b/src/frontend/src/lib/metrics/evidence-targets.ts
@@ -1,5 +1,6 @@
 import {
   evidenceSelection,
+  personsEvidenceSelection,
   type MetricEvidenceSelection,
 } from "@/api/metric-drilldown-client";
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
@@ -30,4 +31,42 @@ export function collectionEvidenceTargets(
     const selection = evidenceSelection(metric.selection, entityId, period);
     return selection ? [{ selection, label: metric.label }] : [];
   });
+}
+
+/**
+ * The same figure, narrowed to what the reader clicked.
+ *
+ * A bar, a segment or a point on a trend answers a slice of the figure above
+ * it, so its dialog has to be that slice: each clicked dimension value becomes
+ * a filter ON TOP of the selection's own, never instead of it, and a clicked
+ * day becomes the period. The narrowed dimensions also join
+ * `display_dimensions` — a reader who arrived by clicking one repository
+ * should see which repository every row belongs to.
+ */
+export function narrowedEvidenceSelection(
+  metric: NormalizedMetricResult | undefined,
+  personIds: readonly string[],
+  narrow: {
+    filters?: readonly { dimension: string; value: string }[];
+    day?: string;
+  }
+): MetricEvidenceSelection | null {
+  if (!metric?.drilldown) return null;
+  const canonical = metric.selection;
+  if (!canonical) return null;
+
+  const named = (narrow.filters ?? []).filter((f) => f.dimension && f.value);
+  const overridden = new Set(named.map((f) => f.dimension));
+  const filters = [
+    ...canonical.filters.filter((f) => !overridden.has(f.dimension)),
+    ...named.map((f) => ({ dimension: f.dimension, values: [f.value] })),
+  ];
+
+  return personsEvidenceSelection(
+    canonical,
+    personIds,
+    narrow.day ? { from: narrow.day, to: narrow.day } : undefined,
+    filters,
+    named.map((f) => f.dimension)
+  );
 }

--- a/src/frontend/src/lib/metrics/evidence-via.test.ts
+++ b/src/frontend/src/lib/metrics/evidence-via.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { evidenceCarriers, evidenceMetricFor } from "./evidence-via";
+
+describe("evidenceMetricFor", () => {
+  it("sends a line count to the commits that carry it", () => {
+    expect(evidenceMetricFor("git.default_branch_code_lines")).toBe(
+      "git.default_branch_commits"
+    );
+    expect(evidenceMetricFor("git.non_default_branch_code_lines")).toBe(
+      "git.non_default_branch_commits"
+    );
+  });
+
+  it("leaves a metric that holds its own records alone", () => {
+    expect(evidenceMetricFor("git.prs_merged")).toBe("git.prs_merged");
+  });
+
+  it("carries every branch reading into its OWN scope's commits", () => {
+    // A crossed pair here would answer a default-branch tile with the commits
+    // that never reached the trunk, which reads as data loss rather than a
+    // wiring mistake — so the pairs are stated, not derived.
+    const pairs = [
+      ["git.default_branch_code_lines", "git.default_branch_commits"],
+      ["git.default_branch_lines_added", "git.default_branch_commits"],
+      ["git.default_branch_lines_removed", "git.default_branch_commits"],
+      ["git.non_default_branch_code_lines", "git.non_default_branch_commits"],
+      ["git.non_default_branch_lines_added", "git.non_default_branch_commits"],
+      [
+        "git.non_default_branch_lines_removed",
+        "git.non_default_branch_commits",
+      ],
+      ["git.code_lines", "git.commits"],
+      ["git.lines_added", "git.commits"],
+      ["git.lines_removed", "git.commits"],
+    ] as const;
+    for (const [key, carrier] of pairs) {
+      expect(evidenceMetricFor(key), key).toBe(carrier);
+    }
+  });
+});
+
+describe("evidenceCarriers", () => {
+  it("names every metric a request must also ask for, once", () => {
+    expect(
+      evidenceCarriers([
+        "git.default_branch_code_lines",
+        "git.default_branch_lines_added",
+        "git.prs_merged",
+      ]).sort()
+    ).toEqual(["git.default_branch_commits"]);
+  });
+
+  it("is empty when nothing needs a carrier", () => {
+    expect(evidenceCarriers(["git.prs_merged", "tasks.closed"])).toEqual([]);
+  });
+});

--- a/src/frontend/src/lib/metrics/evidence-via.ts
+++ b/src/frontend/src/lib/metrics/evidence-via.ts
@@ -1,0 +1,34 @@
+/**
+ * Which records explain a figure, where the figure's own measure cannot.
+ *
+ * A line count is a per-day summary in the warehouse, so its own evidence is
+ * a table of days — which answers "when" and never "what changed". The lines
+ * are carried by commits, and those are the records a reader is asking for
+ * when they click the tile. A key listed here drills into the metric named
+ * beside it, carrying whatever the click narrowed to; anything absent drills
+ * into itself.
+ */
+const CARRIED_BY: Record<string, string> = {
+  "git.code_lines": "git.commits",
+  "git.lines_added": "git.commits",
+  "git.lines_removed": "git.commits",
+  "git.default_branch_code_lines": "git.default_branch_commits",
+  "git.default_branch_lines_added": "git.default_branch_commits",
+  "git.default_branch_lines_removed": "git.default_branch_commits",
+  "git.non_default_branch_code_lines": "git.non_default_branch_commits",
+  "git.non_default_branch_lines_added": "git.non_default_branch_commits",
+  "git.non_default_branch_lines_removed": "git.non_default_branch_commits",
+};
+
+/** The metric whose records explain `key` — `key` itself unless listed. */
+export function evidenceMetricFor(key: string): string {
+  return CARRIED_BY[key] ?? key;
+}
+
+/** Every metric a lens must ask for so its figures stay drillable. */
+export function evidenceCarriers(keys: readonly string[]): string[] {
+  const carriers = keys
+    .map((key) => CARRIED_BY[key])
+    .filter((carrier): carrier is string => carrier != null);
+  return [...new Set(carriers)];
+}

--- a/src/frontend/src/lib/portal/bar-rows.test.ts
+++ b/src/frontend/src/lib/portal/bar-rows.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { toBarRows, type BarEntry } from "./bar-rows";
+
+const entry = (
+  label: string,
+  value: number,
+  split?: [string, string, number][]
+): BarEntry => ({
+  label,
+  value,
+  split: split
+    ? new Map(split.map(([seed, l, v]) => [seed, { seed, label: l, value: v }]))
+    : undefined,
+});
+
+describe("toBarRows", () => {
+  it("keys a row by the dimension value, not by what it shows", () => {
+    const rows = toBarRows(
+      new Map([
+        ["src-a:acme/api", entry("acme/api", 10)],
+        ["src-b:acme/api", entry("acme/api", 4)],
+      ])
+    );
+
+    expect(rows.map((r) => r.key)).toEqual([
+      "src-a:acme/api",
+      "src-b:acme/api",
+    ]);
+    expect(new Set(rows.map((r) => r.label)).size).toBe(1);
+  });
+
+  it("keeps the trunk reading first however small it is", () => {
+    const rows = toBarRows(
+      new Map([
+        [
+          "acme/api",
+          entry("acme/api", 100, [
+            ["non_default", "Other branches", 90],
+            ["default", "Default branch", 10],
+          ]),
+        ],
+      ]),
+      "branch_scope"
+    );
+
+    expect(rows[0]?.segments?.map((s) => s.seed)).toEqual([
+      "default",
+      "non_default",
+    ]);
+  });
+
+  it("sorts by size where the split declares no order", () => {
+    const rows = toBarRows(
+      new Map([
+        [
+          "acme/api",
+          entry("acme/api", 100, [
+            ["small", "Small", 10],
+            ["big", "Big", 90],
+          ]),
+        ],
+      ]),
+      "category"
+    );
+
+    expect(rows[0]?.segments?.map((s) => s.seed)).toEqual(["big", "small"]);
+  });
+
+  it("puts a segment the declared order does not name after the ones it does", () => {
+    const rows = toBarRows(
+      new Map([
+        [
+          "acme/api",
+          entry("acme/api", 100, [
+            ["unsplit", "Unknown", 50],
+            ["default", "Default branch", 30],
+            ["non_default", "Other branches", 20],
+          ]),
+        ],
+      ]),
+      "branch_scope"
+    );
+
+    expect(rows[0]?.segments?.map((s) => s.seed)).toEqual([
+      "default",
+      "non_default",
+      "unsplit",
+    ]);
+  });
+});

--- a/src/frontend/src/lib/portal/bar-rows.ts
+++ b/src/frontend/src/lib/portal/bar-rows.ts
@@ -12,6 +12,12 @@ export interface BarSegment {
 }
 
 export interface BarRow {
+  /**
+   * The dimension VALUE the row is keyed by — the id the response grouped on.
+   * Two rows may share a label; they never share this, which is why React
+   * keys and click narrowing both read it rather than the label.
+   */
+  key: string;
   label: string;
   value: number;
   pct: number;
@@ -39,17 +45,45 @@ export interface BarEntry {
 /** Segment a split row falls in when the response named no split value. */
 export const UNSPLIT_SEGMENT = "unsplit";
 
-export function toBarRows(bucket: Map<string, BarEntry>): BarRow[] {
+/**
+ * Segment order for a split whose values mean something in sequence.
+ *
+ * Sorting a pair like default/non-default by size makes the same reading swap
+ * sides between bars, and a reader then compares the wrong halves. A split
+ * listed here keeps its declared order on every bar; anything else stays
+ * sorted by size, where the largest segment leading is the useful order.
+ */
+const SEGMENT_ORDER: Record<string, readonly string[]> = {
+  branch_scope: ["default", "non_default"],
+};
+
+function segmentsOf(
+  split: Map<string, BarSegment>,
+  splitBy: string | undefined
+): BarSegment[] {
+  const declared = splitBy ? SEGMENT_ORDER[splitBy] : undefined;
+  const segments = [...split.values()];
+  if (!declared) return segments.sort((a, b) => b.value - a.value);
+  const rank = (seed: string) => {
+    const at = declared.indexOf(seed);
+    return at === -1 ? declared.length : at;
+  };
+  return segments.sort((a, b) => rank(a.seed) - rank(b.seed) || b.value - a.value);
+}
+
+export function toBarRows(
+  bucket: Map<string, BarEntry>,
+  splitBy?: string
+): BarRow[] {
   const total =
     [...bucket.values()].reduce((sum, entry) => sum + entry.value, 0) || 1;
-  return [...bucket.values()]
-    .map(({ label, value, split, href }) => ({
+  return [...bucket.entries()]
+    .map(([key, { label, value, split, href }]) => ({
+      key,
       label,
       value,
       href,
-      segments: split
-        ? [...split.values()].sort((a, b) => b.value - a.value)
-        : undefined,
+      segments: split ? segmentsOf(split, splitBy) : undefined,
       // Exact share; rounding happens where it is displayed, so a small one
       // can say so instead of being flattened to zero.
       pct: (value / total) * 100,

--- a/src/frontend/src/lib/portal/bar-rows.ts
+++ b/src/frontend/src/lib/portal/bar-rows.ts
@@ -90,3 +90,44 @@ export function toBarRows(
     }))
     .sort((a, b) => b.value - a.value);
 }
+
+/**
+ * The label a response gave one dimension value, from whichever view named it.
+ *
+ * A URL carries the value — `<source>:<owner>/<repo>` — because that is the id
+ * two look-alike rows are told apart by. What a reader recognises is the label,
+ * and only the rows know it, so a screen about one value has to look it up
+ * rather than parse the id.
+ */
+export function labelForDimensionValue(
+  dimension: string | null,
+  value: string,
+  ...sources: ReadonlyArray<
+    ReadonlyMap<
+      string,
+      {
+        breakdown?: { values: readonly { dimensions: readonly DimensionRef[] }[] };
+        rollup?: { values: readonly { dimensions: readonly DimensionRef[] }[] };
+      }
+    >
+  >
+): string | undefined {
+  if (!dimension) return undefined;
+  for (const byKey of sources) {
+    for (const result of byKey.values()) {
+      for (const view of [result.breakdown, result.rollup]) {
+        for (const row of view?.values ?? []) {
+          const dim = row.dimensions.find((d) => d.key === dimension);
+          if (dim?.value === value && dim.label?.trim()) return dim.label.trim();
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+interface DimensionRef {
+  key: string;
+  value: string;
+  label?: string | null;
+}

--- a/src/frontend/src/lib/portal/day-hour-matrix.ts
+++ b/src/frontend/src/lib/portal/day-hour-matrix.ts
@@ -1,0 +1,53 @@
+/**
+ * Weekday × two-hour-block magnitude, shared by every "when does this happen"
+ * heatmap.
+ *
+ * The block comes from the metric's own `hour_block` dimension; the weekday is
+ * read off each bucket's date, which is why a caller must ask for DAY buckets —
+ * a week-sized bucket has no weekday to read and would pile a whole week into
+ * Monday.
+ */
+
+/** Block starts, "00" … "22" — the values the `hour_block` dimension carries. */
+export const HOUR_BLOCKS = Array.from({ length: 12 }, (_, i) =>
+  String(i * 2).padStart(2, "0")
+);
+
+export const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+export interface DayHourMatrix {
+  /** cells[weekday (Mon=0)][hour-block index] — summed values. */
+  cells: number[][];
+  max: number;
+  total: number;
+}
+
+/** One series per dimension tuple, as a timeseries view answers it. */
+export interface HourBlockSeries {
+  dimensions: ReadonlyArray<{ key: string; value: string }>;
+  points: ReadonlyArray<{ bucket_start: string; value: number | null }>;
+}
+
+export function dayHourMatrix(
+  series: readonly HourBlockSeries[]
+): DayHourMatrix {
+  const cells = WEEKDAY_LABELS.map(() => HOUR_BLOCKS.map(() => 0));
+  let max = 0;
+  let total = 0;
+  for (const entry of series) {
+    const block = entry.dimensions.find((d) => d.key === "hour_block")?.value;
+    const blockIndex = block == null ? -1 : HOUR_BLOCKS.indexOf(block);
+    if (blockIndex < 0) continue;
+    for (const point of entry.points) {
+      if (point.value == null || point.value <= 0) continue;
+      const day = new Date(`${point.bucket_start}T00:00:00Z`);
+      if (Number.isNaN(day.getTime())) continue;
+      // Monday-first, matching WEEKDAY_LABELS: `getUTCDay` puts Sunday at 0.
+      const weekday = (day.getUTCDay() + 6) % 7;
+      cells[weekday]![blockIndex]! += point.value;
+      max = Math.max(max, cells[weekday]![blockIndex]!);
+      total += point.value;
+    }
+  }
+  return { cells, max, total };
+}

--- a/src/frontend/src/lib/portal/lens-configs.ts
+++ b/src/frontend/src/lib/portal/lens-configs.ts
@@ -1,3 +1,4 @@
+import { evidenceCarriers } from "@/lib/metrics/evidence-via";
 import {
   directionHidden,
   directionPlanned,
@@ -1228,5 +1229,8 @@ export function directionMetricKeys(dir: string): string[] {
     if ("comingSoon" in entry || "entity" in entry) continue;
     for (const k of sectionMetricKeys(entry)) keys.add(k);
   }
+  // A figure whose records live under another metric needs that metric in the
+  // same request, or its tile has nothing to open.
+  for (const carrier of evidenceCarriers([...keys])) keys.add(carrier);
   return [...keys];
 }

--- a/src/frontend/src/lib/portal/lens-configs.ts
+++ b/src/frontend/src/lib/portal/lens-configs.ts
@@ -93,6 +93,25 @@ export type SectionSpec =
       dimension: string;
       title: string;
     }
+  // The people who carried one dimension value, ranked, with the leader's
+  // share called out. Only ever rendered inside a drilldown, where the value
+  // is already the subject — a leaderboard of the whole roster is a different
+  // thing and this is not it.
+  | {
+      kind: "contributors";
+      metric: string;
+      title: string;
+      /** People shown before the rest folds into one line. */
+      limit?: number;
+    }
+  // Weekday × two-hour block ramp of one event-grain metric: when the work
+  // lands, read from the metric's own `hour_block` dimension.
+  | {
+      kind: "heatmap-hours";
+      metric: string;
+      title: string;
+      caption: string;
+    }
   | {
       kind: "participation";
       metrics: readonly string[];
@@ -114,6 +133,20 @@ export interface LensConfig {
   sections: readonly SectionSpec[];
   /** Whole-tab message when no metric of the lens is observed (rule 6). */
   notIngested?: string;
+  /**
+   * The screen for ONE value of a dimension the lens already groups by.
+   *
+   * A lens answers "which of these", and past a certain point the reader is
+   * asking about one of them instead. The drilldown is that screen: the same
+   * section kinds, every request filtered to the value, reached by clicking a
+   * row and left by the breadcrumb.
+   */
+  drilldown?: {
+    dimension: string;
+    /** Shown after the value, e.g. "activity, reach & risk". */
+    tagline?: string;
+    sections: readonly SectionSpec[];
+  };
 }
 
 export interface LensRoadmap {
@@ -350,7 +383,9 @@ export function overviewCardDirections(
 /** Unique metric keys a config needs in its period+peer grid. */
 export function sectionMetricKeys(config: LensConfig): string[] {
   const keys = new Set<string>();
-  for (const s of config.sections) {
+  // The drilldown's own sections count: they ride the same grid request, so a
+  // key it needs and the lens does not would otherwise never be asked for.
+  for (const s of [...config.sections, ...(config.drilldown?.sections ?? [])]) {
     switch (s.kind) {
       case "headline":
       case "stat-tiles":
@@ -364,6 +399,8 @@ export function sectionMetricKeys(config: LensConfig): string[] {
       case "composition":
       case "event-histogram":
       case "ownership":
+      case "contributors":
+      case "heatmap-hours":
         keys.add(s.metric);
         break;
       case "dimension-table":
@@ -430,6 +467,8 @@ export function visibleSections(
       case "composition":
       case "event-histogram":
       case "ownership":
+      case "contributors":
+      case "heatmap-hours":
         if (metricVisible(s.metric, showPlanned, policy)) sections.push(s);
         break;
       case "dimension-table": {
@@ -949,6 +988,64 @@ const DEV: Record<string, LensEntry> = {
         title: "How long pull requests stayed open",
       },
     ],
+    // One repository: who carried it, when the work landed, and how it splits
+    // between the trunk and everything else.
+    drilldown: {
+      dimension: "repository",
+      tagline: "one repository",
+      sections: [
+        {
+          kind: "headline",
+          metrics: [
+            "git.prs_merged",
+            "git.default_branch_prs_merged",
+            "git.commits",
+            "git.default_branch_code_lines",
+          ],
+        },
+        {
+          kind: "stat-tiles",
+          title: "Typical values (median)",
+          metrics: [
+            "git.pr_cycle_time_h",
+            "git.pr_cycle_time_p75_h",
+            "git.pr_size",
+            "git.pr_commits",
+            "git.merge_rate",
+            "git.review_coverage",
+          ],
+        },
+        {
+          kind: "contributors",
+          metric: "git.default_branch_code_lines",
+          title: "Top contributors — code lines on the default branch",
+        },
+        {
+          kind: "heatmap-hours",
+          metric: "git.commits",
+          title: "When commits land",
+          caption:
+            "Weekday × two-hour block, in UTC. Click a block for its commits.",
+        },
+        {
+          kind: "composition",
+          metric: "git.code_lines",
+          dimension: "branch_scope",
+          title: "Where the lines went — default branch vs the rest",
+        },
+        {
+          kind: "ownership",
+          metric: "git.default_branch_code_lines",
+          dimension: "repository",
+          title: "Ownership concentration",
+        },
+        {
+          kind: "event-histogram",
+          metric: "git.pr_cycle_time_h",
+          title: "How long pull requests stayed open",
+        },
+      ],
+    },
   },
   Elements: SCREEN_GAP("Element-level (file/module) analytics"),
 };

--- a/src/frontend/src/lib/portal/portal-nav.ts
+++ b/src/frontend/src/lib/portal/portal-nav.ts
@@ -73,6 +73,8 @@ export interface PortalNavActions {
   setLens: (lens: string) => void;
   /** Open a direction on a lens — one write, so one screen and one history entry. */
   openDirection: (dir: string, lens: string) => void;
+  /** Descend into one repository of the current lens, or leave it (""). */
+  openRepository: (repo: string) => void;
   setSlice: (slice: string) => void;
   setScope: (patch: Partial<OrgScope>) => void;
 }
@@ -102,8 +104,12 @@ export function usePortalNavActions(): PortalNavActions {
         ),
       setItem: (item) => setSearch({ item: item ?? undefined, acct: undefined }),
       setAcct: (acct) => setSearch({ acct: acct ?? undefined }),
-      setDir: (dir) => setSearch({ dir: dir || undefined }),
-      setLens: (lens) => setSearch({ lens: lens || undefined, item: undefined }),
+      // `repo` drops with the direction and the lens the same way `item` drops
+      // with the zone: one repository under inspection means nothing on another
+      // screen, and a retained param would reopen it on the way back.
+      setDir: (dir) => setSearch({ dir: dir || undefined, repo: undefined }),
+      setLens: (lens) =>
+        setSearch({ lens: lens || undefined, item: undefined, repo: undefined }),
       openDirection: (dir, lens) =>
         setSearch({
           zone: "directions",
@@ -111,7 +117,9 @@ export function usePortalNavActions(): PortalNavActions {
           lens: lens || undefined,
           item: undefined,
           acct: undefined,
+          repo: undefined,
         }),
+      openRepository: (repo) => setSearch({ repo: repo || undefined }),
       setSlice: (slice) => {
         recordUsageEvent("cohort", slice || "none");
         setSearch({ slice: slice || undefined });

--- a/src/frontend/src/lib/portal/portal-search.test.ts
+++ b/src/frontend/src/lib/portal/portal-search.test.ts
@@ -18,6 +18,12 @@ describe("validatePortalSearch", () => {
     expect(
       validatePortalSearch({ zone: "directions", dir: "dev", lens: "Delivery" }),
     ).toMatchObject({ zone: "directions", dir: "dev", lens: "Delivery" });
+    // A repository is carried by its dimension VALUE, so a shared link
+    // reproduces the one that was opened even when two share a display name.
+    expect(
+      validatePortalSearch({ lens: "Repositories", repo: "src-a:acme/api" }),
+    ).toMatchObject({ lens: "Repositories", repo: "src-a:acme/api" });
+    expect(validatePortalSearch({ repo: "" }).repo).toBeUndefined();
   });
 
   it("lowercases the scope — an email is case-insensitive but our keys are not", () => {

--- a/src/frontend/src/lib/portal/portal-search.ts
+++ b/src/frontend/src/lib/portal/portal-search.ts
@@ -41,6 +41,12 @@ export interface PortalSearch {
   /** Expanded direction + its active lens, within the Directions zone. */
   dir?: string;
   lens?: string;
+  /**
+   * One repository under inspection, by its dimension VALUE (`<source>:<owner>/<repo>`).
+   * The value and not the label, because two repositories can share a display
+   * name and a link has to reproduce the one that was opened.
+   */
+  repo?: string;
   /** Org-scope root: a manager's person id. Absent = the viewer's own subtree. */
   scope?: string;
   /** Narrow the scope to direct reports only. */
@@ -90,6 +96,7 @@ export function validatePortalSearch(raw: Record<string, unknown>): PortalSearch
     find: str(raw.find),
     dir: str(raw.dir),
     lens: str(raw.lens),
+    repo: str(raw.repo),
     // Lower-cased to match `normalizePersonId`: the same id reaches us from a
     // link, an identity record or a hand-edited URL, and the resolver compares
     // it as a string. An id outside the viewer's subtree (or a pre-cutover
@@ -116,6 +123,7 @@ export const PORTAL_SEARCH_KEYS = [
   "find",
   "dir",
   "lens",
+  "repo",
   "scope",
   "direct",
   "slice",

--- a/src/frontend/src/lib/portal/trend-drilldown.test.ts
+++ b/src/frontend/src/lib/portal/trend-drilldown.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
-import { bucketBreakdown, mergeMemberRecords } from "./trend-drilldown";
+import {
+  bucketBreakdown,
+  bucketRange,
+  mergeMemberRecords,
+} from "./trend-drilldown";
 
 const DATE = { key: "date", label: "Date", type: "date" as const };
 const REF = { key: "ref", label: "Ref", type: "string" as const };
@@ -200,4 +204,46 @@ describe("bucketBreakdown", () => {
 
   it("answers with nothing for a metric the response does not carry", () =>
     expect(bucketBreakdown("git.absent", new Map(), MEMBERS)).toEqual([]));
+});
+
+describe("bucketRange", () => {
+  it("makes a day bucket its own single day", () => {
+    expect(bucketRange("2026-07-14", "day")).toEqual({
+      from: "2026-07-14",
+      to: "2026-07-14",
+    });
+  });
+
+  it("covers the seven days a week bucket stands for", () => {
+    expect(bucketRange("2026-07-13", "week")).toEqual({
+      from: "2026-07-13",
+      to: "2026-07-19",
+    });
+  });
+
+  it("closes a month bucket on the month's own last day", () => {
+    // February, and a leap year, because a fixed 30 or 31 would pass the rest.
+    expect(bucketRange("2026-02-01", "month")).toEqual({
+      from: "2026-02-01",
+      to: "2026-02-28",
+    });
+    expect(bucketRange("2024-02-01", "month")).toEqual({
+      from: "2024-02-01",
+      to: "2024-02-29",
+    });
+  });
+
+  it("crosses a year boundary rather than clamping inside one", () => {
+    expect(bucketRange("2026-12-28", "week")).toEqual({
+      from: "2026-12-28",
+      to: "2027-01-03",
+    });
+  });
+
+  it("answers a label it cannot read as that label alone", () => {
+    expect(bucketRange("not a date", "week")).toEqual({
+      from: "not a date",
+      to: "not a date",
+    });
+  });
 });

--- a/src/frontend/src/lib/portal/trend-drilldown.ts
+++ b/src/frontend/src/lib/portal/trend-drilldown.ts
@@ -2,6 +2,7 @@ import type {
   MetricEvidenceColumn,
   MetricEvidenceRow,
 } from "@/api/metric-drilldown-client";
+import type { MetricBucket } from "@/api/metric-results-client";
 import { forEntity, type NormalizedMetricResult } from "@/lib/metrics/collection";
 
 /** One person's evidence page, as the drilldown answered it. */
@@ -110,4 +111,30 @@ export function bucketBreakdown(
         .sort((a, b) => a.localeCompare(b)),
     }))
     .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * The day range one chart bucket covers, from the label the axis shows.
+ *
+ * The axis is keyed by `bucket_start`, and the evidence request needs both
+ * ends: a reader clicking a week wants that week's records, not the day the
+ * week happens to start on. The last bucket is NOT clipped to the period
+ * here — the request's own period does that, and clipping twice would need
+ * this function to know about a period it is not given.
+ */
+export function bucketRange(
+  bucketStart: string,
+  bucket: MetricBucket
+): { from: string; to: string } {
+  const start = new Date(`${bucketStart}T00:00:00Z`);
+  if (Number.isNaN(start.getTime()))
+    return { from: bucketStart, to: bucketStart };
+
+  const end = new Date(start);
+  if (bucket === "week") end.setUTCDate(end.getUTCDate() + 6);
+  else if (bucket === "month") {
+    end.setUTCMonth(end.getUTCMonth() + 1);
+    end.setUTCDate(0);
+  }
+  return { from: bucketStart, to: end.toISOString().slice(0, 10) };
 }

--- a/src/ingestion/dbt/macros/git_file_category.sql
+++ b/src/ingestion/dbt/macros/git_file_category.sql
@@ -71,3 +71,18 @@ multiIf(
     {{ source_expr }}
 )
 {% endmacro %}
+
+{# The two-hour block a timestamp falls in, as the value a dimension carries.
+   Shared with the CI evidence model so one heatmap component reads both. #}
+{% macro hour_block_value(ts_expr) %}
+leftPad(toString(intDiv(toHour({{ ts_expr }}), 2) * 2), 2, '0')
+{% endmacro %}
+
+{# The same block, as the reader sees it: "08–10". #}
+{% macro hour_block_label(ts_expr) %}
+concat(
+    leftPad(toString(intDiv(toHour({{ ts_expr }}), 2) * 2), 2, '0'),
+    '–',
+    leftPad(toString(intDiv(toHour({{ ts_expr }}), 2) * 2 + 2), 2, '0')
+)
+{% endmacro %}

--- a/src/ingestion/gold/ci_metric_evidence.sql
+++ b/src/ingestion/gold/ci_metric_evidence.sql
@@ -78,12 +78,8 @@ run_rows AS (
                 tuple('outcome', outcome, toNullable(outcome)),
                 tuple(
                     'hour_block',
-                    leftPad(toString(intDiv(toHour(started_at), 2) * 2), 2, '0'),
-                    toNullable(concat(
-                        leftPad(toString(intDiv(toHour(started_at), 2) * 2), 2, '0'),
-                        '–',
-                        leftPad(toString(intDiv(toHour(started_at), 2) * 2 + 2), 2, '0')
-                    ))
+                    {{ hour_block_value('started_at') }},
+                    toNullable({{ hour_block_label('started_at') }})
                 )
             ] AS Array(Tuple(key String, value String, label Nullable(String)))
         ) AS run_dimensions

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -757,7 +757,18 @@ SELECT
     if(message = '', commit_hash, message) AS record_label,
     toNullable(toFloat64(commit_measure.2)) AS contribution,
     CAST(NULL AS Nullable(String)) AS subject_key,
-    source_dimensions AS dimensions,
+    -- The hour block rides HERE and not on git_authored_commits: the
+    -- `commit_day` rows group by that model's own dimension tuple, so a
+    -- dimension added there would split one active day into one row per
+    -- block and inflate every active-day reading.
+    arrayConcat(
+        source_dimensions,
+        [tuple(
+            'hour_block',
+            {{ hour_block_value('observed_at') }},
+            toNullable({{ hour_block_label('observed_at') }})
+        )]
+    ) AS dimensions,
     map(
         'source_id', coalesce(toString(source_id), ''),
         'ref', commit_hash,

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -761,13 +761,21 @@ SELECT
     -- `commit_day` rows group by that model's own dimension tuple, so a
     -- dimension added there would split one active day into one row per
     -- block and inflate every active-day reading.
+    --
+    -- INVARIANT: the appended element is CAST to the array's own named tuple
+    -- type. `arrayConcat` with an anonymous or wider-nullability tuple widens
+    -- the whole column to `Tuple(String, Nullable(String), Nullable(String))`,
+    -- which changes this table's DDL and every relation that unions it.
     arrayConcat(
         source_dimensions,
-        [tuple(
-            'hour_block',
-            {{ hour_block_value('observed_at') }},
-            toNullable({{ hour_block_label('observed_at') }})
-        )]
+        CAST(
+            [tuple(
+                'hour_block',
+                coalesce({{ hour_block_value('observed_at') }}, '__unknown__'),
+                toNullable(coalesce({{ hour_block_label('observed_at') }}, 'Unknown'))
+            )]
+            AS Array(Tuple(key String, value String, label Nullable(String)))
+        )
     ) AS dimensions,
     map(
         'source_id', coalesce(toString(source_id), ''),

--- a/src/ingestion/tests/e2e/metrics/git_commit_hour_block.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_commit_hour_block.test.yaml
@@ -1,0 +1,70 @@
+spec_version: 1
+description: >-
+  Commits carry the two-hour block they landed in, so a repository screen can
+  draw when work happens without a second request.
+
+  Alice commits three times on one day — 09:14, 09:52 and 15:03 UTC — and once
+  the next day at 09:30. The blocks are therefore 08 twice on the first day,
+  14 once, and 08 again on the second.
+
+  What the numbers prove:
+    • the breakdown by `hour_block` sums to the commit total, and the 08 block
+      carries three of the four commits;
+    • `git.active_days` stays 2. This is the assertion that matters: the block
+      rides on the commit rows only. Were it added to the model the
+      `commit_day` rows group by, one active day would split into one row per
+      block and this would read 3.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+  bronze_github.branches:
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: br-main, repository: "https://github.com/constructor/insight.git", name: main, head_sha: head-main, is_default: true}
+  bronze_github.commits:
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: c-1, sha: sha-1, author_name: alice, author_email: alice@example.com, committer_name: alice, committer_email: alice@example.com, committed_date: "2026-10-01T09:14:00Z", additions: 5, is_in_default_branch: true}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: c-2, sha: sha-2, author_name: alice, author_email: alice@example.com, committer_name: alice, committer_email: alice@example.com, committed_date: "2026-10-01T09:52:00Z", additions: 5, is_in_default_branch: true}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: c-3, sha: sha-3, author_name: alice, author_email: alice@example.com, committer_name: alice, committer_email: alice@example.com, committed_date: "2026-10-01T15:03:00Z", additions: 5, is_in_default_branch: true}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: c-4, sha: sha-4, author_name: alice, author_email: alice@example.com, committer_name: alice, committer_email: alice@example.com, committed_date: "2026-10-02T09:30:00Z", additions: 5, is_in_default_branch: true}
+  bronze_github.file_changes:
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: f-1, sha: sha-1, filename: src/one.rs, additions: 5}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: f-2, sha: sha-2, filename: src/two.rs, additions: 5}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: f-3, sha: sha-3, filename: src/three.rs, additions: 5}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: f-4, sha: sha-4, filename: src/four.rs, additions: 5}
+
+cases:
+  - name: Commits break down by the block they landed in
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [alice@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-03"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: period}
+              - {view: breakdown, dimensions: [hour_block]}
+    expect:
+      - assert: "status == 200"
+      - {metric: git.commits, view: period, find: {entity_id: alice@example.com}, equal: {value: 4}}
+      # 09:14, 09:52 and 09:30 all fall in the 08–10 block.
+      - {metric: git.commits, view: breakdown, find: {entity_id: alice@example.com, dimensions: {key: hour_block, value: "08"}}, equal: {value: 3}}
+      - {metric: git.commits, view: breakdown, find: {entity_id: alice@example.com, dimensions: {key: hour_block, value: "14"}}, equal: {value: 1}}
+      # The label is what a heatmap axis shows.
+      - {metric: git.commits, view: breakdown, find: {entity_id: alice@example.com, dimensions: {key: hour_block, value: "14"}}, contains: {dimensions: {key: hour_block, label: "14–16"}}}
+
+  - name: The block does not split an active day
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [alice@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-03"}
+        metrics:
+          - metric_key: git.active_days
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      # Two calendar days, however many blocks the commits fell into.
+      - {metric: git.active_days, view: period, find: {entity_id: alice@example.com}, equal: {value: 2}}

--- a/src/ingestion/tests/e2e/metrics/git_commit_hour_block.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_commit_hour_block.test.yaml
@@ -3,13 +3,16 @@ description: >-
   Commits carry the two-hour block they landed in, so a repository screen can
   draw when work happens without a second request.
 
-  Alice commits three times on one day — 09:14, 09:52 and 15:03 UTC — and once
-  the next day at 09:30. The blocks are therefore 08 twice on the first day,
-  14 once, and 08 again on the second.
+  Alice commits three times on one day — 09:14, 09:52 and 15:03 UTC — once the
+  next day at 09:30, and once more that evening at 21:05 on a branch that has
+  not landed. The blocks are therefore 08 three times, 14 once and 20 once.
 
   What the numbers prove:
     • the breakdown by `hour_block` sums to the commit total, and the 08 block
-      carries three of the four commits;
+      carries three of the five commits;
+    • each branch scope answers over the same dimension: the trunk keeps the
+      three 08-block commits, and the block of the one still in flight belongs
+      to the non-default reading;
     • `git.active_days` stays 2. This is the assertion that matters: the block
       rides on the commit rows only. Were it added to the model the
       `commit_day` rows group by, one active day would split into one row per
@@ -25,11 +28,15 @@ bronze:
     - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: c-2, sha: sha-2, author_name: alice, author_email: alice@example.com, committer_name: alice, committer_email: alice@example.com, committed_date: "2026-10-01T09:52:00Z", additions: 5, is_in_default_branch: true}
     - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: c-3, sha: sha-3, author_name: alice, author_email: alice@example.com, committer_name: alice, committer_email: alice@example.com, committed_date: "2026-10-01T15:03:00Z", additions: 5, is_in_default_branch: true}
     - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: c-4, sha: sha-4, author_name: alice, author_email: alice@example.com, committer_name: alice, committer_email: alice@example.com, committed_date: "2026-10-02T09:30:00Z", additions: 5, is_in_default_branch: true}
+    # Still in flight, and late in the day: the non-default scope declares the
+    # same dimension, so a breakdown over it must answer too.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: c-5, sha: sha-5, author_name: alice, author_email: alice@example.com, committer_name: alice, committer_email: alice@example.com, committed_date: "2026-10-02T21:05:00Z", additions: 5, is_in_default_branch: false}
   bronze_github.file_changes:
     - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: f-1, sha: sha-1, filename: src/one.rs, additions: 5}
     - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: f-2, sha: sha-2, filename: src/two.rs, additions: 5}
     - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: f-3, sha: sha-3, filename: src/three.rs, additions: 5}
     - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: f-4, sha: sha-4, filename: src/four.rs, additions: 5}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: f-5, sha: sha-5, filename: src/five.rs, additions: 5}
 
 cases:
   - name: Commits break down by the block they landed in
@@ -46,12 +53,31 @@ cases:
               - {view: breakdown, dimensions: [hour_block]}
     expect:
       - assert: "status == 200"
-      - {metric: git.commits, view: period, find: {entity_id: alice@example.com}, equal: {value: 4}}
+      - {metric: git.commits, view: period, find: {entity_id: alice@example.com}, equal: {value: 5}}
       # 09:14, 09:52 and 09:30 all fall in the 08–10 block.
       - {metric: git.commits, view: breakdown, find: {entity_id: alice@example.com, dimensions: {key: hour_block, value: "08"}}, equal: {value: 3}}
       - {metric: git.commits, view: breakdown, find: {entity_id: alice@example.com, dimensions: {key: hour_block, value: "14"}}, equal: {value: 1}}
       # The label is what a heatmap axis shows.
       - {metric: git.commits, view: breakdown, find: {entity_id: alice@example.com, dimensions: {key: hour_block, value: "14"}}, contains: {dimensions: {key: hour_block, label: "14–16"}}}
+
+  - name: Each branch scope breaks down over the same dimension
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [alice@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-03"}
+        metrics:
+          - metric_key: git.default_branch_commits
+            views:
+              - {view: breakdown, dimensions: [hour_block]}
+          - metric_key: git.non_default_branch_commits
+            views:
+              - {view: breakdown, dimensions: [hour_block]}
+    expect:
+      - assert: "status == 200"
+      - {metric: git.default_branch_commits, view: breakdown, find: {entity_id: alice@example.com, dimensions: {key: hour_block, value: "08"}}, equal: {value: 3}}
+      - {metric: git.non_default_branch_commits, view: breakdown, find: {entity_id: alice@example.com, dimensions: {key: hour_block, value: "20"}}, equal: {value: 1}}
 
   - name: The block does not split an active day
     request:


### PR DESCRIPTION
Closes #2880.

**Why.** Every figure on the Repositories lens was a dead end or disagreed with what it opened: bars and table tails did nothing, a headline tile showed a per-person number and opened the roster's records, and nothing let a reader ask about one repository.

**What changed.** A figure now opens the records that make it. Bars and trend points narrow the evidence request to what was clicked, the table's `Other (N)` row and ownership's `+N more` became the controls that open them, headline tiles lead with the total their dialog lists, and `LensConfig.drilldown` adds a per-repository screen — the same section kinds with every request filtered to one value, reached from a table row and left by a breadcrumb.

**A line count drills into its commits, not into its own evidence.** That measure is a per-day summary, which answers "when" and never "what changed"; `evidence-via` declares the carrier per branch scope. Reversible by emptying that map.

**`hour_block` rides on the commit evidence rows only.** `commit_day` groups by `git_authored_commits`' dimension tuple, so adding it there would split one active day into one row per block and inflate every active-day reading.

**Out of scope.** The pane still greys the lens on installs whose `nav.planned` lists it from when it was a placeholder — a values change, outside this repository.

**Verified.** 2303 frontend unit tests, `cargo test -p analytics` 642, typecheck and eslint clean, passports in sync. A new e2e case pins both halves of the hour block: three of four commits in the `08` block, and `git.active_days` staying 2. No stand screenshots — the seeded stand holds one repository, so the repository-oriented sections correctly draw nothing there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added repository-level drilldowns with scoped metrics, headings, and breadcrumb navigation.
  - Added contributor views and weekday/hour heatmaps.
  - Added clickable charts, bars, segments, and headline cards that open filtered evidence.
  - Added hour-block breakdowns to Git commit metrics.

- **Improvements**
  - Added expandable dimension and ownership tables with hover details.
  - Improved trend drilldowns for day, week, and month ranges.
  - Prevented dates and numeric values from wrapping in drilldown tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->