### PR TITLE
fix(frontend): make the whole column open a timeseries drilldown

### DIFF
--- a/src/frontend/src/components/ui/chart.tsx
+++ b/src/frontend/src/components/ui/chart.tsx
@@ -254,6 +254,7 @@ function ChartTooltipContent({
   color,
   nameKey,
   labelKey,
+  activeKey,
 }: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
   React.ComponentProps<"div"> & {
     hideLabel?: boolean;
@@ -261,6 +262,8 @@ function ChartTooltipContent({
     indicator?: "line" | "dot" | "dashed";
     nameKey?: string;
     labelKey?: string;
+    /** `dataKey` of the series a click would drill into, marked in the list. */
+    activeKey?: string;
   } & Omit<
     RechartsPrimitive.DefaultTooltipContentProps<
       TooltipValueType,
@@ -327,14 +330,18 @@ function ChartTooltipContent({
             const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`;
             const itemConfig = getPayloadConfigFromPayload(config, item, key);
             const indicatorColor = color ?? item.payload?.fill ?? item.color;
+            const isActive =
+              activeKey != null && String(item.dataKey) === activeKey;
 
             return (
               <div
                 key={index}
                 className={cn(
                   "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
-                  indicator === "dot" && "items-center"
+                  indicator === "dot" && "items-center",
+                  isActive && "-mx-1 rounded-sm bg-accent px-1"
                 )}
+                data-active={isActive || undefined}
               >
                 {formatter && item?.value !== undefined && item.name ? (
                   formatter(item.value, item.name, item, index, item.payload)

--- a/src/frontend/src/components/ui/chart.tsx
+++ b/src/frontend/src/components/ui/chart.tsx
@@ -254,7 +254,6 @@ function ChartTooltipContent({
   color,
   nameKey,
   labelKey,
-  activeKey,
 }: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
   React.ComponentProps<"div"> & {
     hideLabel?: boolean;
@@ -262,8 +261,6 @@ function ChartTooltipContent({
     indicator?: "line" | "dot" | "dashed";
     nameKey?: string;
     labelKey?: string;
-    /** `dataKey` of the series a click would drill into, marked in the list. */
-    activeKey?: string;
   } & Omit<
     RechartsPrimitive.DefaultTooltipContentProps<
       TooltipValueType,
@@ -330,18 +327,14 @@ function ChartTooltipContent({
             const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`;
             const itemConfig = getPayloadConfigFromPayload(config, item, key);
             const indicatorColor = color ?? item.payload?.fill ?? item.color;
-            const isActive =
-              activeKey != null && String(item.dataKey) === activeKey;
 
             return (
               <div
                 key={index}
                 className={cn(
                   "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
-                  indicator === "dot" && "items-center",
-                  isActive && "-mx-1 rounded-sm bg-accent px-1"
+                  indicator === "dot" && "items-center"
                 )}
-                data-active={isActive || undefined}
               >
                 {formatter && item?.value !== undefined && item.name ? (
                   formatter(item.value, item.name, item, index, item.payload)

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-chart.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-chart.tsx
@@ -140,8 +140,10 @@ export function MetricTimeseriesChart({
       />
     </>
   );
+  // Recharts reports no active bucket as null, and `Number(null)` is 0 — which
+  // would read as the first bucket rather than as "none".
   const bucketAt = (index: MouseHandlerDataParam["activeTooltipIndex"]) =>
-    data[Number(index)]?.bucketStart;
+    index == null ? undefined : data[Number(index)]?.bucketStart;
   const openBucketFrom = (bucketStart: string) =>
     onEvidence?.(chartModel.valueMetric.metric_key, null, bucketStart);
   const openSegment = (

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-chart.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-chart.tsx
@@ -1,4 +1,6 @@
+import { useRef, useState } from "react";
 import { format } from "date-fns";
+import type { MouseHandlerDataParam } from "recharts";
 
 import {
   BarChart,
@@ -29,9 +31,10 @@ export interface MetricTimeseriesChartProps {
   model: MetricTimeseriesModel;
   selectedMetricKey: string;
   multiMetric?: MetricTimeseriesChartConfig["multiMetric"];
+  /** `columnKey` null drills the whole bucket, narrowed by no dimension value. */
   onEvidence?: (
     metricKey: string,
-    columnKey: string,
+    columnKey: string | null,
     bucketStart: string | null
   ) => void;
 }
@@ -75,6 +78,10 @@ export function MetricTimeseriesChart({
   multiMetric = "selectable",
   onEvidence,
 }: MetricTimeseriesChartProps) {
+  // The segment under the pointer, tracked here rather than read off the click:
+  // recharts routes a click to the chart, not to the rectangle it landed on.
+  const [hoveredSeriesKey, setHoveredSeriesKey] = useState<string | null>(null);
+  const overSegment = useRef(false);
   const chartModel = buildMetricTimeseriesChartModel(
     model,
     selectedMetricKey,
@@ -130,6 +137,7 @@ export function MetricTimeseriesChart({
         content={
           <ChartTooltipContent
             className="min-w-48"
+            activeKey={hoveredSeriesKey ?? undefined}
             labelFormatter={(_, payload) =>
               String(payload?.[0]?.payload?.tooltipLabel ?? "")
             }
@@ -138,18 +146,40 @@ export function MetricTimeseriesChart({
       />
     </>
   );
-  const openPoint = (
-    series: MetricTimeseriesChartModel["series"][number],
-    state: unknown
-  ) => {
-    const point = state as { payload?: { bucketStart?: string } };
-    const bucketStart = point.payload?.bucketStart;
+  const drillableColumn = (columnKey: string) => {
     const column = model.columns.find(
-      (candidate) => candidate.key === series.columnKey
+      (candidate) => candidate.key === columnKey
     );
-    if (bucketStart && column && !column.remainder) {
-      onEvidence?.(series.metricKey, series.columnKey, bucketStart);
+    return column && !column.remainder ? column : undefined;
+  };
+  const openBucket = (state: MouseHandlerDataParam) => {
+    const bucketStart = data[Number(state.activeTooltipIndex)]?.bucketStart;
+    if (!bucketStart) return;
+
+    const hovered = chartModel.series.find(
+      (series) => series.key === hoveredSeriesKey
+    );
+    if (hovered) onEvidence?.(hovered.metricKey, hovered.columnKey, bucketStart);
+    else onEvidence?.(chartModel.valueMetric.metric_key, null, bucketStart);
+  };
+  // A segment's own move reaches the chart handler too, so the flag is what
+  // tells "moved over a segment" from "moved past every one of them".
+  const trackSegment = (
+    series: MetricTimeseriesChartModel["series"][number]
+  ) => {
+    overSegment.current = true;
+    setHoveredSeriesKey(drillableColumn(series.columnKey) ? series.key : null);
+  };
+  const trackPlot = () => {
+    if (overSegment.current) {
+      overSegment.current = false;
+      return;
     }
+    setHoveredSeriesKey(null);
+  };
+  const leavePlot = () => {
+    overSegment.current = false;
+    setHoveredSeriesKey(null);
   };
 
   return (
@@ -162,6 +192,9 @@ export function MetricTimeseriesChart({
           <BarChart
             data={data}
             margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+            onClick={openBucket}
+            onMouseMove={trackPlot}
+            onMouseLeave={leavePlot}
           >
             {chartContent}
             <TimeseriesXAxis data={data} />
@@ -173,7 +206,7 @@ export function MetricTimeseriesChart({
                 fill={`var(--color-${series.key})`}
                 name={series.label}
                 radius={[2, 2, 0, 0]}
-                onClick={(point) => openPoint(series, point)}
+                onMouseMove={() => trackSegment(series)}
               />
             ))}
           </BarChart>
@@ -181,6 +214,7 @@ export function MetricTimeseriesChart({
           <LineChart
             data={data}
             margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+            onClick={openBucket}
           >
             {chartContent}
             <TimeseriesXAxis data={data} numeric />
@@ -219,7 +253,6 @@ export function MetricTimeseriesChart({
                 // a straight line drawn across it.
                 connectNulls={false}
                 name={series.label}
-                onClick={(point) => openPoint(series, point)}
               />
             ))}
           </LineChart>

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-chart.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-chart.tsx
@@ -1,4 +1,3 @@
-import { useRef, useState } from "react";
 import { format } from "date-fns";
 import type { MouseHandlerDataParam } from "recharts";
 
@@ -78,10 +77,6 @@ export function MetricTimeseriesChart({
   multiMetric = "selectable",
   onEvidence,
 }: MetricTimeseriesChartProps) {
-  // The segment under the pointer, tracked here rather than read off the click:
-  // recharts routes a click to the chart, not to the rectangle it landed on.
-  const [hoveredSeriesKey, setHoveredSeriesKey] = useState<string | null>(null);
-  const overSegment = useRef(false);
   const chartModel = buildMetricTimeseriesChartModel(
     model,
     selectedMetricKey,
@@ -137,7 +132,6 @@ export function MetricTimeseriesChart({
         content={
           <ChartTooltipContent
             className="min-w-48"
-            activeKey={hoveredSeriesKey ?? undefined}
             labelFormatter={(_, payload) =>
               String(payload?.[0]?.payload?.tooltipLabel ?? "")
             }
@@ -146,40 +140,43 @@ export function MetricTimeseriesChart({
       />
     </>
   );
-  const drillableColumn = (columnKey: string) => {
-    const column = model.columns.find(
-      (candidate) => candidate.key === columnKey
-    );
-    return column && !column.remainder ? column : undefined;
-  };
-  const openBucket = (state: MouseHandlerDataParam) => {
-    const bucketStart = data[Number(state.activeTooltipIndex)]?.bucketStart;
+  const bucketAt = (index: MouseHandlerDataParam["activeTooltipIndex"]) =>
+    data[Number(index)]?.bucketStart;
+  const openBucketFrom = (bucketStart: string) =>
+    onEvidence?.(chartModel.valueMetric.metric_key, null, bucketStart);
+  const openSegment = (
+    series: MetricTimeseriesChartModel["series"][number],
+    entry: unknown
+  ) => {
+    const point = entry as { payload?: { bucketStart?: string } };
+    const bucketStart = point.payload?.bucketStart;
     if (!bucketStart) return;
 
-    const hovered = chartModel.series.find(
-      (series) => series.key === hoveredSeriesKey
+    const column = model.columns.find(
+      (candidate) => candidate.key === series.columnKey
     );
-    if (hovered) onEvidence?.(hovered.metricKey, hovered.columnKey, bucketStart);
-    else onEvidence?.(chartModel.valueMetric.metric_key, null, bucketStart);
-  };
-  // A segment's own move reaches the chart handler too, so the flag is what
-  // tells "moved over a segment" from "moved past every one of them".
-  const trackSegment = (
-    series: MetricTimeseriesChartModel["series"][number]
-  ) => {
-    overSegment.current = true;
-    setHoveredSeriesKey(drillableColumn(series.columnKey) ? series.key : null);
-  };
-  const trackPlot = () => {
-    if (overSegment.current) {
-      overSegment.current = false;
-      return;
+    // The remainder gathers the dimension values that missed the top N, so no
+    // filter selects it: clicking it reads as clicking past every segment.
+    if (column && !column.remainder) {
+      onEvidence?.(series.metricKey, series.columnKey, bucketStart);
+    } else {
+      openBucketFrom(bucketStart);
     }
-    setHoveredSeriesKey(null);
   };
-  const leavePlot = () => {
-    overSegment.current = false;
-    setHoveredSeriesKey(null);
+  /**
+   * The column outside its drawn segments. A click on a segment reaches here
+   * too, and asking the event where it landed is what keeps both from
+   * answering it — no assumption about which handler runs first.
+   */
+  const openBucket = (
+    state: MouseHandlerDataParam,
+    event: { target: EventTarget | null }
+  ) => {
+    const target = event.target as Element | null;
+    if (target?.closest?.(".recharts-bar-rectangle")) return;
+
+    const bucketStart = bucketAt(state.activeTooltipIndex);
+    if (bucketStart) openBucketFrom(bucketStart);
   };
 
   return (
@@ -193,8 +190,6 @@ export function MetricTimeseriesChart({
             data={data}
             margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
             onClick={openBucket}
-            onMouseMove={trackPlot}
-            onMouseLeave={leavePlot}
           >
             {chartContent}
             <TimeseriesXAxis data={data} />
@@ -206,7 +201,7 @@ export function MetricTimeseriesChart({
                 fill={`var(--color-${series.key})`}
                 name={series.label}
                 radius={[2, 2, 0, 0]}
-                onMouseMove={() => trackSegment(series)}
+                onClick={(point) => openSegment(series, point)}
               />
             ))}
           </BarChart>

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-chrome.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-chrome.tsx
@@ -147,7 +147,7 @@ export function TimeseriesBody({
   onVerticalOverflow?: (overflows: boolean) => void;
   onEvidence?: (
     metricKey: string,
-    columnKey: string,
+    columnKey: string | null,
     bucketStart: string | null
   ) => void;
 }) {

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.tsx
@@ -36,7 +36,7 @@ export interface MetricTimeseriesTableProps {
   onVerticalOverflow?: (overflows: boolean) => void;
   onEvidence?: (
     metricKey: string,
-    columnKey: string,
+    columnKey: string | null,
     bucketStart: string | null
   ) => void;
 }

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
@@ -157,16 +157,9 @@ function emptySpotInBucket(
  * carries coordinates. The target is what a real pointer would be over — the
  * segment where there is one, the wrapper where the column is empty — because a
  * dispatched event reaches the wrapper by bubbling but never travels back down.
- * A move between the two is one gesture, so that leaving the segment is part of
- * it rather than an event nothing ever fires.
  */
 const pointAt = (target: Element, coords: ChartPoint) =>
   userEvent.pointer({ target, coords });
-
-const moveBetween = (
-  from: { target: Element; coords: ChartPoint },
-  to: { target: Element; coords: ChartPoint }
-) => userEvent.pointer([from, to]);
 
 const clickAt = (target: Element, coords: ChartPoint) =>
   userEvent.pointer([
@@ -245,9 +238,9 @@ export const TestChartPresentation: Story = {
 };
 
 /**
- * The click target is the whole column, not the drawn stack: a point above the
- * segments drills the bucket unnarrowed, a segment drills its own series, and
- * the tooltip marks which of the two a click would take.
+ * The click target is the whole column, not the drawn stack: a segment drills
+ * its own series, a point above them drills the bucket unnarrowed, and each
+ * click opens exactly one thing — the two handlers never both answer it.
  */
 export const TestColumnClickDrilldown: Story = {
   tags: ["test"],
@@ -262,19 +255,10 @@ export const TestColumnClickDrilldown: Story = {
     const wrapper = canvasElement.querySelector<HTMLElement>(
       ".recharts-wrapper"
     )!;
-    // Every hover re-renders the chart and recharts rebuilds its rectangles, so
-    // a segment held across one gesture is a detached node by the next.
+    // Recharts rebuilds its rectangles as the pointer moves, so a segment held
+    // across one gesture is a detached node by the next.
     // The series render in rank order, making the first segment org/repo-a's.
     const segment = () => barSegments(canvasElement)[0]!;
-
-    // Over a segment the panel marks the one row a click would open, and the
-    // click opens exactly that row's series.
-    await pointAt(segment(), centreOf(segment()));
-    await waitFor(() =>
-      expect(canvasElement.querySelector("[data-active]")).toHaveTextContent(
-        "org/repo-a"
-      )
-    );
 
     await clickAt(segment(), centreOf(segment()));
     await waitFor(() => expect(drilled).toHaveLength(1));
@@ -285,19 +269,14 @@ export const TestColumnClickDrilldown: Story = {
     });
 
     // 2026-04-27 carries one commit against a six-commit peak, so the top of
-    // its band is the empty space this issue is about. Nothing is marked there,
-    // because the click opens every row instead of one.
+    // its band is the empty space this issue is about.
     const spot = emptySpotInBucket(canvasElement, 1);
-    await moveBetween(
-      { target: segment(), coords: centreOf(segment()) },
-      { target: wrapper, coords: spot }
-    );
+    await pointAt(wrapper, spot);
+    // The panel reads that week there, so the empty space is inside the band
+    // rather than outside the chart's reach.
     await waitFor(() =>
-      expect(canvasElement.querySelector("[data-active]")).toBeNull()
+      expect(canvas.getByText("April 27, 2026")).toBeInTheDocument()
     );
-    // The panel still reads that week there, so the empty space is inside the
-    // band rather than outside the chart's reach.
-    await expect(canvas.getByText("April 27, 2026")).toBeInTheDocument();
 
     await clickAt(wrapper, spot);
     await waitFor(() => expect(drilled).toHaveLength(2));
@@ -306,6 +285,10 @@ export const TestColumnClickDrilldown: Story = {
       period: { from: "2026-04-27", to: "2026-05-03" },
       filters: [],
     });
+
+    // Two clicks, two drilldowns: neither one was answered by both the
+    // segment's handler and the chart's.
+    await expect(drilled).toHaveLength(2);
   },
 };
 

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
@@ -93,8 +93,8 @@ async function openExportMenu(): Promise<void> {
   await userEvent.click(screen.getByRole("button", { name: "Export" }));
 }
 
-/** Selections the chart asked to drill into, newest last. */
-const drilled: MetricEvidenceSelection[] = [];
+/** One entry per drilldown the chart asked for, holding all of its targets. */
+const drilled: MetricEvidenceSelection[][] = [];
 
 /**
  * Stands in for the dialog provider: the assertion is which selection a click
@@ -106,11 +106,9 @@ function captureDrilldowns(Story: () => ReactNode) {
   return (
     <EvidenceDialogContext.Provider
       value={{
-        openEvidence: (selection) => drilled.push(selection),
-        openEvidenceTargets: (targets: readonly EvidenceDialogTarget[]) => {
-          const own = targets[0];
-          if (own) drilled.push(own.selection);
-        },
+        openEvidence: (selection) => drilled.push([selection]),
+        openEvidenceTargets: (targets: readonly EvidenceDialogTarget[]) =>
+          drilled.push(targets.map((target) => target.selection)),
         openEvidencePeople: () => {},
       }}
     >
@@ -280,7 +278,7 @@ export const TestColumnClickDrilldown: Story = {
 
     await clickAt(segment(), centreOf(segment()));
     await waitFor(() => expect(drilled).toHaveLength(1));
-    await expect(drilled[0]).toMatchObject({
+    await expect(drilled[0]?.[0]).toMatchObject({
       metric_key: COMMITS,
       period: { from: "2026-04-20", to: "2026-04-26" },
       filters: [{ dimension: "repository", values: ["org/repo-a"] }],
@@ -303,7 +301,7 @@ export const TestColumnClickDrilldown: Story = {
 
     await clickAt(wrapper, spot);
     await waitFor(() => expect(drilled).toHaveLength(2));
-    await expect(drilled[1]).toMatchObject({
+    await expect(drilled[1]?.[0]).toMatchObject({
       metric_key: COMMITS,
       period: { from: "2026-04-27", to: "2026-05-03" },
       filters: [],
@@ -339,11 +337,21 @@ export const TestLineClickDrilldown: Story = {
     await clickAt(wrapper, spot);
 
     await waitFor(() => expect(drilled).toHaveLength(1));
-    await expect(drilled[0]).toMatchObject({
+    const bucket = { from: "2026-04-27", to: "2026-05-03" };
+    await expect(drilled[0]?.[0]).toMatchObject({
       metric_key: COMMITS,
-      period: { from: "2026-04-27", to: "2026-05-03" },
+      period: bucket,
       filters: [],
     });
+    // Both metrics reach the dialog, and picking the other one there must not
+    // widen the period back out to the widget's own range.
+    await expect(drilled[0]?.map((selection) => selection.metric_key)).toEqual([
+      COMMITS,
+      LINES_ADDED,
+    ]);
+    await expect(
+      drilled[0]?.map((selection) => selection.period)
+    ).toEqual([bucket, bucket]);
   },
 };
 

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
@@ -260,6 +260,19 @@ export const TestColumnClickDrilldown: Story = {
     // The series render in rank order, making the first segment org/repo-a's.
     const segment = () => barSegments(canvasElement)[0]!;
 
+    // A click with nothing under the pointer yet: recharts reports the active
+    // bucket as null there, and null must not read as the first bucket. Raw,
+    // because any pointer gesture would activate a bucket on its way in. What
+    // it must not do is land in `drilled` — the assertions below would then be
+    // reading it instead of the clicks they name.
+    wrapper.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        clientX: wrapper.getBoundingClientRect().left + 4,
+        clientY: wrapper.getBoundingClientRect().top + 4,
+      })
+    );
+
     await clickAt(segment(), centreOf(segment()));
     await waitFor(() => expect(drilled).toHaveLength(1));
     await expect(drilled[0]?.[0]).toMatchObject({

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
@@ -15,11 +15,19 @@
  * See docs/testing/storybook-component-tests.md.
  */
 
+import type { ReactNode } from "react";
+
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, screen, userEvent, waitFor } from "storybook/test";
 
+import type { MetricEvidenceSelection } from "@/api/metric-drilldown-client";
+import {
+  EvidenceDialogContext,
+  type EvidenceDialogTarget,
+} from "@/components/metric-evidence-context";
 import { MetricTimeseriesView } from "@/components/widgets/metric-views/metric-timeseries-view";
 import {
+  BUCKETS,
   COMMITS,
   ENTITY_ID,
   LINES_ADDED,
@@ -84,6 +92,89 @@ function captureDownloads(): () => void {
 async function openExportMenu(): Promise<void> {
   await userEvent.click(screen.getByRole("button", { name: "Export" }));
 }
+
+/** Selections the chart asked to drill into, newest last. */
+const drilled: MetricEvidenceSelection[] = [];
+
+/**
+ * Stands in for the dialog provider: the assertion is which selection a click
+ * produced, and mounting the real dialog would answer that through a second
+ * request instead.
+ */
+function captureDrilldowns(Story: () => ReactNode) {
+  drilled.length = 0;
+  return (
+    <EvidenceDialogContext.Provider
+      value={{
+        openEvidence: (selection) => drilled.push(selection),
+        openEvidenceTargets: (targets: readonly EvidenceDialogTarget[]) => {
+          const own = targets[0];
+          if (own) drilled.push(own.selection);
+        },
+        openEvidencePeople: () => {},
+      }}
+    >
+      <Story />
+    </EvidenceDialogContext.Provider>
+  );
+}
+
+const barSegments = (canvasElement: HTMLElement): HTMLElement[] => [
+  ...canvasElement.querySelectorAll<HTMLElement>(".recharts-bar-rectangle"),
+];
+
+interface ChartPoint {
+  clientX: number;
+  clientY: number;
+}
+
+const centreOf = (element: Element): ChartPoint => {
+  const box = element.getBoundingClientRect();
+  return {
+    clientX: box.left + box.width / 2,
+    clientY: box.top + box.height / 2,
+  };
+};
+
+/**
+ * A point inside one bucket's band that nothing is drawn over: the band's own
+ * centre line at the top edge of the plot, which every bucket but the tallest
+ * leaves empty.
+ */
+function emptySpotInBucket(
+  canvasElement: HTMLElement,
+  bucketIndex: number
+): ChartPoint {
+  const plot = canvasElement
+    .querySelector(".recharts-cartesian-grid")!
+    .getBoundingClientRect();
+  return {
+    clientX: plot.left + (plot.width / BUCKETS.length) * (bucketIndex + 0.5),
+    clientY: plot.top + 4,
+  };
+}
+
+/**
+ * Recharts reads the pointer's position off the chart wrapper, so every gesture
+ * carries coordinates. The target is what a real pointer would be over — the
+ * segment where there is one, the wrapper where the column is empty — because a
+ * dispatched event reaches the wrapper by bubbling but never travels back down.
+ * A move between the two is one gesture, so that leaving the segment is part of
+ * it rather than an event nothing ever fires.
+ */
+const pointAt = (target: Element, coords: ChartPoint) =>
+  userEvent.pointer({ target, coords });
+
+const moveBetween = (
+  from: { target: Element; coords: ChartPoint },
+  to: { target: Element; coords: ChartPoint }
+) => userEvent.pointer([from, to]);
+
+const clickAt = (target: Element, coords: ChartPoint) =>
+  userEvent.pointer([
+    { target, coords },
+    { keys: "[MouseLeft]", target, coords },
+  ]);
 
 const meta: Meta<typeof MetricTimeseriesView> = {
   title: "Widgets/MetricViews/MetricTimeseriesView",
@@ -152,6 +243,107 @@ export const TestChartPresentation: Story = {
     await waitFor(() =>
       expect(canvasElement.querySelector("svg.recharts-surface")).toBeTruthy()
     );
+  },
+};
+
+/**
+ * The click target is the whole column, not the drawn stack: a point above the
+ * segments drills the bucket unnarrowed, a segment drills its own series, and
+ * the tooltip marks which of the two a click would take.
+ */
+export const TestColumnClickDrilldown: Story = {
+  tags: ["test"],
+  args: { id: "column-click", groupBy: TOP_REPOSITORIES },
+  decorators: [captureDrilldowns],
+  play: async ({ canvas, canvasElement }) => {
+    await canvas.findByText("org/repo-a");
+    await waitFor(() =>
+      expect(barSegments(canvasElement).length).toBeGreaterThan(2)
+    );
+
+    const wrapper = canvasElement.querySelector<HTMLElement>(
+      ".recharts-wrapper"
+    )!;
+    // Every hover re-renders the chart and recharts rebuilds its rectangles, so
+    // a segment held across one gesture is a detached node by the next.
+    // The series render in rank order, making the first segment org/repo-a's.
+    const segment = () => barSegments(canvasElement)[0]!;
+
+    // Over a segment the panel marks the one row a click would open, and the
+    // click opens exactly that row's series.
+    await pointAt(segment(), centreOf(segment()));
+    await waitFor(() =>
+      expect(canvasElement.querySelector("[data-active]")).toHaveTextContent(
+        "org/repo-a"
+      )
+    );
+
+    await clickAt(segment(), centreOf(segment()));
+    await waitFor(() => expect(drilled).toHaveLength(1));
+    await expect(drilled[0]).toMatchObject({
+      metric_key: COMMITS,
+      period: { from: "2026-04-20", to: "2026-04-26" },
+      filters: [{ dimension: "repository", values: ["org/repo-a"] }],
+    });
+
+    // 2026-04-27 carries one commit against a six-commit peak, so the top of
+    // its band is the empty space this issue is about. Nothing is marked there,
+    // because the click opens every row instead of one.
+    const spot = emptySpotInBucket(canvasElement, 1);
+    await moveBetween(
+      { target: segment(), coords: centreOf(segment()) },
+      { target: wrapper, coords: spot }
+    );
+    await waitFor(() =>
+      expect(canvasElement.querySelector("[data-active]")).toBeNull()
+    );
+    // The panel still reads that week there, so the empty space is inside the
+    // band rather than outside the chart's reach.
+    await expect(canvas.getByText("April 27, 2026")).toBeInTheDocument();
+
+    await clickAt(wrapper, spot);
+    await waitFor(() => expect(drilled).toHaveLength(2));
+    await expect(drilled[1]).toMatchObject({
+      metric_key: COMMITS,
+      period: { from: "2026-04-27", to: "2026-05-03" },
+      filters: [],
+    });
+  },
+};
+
+/**
+ * The ungrouped line view drills the bucket its band covers. The click never
+ * has to land on the curve, which is two pixels wide.
+ */
+export const TestLineClickDrilldown: Story = {
+  tags: ["test"],
+  args: { id: "line-click", chart: { multiMetric: "combined" } },
+  decorators: [captureDrilldowns],
+  play: async ({ canvas, canvasElement }) => {
+    await canvas.findByText("Commits & Lines added");
+    await waitFor(() =>
+      expect(canvasElement.querySelector(".recharts-line-curve")).toBeTruthy()
+    );
+
+    const wrapper = canvasElement.querySelector<HTMLElement>(
+      ".recharts-wrapper"
+    )!;
+    // The panel has to read the bucket before the click can open it, which is
+    // the order a pointer arrives in anyway.
+    const spot = emptySpotInBucket(canvasElement, 1);
+    await pointAt(wrapper, spot);
+    await waitFor(() =>
+      expect(canvas.getByText("April 27, 2026")).toBeInTheDocument()
+    );
+
+    await clickAt(wrapper, spot);
+
+    await waitFor(() => expect(drilled).toHaveLength(1));
+    await expect(drilled[0]).toMatchObject({
+      metric_key: COMMITS,
+      period: { from: "2026-04-27", to: "2026-05-03" },
+      filters: [],
+    });
   },
 };
 

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.test.tsx
@@ -35,7 +35,7 @@ vi.mock("@/components/widgets/metric-views/metric-timeseries-chart", () => ({
   }: {
     onEvidence?: (
       metricKey: string,
-      columnKey: string,
+      columnKey: string | null,
       bucketStart: string | null
     ) => void;
   }) => (
@@ -48,6 +48,12 @@ vi.mock("@/components/widgets/metric-views/metric-timeseries-chart", () => ({
         }
       >
         drill point
+      </button>
+      <button
+        type="button"
+        onClick={() => onEvidence?.("git.commits", null, "2026-04-20")}
+      >
+        drill bucket
       </button>
     </div>
   ),
@@ -549,8 +555,7 @@ describe("MetricTimeseriesView", () => {
     );
   });
 
-  it("opens a grouped point with its exact period and dimensions", async () => {
-    const user = userEvent.setup();
+  function renderDrillableGroupedChart(id: string): ReturnType<typeof vi.fn> {
     const byKey = timeseriesByKey();
     const metric = byKey.get("git.commits");
     if (!metric) throw new Error("missing fixture metric");
@@ -563,6 +568,7 @@ describe("MetricTimeseriesView", () => {
     };
     mocks.collection.mockReturnValue({ ...ready, byKey });
     mocks.evidenceColumn = groupedTimeseriesModel().columns[0]?.key ?? "";
+
     const openEvidenceTargets = vi.fn();
     render(
       <EvidenceDialogContext.Provider
@@ -573,7 +579,7 @@ describe("MetricTimeseriesView", () => {
       }}
       >
         <MetricTimeseriesView
-          id="point-evidence"
+          id={id}
           entityId={ENTITY_ID}
           range={RANGE}
           metricKeys={["git.commits"]}
@@ -581,6 +587,12 @@ describe("MetricTimeseriesView", () => {
         />
       </EvidenceDialogContext.Provider>
     );
+    return openEvidenceTargets;
+  }
+
+  it("opens a grouped point with its exact period and dimensions", async () => {
+    const user = userEvent.setup();
+    const openEvidenceTargets = renderDrillableGroupedChart("point-evidence");
 
     await user.click(screen.getByRole("button", { name: "drill point" }));
     expect(openEvidenceTargets).toHaveBeenCalledWith(
@@ -595,6 +607,27 @@ describe("MetricTimeseriesView", () => {
                 values: ["org/repo-a"],
               },
             ],
+            display_dimensions: ["repository"],
+          }),
+          label: "Commits",
+        },
+      ],
+      { activeMetricKey: "git.commits" }
+    );
+  });
+
+  it("opens a whole bucket with no dimension narrowing", async () => {
+    const user = userEvent.setup();
+    const openEvidenceTargets = renderDrillableGroupedChart("bucket-evidence");
+
+    await user.click(screen.getByRole("button", { name: "drill bucket" }));
+    expect(openEvidenceTargets).toHaveBeenCalledWith(
+      [
+        {
+          selection: expect.objectContaining({
+            metric_key: "git.commits",
+            period: { from: "2026-04-20", to: "2026-04-26" },
+            filters: [],
             display_dimensions: ["repository"],
           }),
           label: "Commits",

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.test.tsx
@@ -6,7 +6,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { EvidenceDialogContext } from "@/components/metric-evidence-context";
+import {
+  EvidenceDialogContext,
+  type EvidenceDialogTarget,
+} from "@/components/metric-evidence-context";
 import { MetricTimeseriesView } from "@/components/widgets/metric-views/metric-timeseries-view";
 import {
   ENTITY_ID,
@@ -589,6 +592,54 @@ describe("MetricTimeseriesView", () => {
     );
     return openEvidenceTargets;
   }
+
+  it("holds every combined target to the clicked bucket", async () => {
+    const user = userEvent.setup();
+    const byKey = timeseriesByKey();
+    for (const metric of byKey.values()) {
+      metric.drilldown = { granularity: ["event"] };
+      metric.selection = {
+        metric_key: metric.metric_key,
+        entity: { type: "person", ids: [ENTITY_ID] },
+        period: RANGE,
+        filters: [],
+      };
+    }
+    mocks.collection.mockReturnValue({ ...ready, byKey });
+    const openEvidenceTargets = vi.fn();
+    render(
+      <EvidenceDialogContext.Provider
+        value={{
+        openEvidence: vi.fn(),
+        openEvidenceTargets,
+        openEvidencePeople: vi.fn(),
+      }}
+      >
+        <MetricTimeseriesView
+          id="combined-bucket"
+          entityId={ENTITY_ID}
+          range={RANGE}
+          metricKeys={["git.commits", "git.lines_added"]}
+          chart={{ multiMetric: "combined" }}
+        />
+      </EvidenceDialogContext.Provider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "drill bucket" }));
+    const [targets, options] = openEvidenceTargets.mock.calls.at(-1) ?? [];
+    expect(
+      targets.map((target: EvidenceDialogTarget) => target.selection.metric_key)
+    ).toEqual(["git.commits", "git.lines_added"]);
+    // Picking the other metric in the dialog must not widen the period back
+    // out to the widget's own range.
+    for (const target of targets as EvidenceDialogTarget[]) {
+      expect(target.selection.period).toEqual({
+        from: "2026-04-20",
+        to: "2026-04-26",
+      });
+    }
+    expect(options).toEqual({ activeMetricKey: "git.commits" });
+  });
 
   it("opens a grouped point with its exact period and dimensions", async () => {
     const user = userEvent.setup();

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.tsx
@@ -358,21 +358,29 @@ export function MetricTimeseriesView({
       : selectedMetric
         ? [selectedMetric]
         : [];
-  const evidenceTargets = evidenceMetrics.flatMap<EvidenceDialogTarget>(
-    (metric) => {
+  /**
+   * Every metric the dialog can offer, over one period. Switching metric in the
+   * dialog must not switch period with it, so the caller's period reaches all
+   * of them rather than only the one that was opened.
+   */
+  const evidenceTargetsOver = (
+    period: DateRange,
+    exactFilters: typeof filters
+  ): EvidenceDialogTarget[] =>
+    evidenceMetrics.flatMap<EvidenceDialogTarget>((metric) => {
       if (!metric.drilldown) return [];
       const selection = evidenceSelection(
         metric.selection,
         entityId,
-        range,
-        filters,
+        period,
+        exactFilters,
         metric.computation !== "ratio" && selectedGroupBy
           ? [selectedGroupBy]
           : []
       );
       return selection ? [{ selection, label: metric.label }] : [];
-    }
-  );
+    });
+  const evidenceTargets = evidenceTargetsOver(range, filters);
   const filterModels = dimensionOptions
     .filter((dimension) => dimension !== selectedGroupBy)
     .map((dimension) => {
@@ -467,18 +475,22 @@ export function MetricTimeseriesView({
           : range.to,
       };
     }
+    const narrowed = [...exactFilters.values()].sort((left, right) =>
+      left.dimension.localeCompare(right.dimension)
+    );
     const selection = evidenceSelection(
       metric.selection,
       entityId,
       period,
-      [...exactFilters.values()].sort((left, right) =>
-        left.dimension.localeCompare(right.dimension)
-      ),
+      narrowed,
       metric.computation !== "ratio" && selectedGroupBy ? [selectedGroupBy] : []
     );
     if (selection) {
       evidenceContext?.openEvidenceTargets(
-        withOwnTarget(evidenceTargets, { selection, label: metric.label }),
+        withOwnTarget(evidenceTargetsOver(period, narrowed), {
+          selection,
+          label: metric.label,
+        }),
         { activeMetricKey: selection.metric_key }
       );
     }

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.tsx
@@ -432,20 +432,21 @@ export function MetricTimeseriesView({
 
   function openTimeseriesEvidence(
     metricKey: string,
-    columnKey: string,
+    columnKey: string | null,
     bucketStart: string | null
   ): void {
     const metric = model.metrics.find(
       (candidate) => candidate.metric_key === metricKey
     );
+    if (!metric?.drilldown) return;
     const column = model.columns.find(
       (candidate) => candidate.key === columnKey
     );
-    if (!metric?.drilldown || !column || column.remainder) return;
+    if (columnKey !== null && (!column || column.remainder)) return;
     const exactFilters = new Map(
       filters.map((filter) => [filter.dimension, filter])
     );
-    for (const dimension of column.dimensions ?? []) {
+    for (const dimension of column?.dimensions ?? []) {
       exactFilters.set(dimension.key, {
         dimension: dimension.key,
         values: [dimension.value],

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries.story-fixtures.ts
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries.story-fixtures.ts
@@ -258,6 +258,13 @@ export function buildStoryMetricResults(
         format: "integer",
         direction: "higher_is_better",
         computation: "sum",
+        drilldown: { granularity: ["event"] },
+        selection: {
+          metric_key: key,
+          entity: { type: "person", ids: [ENTITY_ID] },
+          period: RANGE,
+          filters: metricRequest.filters ?? [],
+        },
         views: resultViews(key, metricRequest),
       },
     ];


### PR DESCRIPTION
Closes #2797.

**Why.** A click registered only where a segment was drawn, leaving most of a column inert and a bucket with a small value a target a few pixels tall.

**What changed.** A segment keeps its own click and still narrows to its series; the chart now answers the rest of the column too, resolving the bucket from the pointer's x across the full plot height. The ungrouped line view gains the same target, where the click used to need the two-pixel curve.

**The two handlers are told apart by where the event landed,** not by which of them runs first: a click inside a drawn segment is left to that segment. The remainder series, which no filter selects, opens the bucket whole.

**Every metric the dialog offers is scoped to the clicked bucket,** so picking a different one there no longer widens the period back to the widget's range. A combined chart is where a reader meets that.

![Panel open above the stack, reading the whole week](https://raw.githubusercontent.com/constructorfabric/insight/pr-2926-assets/empty-space.png)

From the storybook fixture: the pointer sits above the stack, and the panel reads the week the click would open.

**Out of scope.** Marking the plot as clickable — the cursor is untouched by request.

**Verified.** Chromium storybook journeys for the bar, line and combined charts, each asserting one drilldown per click; 2275 unit tests, typecheck and lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drilldown support for chart segments and entire time buckets.
  * Clicking empty areas or remainder segments now opens bucket-level evidence.
  * Evidence views retain the originating time range and filters across metrics.

* **Bug Fixes**
  * Improved validation for invalid or unavailable column selections.

* **Tests**
  * Added coverage for grouped-bar, combined-line, and empty-bucket drilldowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->