### PR TITLE
perf(analytics): serve a comparison window on the same metric-results request

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -62,6 +62,17 @@
       },
       "BreakdownValueDto": {
         "properties": {
+          "compare_to": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BreakdownWindowValueDto",
+                "description": "This group's reading over `compare_to`; absent when no comparison window\nwas asked for."
+              }
+            ]
+          },
           "dimensions": {
             "items": {
               "$ref": "#/components/schemas/MetricDimensionDto"
@@ -84,13 +95,6 @@
               "number",
               "null"
             ]
-          },
-          "windows": {
-            "description": "One entry per requested extra window, in request order; empty when the\nrequest asked for none.",
-            "items": {
-              "$ref": "#/components/schemas/BreakdownWindowValueDto"
-            },
-            "type": "array"
           }
         },
         "required": [
@@ -100,7 +104,7 @@
         "type": "object"
       },
       "BreakdownWindowValueDto": {
-        "description": "One group's reading over one extra window.\n\n`value` and `present` are independent: a ratio over a group that IS in the\nwindow reads NULL whenever its denominator is zero, so absence cannot be\ninferred from the value. A reader that wants what a standalone request over\nthis window would have returned keeps the rows with `present` and renders\ntheir `value` as it stands, NULL included.",
+        "description": "One group's reading over the comparison window.\n\n`value` and `present` are independent: a ratio over a group that IS in the\nwindow reads NULL whenever its denominator is zero, so absence cannot be\ninferred from the value. A reader that wants what a standalone request over\nthat window would have returned keeps the rows with `present` and renders\ntheir `value` as it stands, NULL included.",
         "properties": {
           "present": {
             "type": "boolean"
@@ -1781,6 +1785,17 @@
       },
       "MetricResultsRequest": {
         "properties": {
+          "compare_to": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MetricResultsPeriod",
+                "description": "A second window answered alongside `period` in the same response — the\nrange a delta or a half-against-half comparison is measured against.\nCarried by the `period` and `breakdown` views only; every other view\nkind answers over `period` alone."
+              }
+            ]
+          },
           "entity": {
             "$ref": "#/components/schemas/MetricResultsEntity"
           },
@@ -1792,13 +1807,6 @@
           },
           "period": {
             "$ref": "#/components/schemas/MetricResultsPeriod"
-          },
-          "windows": {
-            "description": "Extra windows served alongside `period` in the same response, in request\norder. Carried by the `period` and `breakdown` views only; every other\nview kind answers over `period` alone.",
-            "items": {
-              "$ref": "#/components/schemas/MetricResultsPeriod"
-            },
-            "type": "array"
           }
         },
         "required": [
@@ -2132,6 +2140,14 @@
       },
       "PeriodValueDto": {
         "properties": {
+          "compare_to": {
+            "description": "The same reading over `compare_to`; absent when the request asked for no\ncomparison window, and null when it asked but the entity has no value\nthere.",
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "entity_id": {
             "type": "string"
           },
@@ -2141,17 +2157,6 @@
               "number",
               "null"
             ]
-          },
-          "windows": {
-            "description": "One entry per requested extra window, in request order; empty when the\nrequest asked for none, keeping the single-window wire form unchanged.",
-            "items": {
-              "format": "double",
-              "type": [
-                "number",
-                "null"
-              ]
-            },
-            "type": "array"
           }
         },
         "required": [

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -71,6 +71,13 @@
           "entity_id": {
             "type": "string"
           },
+          "present": {
+            "description": "Whether this group has any observation inside the primary period.\nPresent only on a windowed response, where the group set spans every\nwindow and a reader has to know which of them each group belongs to.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "value": {
             "format": "double",
             "type": [
@@ -81,11 +88,7 @@
           "windows": {
             "description": "One entry per requested extra window, in request order; empty when the\nrequest asked for none.",
             "items": {
-              "format": "double",
-              "type": [
-                "number",
-                "null"
-              ]
+              "$ref": "#/components/schemas/BreakdownWindowValueDto"
             },
             "type": "array"
           }
@@ -93,6 +96,25 @@
         "required": [
           "entity_id",
           "dimensions"
+        ],
+        "type": "object"
+      },
+      "BreakdownWindowValueDto": {
+        "description": "One group's reading over one extra window.\n\n`value` and `present` are independent: a ratio over a group that IS in the\nwindow reads NULL whenever its denominator is zero, so absence cannot be\ninferred from the value. A reader that wants what a standalone request over\nthis window would have returned keeps the rows with `present` and renders\ntheir `value` as it stands, NULL included.",
+        "properties": {
+          "present": {
+            "type": "boolean"
+          },
+          "value": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "present"
         ],
         "type": "object"
       },

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -2141,7 +2141,7 @@
       "PeriodValueDto": {
         "properties": {
           "compare_to": {
-            "description": "The same reading over `compare_to`; absent when the request asked for no\ncomparison window, and null when it asked but the entity has no value\nthere.",
+            "description": "The same reading over `compare_to`. Omitted both when no comparison\nwindow was asked for and when the entity has no value in it — the two\nare not distinguished on the wire, and a reader that asked knows which\ncase it is in.",
             "format": "double",
             "type": [
               "number",

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -77,6 +77,17 @@
               "number",
               "null"
             ]
+          },
+          "windows": {
+            "description": "One entry per requested extra window, in request order; empty when the\nrequest asked for none.",
+            "items": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "type": "array"
           }
         },
         "required": [
@@ -1759,6 +1770,13 @@
           },
           "period": {
             "$ref": "#/components/schemas/MetricResultsPeriod"
+          },
+          "windows": {
+            "description": "Extra windows served alongside `period` in the same response, in request\norder. Carried by the `period` and `breakdown` views only; every other\nview kind answers over `period` alone.",
+            "items": {
+              "$ref": "#/components/schemas/MetricResultsPeriod"
+            },
+            "type": "array"
           }
         },
         "required": [
@@ -2101,6 +2119,17 @@
               "number",
               "null"
             ]
+          },
+          "windows": {
+            "description": "One entry per requested extra window, in request order; empty when the\nrequest asked for none, keeping the single-window wire form unchanged.",
+            "items": {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "type": "array"
           }
         },
         "required": [

--- a/src/backend/services/analytics/src/api/metric_results.rs
+++ b/src/backend/services/analytics/src/api/metric_results.rs
@@ -232,9 +232,8 @@ async fn execute_planned(
         PlannedQuery::PeriodBatch { items, query } => {
             let comment = batch_log_comment("period", &items);
             let outcome = match fetch_rows::<PeriodWideRow>(state, query, &comment).await {
-                Ok(rows) => {
-                    demux_period_rows(&items, rows).map_err(|e| assembly_failure(&e, &comment))
-                }
+                Ok(rows) => demux_period_rows(&items, rows, req.windows.len())
+                    .map_err(|e| assembly_failure(&e, &comment)),
                 Err(failure) => Err(failure),
             };
             match outcome {

--- a/src/backend/services/analytics/src/api/metric_results.rs
+++ b/src/backend/services/analytics/src/api/metric_results.rs
@@ -232,7 +232,7 @@ async fn execute_planned(
         PlannedQuery::PeriodBatch { items, query } => {
             let comment = batch_log_comment("period", &items);
             let outcome = match fetch_rows::<PeriodWideRow>(state, query, &comment).await {
-                Ok(rows) => demux_period_rows(&items, rows, req.windows.len())
+                Ok(rows) => demux_period_rows(&items, rows, req.compare_to.is_some())
                     .map_err(|e| assembly_failure(&e, &comment)),
                 Err(failure) => Err(failure),
             };

--- a/src/backend/services/analytics/src/domain/metric_results/batch.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/batch.rs
@@ -427,19 +427,11 @@ pub(crate) fn period_alias(item_index: usize) -> String {
     format!("m{item_index}")
 }
 
-/// The alias carrying one item's value over an extra window. The primary
-/// window keeps the bare `period_alias`, so a single-window batch is unchanged.
-pub(crate) fn period_window_alias(item_index: usize, window_index: usize) -> String {
-    format!("m{item_index}_w{window_index}")
-}
-
-/// The alias of one item's value column, by column index: 0 is the primary
-/// window, and the rest follow the request's extra windows in order.
-pub(crate) fn period_column_alias(item_index: usize, column_index: usize) -> String {
-    match column_index.checked_sub(1) {
-        None => period_alias(item_index),
-        Some(window_index) => period_window_alias(item_index, window_index),
-    }
+/// The alias carrying one item's value over the comparison window. The primary
+/// period keeps the bare `period_alias`, so a request without a comparison
+/// window compiles unchanged.
+pub(crate) fn period_compare_alias(item_index: usize) -> String {
+    format!("m{item_index}_compare")
 }
 
 pub(crate) struct PeerAliases {
@@ -481,18 +473,19 @@ pub struct PeerWideRow {
 pub fn demux_period_rows(
     items: &[BatchItem],
     rows: Vec<PeriodWideRow>,
-    window_count: usize,
+    compared: bool,
 ) -> Result<Vec<Vec<PeriodQueryRow>>, CanonicalError> {
     let mut per_item: Vec<Vec<PeriodQueryRow>> = items.iter().map(|_| Vec::new()).collect();
     for row in rows {
         for (item_index, item_rows) in per_item.iter_mut().enumerate() {
             let value = wide_field(&row.extra, &period_alias(item_index))?;
-            let windows = (0..window_count)
-                .map(|window_index| {
-                    wide_field(&row.extra, &period_window_alias(item_index, window_index))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            let narrow = json!({ "entity_id": row.entity_id, "value": value, "windows": windows });
+            let compare_to = if compared {
+                Some(wide_field(&row.extra, &period_compare_alias(item_index))?)
+            } else {
+                None
+            };
+            let narrow =
+                json!({ "entity_id": row.entity_id, "value": value, "compare_to": compare_to });
             item_rows.push(decode_narrow_row(narrow)?);
         }
     }
@@ -600,7 +593,7 @@ mod tests {
             },
             from: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap_or_default(),
             to: NaiveDate::from_ymd_opt(2026, 1, 31).unwrap_or_default(),
-            windows: Vec::new(),
+            compare_to: None,
             metrics,
             enforce_tenant_scope: true,
         }
@@ -852,7 +845,7 @@ mod tests {
             .into_iter()
             .collect(),
         }];
-        let Ok(per_item) = demux_period_rows(&items(2), rows, 0) else {
+        let Ok(per_item) = demux_period_rows(&items(2), rows, false) else {
             panic!("expected demux to succeed");
         };
         assert_eq!(per_item[0][0].value, Some(1.5));
@@ -865,34 +858,33 @@ mod tests {
     }
 
     #[test]
-    fn demux_period_reads_one_window_column_per_requested_window() {
+    fn demux_period_reads_the_comparison_column() {
         let rows = vec![PeriodWideRow {
             entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
             extra: [
                 ("m0".to_owned(), json!(4.0)),
-                ("m0_w0".to_owned(), json!(2.0)),
-                ("m0_w1".to_owned(), json!(null)),
+                ("m0_compare".to_owned(), json!(2.0)),
             ]
             .into_iter()
             .collect(),
         }];
 
-        let Ok(per_item) = demux_period_rows(&items(1), rows, 2) else {
+        let Ok(per_item) = demux_period_rows(&items(1), rows, true) else {
             panic!("expected demux to succeed");
         };
 
         assert_eq!(per_item[0][0].value, Some(4.0));
-        assert_eq!(per_item[0][0].windows, vec![Some(2.0), None]);
+        assert_eq!(per_item[0][0].compare_to, Some(2.0));
     }
 
     #[test]
-    fn demux_period_fails_when_a_window_column_is_absent() {
+    fn demux_period_fails_when_the_comparison_column_is_absent() {
         let rows = vec![PeriodWideRow {
             entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
             extra: [("m0".to_owned(), json!(4.0))].into_iter().collect(),
         }];
 
-        assert!(demux_period_rows(&items(1), rows, 1).is_err());
+        assert!(demux_period_rows(&items(1), rows, true).is_err());
     }
 
     #[test]
@@ -928,7 +920,7 @@ mod tests {
             entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
             extra: HashMap::new(),
         }];
-        assert!(demux_period_rows(&items(1), period_rows, 0).is_err());
+        assert!(demux_period_rows(&items(1), period_rows, false).is_err());
 
         let peer_rows = vec![PeerWideRow {
             entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),

--- a/src/backend/services/analytics/src/domain/metric_results/batch.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/batch.rs
@@ -427,6 +427,21 @@ pub(crate) fn period_alias(item_index: usize) -> String {
     format!("m{item_index}")
 }
 
+/// The alias carrying one item's value over an extra window. The primary
+/// window keeps the bare `period_alias`, so a single-window batch is unchanged.
+pub(crate) fn period_window_alias(item_index: usize, window_index: usize) -> String {
+    format!("m{item_index}_w{window_index}")
+}
+
+/// The alias of one item's value column, by column index: 0 is the primary
+/// window, and the rest follow the request's extra windows in order.
+pub(crate) fn period_column_alias(item_index: usize, column_index: usize) -> String {
+    match column_index.checked_sub(1) {
+        None => period_alias(item_index),
+        Some(window_index) => period_window_alias(item_index, window_index),
+    }
+}
+
 pub(crate) struct PeerAliases {
     pub target: String,
     pub p25: String,
@@ -466,12 +481,18 @@ pub struct PeerWideRow {
 pub fn demux_period_rows(
     items: &[BatchItem],
     rows: Vec<PeriodWideRow>,
+    window_count: usize,
 ) -> Result<Vec<Vec<PeriodQueryRow>>, CanonicalError> {
     let mut per_item: Vec<Vec<PeriodQueryRow>> = items.iter().map(|_| Vec::new()).collect();
     for row in rows {
         for (item_index, item_rows) in per_item.iter_mut().enumerate() {
             let value = wide_field(&row.extra, &period_alias(item_index))?;
-            let narrow = json!({ "entity_id": row.entity_id, "value": value });
+            let windows = (0..window_count)
+                .map(|window_index| {
+                    wide_field(&row.extra, &period_window_alias(item_index, window_index))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let narrow = json!({ "entity_id": row.entity_id, "value": value, "windows": windows });
             item_rows.push(decode_narrow_row(narrow)?);
         }
     }
@@ -579,6 +600,7 @@ mod tests {
             },
             from: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap_or_default(),
             to: NaiveDate::from_ymd_opt(2026, 1, 31).unwrap_or_default(),
+            windows: Vec::new(),
             metrics,
             enforce_tenant_scope: true,
         }
@@ -830,7 +852,7 @@ mod tests {
             .into_iter()
             .collect(),
         }];
-        let Ok(per_item) = demux_period_rows(&items(2), rows) else {
+        let Ok(per_item) = demux_period_rows(&items(2), rows, 0) else {
             panic!("expected demux to succeed");
         };
         assert_eq!(per_item[0][0].value, Some(1.5));
@@ -840,6 +862,37 @@ mod tests {
                 .iter()
                 .all(|rows| rows[0].entity_id == "00000000-0000-0000-0000-00000000000a")
         );
+    }
+
+    #[test]
+    fn demux_period_reads_one_window_column_per_requested_window() {
+        let rows = vec![PeriodWideRow {
+            entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
+            extra: [
+                ("m0".to_owned(), json!(4.0)),
+                ("m0_w0".to_owned(), json!(2.0)),
+                ("m0_w1".to_owned(), json!(null)),
+            ]
+            .into_iter()
+            .collect(),
+        }];
+
+        let Ok(per_item) = demux_period_rows(&items(1), rows, 2) else {
+            panic!("expected demux to succeed");
+        };
+
+        assert_eq!(per_item[0][0].value, Some(4.0));
+        assert_eq!(per_item[0][0].windows, vec![Some(2.0), None]);
+    }
+
+    #[test]
+    fn demux_period_fails_when_a_window_column_is_absent() {
+        let rows = vec![PeriodWideRow {
+            entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
+            extra: [("m0".to_owned(), json!(4.0))].into_iter().collect(),
+        }];
+
+        assert!(demux_period_rows(&items(1), rows, 1).is_err());
     }
 
     #[test]
@@ -875,7 +928,7 @@ mod tests {
             entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
             extra: HashMap::new(),
         }];
-        assert!(demux_period_rows(&items(1), period_rows).is_err());
+        assert!(demux_period_rows(&items(1), period_rows, 0).is_err());
 
         let peer_rows = vec![PeerWideRow {
             entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),

--- a/src/backend/services/analytics/src/domain/metric_results/builder.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/builder.rs
@@ -9,12 +9,12 @@ use super::batch::{RankedDimension, RankedGroup};
 use super::compiler::{
     BreakdownQueryRow, HistogramQueryRow, PeerQueryRow, PeriodQueryRow, PooledHistogramQueryRow,
     RankingQueryRow, RollupQueryRow, TimeseriesQueryRow, UNKNOWN_DIMENSION_LABEL,
-    UNKNOWN_DIMENSION_VALUE, breakdown_window_alias, dimension_aliases,
+    UNKNOWN_DIMENSION_VALUE, breakdown_presence_alias, breakdown_window_alias, dimension_aliases,
 };
 use super::dto::{
-    BreakdownValueDto, ComputationDto, HistogramBinDto, HistogramValueDto, MetricDimensionDto,
-    MetricResultDto, MetricResultViewDto, PeerValueDto, PeriodValueDto, RollupValueDto,
-    TimeseriesDto, TimeseriesPointDto,
+    BreakdownValueDto, BreakdownWindowValueDto, ComputationDto, HistogramBinDto, HistogramValueDto,
+    MetricDimensionDto, MetricResultDto, MetricResultViewDto, PeerValueDto, PeriodValueDto,
+    RollupValueDto, TimeseriesDto, TimeseriesPointDto,
 };
 use super::validation::{
     HISTOGRAM_BINS, ValidatedMetricResultsRequest, enumerate_buckets, metric_result_too_large,
@@ -230,13 +230,20 @@ pub fn build_breakdown_view(
                     repository.label.as_deref(),
                 );
             }
+            let windowed = !req.windows.is_empty();
             let windows = (0..req.windows.len())
-                .map(|window_index| window_value(&row.extra, window_index))
+                .map(|window_index| {
+                    Ok(BreakdownWindowValueDto {
+                        value: window_value(&row.extra, window_index)?,
+                        present: presence_flag(&row.extra, window_index + 1)?,
+                    })
+                })
                 .collect::<Result<Vec<_>, CanonicalError>>()?;
             Ok(BreakdownValueDto {
                 entity_id: req.entity.canonicalize_entity_id(row.entity_id),
                 dimensions,
                 value: row.value,
+                present: windowed.then(|| presence_flag(&row.extra, 0)).transpose()?,
                 windows,
             })
         })
@@ -491,6 +498,26 @@ fn window_value(
         tracing::error!(alias = %alias, "breakdown window value is not a number");
         CanonicalError::internal("metric result shape mismatch").create()
     })
+}
+
+/// One column's presence flag off a breakdown row. `countIf(...) > 0` arrives
+/// as 0/1, which is what the wire's boolean is built from.
+fn presence_flag(
+    extra: &HashMap<String, serde_json::Value>,
+    column_index: usize,
+) -> Result<bool, CanonicalError> {
+    let alias = breakdown_presence_alias(column_index);
+    let raw = extra.get(&alias).ok_or_else(|| {
+        tracing::error!(alias = %alias, "breakdown row missing presence alias");
+        CanonicalError::internal("metric result shape mismatch").create()
+    })?;
+    match raw.as_u64() {
+        Some(flag) => Ok(flag != 0),
+        None => {
+            tracing::error!(alias = %alias, "breakdown presence flag is not a number");
+            Err(CanonicalError::internal("metric result shape mismatch").create())
+        }
+    }
 }
 
 fn row_dimensions(

--- a/src/backend/services/analytics/src/domain/metric_results/builder.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/builder.rs
@@ -7,9 +7,9 @@ use crate::domain::metric_definitions::{ComputationSpec, MetricDefinition};
 
 use super::batch::{RankedDimension, RankedGroup};
 use super::compiler::{
-    BreakdownQueryRow, HistogramQueryRow, PeerQueryRow, PeriodQueryRow, PooledHistogramQueryRow,
-    RankingQueryRow, RollupQueryRow, TimeseriesQueryRow, UNKNOWN_DIMENSION_LABEL,
-    UNKNOWN_DIMENSION_VALUE, breakdown_presence_alias, breakdown_window_alias, dimension_aliases,
+    BreakdownQueryRow, HistogramQueryRow, PRESENT, PRESENT_COMPARE, PeerQueryRow, PeriodQueryRow,
+    PooledHistogramQueryRow, RankingQueryRow, RollupQueryRow, TimeseriesQueryRow,
+    UNKNOWN_DIMENSION_LABEL, UNKNOWN_DIMENSION_VALUE, VALUE_COMPARE, dimension_aliases,
 };
 use super::dto::{
     BreakdownValueDto, BreakdownWindowValueDto, ComputationDto, HistogramBinDto, HistogramValueDto,
@@ -51,12 +51,12 @@ pub fn build_period_view(
     req: &ValidatedMetricResultsRequest,
     rows: Vec<PeriodQueryRow>,
 ) -> MetricResultViewDto {
-    let values_by_entity: HashMap<String, (Option<f64>, Vec<Option<f64>>)> = rows
+    let values_by_entity: HashMap<String, (Option<f64>, Option<f64>)> = rows
         .into_iter()
         .map(|row| {
             (
                 req.entity.canonicalize_entity_id(row.entity_id),
-                (row.value, row.windows),
+                (row.value, row.compare_to),
             )
         })
         .collect();
@@ -69,16 +69,14 @@ pub fn build_period_view(
         .into_iter()
         .map(|entity_id| {
             let observed = values_by_entity.get(&entity_id);
-            // An entity the scan never saw still reports one slot per requested
-            // window, so the wire array's length always answers the request.
-            let windows = observed.map_or_else(
-                || vec![None; req.windows.len()],
-                |(_, windows)| windows.clone(),
-            );
             PeriodValueDto {
                 entity_id,
                 value: observed.and_then(|(value, _)| *value),
-                windows,
+                // An entity the scan never saw still reports the slot, so the
+                // wire always answers the request it was given.
+                compare_to: req
+                    .compare_to
+                    .and(observed.and_then(|(_, compare_to)| *compare_to)),
             }
         })
         .collect();
@@ -230,21 +228,23 @@ pub fn build_breakdown_view(
                     repository.label.as_deref(),
                 );
             }
-            let windowed = !req.windows.is_empty();
-            let windows = (0..req.windows.len())
-                .map(|window_index| {
-                    Ok(BreakdownWindowValueDto {
-                        value: window_value(&row.extra, window_index)?,
-                        present: presence_flag(&row.extra, window_index + 1)?,
+            let compared = req.compare_to.is_some();
+            let compare_to = compared
+                .then(|| {
+                    Ok::<_, CanonicalError>(BreakdownWindowValueDto {
+                        value: window_value(&row.extra)?,
+                        present: presence_flag(&row.extra, PRESENT_COMPARE)?,
                     })
                 })
-                .collect::<Result<Vec<_>, CanonicalError>>()?;
+                .transpose()?;
             Ok(BreakdownValueDto {
                 entity_id: req.entity.canonicalize_entity_id(row.entity_id),
                 dimensions,
                 value: row.value,
-                present: windowed.then(|| presence_flag(&row.extra, 0)).transpose()?,
-                windows,
+                present: compared
+                    .then(|| presence_flag(&row.extra, PRESENT))
+                    .transpose()?,
+                compare_to,
             })
         })
         .collect::<Result<Vec<_>, CanonicalError>>()?;
@@ -480,14 +480,11 @@ fn view_size(view: &MetricResultViewDto) -> usize {
     }
 }
 
-/// One extra window's value off a breakdown row. The aliases ride in `extra`
-/// like every other non-fixed column of that row shape.
-fn window_value(
-    extra: &HashMap<String, serde_json::Value>,
-    window_index: usize,
-) -> Result<Option<f64>, CanonicalError> {
-    let alias = breakdown_window_alias(window_index);
-    let raw = extra.get(&alias).ok_or_else(|| {
+/// The comparison window's value off a breakdown row. The alias rides in
+/// `extra` like every other non-fixed column of that row shape.
+fn window_value(extra: &HashMap<String, serde_json::Value>) -> Result<Option<f64>, CanonicalError> {
+    let alias = VALUE_COMPARE;
+    let raw = extra.get(alias).ok_or_else(|| {
         tracing::error!(alias = %alias, "breakdown row missing window alias");
         CanonicalError::internal("metric result shape mismatch").create()
     })?;
@@ -504,19 +501,17 @@ fn window_value(
 /// as 0/1, which is what the wire's boolean is built from.
 fn presence_flag(
     extra: &HashMap<String, serde_json::Value>,
-    column_index: usize,
+    alias: &str,
 ) -> Result<bool, CanonicalError> {
-    let alias = breakdown_presence_alias(column_index);
-    let raw = extra.get(&alias).ok_or_else(|| {
+    let raw = extra.get(alias).ok_or_else(|| {
         tracing::error!(alias = %alias, "breakdown row missing presence alias");
         CanonicalError::internal("metric result shape mismatch").create()
     })?;
-    match raw.as_u64() {
-        Some(flag) => Ok(flag != 0),
-        None => {
-            tracing::error!(alias = %alias, "breakdown presence flag is not a number");
-            Err(CanonicalError::internal("metric result shape mismatch").create())
-        }
+    if let Some(flag) = raw.as_u64() {
+        Ok(flag != 0)
+    } else {
+        tracing::error!(alias = %alias, "breakdown presence flag is not a number");
+        Err(CanonicalError::internal("metric result shape mismatch").create())
     }
 }
 
@@ -691,7 +686,7 @@ mod tests {
                 Ok(date) => date,
                 Err(error) => panic!("bad test date {to}: {error}"),
             },
-            windows: Vec::new(),
+            compare_to: None,
             metrics: Vec::new(),
             enforce_tenant_scope: true,
         }
@@ -710,7 +705,7 @@ mod tests {
         let rows = vec![PeriodQueryRow {
             entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
             value: Some(5.0),
-            windows: Vec::new(),
+            compare_to: None,
         }];
         let MetricResultViewDto::Period { values } = build_period_view(&sum_metric(), &req, rows)
         else {
@@ -723,7 +718,7 @@ mod tests {
     }
 
     #[test]
-    fn period_view_reports_a_window_slot_even_for_an_unobserved_entity() {
+    fn period_view_reports_the_comparison_slot_even_for_an_unobserved_entity() {
         let mut req = request(
             vec![
                 "00000000-0000-0000-0000-00000000000b",
@@ -732,14 +727,14 @@ mod tests {
             "2026-02-01",
             "2026-02-28",
         );
-        req.windows = vec![super::super::validation::DateWindow {
+        req.compare_to = Some(super::super::validation::DateWindow {
             from: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap_or_default(),
             to: NaiveDate::from_ymd_opt(2026, 1, 31).unwrap_or_default(),
-        }];
+        });
         let rows = vec![PeriodQueryRow {
             entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
             value: Some(5.0),
-            windows: vec![Some(3.0)],
+            compare_to: Some(3.0),
         }];
 
         let MetricResultViewDto::Period { values } = build_period_view(&sum_metric(), &req, rows)
@@ -747,8 +742,8 @@ mod tests {
             panic!("expected period view");
         };
 
-        assert_eq!(values[0].windows, vec![None]);
-        assert_eq!(values[1].windows, vec![Some(3.0)]);
+        assert_eq!(values[0].compare_to, None);
+        assert_eq!(values[1].compare_to, Some(3.0));
     }
 
     #[test]
@@ -759,7 +754,7 @@ mod tests {
         let rows = vec![PeriodQueryRow {
             entity_id: "default".to_owned(),
             value: Some(5.0),
-            windows: Vec::new(),
+            compare_to: None,
         }];
 
         let MetricResultViewDto::Period { values } = build_period_view(&sum_metric(), &req, rows)
@@ -1383,7 +1378,7 @@ mod tests {
             .map(|index| PeriodValueDto {
                 entity_id: Uuid::from_u128(index as u128 + 1).to_string(),
                 value: Some(1.0),
-                windows: Vec::new(),
+                compare_to: None,
             })
             .collect();
         let view = MetricResultViewDto::Period { values };

--- a/src/backend/services/analytics/src/domain/metric_results/builder.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/builder.rs
@@ -9,7 +9,7 @@ use super::batch::{RankedDimension, RankedGroup};
 use super::compiler::{
     BreakdownQueryRow, HistogramQueryRow, PeerQueryRow, PeriodQueryRow, PooledHistogramQueryRow,
     RankingQueryRow, RollupQueryRow, TimeseriesQueryRow, UNKNOWN_DIMENSION_LABEL,
-    UNKNOWN_DIMENSION_VALUE, dimension_aliases,
+    UNKNOWN_DIMENSION_VALUE, breakdown_window_alias, dimension_aliases,
 };
 use super::dto::{
     BreakdownValueDto, ComputationDto, HistogramBinDto, HistogramValueDto, MetricDimensionDto,
@@ -51,9 +51,14 @@ pub fn build_period_view(
     req: &ValidatedMetricResultsRequest,
     rows: Vec<PeriodQueryRow>,
 ) -> MetricResultViewDto {
-    let values_by_entity: HashMap<String, Option<f64>> = rows
+    let values_by_entity: HashMap<String, (Option<f64>, Vec<Option<f64>>)> = rows
         .into_iter()
-        .map(|row| (req.entity.canonicalize_entity_id(row.entity_id), row.value))
+        .map(|row| {
+            (
+                req.entity.canonicalize_entity_id(row.entity_id),
+                (row.value, row.windows),
+            )
+        })
         .collect();
     // `entity_id` IS the canonical contract on the wire and in the relations;
     // the selection renders the ids in that form, one rule for every view
@@ -63,8 +68,18 @@ pub fn build_period_view(
         .entity_ids()
         .into_iter()
         .map(|entity_id| {
-            let value = values_by_entity.get(&entity_id).copied().flatten();
-            PeriodValueDto { entity_id, value }
+            let observed = values_by_entity.get(&entity_id);
+            // An entity the scan never saw still reports one slot per requested
+            // window, so the wire array's length always answers the request.
+            let windows = observed.map_or_else(
+                || vec![None; req.windows.len()],
+                |(_, windows)| windows.clone(),
+            );
+            PeriodValueDto {
+                entity_id,
+                value: observed.and_then(|(value, _)| *value),
+                windows,
+            }
         })
         .collect();
     MetricResultViewDto::Period { values }
@@ -215,10 +230,14 @@ pub fn build_breakdown_view(
                     repository.label.as_deref(),
                 );
             }
+            let windows = (0..req.windows.len())
+                .map(|window_index| window_value(&row.extra, window_index))
+                .collect::<Result<Vec<_>, CanonicalError>>()?;
             Ok(BreakdownValueDto {
                 entity_id: req.entity.canonicalize_entity_id(row.entity_id),
                 dimensions,
                 value: row.value,
+                windows,
             })
         })
         .collect::<Result<Vec<_>, CanonicalError>>()?;
@@ -454,6 +473,26 @@ fn view_size(view: &MetricResultViewDto) -> usize {
     }
 }
 
+/// One extra window's value off a breakdown row. The aliases ride in `extra`
+/// like every other non-fixed column of that row shape.
+fn window_value(
+    extra: &HashMap<String, serde_json::Value>,
+    window_index: usize,
+) -> Result<Option<f64>, CanonicalError> {
+    let alias = breakdown_window_alias(window_index);
+    let raw = extra.get(&alias).ok_or_else(|| {
+        tracing::error!(alias = %alias, "breakdown row missing window alias");
+        CanonicalError::internal("metric result shape mismatch").create()
+    })?;
+    if raw.is_null() {
+        return Ok(None);
+    }
+    raw.as_f64().map(Some).ok_or_else(|| {
+        tracing::error!(alias = %alias, "breakdown window value is not a number");
+        CanonicalError::internal("metric result shape mismatch").create()
+    })
+}
+
 fn row_dimensions(
     extra: &HashMap<String, serde_json::Value>,
     dimensions: &[String],
@@ -625,6 +664,7 @@ mod tests {
                 Ok(date) => date,
                 Err(error) => panic!("bad test date {to}: {error}"),
             },
+            windows: Vec::new(),
             metrics: Vec::new(),
             enforce_tenant_scope: true,
         }
@@ -643,6 +683,7 @@ mod tests {
         let rows = vec![PeriodQueryRow {
             entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
             value: Some(5.0),
+            windows: Vec::new(),
         }];
         let MetricResultViewDto::Period { values } = build_period_view(&sum_metric(), &req, rows)
         else {
@@ -655,6 +696,35 @@ mod tests {
     }
 
     #[test]
+    fn period_view_reports_a_window_slot_even_for_an_unobserved_entity() {
+        let mut req = request(
+            vec![
+                "00000000-0000-0000-0000-00000000000b",
+                "00000000-0000-0000-0000-00000000000a",
+            ],
+            "2026-02-01",
+            "2026-02-28",
+        );
+        req.windows = vec![super::super::validation::DateWindow {
+            from: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap_or_default(),
+            to: NaiveDate::from_ymd_opt(2026, 1, 31).unwrap_or_default(),
+        }];
+        let rows = vec![PeriodQueryRow {
+            entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
+            value: Some(5.0),
+            windows: vec![Some(3.0)],
+        }];
+
+        let MetricResultViewDto::Period { values } = build_period_view(&sum_metric(), &req, rows)
+        else {
+            panic!("expected period view");
+        };
+
+        assert_eq!(values[0].windows, vec![None]);
+        assert_eq!(values[1].windows, vec![Some(3.0)]);
+    }
+
+    #[test]
     fn tenant_period_view_exposes_the_session_tenant_not_the_storage_key() {
         let tenant_id = Uuid::from_u128(0x1967);
         let mut req = request(Vec::new(), "2026-01-01", "2026-01-31");
@@ -662,6 +732,7 @@ mod tests {
         let rows = vec![PeriodQueryRow {
             entity_id: "default".to_owned(),
             value: Some(5.0),
+            windows: Vec::new(),
         }];
 
         let MetricResultViewDto::Period { values } = build_period_view(&sum_metric(), &req, rows)
@@ -1285,6 +1356,7 @@ mod tests {
             .map(|index| PeriodValueDto {
                 entity_id: Uuid::from_u128(index as u128 + 1).to_string(),
                 value: Some(1.0),
+                windows: Vec::new(),
             })
             .collect();
         let view = MetricResultViewDto::Period { values };

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -3,9 +3,11 @@ use std::fmt::Write;
 
 use serde::Deserialize;
 
-use super::batch::{PeerPopulation, ResolvedGroupLimit, peer_aliases, period_alias};
+use super::batch::{
+    PeerPopulation, ResolvedGroupLimit, peer_aliases, period_alias, period_column_alias,
+};
 use super::validation::{
-    HISTOGRAM_BINS, ValidatedDimensionFilter, ValidatedEntitySelection,
+    DateWindow, HISTOGRAM_BINS, ValidatedDimensionFilter, ValidatedEntitySelection,
     ValidatedMetricResultsRequest, query_row_limit,
 };
 use super::view::Bucket;
@@ -54,6 +56,10 @@ pub struct CompiledQuery {
 pub struct PeriodQueryRow {
     pub entity_id: String,
     pub value: Option<f64>,
+    /// One value per extra window, in request order; empty when none were
+    /// requested.
+    #[serde(default)]
+    pub windows: Vec<Option<f64>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -146,9 +152,22 @@ pub(crate) fn compile_period_batch_query(
     filters: &[ValidatedDimensionFilter],
 ) -> CompiledQuery {
     let mut params = Vec::new();
-    let selects = item_value_selects(defs, &mut params, period_alias);
+    // With extra windows the outer WHERE spans all of them, so every aggregate
+    // — the primary one included — carries its own window term. Without them
+    // the outer WHERE alone scopes the dates and the SQL is unchanged.
+    let columns = column_windows(req);
+    let mut selects = String::new();
+    for (column_index, window) in columns.iter().enumerate() {
+        selects.push_str(&item_value_selects(
+            defs,
+            &mut params,
+            |item_index| period_column_alias(item_index, column_index),
+            *window,
+        ));
+    }
     let read = batch_resolved_observation_from(defs, req, &mut params);
-    let metric_scope = shared_observation_where(defs, req, filters, &mut params);
+    let metric_scope =
+        shared_observation_where_within(defs, req, filters, &mut params, observation_bounds(req));
     let entity_scope = read.entity_scope(req, &mut params);
     let observation_table = &read.from;
     let limit = query_row_limit();
@@ -162,8 +181,64 @@ pub(crate) fn compile_period_batch_query(
         LIMIT {limit}
         "
     );
-    let sql = transformed_batch(defs, inner, period_alias);
+    let sql = transformed_batch(defs, inner, columns.len());
     CompiledQuery { sql, params }
+}
+
+/// The window each value column of a batched query answers, primary first and
+/// then the extra windows in request order. A request with no extra windows
+/// yields one `None` column, which is what keeps its compiled SQL identical to
+/// the pre-windows form.
+fn column_windows(req: &ValidatedMetricResultsRequest) -> Vec<Option<DateWindow>> {
+    if req.windows.is_empty() {
+        return vec![None];
+    }
+    let mut windows = Vec::with_capacity(req.windows.len() + 1);
+    windows.push(Some(DateWindow {
+        from: req.from,
+        to: req.to,
+    }));
+    windows.extend(req.windows.iter().copied().map(Some));
+    windows
+}
+
+/// Bind the scan range an identity-resolving read must cover.
+///
+/// INVARIANT: this is the union, not `req.from..req.to`. The resolved read
+/// pre-filters observations before the conditional aggregates run, so scoping
+/// it to the primary period alone would answer NULL for every extra window.
+fn push_observation_bounds(req: &ValidatedMetricResultsRequest, params: &mut Vec<String>) {
+    let bounds = observation_bounds(req);
+    params.push(bounds.from.to_string());
+    params.push(bounds.to.to_string());
+}
+
+/// The union of the primary period and every extra window — the range the
+/// observation scan has to cover for the conditional aggregates to see their
+/// rows.
+fn observation_bounds(req: &ValidatedMetricResultsRequest) -> DateWindow {
+    let mut bounds = DateWindow {
+        from: req.from,
+        to: req.to,
+    };
+    for window in &req.windows {
+        bounds.from = bounds.from.min(window.from);
+        bounds.to = bounds.to.max(window.to);
+    }
+    bounds
+}
+
+/// The SQL term scoping one conditional aggregate to a window, with its bounds
+/// pushed in textual order. Empty for the unwindowed form.
+fn window_term(window: Option<DateWindow>, params: &mut Vec<String>) -> String {
+    match window {
+        None => String::new(),
+        Some(window) => {
+            params.push(window.from.to_string());
+            params.push(window.to.to_string());
+            " AND metric_date >= toDate(?) AND metric_date <= toDate(?)".to_owned()
+        }
+    }
 }
 
 pub(crate) fn compile_timeseries_query(
@@ -430,9 +505,23 @@ pub(crate) fn compile_breakdown_query(
     dimensions: &[String],
     filters: &[ValidatedDimensionFilter],
 ) -> CompiledQuery {
-    let mut params = grouped_value_params(def);
+    let mut params = Vec::new();
+    let aliases = breakdown_aliases(req);
+    let mut value_selects = String::new();
+    for (alias, window) in &aliases {
+        let expr = grouped_value_expr_within(def, *window, &mut params);
+        let _ = write!(
+            value_selects,
+            ",
+            {expr} AS {alias}"
+        );
+    }
     let read = single_resolved_observation_from(def, req, &mut params);
-    params.extend(metric_where_params(def, req));
+    params.extend(metric_where_params_within(
+        def,
+        req,
+        observation_bounds(req),
+    ));
     let filter_where = dimension_filter_where(filters, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
     let observation_table = &read.from;
@@ -445,12 +534,10 @@ pub(crate) fn compile_breakdown_query(
     };
     let group = format!("{group}{source_group}");
     let limit = query_row_limit();
-    let value_expr = grouped_value_expr(def);
     let inner = format!(
         r"
         SELECT
-            entity_id{dim_select}{source_select},
-            {value_expr} AS value
+            entity_id{dim_select}{source_select}{value_selects}
         FROM {observation_table}
         WHERE {metric_where}
           {filter_where}{entity_scope}
@@ -460,8 +547,75 @@ pub(crate) fn compile_breakdown_query(
         ",
         metric_where = metric_where(def, req.enforce_tenant_scope),
     );
-    let sql = transformed_single(def, inner);
+    let sql = if req.windows.is_empty() {
+        transformed_single(def, inner)
+    } else {
+        projected_breakdown_windows(def, &inner, aliases.len())
+    };
     CompiledQuery { sql, params }
+}
+
+/// The value column per window a breakdown computes, innermost names first.
+///
+/// INVARIANT: a windowed breakdown must NOT alias any aggregate `value`. The
+/// aggregates read a column of that name, and a sibling's argument resolves to
+/// the alias instead of the column — which ClickHouse rejects outright as an
+/// aggregate inside an aggregate. The wire names are put back by
+/// `projected_breakdown_windows`.
+fn breakdown_aliases(req: &ValidatedMetricResultsRequest) -> Vec<(String, Option<DateWindow>)> {
+    if req.windows.is_empty() {
+        return vec![("value".to_owned(), None)];
+    }
+    let mut aliases = vec![(
+        staged_window_alias(0),
+        Some(DateWindow {
+            from: req.from,
+            to: req.to,
+        }),
+    )];
+    for (window_index, window) in req.windows.iter().enumerate() {
+        aliases.push((staged_window_alias(window_index + 1), Some(*window)));
+    }
+    aliases
+}
+
+fn staged_window_alias(column_index: usize) -> String {
+    format!("staged_w{column_index}")
+}
+
+pub(crate) fn breakdown_window_alias(window_index: usize) -> String {
+    format!("value_w{window_index}")
+}
+
+/// Rename the staged window columns to their wire names, applying the value
+/// transform on the way — the projection stage `transformed_single` performs
+/// for a single-window breakdown, over every window.
+fn projected_breakdown_windows(def: &MetricDefinition, inner: &str, column_count: usize) -> String {
+    let staged = (0..column_count)
+        .map(staged_window_alias)
+        .collect::<Vec<_>>();
+    let mut selects = String::new();
+    for (column_index, alias) in staged.iter().enumerate() {
+        let wire = if column_index == 0 {
+            "value".to_owned()
+        } else {
+            breakdown_window_alias(column_index - 1)
+        };
+        let expr = transformed(def, alias.clone());
+        let _ = write!(
+            selects,
+            ",
+            {expr} AS {wire}"
+        );
+    }
+    let excluded = staged.join(", ");
+    format!(
+        r"
+        SELECT
+            * EXCEPT ({excluded}){selects}
+        FROM ({inner})
+        "
+    )
 }
 
 pub(crate) fn compile_rollup_query(
@@ -630,6 +784,58 @@ fn grouped_value_expr(def: &MetricDefinition) -> String {
     }
 }
 
+/// `grouped_value_expr` scoped to one window, pushing its own placeholders in
+/// textual order — the SELECT-list arity now varies per request, so the ratio
+/// arm can no longer lean on `metric_params` leading with a fixed pair.
+/// `window: None` reproduces the unwindowed expression exactly.
+fn grouped_value_expr_within(
+    def: &MetricDefinition,
+    window: Option<DateWindow>,
+    params: &mut Vec<String>,
+) -> String {
+    match &def.spec {
+        ComputationSpec::Sum { .. } => {
+            let window = window_term(window, params);
+            format!("sumIf(value, value IS NOT NULL{window})")
+        }
+        ComputationSpec::Ratio {
+            numerator,
+            denominator,
+            scale,
+            denominator_aggregation,
+        } => {
+            params.push(numerator.measure_key.clone());
+            let numerator_window = window_term(window, params);
+            params.push(denominator.measure_key.clone());
+            let denominator_window = window_term(window, params);
+            let denominator = ratio_denominator_expr(
+                *denominator_aggregation,
+                &format!("measure_key = ? AND value IS NOT NULL{denominator_window}"),
+                &format!("measure_key = ? AND subject_key IS NOT NULL{denominator_window}"),
+            );
+            format!(
+                "{scale} * sumIfOrNull(value, measure_key = ? AND value IS NOT NULL{numerator_window}) / nullIf({denominator}, 0)"
+            )
+        }
+        ComputationSpec::Median { .. } => {
+            let window = window_term(window, params);
+            format!("quantileExactIf(0.5)(value, value IS NOT NULL{window})")
+        }
+        ComputationSpec::Percentile { q, .. } => {
+            let window = window_term(window, params);
+            format!("quantileExactIf({q})(value, value IS NOT NULL{window})")
+        }
+        ComputationSpec::Stddev { .. } => {
+            let window = window_term(window, params);
+            format!("stddevSampIf(value, value IS NOT NULL{window})")
+        }
+        ComputationSpec::DistinctCount { .. } => {
+            let window = window_term(window, params);
+            format!("toFloat64(uniqExactIf(subject_key, subject_key IS NOT NULL{window}))")
+        }
+    }
+}
+
 // Deterministic fixed-width binning over each entity's exact [min, max]:
 // pure arithmetic over exact aggregates, so identical data always yields
 // identical bins (the adaptive `histogram()` aggregate is merge-order
@@ -794,7 +1000,7 @@ fn compile_declared_cohort_peer_batch_query(
     push_cohort_scope(&mut params, req, cohort_key);
     params.extend(req.entity.entity_ids());
     push_cohort_scope(&mut params, req, cohort_key);
-    let value_selects = item_value_selects(defs, &mut params, period_alias);
+    let value_selects = item_value_selects(defs, &mut params, period_alias, None);
     let collapses = batch_alias_collapses(defs);
     let observation_table = resolved_observation_from(
         batch_observation_source(defs),
@@ -868,7 +1074,7 @@ fn compile_tenant_peer_batch_query(
     filters: &[ValidatedDimensionFilter],
 ) -> CompiledQuery {
     let mut params = req.entity.entity_ids();
-    let value_selects = item_value_selects(defs, &mut params, period_alias);
+    let value_selects = item_value_selects(defs, &mut params, period_alias, None);
     let collapses = batch_alias_collapses(defs);
     let observation_table = resolved_observation_from(
         batch_observation_source(defs),
@@ -1036,11 +1242,12 @@ fn push_peer_stat_selects(selects: &mut String, item_index: usize) {
 fn item_value_selects(
     defs: &[&MetricDefinition],
     params: &mut Vec<String>,
-    alias: fn(usize) -> String,
+    alias: impl Fn(usize) -> String,
+    window: Option<DateWindow>,
 ) -> String {
     let mut selects = String::new();
     for (item_index, def) in defs.iter().enumerate() {
-        let expr = item_value_expr(def, params);
+        let expr = item_value_expr(def, params, window);
         let _ = write!(
             selects,
             ",
@@ -1058,13 +1265,19 @@ fn item_value_selects(
 // macro guards HAVING countIf(value IS NOT NULL) > 0 — but a future custom
 // SQL source could produce one; OrNull excludes it from pools by
 // construction.)
-fn item_value_expr(def: &MetricDefinition, params: &mut Vec<String>) -> String {
+fn item_value_expr(
+    def: &MetricDefinition,
+    params: &mut Vec<String>,
+    window: Option<DateWindow>,
+) -> String {
     match &def.spec {
         ComputationSpec::Sum { value } => {
             params.push(value.source_key.clone());
             params.push(value.measure_key.clone());
-            "sumIfOrNull(value, source_key = ? AND measure_key = ? AND value IS NOT NULL)"
-                .to_owned()
+            let window = window_term(window, params);
+            format!(
+                "sumIfOrNull(value, source_key = ? AND measure_key = ? AND value IS NOT NULL{window})"
+            )
         }
         ComputationSpec::Ratio {
             numerator,
@@ -1081,15 +1294,21 @@ fn item_value_expr(def: &MetricDefinition, params: &mut Vec<String>) -> String {
             // 0 for no rows and nullIf already turns that into NULL.
             params.push(numerator.source_key.clone());
             params.push(numerator.measure_key.clone());
+            let numerator_window = window_term(window, params);
             params.push(numerator.source_key.clone());
             params.push(denominator.measure_key.clone());
+            let denominator_window = window_term(window, params);
             let denominator = ratio_denominator_expr(
                 *denominator_aggregation,
-                "source_key = ? AND measure_key = ? AND value IS NOT NULL",
-                "source_key = ? AND measure_key = ? AND subject_key IS NOT NULL",
+                &format!(
+                    "source_key = ? AND measure_key = ? AND value IS NOT NULL{denominator_window}"
+                ),
+                &format!(
+                    "source_key = ? AND measure_key = ? AND subject_key IS NOT NULL{denominator_window}"
+                ),
             );
             format!(
-                "{scale} * sumIfOrNull(value, source_key = ? AND measure_key = ? AND value IS NOT NULL) / nullIf({denominator}, 0)"
+                "{scale} * sumIfOrNull(value, source_key = ? AND measure_key = ? AND value IS NOT NULL{numerator_window}) / nullIf({denominator}, 0)"
             )
         }
         ComputationSpec::Median { value } => {
@@ -1098,16 +1317,19 @@ fn item_value_expr(def: &MetricDefinition, params: &mut Vec<String>) -> String {
             // builder never zero-fills medians (honest-null).
             params.push(value.source_key.clone());
             params.push(value.measure_key.clone());
-            "quantileExactIfOrNull(0.5)(value, source_key = ? AND measure_key = ? AND value IS NOT NULL)"
-                .to_owned()
+            let window = window_term(window, params);
+            format!(
+                "quantileExactIfOrNull(0.5)(value, source_key = ? AND measure_key = ? AND value IS NOT NULL{window})"
+            )
         }
         ComputationSpec::Percentile { value, q } => {
             // Honest-null like Median — same event-grain shape, different point
             // on the distribution.
             params.push(value.source_key.clone());
             params.push(value.measure_key.clone());
+            let window = window_term(window, params);
             format!(
-                "quantileExactIfOrNull({q})(value, source_key = ? AND measure_key = ? AND value IS NOT NULL)"
+                "quantileExactIfOrNull({q})(value, source_key = ? AND measure_key = ? AND value IS NOT NULL{window})"
             )
         }
         ComputationSpec::Stddev { value } => {
@@ -1115,8 +1337,10 @@ fn item_value_expr(def: &MetricDefinition, params: &mut Vec<String>) -> String {
             // reads NULL (no spread is measurable), never a fabricated 0.
             params.push(value.source_key.clone());
             params.push(value.measure_key.clone());
-            "stddevSampIfOrNull(value, source_key = ? AND measure_key = ? AND value IS NOT NULL)"
-                .to_owned()
+            let window = window_term(window, params);
+            format!(
+                "stddevSampIfOrNull(value, source_key = ? AND measure_key = ? AND value IS NOT NULL{window})"
+            )
         }
         ComputationSpec::DistinctCount { value } => {
             // OrNull like sum: an entity present via another measure but with
@@ -1126,11 +1350,13 @@ fn item_value_expr(def: &MetricDefinition, params: &mut Vec<String>) -> String {
             // as it does sums. Counts distinct `subject_key`, not `value`.
             params.push(value.source_key.clone());
             params.push(value.measure_key.clone());
+            let window = window_term(window, params);
             // toFloat64 so the wide column is Float64, not a JSON-quoted
             // UInt64 (uniqExact's native type) the f64 row decoder rejects.
             // OrNull is preserved through the cast (NULL stays NULL).
-            "toFloat64(uniqExactIfOrNull(subject_key, source_key = ? AND measure_key = ? AND subject_key IS NOT NULL))"
-                .to_owned()
+            format!(
+                "toFloat64(uniqExactIfOrNull(subject_key, source_key = ? AND measure_key = ? AND subject_key IS NOT NULL{window}))"
+            )
         }
     }
 }
@@ -1178,20 +1404,19 @@ fn transformed_single(def: &MetricDefinition, inner: String) -> String {
     )
 }
 
-// Batch variant: re-projects each transformed item column by alias.
-fn transformed_batch(
-    defs: &[&MetricDefinition],
-    inner: String,
-    alias: fn(usize) -> String,
-) -> String {
+// Batch variant: re-projects each transformed item column by alias, over every
+// window's column and not just the primary one.
+fn transformed_batch(defs: &[&MetricDefinition], inner: String, column_count: usize) -> String {
     if defs.iter().all(|def| def.transform.is_none()) {
         return inner;
     }
     let mut selects = String::new();
-    for (item_index, def) in defs.iter().enumerate() {
-        let value = alias(item_index);
-        let expr = transformed(def, value.clone());
-        let _ = write!(selects, ", {expr} AS {value}");
+    for column_index in 0..column_count {
+        for (item_index, def) in defs.iter().enumerate() {
+            let value = period_column_alias(item_index, column_index);
+            let expr = transformed(def, value.clone());
+            let _ = write!(selects, ", {expr} AS {value}");
+        }
     }
     format!(
         r"
@@ -1220,10 +1445,32 @@ fn shared_observation_where(
     filters: &[ValidatedDimensionFilter],
     params: &mut Vec<String>,
 ) -> String {
+    shared_observation_where_within(
+        defs,
+        req,
+        filters,
+        params,
+        DateWindow {
+            from: req.from,
+            to: req.to,
+        },
+    )
+}
+
+/// `shared_observation_where` over an explicit scan range: a windowed batch
+/// scans the union of its windows once and lets each conditional aggregate
+/// pick its own out of it.
+fn shared_observation_where_within(
+    defs: &[&MetricDefinition],
+    req: &ValidatedMetricResultsRequest,
+    filters: &[ValidatedDimensionFilter],
+    params: &mut Vec<String>,
+    bounds: DateWindow,
+) -> String {
     params.push(req.tenant_id.to_string());
     params.push(req.entity.entity_type().to_owned());
-    params.push(req.from.to_string());
-    params.push(req.to.to_string());
+    params.push(bounds.from.to_string());
+    params.push(bounds.to.to_string());
     let pairs = measure_pairs(defs);
     for (source_key, measure_key) in &pairs {
         params.push(source_key.clone());
@@ -1379,6 +1626,23 @@ fn grouped_value_params(def: &MetricDefinition) -> Vec<String> {
 }
 
 fn metric_where_params(def: &MetricDefinition, req: &ValidatedMetricResultsRequest) -> Vec<String> {
+    metric_where_params_within(
+        def,
+        req,
+        DateWindow {
+            from: req.from,
+            to: req.to,
+        },
+    )
+}
+
+/// `metric_where_params` over an explicit scan range, for a query whose value
+/// columns pick their own window out of a wider scan.
+fn metric_where_params_within(
+    def: &MetricDefinition,
+    req: &ValidatedMetricResultsRequest,
+    bounds: DateWindow,
+) -> Vec<String> {
     match &def.spec {
         ComputationSpec::Sum { value }
         | ComputationSpec::Median { value }
@@ -1388,8 +1652,8 @@ fn metric_where_params(def: &MetricDefinition, req: &ValidatedMetricResultsReque
             req.tenant_id.to_string(),
             value.source_key.clone(),
             req.entity.entity_type().to_owned(),
-            req.from.to_string(),
-            req.to.to_string(),
+            bounds.from.to_string(),
+            bounds.to.to_string(),
             value.measure_key.clone(),
         ],
         ComputationSpec::Ratio {
@@ -1400,8 +1664,8 @@ fn metric_where_params(def: &MetricDefinition, req: &ValidatedMetricResultsReque
             req.tenant_id.to_string(),
             numerator.source_key.clone(),
             req.entity.entity_type().to_owned(),
-            req.from.to_string(),
-            req.to.to_string(),
+            bounds.from.to_string(),
+            bounds.to.to_string(),
             numerator.measure_key.clone(),
             denominator.measure_key.clone(),
         ],
@@ -1571,8 +1835,7 @@ fn resolved_observation_from(
     let (inner_where, resolved_filter) = match scope {
         PersonScope::Requested(req) => {
             params.extend(req.entity.entity_ids());
-            params.push(req.from.to_string());
-            params.push(req.to.to_string());
+            push_observation_bounds(req, params);
             params.extend(req.entity.entity_ids());
             let person_params = placeholders(req.entity.len());
             (
@@ -1584,8 +1847,7 @@ fn resolved_observation_from(
             )
         }
         PersonScope::CohortMembers(req) => {
-            params.push(req.from.to_string());
-            params.push(req.to.to_string());
+            push_observation_bounds(req, params);
             (
                 format!(
                     "(obs.entity_id IN (SELECT email FROM {PERSON_MAP_RELATION} \
@@ -1596,8 +1858,7 @@ fn resolved_observation_from(
             )
         }
         PersonScope::TenantWide(req) => {
-            params.push(req.from.to_string());
-            params.push(req.to.to_string());
+            push_observation_bounds(req, params);
             (
                 "obs.metric_date >= toDate(?)\n          AND obs.metric_date <= toDate(?)"
                     .to_owned(),
@@ -1987,6 +2248,7 @@ mod tests {
             },
             from: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap_or_default(),
             to: NaiveDate::from_ymd_opt(2026, 1, 31).unwrap_or_default(),
+            windows: Vec::new(),
             metrics: Vec::new(),
             enforce_tenant_scope: true,
         }
@@ -2048,6 +2310,149 @@ mod tests {
                 "accepted_lines",
                 "ai_usage",
                 "tool_use_offered",
+            ]
+        );
+    }
+
+    fn windowed_request() -> ValidatedMetricResultsRequest {
+        let mut req = request();
+        req.windows = vec![DateWindow {
+            from: NaiveDate::from_ymd_opt(2025, 12, 1).unwrap_or_default(),
+            to: NaiveDate::from_ymd_opt(2025, 12, 31).unwrap_or_default(),
+        }];
+        req
+    }
+
+    #[test]
+    fn period_batch_over_windows_scans_their_union_and_scopes_every_column() {
+        let sum = sum_metric();
+        let query = compile_period_batch_query(&[&sum], &windowed_request(), &[]);
+
+        assert!(query.sql.contains("AS m0"));
+        assert!(query.sql.contains("AS m0_w0"));
+        assert_eq!(
+            query
+                .sql
+                .matches("AND metric_date >= toDate(?) AND metric_date <= toDate(?)")
+                .count(),
+            3,
+            "one term per value column plus the shared scan range"
+        );
+        assert_eq!(query.sql.matches('?').count(), query.params.len());
+        assert_eq!(
+            query.params,
+            vec![
+                // primary column, scoped to the period
+                "ai_usage",
+                "accepted_lines",
+                "2026-01-01",
+                "2026-01-31",
+                // extra window column
+                "ai_usage",
+                "accepted_lines",
+                "2025-12-01",
+                "2025-12-31",
+                // the identity-resolving read, scoped to the union: it filters
+                // observations BEFORE the aggregates, so the primary period
+                // alone would answer NULL for the extra window
+                "00000000-0000-0000-0000-00000000000a",
+                "00000000-0000-0000-0000-00000000000b",
+                "2025-12-01",
+                "2026-01-31",
+                "00000000-0000-0000-0000-00000000000a",
+                "00000000-0000-0000-0000-00000000000b",
+                // shared scope over the union of both windows
+                TEST_TENANT_STR,
+                "person",
+                "2025-12-01",
+                "2026-01-31",
+                "ai_usage",
+                "accepted_lines",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_ratio_over_windows_scopes_both_halves_of_the_fraction() {
+        let ratio = ratio_metric();
+        let query = compile_period_batch_query(&[&ratio], &windowed_request(), &[]);
+
+        assert_eq!(query.sql.matches('?').count(), query.params.len());
+        assert_eq!(
+            query.params,
+            vec![
+                "ai_usage",
+                "accepted_edit_actions",
+                "2026-01-01",
+                "2026-01-31",
+                "ai_usage",
+                "tool_use_offered",
+                "2026-01-01",
+                "2026-01-31",
+                "ai_usage",
+                "accepted_edit_actions",
+                "2025-12-01",
+                "2025-12-31",
+                "ai_usage",
+                "tool_use_offered",
+                "2025-12-01",
+                "2025-12-31",
+                "00000000-0000-0000-0000-00000000000a",
+                "00000000-0000-0000-0000-00000000000b",
+                "2025-12-01",
+                "2026-01-31",
+                "00000000-0000-0000-0000-00000000000a",
+                "00000000-0000-0000-0000-00000000000b",
+                TEST_TENANT_STR,
+                "person",
+                "2025-12-01",
+                "2026-01-31",
+                "ai_usage",
+                "accepted_edit_actions",
+                "ai_usage",
+                "tool_use_offered",
+            ]
+        );
+    }
+
+    #[test]
+    fn breakdown_over_windows_emits_one_value_column_per_window() {
+        let sum = sum_metric();
+        let query = compile_breakdown_query(
+            &sum,
+            &windowed_request(),
+            std::slice::from_ref(&"tool".to_owned()),
+            &[],
+        );
+
+        assert!(query.sql.contains("AS value"));
+        assert!(query.sql.contains("AS value_w0"));
+        // The aggregates stage under names that cannot collide with the
+        // observation's own `value` column — see `breakdown_aliases`.
+        assert!(query.sql.contains("AS staged_w0"));
+        assert!(!query.sql.contains(
+            "IS NOT NULL AND metric_date >= toDate(?) AND metric_date <= toDate(?)) AS value"
+        ));
+        assert_eq!(query.sql.matches('?').count(), query.params.len());
+        assert_eq!(
+            query.params,
+            vec![
+                "2026-01-01",
+                "2026-01-31",
+                "2025-12-01",
+                "2025-12-31",
+                "00000000-0000-0000-0000-00000000000a",
+                "00000000-0000-0000-0000-00000000000b",
+                "2025-12-01",
+                "2026-01-31",
+                "00000000-0000-0000-0000-00000000000a",
+                "00000000-0000-0000-0000-00000000000b",
+                TEST_TENANT_STR,
+                "ai_usage",
+                "person",
+                "2025-12-01",
+                "2026-01-31",
+                "accepted_lines",
             ]
         );
     }

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -164,8 +164,9 @@ pub(crate) fn compile_period_batch_query(
             Some(compare_to),
         ));
     }
-    let read = batch_resolved_observation_from(defs, req, &mut params);
-    let metric_scope = shared_observation_where_within(defs, req, filters, &mut params);
+    let read = batch_resolved_observation_from(defs, req, ScanScope::WithComparison, &mut params);
+    let metric_scope =
+        shared_observation_where_within(defs, req, filters, ScanScope::WithComparison, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
     let observation_table = &read.from;
     let limit = query_row_limit();
@@ -192,8 +193,34 @@ fn primary_window(req: &ValidatedMetricResultsRequest) -> Option<DateWindow> {
     })
 }
 
-/// The date predicate a windowed read scans: the primary period, then every
-/// extra window, as a disjunction of closed ranges.
+/// Which ranges a read scans.
+///
+/// INVARIANT: this is a property of the VIEW, not of the request. Only `period`
+/// and `breakdown` answer the comparison window, and they scope each aggregate
+/// to its own range. Every other view answers over the primary period alone and
+/// its aggregates carry NO window term — widening its scan would silently fold
+/// both ranges into one number.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScanScope {
+    PrimaryOnly,
+    WithComparison,
+}
+
+impl ScanScope {
+    fn windows(self, req: &ValidatedMetricResultsRequest) -> Vec<DateWindow> {
+        let primary = DateWindow {
+            from: req.from,
+            to: req.to,
+        };
+        match (self, req.compare_to) {
+            (Self::WithComparison, Some(compare_to)) => vec![primary, compare_to],
+            _ => vec![primary],
+        }
+    }
+}
+
+/// The date predicate a read scans: the primary period, and the comparison
+/// window when the view is one that answers it.
 ///
 /// INVARIANT: a disjunction, never `min(from)..max(to)`. The envelope form
 /// reads every day BETWEEN two far-apart windows and lets the conditional
@@ -204,10 +231,11 @@ fn scan_window_predicate(
     req: &ValidatedMetricResultsRequest,
     column: &str,
     separator: &str,
+    scope: ScanScope,
     params: &mut Vec<String>,
 ) -> String {
     let mut terms = Vec::with_capacity(2);
-    for window in scanned_windows(req) {
+    for window in scope.windows(req) {
         params.push(window.from.to_string());
         params.push(window.to.to_string());
         terms.push(format!(
@@ -224,19 +252,6 @@ fn scan_window_predicate(
                 .collect::<Vec<_>>()
                 .join(" OR ")
         ),
-    }
-}
-
-/// Every range a request's rows can come from: the primary period, and the
-/// comparison window when one was asked for.
-fn scanned_windows(req: &ValidatedMetricResultsRequest) -> Vec<DateWindow> {
-    let primary = DateWindow {
-        from: req.from,
-        to: req.to,
-    };
-    match req.compare_to {
-        None => vec![primary],
-        Some(compare_to) => vec![primary, compare_to],
     }
 }
 
@@ -265,7 +280,7 @@ pub(crate) fn compile_timeseries_query(
         return compile_capped_timeseries_query(def, req, bucket, dimensions, filters, group_limit);
     }
     let mut params = grouped_value_params(def);
-    let read = single_resolved_observation_from(def, req, &mut params);
+    let read = single_resolved_observation_from(def, req, ScanScope::PrimaryOnly, &mut params);
     params.extend(metric_where_params(def, req));
     let filter_where = dimension_filter_where(filters, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
@@ -315,7 +330,7 @@ pub(crate) fn compile_group_ranking_query(
     count: usize,
 ) -> CompiledQuery {
     let mut params = grouped_value_params(def);
-    let read = single_resolved_observation_from(def, req, &mut params);
+    let read = single_resolved_observation_from(def, req, ScanScope::PrimaryOnly, &mut params);
     params.extend(metric_where_params(def, req));
     let filter_where = dimension_filter_where(filters, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
@@ -356,7 +371,7 @@ fn compile_capped_timeseries_query(
     group_limit: &ResolvedGroupLimit,
 ) -> CompiledQuery {
     let mut params = Vec::new();
-    let read = single_resolved_observation_from(def, req, &mut params);
+    let read = single_resolved_observation_from(def, req, ScanScope::PrimaryOnly, &mut params);
     params.extend(metric_where_params(def, req));
     let filter_where = dimension_filter_where(filters, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
@@ -541,7 +556,7 @@ pub(crate) fn compile_breakdown_query(
             {presence} AS {presence_alias}"
         );
     }
-    let read = single_resolved_observation_from(def, req, &mut params);
+    let read = single_resolved_observation_from(def, req, ScanScope::WithComparison, &mut params);
     let metric_where = metric_where_scanned(def, req, &mut params);
     let filter_where = dimension_filter_where(filters, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
@@ -644,7 +659,7 @@ fn metric_where_scanned(
     params.push(req.tenant_id.to_string());
     params.push(source_key);
     params.push(req.entity.entity_type().to_owned());
-    let scan = scan_window_predicate(req, "metric_date", " ", params);
+    let scan = scan_window_predicate(req, "metric_date", " ", ScanScope::WithComparison, params);
     let measure_predicate = if measures.len() == 1 {
         "measure_key = ?"
     } else {
@@ -701,7 +716,7 @@ fn compile_uncapped_rollup_query(
     filters: &[ValidatedDimensionFilter],
 ) -> CompiledQuery {
     let mut params = grouped_value_params(def);
-    let read = single_resolved_observation_from(def, req, &mut params);
+    let read = single_resolved_observation_from(def, req, ScanScope::PrimaryOnly, &mut params);
     params.extend(metric_where_params(def, req));
     let filter_where = dimension_filter_where(filters, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
@@ -739,7 +754,7 @@ fn compile_capped_rollup_query(
     group_limit: &ResolvedGroupLimit,
 ) -> CompiledQuery {
     let mut params = Vec::new();
-    let read = single_resolved_observation_from(def, req, &mut params);
+    let read = single_resolved_observation_from(def, req, ScanScope::PrimaryOnly, &mut params);
     params.extend(metric_where_params(def, req));
     let filter_where = dimension_filter_where(filters, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
@@ -911,7 +926,7 @@ pub(crate) fn compile_histogram_query(
     filters: &[ValidatedDimensionFilter],
 ) -> CompiledQuery {
     let mut params = grouped_value_params(def);
-    let read = single_resolved_observation_from(def, req, &mut params);
+    let read = single_resolved_observation_from(def, req, ScanScope::PrimaryOnly, &mut params);
     params.extend(metric_where_params(def, req));
     let filter_where = dimension_filter_where(filters, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
@@ -975,7 +990,7 @@ pub(crate) fn compile_pooled_histogram_query(
     filters: &[ValidatedDimensionFilter],
 ) -> CompiledQuery {
     let mut params = grouped_value_params(def);
-    let read = single_resolved_observation_from(def, req, &mut params);
+    let read = single_resolved_observation_from(def, req, ScanScope::PrimaryOnly, &mut params);
     params.extend(metric_where_params(def, req));
     let filter_where = dimension_filter_where(filters, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
@@ -1067,10 +1082,12 @@ fn compile_declared_cohort_peer_batch_query(
         batch_observation_source(defs),
         &PersonScope::CohortMembers(req),
         &collapses,
+        ScanScope::PrimaryOnly,
         &mut params,
     )
     .from;
-    let metric_scope = shared_observation_where_within(defs, req, filters, &mut params);
+    let metric_scope =
+        shared_observation_where_within(defs, req, filters, ScanScope::PrimaryOnly, &mut params);
 
     let entity_id_params = placeholders(req.entity.len());
     let cohort_table = cohort_table(CohortSource::MetricEntityCohortsCurrent);
@@ -1141,10 +1158,12 @@ fn compile_tenant_peer_batch_query(
         batch_observation_source(defs),
         &PersonScope::TenantWide(req),
         &collapses,
+        ScanScope::PrimaryOnly,
         &mut params,
     )
     .from;
-    let metric_scope = shared_observation_where_within(defs, req, filters, &mut params);
+    let metric_scope =
+        shared_observation_where_within(defs, req, filters, ScanScope::PrimaryOnly, &mut params);
 
     let entity_id_params = placeholders(req.entity.len());
     let limit = query_row_limit();
@@ -1512,11 +1531,12 @@ fn shared_observation_where_within(
     defs: &[&MetricDefinition],
     req: &ValidatedMetricResultsRequest,
     filters: &[ValidatedDimensionFilter],
+    scope: ScanScope,
     params: &mut Vec<String>,
 ) -> String {
     params.push(req.tenant_id.to_string());
     params.push(req.entity.entity_type().to_owned());
-    let scan = scan_window_predicate(req, "metric_date", " ", params);
+    let scan = scan_window_predicate(req, "metric_date", " ", scope, params);
     let pairs = measure_pairs(defs);
     for (source_key, measure_key) in &pairs {
         params.push(source_key.clone());
@@ -1584,6 +1604,7 @@ fn batch_observation_source<'a>(defs: &'a [&MetricDefinition]) -> &'a Observatio
 fn batch_resolved_observation_from(
     defs: &[&MetricDefinition],
     req: &ValidatedMetricResultsRequest,
+    scope: ScanScope,
     params: &mut Vec<String>,
 ) -> ObservationRead {
     let def = defs
@@ -1594,6 +1615,7 @@ fn batch_resolved_observation_from(
         def.observation_source(),
         &PersonScope::Requested(req),
         &collapses,
+        scope,
         params,
     )
 }
@@ -1601,6 +1623,7 @@ fn batch_resolved_observation_from(
 fn single_resolved_observation_from(
     def: &MetricDefinition,
     req: &ValidatedMetricResultsRequest,
+    scope: ScanScope,
     params: &mut Vec<String>,
 ) -> ObservationRead {
     let defs = [def];
@@ -1609,6 +1632,7 @@ fn single_resolved_observation_from(
         def.observation_source(),
         &PersonScope::Requested(req),
         &collapses,
+        scope,
         params,
     )
 }
@@ -1846,12 +1870,13 @@ pub(crate) fn account_id_expr(alias: &str) -> String {
 /// prune let through.
 fn resolved_observation_from(
     source: &ObservationSource,
-    scope: &PersonScope<'_>,
+    person_scope: &PersonScope<'_>,
     collapses: &[(&MetricInput, AliasCollapse)],
+    scan: ScanScope,
     params: &mut Vec<String>,
 ) -> ObservationRead {
     let table = observation_table(source);
-    let resolution = EntityResolution::of(source, &scope.request().entity);
+    let resolution = EntityResolution::of(source, &person_scope.request().entity);
     if resolution == EntityResolution::Canonical {
         return ObservationRead {
             from: table,
@@ -1860,15 +1885,17 @@ fn resolved_observation_from(
     }
 
     // INVARIANT: this read pre-filters observations before the outer aggregates
-    // run, so its dates must cover EVERY window the request asks for — scoping
-    // it to the primary period alone would answer NULL for each extra one.
+    // run, so its dates must cover every range the VIEW answers: the primary
+    // period alone would answer NULL for a comparison window, and both ranges
+    // would make a view that answers only the primary period read rows it must
+    // not see.
     let scan_of = |req: &ValidatedMetricResultsRequest, params: &mut Vec<String>| {
         format!(
             "\n          AND {}",
-            scan_window_predicate(req, "obs.metric_date", "\n          ", params)
+            scan_window_predicate(req, "obs.metric_date", "\n          ", scan, params)
         )
     };
-    let (inner_where, resolved_filter) = match scope {
+    let (inner_where, resolved_filter) = match person_scope {
         PersonScope::Requested(req) => {
             params.extend(req.entity.entity_ids());
             let date_scope = scan_of(req, params);
@@ -1894,7 +1921,8 @@ fn resolved_observation_from(
             )
         }
         PersonScope::TenantWide(req) => {
-            let date_scope = scan_window_predicate(req, "obs.metric_date", "\n          ", params);
+            let date_scope =
+                scan_window_predicate(req, "obs.metric_date", "\n          ", scan, params);
             (date_scope, "resolved_person_id != ''".to_owned())
         }
     };
@@ -2403,6 +2431,95 @@ mod tests {
                 "ai_usage",
                 "accepted_lines",
             ]
+        );
+    }
+
+    /// One view's compiler, named for the assertion message.
+    type UnwidenedCase = (
+        &'static str,
+        fn(&ValidatedMetricResultsRequest) -> CompiledQuery,
+    );
+
+    /// The contract says only `period` and `breakdown` answer the comparison
+    /// window. Every other view's aggregates carry no window term of their own,
+    /// so a widened scan would fold both ranges into one number instead — a
+    /// peer target summing two months, and percentiles built on those.
+    ///
+    /// The check is the strongest available: for those views the compiled SQL
+    /// and its bound parameters must be IDENTICAL with and without
+    /// `compare_to`, down to the identity-resolving subquery.
+    #[test]
+    fn only_period_and_breakdown_widen_their_scan_for_a_comparison_window() {
+        let sum = sum_metric();
+        let mut dimensioned = sum_metric();
+        dimensioned.base.allowed_dimensions = vec!["tool".to_owned()];
+        let dims = vec!["tool".to_owned()];
+
+        let unchanged: Vec<UnwidenedCase> = vec![
+            ("peer (declared cohort)", |req| {
+                compile_peer_batch_query(
+                    &[&sum_metric()],
+                    req,
+                    "org_unit",
+                    PeerPopulation::DeclaredCohort,
+                    &[],
+                )
+            }),
+            ("peer (tenant)", |req| {
+                compile_peer_batch_query(
+                    &[&sum_metric()],
+                    req,
+                    "org_unit",
+                    PeerPopulation::Tenant,
+                    &[],
+                )
+            }),
+            ("timeseries", |req| {
+                compile_timeseries_query(&sum_metric(), req, Bucket::Week, &[], &[], None)
+            }),
+            ("rollup", |req| {
+                compile_rollup_query(
+                    &sum_metric(),
+                    req,
+                    std::slice::from_ref(&"tool".to_owned()),
+                    &[],
+                    None,
+                )
+            }),
+            ("histogram", |req| {
+                compile_histogram_query(&median_metric(), req, &[])
+            }),
+            ("ranking", |req| {
+                compile_group_ranking_query(
+                    &sum_metric(),
+                    req,
+                    std::slice::from_ref(&"tool".to_owned()),
+                    &[],
+                    5,
+                )
+            }),
+        ];
+        for (name, compile) in unchanged {
+            let plain = compile(&request());
+            let compared = compile(&windowed_request());
+            assert_eq!(plain.sql, compared.sql, "{name}: SQL must not widen");
+            assert_eq!(
+                plain.params, compared.params,
+                "{name}: bound dates must not widen"
+            );
+        }
+
+        // ...and the two that do answer it must change.
+        let period_plain = compile_period_batch_query(&[&sum], &request(), &[]);
+        let period_compared = compile_period_batch_query(&[&sum], &windowed_request(), &[]);
+        assert_ne!(period_plain.sql, period_compared.sql, "period must widen");
+
+        let breakdown_plain = compile_breakdown_query(&dimensioned, &request(), &dims, &[]);
+        let breakdown_compared =
+            compile_breakdown_query(&dimensioned, &windowed_request(), &dims, &[]);
+        assert_ne!(
+            breakdown_plain.sql, breakdown_compared.sql,
+            "breakdown must widen"
         );
     }
 

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -4,7 +4,7 @@ use std::fmt::Write;
 use serde::Deserialize;
 
 use super::batch::{
-    PeerPopulation, ResolvedGroupLimit, peer_aliases, period_alias, period_column_alias,
+    PeerPopulation, ResolvedGroupLimit, peer_aliases, period_alias, period_compare_alias,
 };
 use super::validation::{
     DateWindow, HISTOGRAM_BINS, ValidatedDimensionFilter, ValidatedEntitySelection,
@@ -56,10 +56,10 @@ pub struct CompiledQuery {
 pub struct PeriodQueryRow {
     pub entity_id: String,
     pub value: Option<f64>,
-    /// One value per extra window, in request order; empty when none were
-    /// requested.
+    /// The same reading over the comparison window; `None` when none was asked
+    /// for.
     #[serde(default)]
-    pub windows: Vec<Option<f64>>,
+    pub compare_to: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -152,17 +152,16 @@ pub(crate) fn compile_period_batch_query(
     filters: &[ValidatedDimensionFilter],
 ) -> CompiledQuery {
     let mut params = Vec::new();
-    // With extra windows the outer WHERE spans all of them, so every aggregate
-    // — the primary one included — carries its own window term. Without them
-    // the outer WHERE alone scopes the dates and the SQL is unchanged.
-    let columns = column_windows(req);
-    let mut selects = String::new();
-    for (column_index, window) in columns.iter().enumerate() {
+    // With a comparison window the outer WHERE spans both, so each aggregate —
+    // the primary one included — carries its own window term. Without one the
+    // outer WHERE alone scopes the dates and the SQL is unchanged.
+    let mut selects = item_value_selects(defs, &mut params, period_alias, primary_window(req));
+    if let Some(compare_to) = req.compare_to {
         selects.push_str(&item_value_selects(
             defs,
             &mut params,
-            |item_index| period_column_alias(item_index, column_index),
-            *window,
+            period_compare_alias,
+            Some(compare_to),
         ));
     }
     let read = batch_resolved_observation_from(defs, req, &mut params);
@@ -180,25 +179,17 @@ pub(crate) fn compile_period_batch_query(
         LIMIT {limit}
         "
     );
-    let sql = transformed_batch(defs, inner, columns.len());
+    let sql = transformed_batch(defs, inner, req.compare_to.is_some());
     CompiledQuery { sql, params }
 }
 
-/// The window each value column of a batched query answers, primary first and
-/// then the extra windows in request order. A request with no extra windows
-/// yields one `None` column, which is what keeps its compiled SQL identical to
-/// the pre-windows form.
-fn column_windows(req: &ValidatedMetricResultsRequest) -> Vec<Option<DateWindow>> {
-    if req.windows.is_empty() {
-        return vec![None];
-    }
-    let mut windows = Vec::with_capacity(req.windows.len() + 1);
-    windows.push(Some(DateWindow {
+/// The window the primary value column answers: `None` — and so no window term
+/// at all — until a comparison window makes the outer WHERE span two ranges.
+fn primary_window(req: &ValidatedMetricResultsRequest) -> Option<DateWindow> {
+    req.compare_to.map(|_| DateWindow {
         from: req.from,
         to: req.to,
-    }));
-    windows.extend(req.windows.iter().copied().map(Some));
-    windows
+    })
 }
 
 /// The date predicate a windowed read scans: the primary period, then every
@@ -215,7 +206,7 @@ fn scan_window_predicate(
     separator: &str,
     params: &mut Vec<String>,
 ) -> String {
-    let mut terms = Vec::with_capacity(req.windows.len() + 1);
+    let mut terms = Vec::with_capacity(2);
     for window in scanned_windows(req) {
         params.push(window.from.to_string());
         params.push(window.to.to_string());
@@ -236,16 +227,17 @@ fn scan_window_predicate(
     }
 }
 
-/// Every range a request's rows can come from: the primary period first, then
-/// the extra windows in request order.
+/// Every range a request's rows can come from: the primary period, and the
+/// comparison window when one was asked for.
 fn scanned_windows(req: &ValidatedMetricResultsRequest) -> Vec<DateWindow> {
-    let mut windows = Vec::with_capacity(req.windows.len() + 1);
-    windows.push(DateWindow {
+    let primary = DateWindow {
         from: req.from,
         to: req.to,
-    });
-    windows.extend(req.windows.iter().copied());
-    windows
+    };
+    match req.compare_to {
+        None => vec![primary],
+        Some(compare_to) => vec![primary, compare_to],
+    }
 }
 
 /// The SQL term scoping one conditional aggregate to a window, with its bounds
@@ -526,27 +518,27 @@ pub(crate) fn compile_breakdown_query(
     filters: &[ValidatedDimensionFilter],
 ) -> CompiledQuery {
     let mut params = Vec::new();
-    let aliases = breakdown_aliases(req);
     let mut value_selects = String::new();
-    for (column_index, (alias, window)) in aliases.iter().enumerate() {
-        let expr = grouped_value_expr_within(def, *window, &mut params);
+    for (staged, presence_alias, window) in breakdown_columns(req) {
+        let expr = grouped_value_expr_within(def, window, &mut params);
         let _ = write!(
             value_selects,
             ",
-            {expr} AS {alias}"
+            {expr} AS {staged}"
         );
         // Presence is its own column because the value cannot carry it: a
         // ratio over a group that IS in the window reads NULL whenever its
         // denominator is zero, which is indistinguishable from a group the
         // window never had. A standalone request over that window returns the
         // first and omits the second, so the projection needs both facts.
-        let Some(window) = *window else { continue };
+        let (Some(window), Some(presence_alias)) = (window, presence_alias) else {
+            continue;
+        };
         let presence = window_presence_expr(window, &mut params);
-        let alias = breakdown_presence_alias(column_index);
         let _ = write!(
             value_selects,
             ",
-            {presence} AS {alias}"
+            {presence} AS {presence_alias}"
         );
     }
     let read = single_resolved_observation_from(def, req, &mut params);
@@ -575,56 +567,43 @@ pub(crate) fn compile_breakdown_query(
         LIMIT {limit}
         "
     );
-    let sql = if req.windows.is_empty() {
+    let sql = if req.compare_to.is_none() {
         transformed_single(def, inner)
     } else {
-        projected_breakdown_windows(def, &inner, aliases.len())
+        projected_breakdown_columns(def, &inner)
     };
     CompiledQuery { sql, params }
 }
 
-/// The value column per window a breakdown computes, innermost names first.
+/// The value column per window a breakdown computes, with the staged name it
+/// is aliased to inside the query and the presence flag beside it.
 ///
 /// INVARIANT: a windowed breakdown must NOT alias any aggregate `value`. The
 /// aggregates read a column of that name, and a sibling's argument resolves to
 /// the alias instead of the column — which ClickHouse rejects outright as an
 /// aggregate inside an aggregate. The wire names are put back by
-/// `projected_breakdown_windows`.
-fn breakdown_aliases(req: &ValidatedMetricResultsRequest) -> Vec<(String, Option<DateWindow>)> {
-    if req.windows.is_empty() {
-        return vec![("value".to_owned(), None)];
-    }
-    let mut aliases = vec![(
-        staged_window_alias(0),
-        Some(DateWindow {
-            from: req.from,
-            to: req.to,
-        }),
-    )];
-    for (window_index, window) in req.windows.iter().enumerate() {
-        aliases.push((staged_window_alias(window_index + 1), Some(*window)));
-    }
-    aliases
+/// `projected_breakdown_columns`.
+type BreakdownColumn = (&'static str, Option<&'static str>, Option<DateWindow>);
+
+fn breakdown_columns(req: &ValidatedMetricResultsRequest) -> Vec<BreakdownColumn> {
+    let Some(compare_to) = req.compare_to else {
+        return vec![("value", None, None)];
+    };
+    let primary = DateWindow {
+        from: req.from,
+        to: req.to,
+    };
+    vec![
+        (STAGED_VALUE, Some(PRESENT), Some(primary)),
+        (STAGED_COMPARE, Some(PRESENT_COMPARE), Some(compare_to)),
+    ]
 }
 
-fn staged_window_alias(column_index: usize) -> String {
-    format!("staged_w{column_index}")
-}
-
-pub(crate) fn breakdown_window_alias(window_index: usize) -> String {
-    format!("value_w{window_index}")
-}
-
-/// The wire name of one column's presence flag: `present` for the primary
-/// window, `present_w{n}` for each extra one. Emitted by the inner query and
-/// carried through the projection stage untouched — unlike the value columns,
-/// these names cannot collide with an observation column.
-pub(crate) fn breakdown_presence_alias(column_index: usize) -> String {
-    match column_index.checked_sub(1) {
-        None => "present".to_owned(),
-        Some(window_index) => format!("present_w{window_index}"),
-    }
-}
+const STAGED_VALUE: &str = "staged_value";
+const STAGED_COMPARE: &str = "staged_compare";
+pub(crate) const PRESENT: &str = "present";
+pub(crate) const PRESENT_COMPARE: &str = "present_compare";
+pub(crate) const VALUE_COMPARE: &str = "value_compare";
 
 /// Whether a group has any row inside one window — the fact a standalone
 /// request over that window expresses by emitting the group or not.
@@ -677,28 +656,20 @@ fn metric_where_scanned(
     format!("{tenant} AND source_key = ? AND entity_type = ? AND {scan} AND {measure_predicate}")
 }
 
-/// Rename the staged window columns to their wire names, applying the value
-/// transform on the way — the projection stage `transformed_single` performs
-/// for a single-window breakdown, over every window.
-fn projected_breakdown_windows(def: &MetricDefinition, inner: &str, column_count: usize) -> String {
-    let staged = (0..column_count)
-        .map(staged_window_alias)
-        .collect::<Vec<_>>();
+/// Rename the staged columns to their wire names, applying the value transform
+/// on the way — the projection stage `transformed_single` performs for an
+/// uncompared breakdown, over both columns.
+fn projected_breakdown_columns(def: &MetricDefinition, inner: &str) -> String {
     let mut selects = String::new();
-    for (column_index, alias) in staged.iter().enumerate() {
-        let wire = if column_index == 0 {
-            "value".to_owned()
-        } else {
-            breakdown_window_alias(column_index - 1)
-        };
-        let expr = transformed(def, alias.clone());
+    for (staged, wire) in [(STAGED_VALUE, "value"), (STAGED_COMPARE, VALUE_COMPARE)] {
+        let expr = transformed(def, staged.to_owned());
         let _ = write!(
             selects,
             ",
             {expr} AS {wire}"
         );
     }
-    let excluded = staged.join(", ");
+    let excluded = format!("{STAGED_VALUE}, {STAGED_COMPARE}");
     format!(
         r"
         SELECT
@@ -1494,16 +1465,21 @@ fn transformed_single(def: &MetricDefinition, inner: String) -> String {
     )
 }
 
-// Batch variant: re-projects each transformed item column by alias, over every
-// window's column and not just the primary one.
-fn transformed_batch(defs: &[&MetricDefinition], inner: String, column_count: usize) -> String {
+// Batch variant: re-projects each transformed item column by alias, the
+// comparison window's column included.
+fn transformed_batch(defs: &[&MetricDefinition], inner: String, compared: bool) -> String {
     if defs.iter().all(|def| def.transform.is_none()) {
         return inner;
     }
     let mut selects = String::new();
-    for column_index in 0..column_count {
-        for (item_index, def) in defs.iter().enumerate() {
-            let value = period_column_alias(item_index, column_index);
+    for (item_index, def) in defs.iter().enumerate() {
+        for value in [
+            Some(period_alias(item_index)),
+            compared.then(|| period_compare_alias(item_index)),
+        ]
+        .into_iter()
+        .flatten()
+        {
             let expr = transformed(def, value.clone());
             let _ = write!(selects, ", {expr} AS {value}");
         }
@@ -2304,7 +2280,7 @@ mod tests {
             },
             from: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap_or_default(),
             to: NaiveDate::from_ymd_opt(2026, 1, 31).unwrap_or_default(),
-            windows: Vec::new(),
+            compare_to: None,
             metrics: Vec::new(),
             enforce_tenant_scope: true,
         }
@@ -2372,20 +2348,20 @@ mod tests {
 
     fn windowed_request() -> ValidatedMetricResultsRequest {
         let mut req = request();
-        req.windows = vec![DateWindow {
+        req.compare_to = Some(DateWindow {
             from: NaiveDate::from_ymd_opt(2025, 12, 1).unwrap_or_default(),
             to: NaiveDate::from_ymd_opt(2025, 12, 31).unwrap_or_default(),
-        }];
+        });
         req
     }
 
     #[test]
-    fn period_batch_over_windows_scans_each_range_and_scopes_every_column() {
+    fn a_compared_period_batch_scans_each_range_and_scopes_both_columns() {
         let sum = sum_metric();
         let query = compile_period_batch_query(&[&sum], &windowed_request(), &[]);
 
         assert!(query.sql.contains("AS m0"));
-        assert!(query.sql.contains("AS m0_w0"));
+        assert!(query.sql.contains("AS m0_compare"));
         // The scan is a disjunction of the requested ranges. The envelope form
         // — one range from the earliest `from` to the latest `to` — would read
         // every day between two far-apart windows.
@@ -2431,7 +2407,7 @@ mod tests {
     }
 
     #[test]
-    fn an_unwindowed_batch_keeps_the_single_range_form() {
+    fn an_uncompared_batch_keeps_the_single_range_form() {
         // The whole change rests on this: a request that asks for no extra
         // window compiles the SQL it always did.
         let sum = sum_metric();
@@ -2443,7 +2419,7 @@ mod tests {
                 .contains("AND metric_date >= toDate(?) AND metric_date <= toDate(?) AND")
         );
         assert!(!query.sql.contains(" OR ("));
-        assert!(!query.sql.contains("AS m0_w0"));
+        assert!(!query.sql.contains("AS m0_compare"));
     }
 
     #[test]
@@ -2494,7 +2470,7 @@ mod tests {
     }
 
     #[test]
-    fn breakdown_over_windows_emits_a_value_and_a_presence_column_per_window() {
+    fn a_compared_breakdown_emits_a_value_and_a_presence_column_per_window() {
         let sum = sum_metric();
         let query = compile_breakdown_query(
             &sum,
@@ -2504,12 +2480,12 @@ mod tests {
         );
 
         assert!(query.sql.contains("AS value"));
-        assert!(query.sql.contains("AS value_w0"));
+        assert!(query.sql.contains("AS value_compare"));
         // Presence rides its own column: a group's value cannot express it,
         // because a ratio over a group that IS in the window reads NULL when
         // its denominator is zero.
         assert!(query.sql.contains("AS present"));
-        assert!(query.sql.contains("AS present_w0"));
+        assert!(query.sql.contains("AS present_compare"));
         assert_eq!(
             query
                 .sql
@@ -2520,7 +2496,7 @@ mod tests {
         );
         // The aggregates stage under names that cannot collide with the
         // observation's own `value` column — see `breakdown_aliases`.
-        assert!(query.sql.contains("AS staged_w0"));
+        assert!(query.sql.contains("AS staged_value"));
         assert_eq!(query.sql.matches('?').count(), query.params.len());
         assert_eq!(
             query.params,
@@ -2558,7 +2534,7 @@ mod tests {
     }
 
     #[test]
-    fn an_unwindowed_breakdown_carries_no_presence_column() {
+    fn an_uncompared_breakdown_carries_no_presence_column() {
         let sum = sum_metric();
         let query = compile_breakdown_query(
             &sum,
@@ -2568,7 +2544,7 @@ mod tests {
         );
 
         assert!(!query.sql.contains("present"));
-        assert!(!query.sql.contains("staged_w"));
+        assert!(!query.sql.contains("staged_"));
         assert!(!query.sql.contains(" OR ("));
     }
 

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -214,7 +214,7 @@ impl ScanScope {
         };
         match (self, req.compare_to) {
             (Self::WithComparison, Some(compare_to)) => vec![primary, compare_to],
-            _ => vec![primary],
+            (Self::WithComparison, None) | (Self::PrimaryOnly, _) => vec![primary],
         }
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -166,8 +166,7 @@ pub(crate) fn compile_period_batch_query(
         ));
     }
     let read = batch_resolved_observation_from(defs, req, &mut params);
-    let metric_scope =
-        shared_observation_where_within(defs, req, filters, &mut params, observation_bounds(req));
+    let metric_scope = shared_observation_where_within(defs, req, filters, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
     let observation_table = &read.from;
     let limit = query_row_limit();
@@ -202,30 +201,51 @@ fn column_windows(req: &ValidatedMetricResultsRequest) -> Vec<Option<DateWindow>
     windows
 }
 
-/// Bind the scan range an identity-resolving read must cover.
+/// The date predicate a windowed read scans: the primary period, then every
+/// extra window, as a disjunction of closed ranges.
 ///
-/// INVARIANT: this is the union, not `req.from..req.to`. The resolved read
-/// pre-filters observations before the conditional aggregates run, so scoping
-/// it to the primary period alone would answer NULL for every extra window.
-fn push_observation_bounds(req: &ValidatedMetricResultsRequest, params: &mut Vec<String>) {
-    let bounds = observation_bounds(req);
-    params.push(bounds.from.to_string());
-    params.push(bounds.to.to_string());
+/// INVARIANT: a disjunction, never `min(from)..max(to)`. The envelope form
+/// reads every day BETWEEN two far-apart windows and lets the conditional
+/// aggregates discard it, which is the cost this whole request shape exists to
+/// avoid. A single-range request yields the bare term it always had, so its
+/// compiled SQL is unchanged.
+fn scan_window_predicate(
+    req: &ValidatedMetricResultsRequest,
+    column: &str,
+    separator: &str,
+    params: &mut Vec<String>,
+) -> String {
+    let mut terms = Vec::with_capacity(req.windows.len() + 1);
+    for window in scanned_windows(req) {
+        params.push(window.from.to_string());
+        params.push(window.to.to_string());
+        terms.push(format!(
+            "{column} >= toDate(?){separator}AND {column} <= toDate(?)"
+        ));
+    }
+    match terms.len() {
+        1 => terms.into_iter().next().unwrap_or_default(),
+        _ => format!(
+            "({})",
+            terms
+                .into_iter()
+                .map(|term| format!("({term})"))
+                .collect::<Vec<_>>()
+                .join(" OR ")
+        ),
+    }
 }
 
-/// The union of the primary period and every extra window — the range the
-/// observation scan has to cover for the conditional aggregates to see their
-/// rows.
-fn observation_bounds(req: &ValidatedMetricResultsRequest) -> DateWindow {
-    let mut bounds = DateWindow {
+/// Every range a request's rows can come from: the primary period first, then
+/// the extra windows in request order.
+fn scanned_windows(req: &ValidatedMetricResultsRequest) -> Vec<DateWindow> {
+    let mut windows = Vec::with_capacity(req.windows.len() + 1);
+    windows.push(DateWindow {
         from: req.from,
         to: req.to,
-    };
-    for window in &req.windows {
-        bounds.from = bounds.from.min(window.from);
-        bounds.to = bounds.to.max(window.to);
-    }
-    bounds
+    });
+    windows.extend(req.windows.iter().copied());
+    windows
 }
 
 /// The SQL term scoping one conditional aggregate to a window, with its bounds
@@ -508,20 +528,29 @@ pub(crate) fn compile_breakdown_query(
     let mut params = Vec::new();
     let aliases = breakdown_aliases(req);
     let mut value_selects = String::new();
-    for (alias, window) in &aliases {
+    for (column_index, (alias, window)) in aliases.iter().enumerate() {
         let expr = grouped_value_expr_within(def, *window, &mut params);
         let _ = write!(
             value_selects,
             ",
             {expr} AS {alias}"
         );
+        // Presence is its own column because the value cannot carry it: a
+        // ratio over a group that IS in the window reads NULL whenever its
+        // denominator is zero, which is indistinguishable from a group the
+        // window never had. A standalone request over that window returns the
+        // first and omits the second, so the projection needs both facts.
+        let Some(window) = *window else { continue };
+        let presence = window_presence_expr(window, &mut params);
+        let alias = breakdown_presence_alias(column_index);
+        let _ = write!(
+            value_selects,
+            ",
+            {presence} AS {alias}"
+        );
     }
     let read = single_resolved_observation_from(def, req, &mut params);
-    params.extend(metric_where_params_within(
-        def,
-        req,
-        observation_bounds(req),
-    ));
+    let metric_where = metric_where_scanned(def, req, &mut params);
     let filter_where = dimension_filter_where(filters, &mut params);
     let entity_scope = read.entity_scope(req, &mut params);
     let observation_table = &read.from;
@@ -544,8 +573,7 @@ pub(crate) fn compile_breakdown_query(
         GROUP BY {group}
         ORDER BY entity_id
         LIMIT {limit}
-        ",
-        metric_where = metric_where(def, req.enforce_tenant_scope),
+        "
     );
     let sql = if req.windows.is_empty() {
         transformed_single(def, inner)
@@ -585,6 +613,68 @@ fn staged_window_alias(column_index: usize) -> String {
 
 pub(crate) fn breakdown_window_alias(window_index: usize) -> String {
     format!("value_w{window_index}")
+}
+
+/// The wire name of one column's presence flag: `present` for the primary
+/// window, `present_w{n}` for each extra one. Emitted by the inner query and
+/// carried through the projection stage untouched — unlike the value columns,
+/// these names cannot collide with an observation column.
+pub(crate) fn breakdown_presence_alias(column_index: usize) -> String {
+    match column_index.checked_sub(1) {
+        None => "present".to_owned(),
+        Some(window_index) => format!("present_w{window_index}"),
+    }
+}
+
+/// Whether a group has any row inside one window — the fact a standalone
+/// request over that window expresses by emitting the group or not.
+fn window_presence_expr(window: DateWindow, params: &mut Vec<String>) -> String {
+    params.push(window.from.to_string());
+    params.push(window.to.to_string());
+    "countIf(metric_date >= toDate(?) AND metric_date <= toDate(?)) > 0".to_owned()
+}
+
+/// `metric_where` with its own placeholders bound, so the scanned dates can be
+/// a disjunction whose arity depends on the request.
+fn metric_where_scanned(
+    def: &MetricDefinition,
+    req: &ValidatedMetricResultsRequest,
+    params: &mut Vec<String>,
+) -> String {
+    let (source_key, measures) = match &def.spec {
+        ComputationSpec::Sum { value }
+        | ComputationSpec::Median { value }
+        | ComputationSpec::Percentile { value, .. }
+        | ComputationSpec::Stddev { value }
+        | ComputationSpec::DistinctCount { value } => {
+            (value.source_key.clone(), vec![value.measure_key.clone()])
+        }
+        ComputationSpec::Ratio {
+            numerator,
+            denominator,
+            ..
+        } => (
+            numerator.source_key.clone(),
+            vec![
+                numerator.measure_key.clone(),
+                denominator.measure_key.clone(),
+            ],
+        ),
+    };
+    let tenant = tenant_predicate(req.enforce_tenant_scope);
+    params.push(req.tenant_id.to_string());
+    params.push(source_key);
+    params.push(req.entity.entity_type().to_owned());
+    let scan = scan_window_predicate(req, "metric_date", " ", params);
+    let measure_predicate = if measures.len() == 1 {
+        "measure_key = ?"
+    } else {
+        "measure_key IN (?, ?)"
+    };
+    for measure in measures {
+        params.push(measure);
+    }
+    format!("{tenant} AND source_key = ? AND entity_type = ? AND {scan} AND {measure_predicate}")
 }
 
 /// Rename the staged window columns to their wire names, applying the value
@@ -1009,7 +1099,7 @@ fn compile_declared_cohort_peer_batch_query(
         &mut params,
     )
     .from;
-    let metric_scope = shared_observation_where(defs, req, filters, &mut params);
+    let metric_scope = shared_observation_where_within(defs, req, filters, &mut params);
 
     let entity_id_params = placeholders(req.entity.len());
     let cohort_table = cohort_table(CohortSource::MetricEntityCohortsCurrent);
@@ -1083,7 +1173,7 @@ fn compile_tenant_peer_batch_query(
         &mut params,
     )
     .from;
-    let metric_scope = shared_observation_where(defs, req, filters, &mut params);
+    let metric_scope = shared_observation_where_within(defs, req, filters, &mut params);
 
     let entity_id_params = placeholders(req.entity.len());
     let limit = query_row_limit();
@@ -1439,24 +1529,6 @@ fn push_cohort_scope(
     params.push(cohort_key.to_owned());
 }
 
-fn shared_observation_where(
-    defs: &[&MetricDefinition],
-    req: &ValidatedMetricResultsRequest,
-    filters: &[ValidatedDimensionFilter],
-    params: &mut Vec<String>,
-) -> String {
-    shared_observation_where_within(
-        defs,
-        req,
-        filters,
-        params,
-        DateWindow {
-            from: req.from,
-            to: req.to,
-        },
-    )
-}
-
 /// `shared_observation_where` over an explicit scan range: a windowed batch
 /// scans the union of its windows once and lets each conditional aggregate
 /// pick its own out of it.
@@ -1465,12 +1537,10 @@ fn shared_observation_where_within(
     req: &ValidatedMetricResultsRequest,
     filters: &[ValidatedDimensionFilter],
     params: &mut Vec<String>,
-    bounds: DateWindow,
 ) -> String {
     params.push(req.tenant_id.to_string());
     params.push(req.entity.entity_type().to_owned());
-    params.push(bounds.from.to_string());
-    params.push(bounds.to.to_string());
+    let scan = scan_window_predicate(req, "metric_date", " ", params);
     let pairs = measure_pairs(defs);
     for (source_key, measure_key) in &pairs {
         params.push(source_key.clone());
@@ -1479,7 +1549,7 @@ fn shared_observation_where_within(
     let pair_placeholders = vec!["(?, ?)"; pairs.len()].join(", ");
     let tenant = tenant_predicate(req.enforce_tenant_scope);
     let mut where_clause = format!(
-        "{tenant} AND entity_type = ? AND metric_date >= toDate(?) AND metric_date <= toDate(?) AND (source_key, measure_key) IN ({pair_placeholders})"
+        "{tenant} AND entity_type = ? AND {scan} AND (source_key, measure_key) IN ({pair_placeholders})"
     );
     where_clause.push_str(&dimension_filter_where(filters, params));
     where_clause
@@ -1626,23 +1696,6 @@ fn grouped_value_params(def: &MetricDefinition) -> Vec<String> {
 }
 
 fn metric_where_params(def: &MetricDefinition, req: &ValidatedMetricResultsRequest) -> Vec<String> {
-    metric_where_params_within(
-        def,
-        req,
-        DateWindow {
-            from: req.from,
-            to: req.to,
-        },
-    )
-}
-
-/// `metric_where_params` over an explicit scan range, for a query whose value
-/// columns pick their own window out of a wider scan.
-fn metric_where_params_within(
-    def: &MetricDefinition,
-    req: &ValidatedMetricResultsRequest,
-    bounds: DateWindow,
-) -> Vec<String> {
     match &def.spec {
         ComputationSpec::Sum { value }
         | ComputationSpec::Median { value }
@@ -1652,8 +1705,8 @@ fn metric_where_params_within(
             req.tenant_id.to_string(),
             value.source_key.clone(),
             req.entity.entity_type().to_owned(),
-            bounds.from.to_string(),
-            bounds.to.to_string(),
+            req.from.to_string(),
+            req.to.to_string(),
             value.measure_key.clone(),
         ],
         ComputationSpec::Ratio {
@@ -1664,8 +1717,8 @@ fn metric_where_params_within(
             req.tenant_id.to_string(),
             numerator.source_key.clone(),
             req.entity.entity_type().to_owned(),
-            bounds.from.to_string(),
-            bounds.to.to_string(),
+            req.from.to_string(),
+            req.to.to_string(),
             numerator.measure_key.clone(),
             denominator.measure_key.clone(),
         ],
@@ -1830,12 +1883,19 @@ fn resolved_observation_from(
         };
     }
 
-    let date_scope =
-        "\n          AND obs.metric_date >= toDate(?)\n          AND obs.metric_date <= toDate(?)";
+    // INVARIANT: this read pre-filters observations before the outer aggregates
+    // run, so its dates must cover EVERY window the request asks for — scoping
+    // it to the primary period alone would answer NULL for each extra one.
+    let scan_of = |req: &ValidatedMetricResultsRequest, params: &mut Vec<String>| {
+        format!(
+            "\n          AND {}",
+            scan_window_predicate(req, "obs.metric_date", "\n          ", params)
+        )
+    };
     let (inner_where, resolved_filter) = match scope {
         PersonScope::Requested(req) => {
             params.extend(req.entity.entity_ids());
-            push_observation_bounds(req, params);
+            let date_scope = scan_of(req, params);
             params.extend(req.entity.entity_ids());
             let person_params = placeholders(req.entity.len());
             (
@@ -1847,7 +1907,7 @@ fn resolved_observation_from(
             )
         }
         PersonScope::CohortMembers(req) => {
-            push_observation_bounds(req, params);
+            let date_scope = scan_of(req, params);
             (
                 format!(
                     "(obs.entity_id IN (SELECT email FROM {PERSON_MAP_RELATION} \
@@ -1858,12 +1918,8 @@ fn resolved_observation_from(
             )
         }
         PersonScope::TenantWide(req) => {
-            push_observation_bounds(req, params);
-            (
-                "obs.metric_date >= toDate(?)\n          AND obs.metric_date <= toDate(?)"
-                    .to_owned(),
-                "resolved_person_id != ''".to_owned(),
-            )
+            let date_scope = scan_window_predicate(req, "obs.metric_date", "\n          ", params);
+            (date_scope, "resolved_person_id != ''".to_owned())
         }
     };
 
@@ -2324,20 +2380,18 @@ mod tests {
     }
 
     #[test]
-    fn period_batch_over_windows_scans_their_union_and_scopes_every_column() {
+    fn period_batch_over_windows_scans_each_range_and_scopes_every_column() {
         let sum = sum_metric();
         let query = compile_period_batch_query(&[&sum], &windowed_request(), &[]);
 
         assert!(query.sql.contains("AS m0"));
         assert!(query.sql.contains("AS m0_w0"));
-        assert_eq!(
-            query
-                .sql
-                .matches("AND metric_date >= toDate(?) AND metric_date <= toDate(?)")
-                .count(),
-            3,
-            "one term per value column plus the shared scan range"
-        );
+        // The scan is a disjunction of the requested ranges. The envelope form
+        // — one range from the earliest `from` to the latest `to` — would read
+        // every day between two far-apart windows.
+        assert!(query.sql.contains(
+            "(metric_date >= toDate(?) AND metric_date <= toDate(?)) OR (metric_date >= toDate(?) AND metric_date <= toDate(?))"
+        ));
         assert_eq!(query.sql.matches('?').count(), query.params.len());
         assert_eq!(
             query.params,
@@ -2352,24 +2406,44 @@ mod tests {
                 "accepted_lines",
                 "2025-12-01",
                 "2025-12-31",
-                // the identity-resolving read, scoped to the union: it filters
-                // observations BEFORE the aggregates, so the primary period
-                // alone would answer NULL for the extra window
+                // the identity-resolving read: it filters observations BEFORE
+                // the aggregates, so it scans both ranges and neither the gap
+                // nor the primary period alone
                 "00000000-0000-0000-0000-00000000000a",
                 "00000000-0000-0000-0000-00000000000b",
-                "2025-12-01",
+                "2026-01-01",
                 "2026-01-31",
+                "2025-12-01",
+                "2025-12-31",
                 "00000000-0000-0000-0000-00000000000a",
                 "00000000-0000-0000-0000-00000000000b",
-                // shared scope over the union of both windows
+                // shared scope, same two ranges
                 TEST_TENANT_STR,
                 "person",
-                "2025-12-01",
+                "2026-01-01",
                 "2026-01-31",
+                "2025-12-01",
+                "2025-12-31",
                 "ai_usage",
                 "accepted_lines",
             ]
         );
+    }
+
+    #[test]
+    fn an_unwindowed_batch_keeps_the_single_range_form() {
+        // The whole change rests on this: a request that asks for no extra
+        // window compiles the SQL it always did.
+        let sum = sum_metric();
+        let query = compile_period_batch_query(&[&sum], &request(), &[]);
+
+        assert!(
+            query
+                .sql
+                .contains("AND metric_date >= toDate(?) AND metric_date <= toDate(?) AND")
+        );
+        assert!(!query.sql.contains(" OR ("));
+        assert!(!query.sql.contains("AS m0_w0"));
     }
 
     #[test]
@@ -2399,14 +2473,18 @@ mod tests {
                 "2025-12-31",
                 "00000000-0000-0000-0000-00000000000a",
                 "00000000-0000-0000-0000-00000000000b",
-                "2025-12-01",
+                "2026-01-01",
                 "2026-01-31",
+                "2025-12-01",
+                "2025-12-31",
                 "00000000-0000-0000-0000-00000000000a",
                 "00000000-0000-0000-0000-00000000000b",
                 TEST_TENANT_STR,
                 "person",
-                "2025-12-01",
+                "2026-01-01",
                 "2026-01-31",
+                "2025-12-01",
+                "2025-12-31",
                 "ai_usage",
                 "accepted_edit_actions",
                 "ai_usage",
@@ -2416,7 +2494,7 @@ mod tests {
     }
 
     #[test]
-    fn breakdown_over_windows_emits_one_value_column_per_window() {
+    fn breakdown_over_windows_emits_a_value_and_a_presence_column_per_window() {
         let sum = sum_metric();
         let query = compile_breakdown_query(
             &sum,
@@ -2427,34 +2505,71 @@ mod tests {
 
         assert!(query.sql.contains("AS value"));
         assert!(query.sql.contains("AS value_w0"));
+        // Presence rides its own column: a group's value cannot express it,
+        // because a ratio over a group that IS in the window reads NULL when
+        // its denominator is zero.
+        assert!(query.sql.contains("AS present"));
+        assert!(query.sql.contains("AS present_w0"));
+        assert_eq!(
+            query
+                .sql
+                .matches("countIf(metric_date >= toDate(?) AND metric_date <= toDate(?)) > 0")
+                .count(),
+            2,
+            "one presence column per window, the primary included"
+        );
         // The aggregates stage under names that cannot collide with the
         // observation's own `value` column — see `breakdown_aliases`.
         assert!(query.sql.contains("AS staged_w0"));
-        assert!(!query.sql.contains(
-            "IS NOT NULL AND metric_date >= toDate(?) AND metric_date <= toDate(?)) AS value"
-        ));
         assert_eq!(query.sql.matches('?').count(), query.params.len());
         assert_eq!(
             query.params,
             vec![
+                // primary value, then primary presence
+                "2026-01-01",
+                "2026-01-31",
+                "2026-01-01",
+                "2026-01-31",
+                // the extra window's value, then its presence
+                "2025-12-01",
+                "2025-12-31",
+                "2025-12-01",
+                "2025-12-31",
+                // identity-resolving read over both ranges
+                "00000000-0000-0000-0000-00000000000a",
+                "00000000-0000-0000-0000-00000000000b",
                 "2026-01-01",
                 "2026-01-31",
                 "2025-12-01",
                 "2025-12-31",
                 "00000000-0000-0000-0000-00000000000a",
                 "00000000-0000-0000-0000-00000000000b",
-                "2025-12-01",
-                "2026-01-31",
-                "00000000-0000-0000-0000-00000000000a",
-                "00000000-0000-0000-0000-00000000000b",
+                // metric scope, same two ranges
                 TEST_TENANT_STR,
                 "ai_usage",
                 "person",
-                "2025-12-01",
+                "2026-01-01",
                 "2026-01-31",
+                "2025-12-01",
+                "2025-12-31",
                 "accepted_lines",
             ]
         );
+    }
+
+    #[test]
+    fn an_unwindowed_breakdown_carries_no_presence_column() {
+        let sum = sum_metric();
+        let query = compile_breakdown_query(
+            &sum,
+            &request(),
+            std::slice::from_ref(&"tool".to_owned()),
+            &[],
+        );
+
+        assert!(!query.sql.contains("present"));
+        assert!(!query.sql.contains("staged_w"));
+        assert!(!query.sql.contains(" OR ("));
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_results/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/dto.rs
@@ -299,10 +299,28 @@ pub struct BreakdownValueDto {
     pub entity_id: String,
     pub dimensions: Vec<MetricDimensionDto>,
     pub value: Option<f64>,
+    /// Whether this group has any observation inside the primary period.
+    /// Present only on a windowed response, where the group set spans every
+    /// window and a reader has to know which of them each group belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub present: Option<bool>,
     /// One entry per requested extra window, in request order; empty when the
     /// request asked for none.
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub windows: Vec<Option<f64>>,
+    pub windows: Vec<BreakdownWindowValueDto>,
+}
+
+/// One group's reading over one extra window.
+///
+/// `value` and `present` are independent: a ratio over a group that IS in the
+/// window reads NULL whenever its denominator is zero, so absence cannot be
+/// inferred from the value. A reader that wants what a standalone request over
+/// this window would have returned keeps the rows with `present` and renders
+/// their `value` as it stands, NULL included.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct BreakdownWindowValueDto {
+    pub value: Option<f64>,
+    pub present: bool,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]

--- a/src/backend/services/analytics/src/domain/metric_results/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/dto.rs
@@ -255,9 +255,10 @@ pub struct MetricDimensionDto {
 pub struct PeriodValueDto {
     pub entity_id: String,
     pub value: Option<f64>,
-    /// The same reading over `compare_to`; absent when the request asked for no
-    /// comparison window, and null when it asked but the entity has no value
-    /// there.
+    /// The same reading over `compare_to`. Omitted both when no comparison
+    /// window was asked for and when the entity has no value in it — the two
+    /// are not distinguished on the wire, and a reader that asked knows which
+    /// case it is in.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compare_to: Option<f64>,
 }

--- a/src/backend/services/analytics/src/domain/metric_results/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/dto.rs
@@ -8,11 +8,11 @@ use crate::domain::metric_drilldown::MetricDrilldownCapability;
 pub struct MetricResultsRequest {
     pub entity: MetricResultsEntity,
     pub period: MetricResultsPeriod,
-    /// Extra windows served alongside `period` in the same response, in request
-    /// order. Carried by the `period` and `breakdown` views only; every other
-    /// view kind answers over `period` alone.
-    #[serde(default)]
-    pub windows: Vec<MetricResultsPeriod>,
+    /// A second window answered alongside `period` in the same response — the
+    /// range a delta or a half-against-half comparison is measured against.
+    /// Carried by the `period` and `breakdown` views only; every other view
+    /// kind answers over `period` alone.
+    pub compare_to: Option<MetricResultsPeriod>,
     pub metrics: Vec<MetricRequest>,
 }
 
@@ -255,10 +255,11 @@ pub struct MetricDimensionDto {
 pub struct PeriodValueDto {
     pub entity_id: String,
     pub value: Option<f64>,
-    /// One entry per requested extra window, in request order; empty when the
-    /// request asked for none, keeping the single-window wire form unchanged.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub windows: Vec<Option<f64>>,
+    /// The same reading over `compare_to`; absent when the request asked for no
+    /// comparison window, and null when it asked but the entity has no value
+    /// there.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compare_to: Option<f64>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -304,18 +305,18 @@ pub struct BreakdownValueDto {
     /// window and a reader has to know which of them each group belongs to.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub present: Option<bool>,
-    /// One entry per requested extra window, in request order; empty when the
-    /// request asked for none.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub windows: Vec<BreakdownWindowValueDto>,
+    /// This group's reading over `compare_to`; absent when no comparison window
+    /// was asked for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compare_to: Option<BreakdownWindowValueDto>,
 }
 
-/// One group's reading over one extra window.
+/// One group's reading over the comparison window.
 ///
 /// `value` and `present` are independent: a ratio over a group that IS in the
 /// window reads NULL whenever its denominator is zero, so absence cannot be
 /// inferred from the value. A reader that wants what a standalone request over
-/// this window would have returned keeps the rows with `present` and renders
+/// that window would have returned keeps the rows with `present` and renders
 /// their `value` as it stands, NULL included.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct BreakdownWindowValueDto {

--- a/src/backend/services/analytics/src/domain/metric_results/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/dto.rs
@@ -8,6 +8,11 @@ use crate::domain::metric_drilldown::MetricDrilldownCapability;
 pub struct MetricResultsRequest {
     pub entity: MetricResultsEntity,
     pub period: MetricResultsPeriod,
+    /// Extra windows served alongside `period` in the same response, in request
+    /// order. Carried by the `period` and `breakdown` views only; every other
+    /// view kind answers over `period` alone.
+    #[serde(default)]
+    pub windows: Vec<MetricResultsPeriod>,
     pub metrics: Vec<MetricRequest>,
 }
 
@@ -250,6 +255,10 @@ pub struct MetricDimensionDto {
 pub struct PeriodValueDto {
     pub entity_id: String,
     pub value: Option<f64>,
+    /// One entry per requested extra window, in request order; empty when the
+    /// request asked for none, keeping the single-window wire form unchanged.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub windows: Vec<Option<f64>>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -290,6 +299,10 @@ pub struct BreakdownValueDto {
     pub entity_id: String,
     pub dimensions: Vec<MetricDimensionDto>,
     pub value: Option<f64>,
+    /// One entry per requested extra window, in request order; empty when the
+    /// request asked for none.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub windows: Vec<Option<f64>>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]

--- a/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
@@ -29,6 +29,7 @@ use crate::domain::metric_definitions::definition::ValueTransform;
 use crate::domain::metric_definitions::definition::{
     AliasCollapse, ComputationSpec, CustomObservationSql, MetricBase, MetricDefinition,
     MetricDirection, MetricFormat, MetricInput, MetricInputRole, ObservationSource,
+    RatioDenominatorAggregation,
 };
 
 const URL_VAR: &str = "INTEGRATION_TESTS_CLICKHOUSE_URL";
@@ -73,6 +74,25 @@ fn nullable_date_sql() -> String {
             CAST([] AS Array(Tuple(key String, value String, label Nullable(String)))) AS dimensions \
         FROM numbers(4)"
     )
+}
+
+/// Two dimension groups that do NOT overlap in time: `org/a` only in
+/// 2026-08-15..16, `org/b` only in 2026-08-13..14. A standalone request over
+/// either window returns exactly one of them — which is what the windowed
+/// shape has to reproduce.
+fn disjoint_groups_sql() -> String {
+    let row = |repo: &str, day: &str, value: &str, measure: &str| {
+        format!(
+            "SELECT                 '{TENANT}' AS tenant_id,                 'custom_repro' AS source_key,                 'person' AS entity_type,                 '{PERSON}' AS entity_id,                 CAST(toDate('{day}') AS Nullable(Date)) AS metric_date,                 '{measure}' AS measure_key,                 now() AS observed_at,                 toFloat64({value}) AS value,                 CAST(NULL AS Nullable(String)) AS subject_key,                 CAST([('repository', '{repo}', NULL)] AS Array(Tuple(key String, value String, label Nullable(String)))) AS dimensions"
+        )
+    };
+    [
+        row("org/a", "2026-08-15", "10", "repro_value"),
+        row("org/a", "2026-08-16", "0", "repro_denominator"),
+        row("org/b", "2026-08-13", "20", "repro_value"),
+        row("org/b", "2026-08-13", "4", "repro_denominator"),
+    ]
+    .join(" UNION ALL ")
 }
 
 fn nullable_date_metric() -> MetricDefinition {
@@ -201,6 +221,123 @@ async fn a_windowed_period_batch_answers_each_window_from_one_scan() -> anyhow::
     Ok(())
 }
 
+/// A ratio over the disjoint-group fixture: `org/a` lives only in the primary
+/// window and its denominator is zero there, `org/b` only in the extra window.
+/// This is the case a value column cannot express on its own.
+fn disjoint_ratio_metric() -> MetricDefinition {
+    let sql = disjoint_groups_sql();
+    MetricDefinition {
+        transform: None,
+        base: MetricBase {
+            key: "custom.disjoint_ratio".to_owned(),
+            label: "Disjoint ratio".to_owned(),
+            short_label: None,
+            description: None,
+            explanation: None,
+            entity_type: "person".to_owned(),
+            format: MetricFormat::Percent,
+            unit: None,
+            direction: MetricDirection::HigherIsBetter,
+            peer_cohort_key: None,
+            allowed_dimensions: vec!["repository".to_owned()],
+        },
+        spec: ComputationSpec::Ratio {
+            numerator: MetricInput {
+                role: MetricInputRole::Numerator,
+                observation: ObservationSource::Custom(CustomObservationSql::new(sql.clone())),
+                source_key: "custom_repro".to_owned(),
+                measure_key: "repro_value".to_owned(),
+                alias_collapse: AliasCollapse::Sum,
+            },
+            denominator: MetricInput {
+                role: MetricInputRole::Denominator,
+                observation: ObservationSource::Custom(CustomObservationSql::new(sql)),
+                source_key: "custom_repro".to_owned(),
+                measure_key: "repro_denominator".to_owned(),
+                alias_collapse: AliasCollapse::Sum,
+            },
+            scale: 100.0,
+            denominator_aggregation: RatioDenominatorAggregation::Sum,
+        },
+    }
+}
+
+/// The contract a projected window rests on: per group and per window, the
+/// response has to say whether a standalone request over that window would
+/// have returned the group at all — independently of its value.
+#[tokio::test]
+#[ignore = "requires live ClickHouse; set INTEGRATION_TESTS_CLICKHOUSE_URL to enable"]
+async fn a_windowed_breakdown_reports_presence_apart_from_value() -> anyhow::Result<()> {
+    let Some(ch) = client_or_skip() else {
+        return Ok(());
+    };
+    let def = disjoint_ratio_metric();
+    let mut req = request();
+    req.from = NaiveDate::from_ymd_opt(2026, 8, 15).unwrap_or_default();
+    req.to = NaiveDate::from_ymd_opt(2026, 8, 16).unwrap_or_default();
+    req.windows = vec![DateWindow {
+        from: NaiveDate::from_ymd_opt(2026, 8, 13).unwrap_or_default(),
+        to: NaiveDate::from_ymd_opt(2026, 8, 14).unwrap_or_default(),
+    }];
+    let dimensions = vec!["repository".to_owned()];
+
+    let query = compile_breakdown_query(&def, &req, &dimensions, &[]);
+    let rows: Vec<BreakdownQueryRow> = fetch_rows(&ch, &query).await?;
+    let view = build_breakdown_view(&req, &dimensions, rows, &ExternalSourceRegistry::default())?;
+    let MetricResultViewDto::Breakdown { values, .. } = view else {
+        anyhow::bail!("expected a breakdown view");
+    };
+
+    let group = |repo: &str| {
+        values.iter().find(|value| {
+            value
+                .dimensions
+                .iter()
+                .any(|dimension| dimension.value == repo)
+        })
+    };
+    let Some(a) = group("org/a") else {
+        anyhow::bail!("org/a must be in the combined row set");
+    };
+    let Some(b) = group("org/b") else {
+        anyhow::bail!("org/b must be in the combined row set");
+    };
+
+    // org/a IS in the primary window, and its ratio reads NULL there because
+    // the denominator sums to zero. A reader dropping NULL values would lose a
+    // row that a standalone request returns.
+    anyhow::ensure!(
+        a.present == Some(true) && a.value.is_none(),
+        "org/a must be present in the primary window with a NULL value, got {:?}",
+        (a.present, a.value)
+    );
+    let [ref a_window] = a.windows[..] else {
+        anyhow::bail!("expected one extra window for org/a");
+    };
+    anyhow::ensure!(
+        !a_window.present,
+        "org/a has no rows in the extra window, got present={}",
+        a_window.present
+    );
+
+    // org/b is the mirror image: absent from the primary window, present in
+    // the extra one with a real value.
+    let [ref b_window] = b.windows[..] else {
+        anyhow::bail!("expected one extra window for org/b");
+    };
+    anyhow::ensure!(
+        b.present == Some(false),
+        "org/b has no rows in the primary window, got {:?}",
+        b.present
+    );
+    anyhow::ensure!(
+        b_window.present && b_window.value == Some(500.0),
+        "org/b must read 100 * 20 / 4 in the extra window, got {:?}",
+        (b_window.present, b_window.value)
+    );
+    Ok(())
+}
+
 /// The breakdown's window columns, through the transform projection stage that
 /// re-selects every one of them by name.
 #[tokio::test]
@@ -241,10 +378,18 @@ async fn a_windowed_breakdown_transforms_every_window_column() -> anyhow::Result
         "the primary window must be the transformed 3 + 4, got {:?}",
         one.value
     );
+    let [ref window] = one.windows[..] else {
+        anyhow::bail!("expected one extra window, got {}", one.windows.len());
+    };
     anyhow::ensure!(
-        one.windows == vec![Some(30.0)],
-        "the extra window must be transformed too, got {:?}",
-        one.windows
+        window.value == Some(30.0) && window.present,
+        "the extra window must be present and transformed, got {:?}",
+        (window.value, window.present)
+    );
+    anyhow::ensure!(
+        one.present == Some(true),
+        "the group is observed in the primary window too, got {:?}",
+        one.present
     );
     Ok(())
 }

--- a/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
@@ -11,14 +11,21 @@ use chrono::NaiveDate;
 use serde::de::DeserializeOwned;
 use uuid::Uuid;
 
-use super::batch::{RankedDimension, RankedGroup, ResolvedGroupLimit};
-use super::builder::build_timeseries_view;
-use super::compiler::{CompiledQuery, TimeseriesQueryRow, compile_timeseries_query};
+use super::batch::{
+    BatchItem, PeriodWideRow, RankedDimension, RankedGroup, ResolvedGroupLimit, demux_period_rows,
+};
+use super::builder::{build_breakdown_view, build_period_view, build_timeseries_view};
+use super::compiler::{
+    BreakdownQueryRow, CompiledQuery, TimeseriesQueryRow, compile_breakdown_query,
+    compile_period_batch_query, compile_timeseries_query,
+};
 use super::dto::MetricResultViewDto;
 use super::dto::MetricViewErrorCode;
 use super::failure::ViewFailure;
-use super::validation::{ValidatedEntitySelection, ValidatedMetricResultsRequest};
+use super::validation::{DateWindow, ValidatedEntitySelection, ValidatedMetricResultsRequest};
 use super::view::Bucket;
+use crate::domain::external_links::ExternalSourceRegistry;
+use crate::domain::metric_definitions::definition::ValueTransform;
 use crate::domain::metric_definitions::definition::{
     AliasCollapse, ComputationSpec, CustomObservationSql, MetricBase, MetricDefinition,
     MetricDirection, MetricFormat, MetricInput, MetricInputRole, ObservationSource,
@@ -104,6 +111,7 @@ fn request() -> ValidatedMetricResultsRequest {
         entity: ValidatedEntitySelection::Person { ids: vec![PERSON] },
         from: NaiveDate::from_ymd_opt(2026, 8, 13).unwrap_or_default(),
         to: NaiveDate::from_ymd_opt(2026, 8, 16).unwrap_or_default(),
+        windows: Vec::new(),
         metrics: Vec::new(),
         enforce_tenant_scope: true,
     }
@@ -126,6 +134,119 @@ async fn fetch_rows<T: DeserializeOwned>(
         .filter(|line| !line.is_empty())
         .map(|line| serde_json::from_slice(line).map_err(Into::into))
         .collect()
+}
+
+/// The four observations of `nullable_date_sql` split across two windows:
+/// 2026-08-13..14 carry 1 + 2, and 2026-08-15..16 carry 3 + 4. A windowed
+/// request must read both out of ONE scan of the union.
+#[tokio::test]
+#[ignore = "requires live ClickHouse; set INTEGRATION_TESTS_CLICKHOUSE_URL to enable"]
+async fn a_windowed_period_batch_answers_each_window_from_one_scan() -> anyhow::Result<()> {
+    let Some(ch) = client_or_skip() else {
+        return Ok(());
+    };
+    let mut req = request();
+    req.from = NaiveDate::from_ymd_opt(2026, 8, 15).unwrap_or_default();
+    req.to = NaiveDate::from_ymd_opt(2026, 8, 16).unwrap_or_default();
+    req.windows = vec![DateWindow {
+        from: NaiveDate::from_ymd_opt(2026, 8, 13).unwrap_or_default(),
+        to: NaiveDate::from_ymd_opt(2026, 8, 14).unwrap_or_default(),
+    }];
+
+    // The second pass adds a transform, so the batch's projection stage has to
+    // re-select every window's column and not just the primary one.
+    for multiplier in [None, Some(10.0)] {
+        let mut def = nullable_date_metric();
+        def.transform = multiplier.map(|multiplier| ValueTransform {
+            multiplier: Some(multiplier),
+            offset: None,
+            clamp_min: None,
+            clamp_max: None,
+        });
+        let scale = multiplier.unwrap_or(1.0);
+
+        let query = compile_period_batch_query(&[&def], &req, &[]);
+        let rows: Vec<PeriodWideRow> = fetch_rows(&ch, &query)
+            .await
+            .map_err(|e| anyhow::anyhow!("multiplier {multiplier:?}: {e}"))?;
+        let items = vec![BatchItem {
+            metric_index: 0,
+            view_index: 0,
+            def: def.clone(),
+        }];
+        let per_item = demux_period_rows(&items, rows, req.windows.len())?;
+
+        let MetricResultViewDto::Period { values } =
+            build_period_view(&def, &req, per_item.into_iter().next().unwrap_or_default())
+        else {
+            anyhow::bail!("multiplier {multiplier:?}: expected a period view");
+        };
+        let [ref one] = values[..] else {
+            anyhow::bail!(
+                "multiplier {multiplier:?}: expected one entity, got {}",
+                values.len()
+            );
+        };
+        anyhow::ensure!(
+            one.value == Some(7.0 * scale),
+            "multiplier {multiplier:?}: the primary window must sum 3 + 4, got {:?}",
+            one.value
+        );
+        anyhow::ensure!(
+            one.windows == vec![Some(3.0 * scale)],
+            "multiplier {multiplier:?}: the extra window must sum 1 + 2, got {:?}",
+            one.windows
+        );
+    }
+    Ok(())
+}
+
+/// The breakdown's window columns, through the transform projection stage that
+/// re-selects every one of them by name.
+#[tokio::test]
+#[ignore = "requires live ClickHouse; set INTEGRATION_TESTS_CLICKHOUSE_URL to enable"]
+async fn a_windowed_breakdown_transforms_every_window_column() -> anyhow::Result<()> {
+    let Some(ch) = client_or_skip() else {
+        return Ok(());
+    };
+    let mut def = nullable_date_metric();
+    def.base.allowed_dimensions = vec!["tool".to_owned()];
+    def.transform = Some(ValueTransform {
+        multiplier: Some(10.0),
+        offset: None,
+        clamp_min: None,
+        clamp_max: None,
+    });
+    let mut req = request();
+    req.from = NaiveDate::from_ymd_opt(2026, 8, 15).unwrap_or_default();
+    req.to = NaiveDate::from_ymd_opt(2026, 8, 16).unwrap_or_default();
+    req.windows = vec![DateWindow {
+        from: NaiveDate::from_ymd_opt(2026, 8, 13).unwrap_or_default(),
+        to: NaiveDate::from_ymd_opt(2026, 8, 14).unwrap_or_default(),
+    }];
+    let dimensions = vec!["tool".to_owned()];
+
+    let query = compile_breakdown_query(&def, &req, &dimensions, &[]);
+    let rows: Vec<BreakdownQueryRow> = fetch_rows(&ch, &query).await?;
+
+    let view = build_breakdown_view(&req, &dimensions, rows, &ExternalSourceRegistry::default())?;
+    let MetricResultViewDto::Breakdown { values, .. } = view else {
+        anyhow::bail!("expected a breakdown view");
+    };
+    let [ref one] = values[..] else {
+        anyhow::bail!("expected one dimension group, got {}", values.len());
+    };
+    anyhow::ensure!(
+        one.value == Some(70.0),
+        "the primary window must be the transformed 3 + 4, got {:?}",
+        one.value
+    );
+    anyhow::ensure!(
+        one.windows == vec![Some(30.0)],
+        "the extra window must be transformed too, got {:?}",
+        one.windows
+    );
+    Ok(())
 }
 
 #[tokio::test]

--- a/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
@@ -131,7 +131,7 @@ fn request() -> ValidatedMetricResultsRequest {
         entity: ValidatedEntitySelection::Person { ids: vec![PERSON] },
         from: NaiveDate::from_ymd_opt(2026, 8, 13).unwrap_or_default(),
         to: NaiveDate::from_ymd_opt(2026, 8, 16).unwrap_or_default(),
-        windows: Vec::new(),
+        compare_to: None,
         metrics: Vec::new(),
         enforce_tenant_scope: true,
     }
@@ -168,10 +168,10 @@ async fn a_windowed_period_batch_answers_each_window_from_one_scan() -> anyhow::
     let mut req = request();
     req.from = NaiveDate::from_ymd_opt(2026, 8, 15).unwrap_or_default();
     req.to = NaiveDate::from_ymd_opt(2026, 8, 16).unwrap_or_default();
-    req.windows = vec![DateWindow {
+    req.compare_to = Some(DateWindow {
         from: NaiveDate::from_ymd_opt(2026, 8, 13).unwrap_or_default(),
         to: NaiveDate::from_ymd_opt(2026, 8, 14).unwrap_or_default(),
-    }];
+    });
 
     // The second pass adds a transform, so the batch's projection stage has to
     // re-select every window's column and not just the primary one.
@@ -194,7 +194,7 @@ async fn a_windowed_period_batch_answers_each_window_from_one_scan() -> anyhow::
             view_index: 0,
             def: def.clone(),
         }];
-        let per_item = demux_period_rows(&items, rows, req.windows.len())?;
+        let per_item = demux_period_rows(&items, rows, req.compare_to.is_some())?;
 
         let MetricResultViewDto::Period { values } =
             build_period_view(&def, &req, per_item.into_iter().next().unwrap_or_default())
@@ -213,9 +213,9 @@ async fn a_windowed_period_batch_answers_each_window_from_one_scan() -> anyhow::
             one.value
         );
         anyhow::ensure!(
-            one.windows == vec![Some(3.0 * scale)],
-            "multiplier {multiplier:?}: the extra window must sum 1 + 2, got {:?}",
-            one.windows
+            one.compare_to == Some(3.0 * scale),
+            "multiplier {multiplier:?}: the comparison window must sum 1 + 2, got {:?}",
+            one.compare_to
         );
     }
     Ok(())
@@ -275,10 +275,10 @@ async fn a_windowed_breakdown_reports_presence_apart_from_value() -> anyhow::Res
     let mut req = request();
     req.from = NaiveDate::from_ymd_opt(2026, 8, 15).unwrap_or_default();
     req.to = NaiveDate::from_ymd_opt(2026, 8, 16).unwrap_or_default();
-    req.windows = vec![DateWindow {
+    req.compare_to = Some(DateWindow {
         from: NaiveDate::from_ymd_opt(2026, 8, 13).unwrap_or_default(),
         to: NaiveDate::from_ymd_opt(2026, 8, 14).unwrap_or_default(),
-    }];
+    });
     let dimensions = vec!["repository".to_owned()];
 
     let query = compile_breakdown_query(&def, &req, &dimensions, &[]);
@@ -311,19 +311,19 @@ async fn a_windowed_breakdown_reports_presence_apart_from_value() -> anyhow::Res
         "org/a must be present in the primary window with a NULL value, got {:?}",
         (a.present, a.value)
     );
-    let [ref a_window] = a.windows[..] else {
-        anyhow::bail!("expected one extra window for org/a");
+    let Some(ref a_window) = a.compare_to else {
+        anyhow::bail!("expected a comparison window for org/a");
     };
     anyhow::ensure!(
         !a_window.present,
-        "org/a has no rows in the extra window, got present={}",
+        "org/a has no rows in the comparison window, got present={}",
         a_window.present
     );
 
     // org/b is the mirror image: absent from the primary window, present in
     // the extra one with a real value.
-    let [ref b_window] = b.windows[..] else {
-        anyhow::bail!("expected one extra window for org/b");
+    let Some(ref b_window) = b.compare_to else {
+        anyhow::bail!("expected a comparison window for org/b");
     };
     anyhow::ensure!(
         b.present == Some(false),
@@ -332,7 +332,7 @@ async fn a_windowed_breakdown_reports_presence_apart_from_value() -> anyhow::Res
     );
     anyhow::ensure!(
         b_window.present && b_window.value == Some(500.0),
-        "org/b must read 100 * 20 / 4 in the extra window, got {:?}",
+        "org/b must read 100 * 20 / 4 in the comparison window, got {:?}",
         (b_window.present, b_window.value)
     );
     Ok(())
@@ -357,10 +357,10 @@ async fn a_windowed_breakdown_transforms_every_window_column() -> anyhow::Result
     let mut req = request();
     req.from = NaiveDate::from_ymd_opt(2026, 8, 15).unwrap_or_default();
     req.to = NaiveDate::from_ymd_opt(2026, 8, 16).unwrap_or_default();
-    req.windows = vec![DateWindow {
+    req.compare_to = Some(DateWindow {
         from: NaiveDate::from_ymd_opt(2026, 8, 13).unwrap_or_default(),
         to: NaiveDate::from_ymd_opt(2026, 8, 14).unwrap_or_default(),
-    }];
+    });
     let dimensions = vec!["tool".to_owned()];
 
     let query = compile_breakdown_query(&def, &req, &dimensions, &[]);
@@ -378,12 +378,12 @@ async fn a_windowed_breakdown_transforms_every_window_column() -> anyhow::Result
         "the primary window must be the transformed 3 + 4, got {:?}",
         one.value
     );
-    let [ref window] = one.windows[..] else {
-        anyhow::bail!("expected one extra window, got {}", one.windows.len());
+    let Some(ref window) = one.compare_to else {
+        anyhow::bail!("expected a comparison window");
     };
     anyhow::ensure!(
         window.value == Some(30.0) && window.present,
-        "the extra window must be present and transformed, got {:?}",
+        "the comparison window must be present and transformed, got {:?}",
         (window.value, window.present)
     );
     anyhow::ensure!(

--- a/src/backend/services/analytics/src/domain/metric_results/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/validation.rs
@@ -22,10 +22,6 @@ const MAX_METRICS: usize = 50;
 // would turn a legal request into a 400 from a service the caller never named.
 const MAX_PERSON_IDS: usize = 1000;
 const MAX_PERIOD_DAYS: i64 = 400;
-// Extra windows are columns, not rows: each one widens the batched period
-// aggregate by one conditional term. The cap bounds the widening a single
-// request can ask for.
-const MAX_WINDOWS: usize = 4;
 const MAX_FILTERS: usize = 10;
 const MAX_FILTER_VALUES: usize = 100;
 const MAX_FILTER_VALUE_BYTES: usize = 512;
@@ -108,10 +104,10 @@ pub struct ValidatedMetricResultsRequest {
     pub entity: ValidatedEntitySelection,
     pub from: NaiveDate,
     pub to: NaiveDate,
-    /// Extra windows the `period` and `breakdown` views carry alongside
-    /// `from..to`, in request order. Empty for a single-window request, and the
-    /// compiler emits byte-identical SQL in that case.
-    pub windows: Vec<DateWindow>,
+    /// The comparison window the `period` and `breakdown` views carry alongside
+    /// `from..to`. `None` for a single-window request, and the compiler emits
+    /// byte-identical SQL in that case.
+    pub compare_to: Option<DateWindow>,
     pub metrics: Vec<ValidatedMetricRequest>,
     /// Whether the compiler injects the per-tenant observation filter (#1967).
     /// Set from the `metric_catalog.enforce_tenant_scope` config key by the handler; the
@@ -168,7 +164,7 @@ struct RequestShape {
     entity: ValidatedEntitySelection,
     from: NaiveDate,
     to: NaiveDate,
-    windows: Vec<DateWindow>,
+    compare_to: Option<DateWindow>,
     metric_keys: Vec<String>,
 }
 
@@ -182,7 +178,7 @@ pub async fn validate_request(
         entity,
         from,
         to,
-        windows,
+        compare_to,
         metric_keys,
     } = shape;
 
@@ -267,7 +263,7 @@ pub async fn validate_request(
         entity,
         from,
         to,
-        windows,
+        compare_to,
         metrics,
         // Off unless the handler turns it on from config; the ingest tenant is
         // not yet aligned to the JWT tenant (#1829), so enforcing here empties
@@ -332,30 +328,26 @@ fn validate_request_shape(
         );
     }
 
-    if req.windows.len() > MAX_WINDOWS {
-        return invalid(
-            "windows",
-            format!("at most {MAX_WINDOWS} extra windows per request"),
-        );
-    }
-    let mut windows = Vec::with_capacity(req.windows.len());
-    for (index, window) in req.windows.iter().enumerate() {
-        let from = parse_date("windows.from", &window.from)?;
-        let to = parse_date("windows.to", &window.to)?;
-        if from > to {
-            return invalid(
-                "windows",
-                format!("windows[{index}].from must be before or equal to windows[{index}].to"),
-            );
+    let compare_to = match &req.compare_to {
+        None => None,
+        Some(window) => {
+            let from = parse_date("compare_to.from", &window.from)?;
+            let to = parse_date("compare_to.to", &window.to)?;
+            if from > to {
+                return invalid(
+                    "compare_to",
+                    "compare_to.from must be before or equal to compare_to.to",
+                );
+            }
+            if (to - from).num_days() >= MAX_PERIOD_DAYS {
+                return invalid(
+                    "compare_to",
+                    format!("compare_to must not exceed {MAX_PERIOD_DAYS} days"),
+                );
+            }
+            Some(DateWindow { from, to })
         }
-        if (to - from).num_days() >= MAX_PERIOD_DAYS {
-            return invalid(
-                "windows",
-                format!("windows[{index}] must not exceed {MAX_PERIOD_DAYS} days"),
-            );
-        }
-        windows.push(DateWindow { from, to });
-    }
+    };
 
     let mut seen_metric_keys = BTreeSet::new();
     let mut metric_keys = Vec::with_capacity(req.metrics.len());
@@ -377,7 +369,7 @@ fn validate_request_shape(
         entity,
         from,
         to,
-        windows,
+        compare_to,
         metric_keys,
     })
 }
@@ -829,7 +821,7 @@ mod tests {
                 from: from.to_owned(),
                 to: to.to_owned(),
             },
-            windows: Vec::new(),
+            compare_to: None,
             metrics: metric_keys
                 .into_iter()
                 .map(|key| super::super::dto::MetricRequest {
@@ -1041,48 +1033,48 @@ mod tests {
     }
 
     #[test]
-    fn shape_keeps_extra_windows_in_request_order() {
+    fn shape_carries_the_comparison_window() {
         let mut req = shape_request(
             vec!["019e27bc-dec0-7626-81a9-c5524662a6a9"],
             "2026-02-01",
             "2026-02-28",
             vec!["ai.x"],
         );
-        req.windows = vec![window("2026-01-01", "2026-01-31")];
+        req.compare_to = Some(window("2026-01-01", "2026-01-31"));
 
         let Ok(shape) = validate_request_shape(&req, Uuid::nil()) else {
             panic!("expected the shape to validate");
         };
 
-        assert_eq!(shape.windows.len(), 1);
-        assert_eq!(shape.windows[0].from, day("2026-01-01"));
-        assert_eq!(shape.windows[0].to, day("2026-01-31"));
+        let Some(compare_to) = shape.compare_to else {
+            panic!("expected a comparison window");
+        };
+        assert_eq!(compare_to.from, day("2026-01-01"));
+        assert_eq!(compare_to.to, day("2026-01-31"));
     }
 
     #[test]
-    fn shape_rejects_a_reversed_window() {
+    fn shape_rejects_a_reversed_comparison_window() {
         let mut req = shape_request(
             vec!["019e27bc-dec0-7626-81a9-c5524662a6a9"],
             "2026-02-01",
             "2026-02-28",
             vec!["ai.x"],
         );
-        req.windows = vec![window("2026-01-31", "2026-01-01")];
+        req.compare_to = Some(window("2026-01-31", "2026-01-01"));
 
         assert!(validate_request_shape(&req, Uuid::nil()).is_err());
     }
 
     #[test]
-    fn shape_rejects_more_windows_than_the_cap() {
+    fn shape_rejects_an_oversized_comparison_window() {
         let mut req = shape_request(
             vec!["019e27bc-dec0-7626-81a9-c5524662a6a9"],
             "2026-02-01",
             "2026-02-28",
             vec!["ai.x"],
         );
-        req.windows = (0..=MAX_WINDOWS)
-            .map(|_| window("2026-01-01", "2026-01-31"))
-            .collect();
+        req.compare_to = Some(window("2020-01-01", "2026-01-31"));
 
         assert!(validate_request_shape(&req, Uuid::nil()).is_err());
     }
@@ -1523,7 +1515,7 @@ mod tests {
             },
             from: day("2026-01-01"),
             to: day("2026-03-31"),
-            windows: Vec::new(),
+            compare_to: None,
             metrics: vec![ValidatedMetricRequest {
                 def,
                 filters: vec![],
@@ -1557,7 +1549,7 @@ mod tests {
             },
             from: day("2025-07-21"),
             to: day("2026-07-20"),
-            windows: Vec::new(),
+            compare_to: None,
             metrics: (0..4)
                 .map(|_| ValidatedMetricRequest {
                     def: def.clone(),
@@ -1591,7 +1583,7 @@ mod tests {
             },
             from: day("2026-01-01"),
             to: day("2026-01-31"),
-            windows: Vec::new(),
+            compare_to: None,
             metrics: vec![ValidatedMetricRequest {
                 def: median_definition(),
                 filters: vec![],
@@ -1620,7 +1612,7 @@ mod tests {
             },
             from: day("2026-01-01"),
             to: day("2026-01-31"),
-            windows: Vec::new(),
+            compare_to: None,
             metrics: vec![ValidatedMetricRequest {
                 def,
                 filters: vec![],

--- a/src/backend/services/analytics/src/domain/metric_results/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/validation.rs
@@ -22,6 +22,10 @@ const MAX_METRICS: usize = 50;
 // would turn a legal request into a 400 from a service the caller never named.
 const MAX_PERSON_IDS: usize = 1000;
 const MAX_PERIOD_DAYS: i64 = 400;
+// Extra windows are columns, not rows: each one widens the batched period
+// aggregate by one conditional term. The cap bounds the widening a single
+// request can ask for.
+const MAX_WINDOWS: usize = 4;
 const MAX_FILTERS: usize = 10;
 const MAX_FILTER_VALUES: usize = 100;
 const MAX_FILTER_VALUE_BYTES: usize = 512;
@@ -90,12 +94,24 @@ impl ValidatedEntitySelection {
     }
 }
 
+/// One closed day range. `from <= to` holds for every value the validator
+/// admits, so the compiler binds a window without re-checking it.
+#[derive(Debug, Clone, Copy)]
+pub struct DateWindow {
+    pub from: NaiveDate,
+    pub to: NaiveDate,
+}
+
 #[derive(Debug)]
 pub struct ValidatedMetricResultsRequest {
     pub tenant_id: Uuid,
     pub entity: ValidatedEntitySelection,
     pub from: NaiveDate,
     pub to: NaiveDate,
+    /// Extra windows the `period` and `breakdown` views carry alongside
+    /// `from..to`, in request order. Empty for a single-window request, and the
+    /// compiler emits byte-identical SQL in that case.
+    pub windows: Vec<DateWindow>,
     pub metrics: Vec<ValidatedMetricRequest>,
     /// Whether the compiler injects the per-tenant observation filter (#1967).
     /// Set from the `metric_catalog.enforce_tenant_scope` config key by the handler; the
@@ -152,6 +168,7 @@ struct RequestShape {
     entity: ValidatedEntitySelection,
     from: NaiveDate,
     to: NaiveDate,
+    windows: Vec<DateWindow>,
     metric_keys: Vec<String>,
 }
 
@@ -165,6 +182,7 @@ pub async fn validate_request(
         entity,
         from,
         to,
+        windows,
         metric_keys,
     } = shape;
 
@@ -249,6 +267,7 @@ pub async fn validate_request(
         entity,
         from,
         to,
+        windows,
         metrics,
         // Off unless the handler turns it on from config; the ingest tenant is
         // not yet aligned to the JWT tenant (#1829), so enforcing here empties
@@ -313,6 +332,31 @@ fn validate_request_shape(
         );
     }
 
+    if req.windows.len() > MAX_WINDOWS {
+        return invalid(
+            "windows",
+            format!("at most {MAX_WINDOWS} extra windows per request"),
+        );
+    }
+    let mut windows = Vec::with_capacity(req.windows.len());
+    for (index, window) in req.windows.iter().enumerate() {
+        let from = parse_date("windows.from", &window.from)?;
+        let to = parse_date("windows.to", &window.to)?;
+        if from > to {
+            return invalid(
+                "windows",
+                format!("windows[{index}].from must be before or equal to windows[{index}].to"),
+            );
+        }
+        if (to - from).num_days() >= MAX_PERIOD_DAYS {
+            return invalid(
+                "windows",
+                format!("windows[{index}] must not exceed {MAX_PERIOD_DAYS} days"),
+            );
+        }
+        windows.push(DateWindow { from, to });
+    }
+
     let mut seen_metric_keys = BTreeSet::new();
     let mut metric_keys = Vec::with_capacity(req.metrics.len());
     for metric in &req.metrics {
@@ -333,6 +377,7 @@ fn validate_request_shape(
         entity,
         from,
         to,
+        windows,
         metric_keys,
     })
 }
@@ -784,6 +829,7 @@ mod tests {
                 from: from.to_owned(),
                 to: to.to_owned(),
             },
+            windows: Vec::new(),
             metrics: metric_keys
                 .into_iter()
                 .map(|key| super::super::dto::MetricRequest {
@@ -984,6 +1030,60 @@ mod tests {
             "2026-01-01",
             vec!["ai.x"],
         );
+        assert!(validate_request_shape(&req, Uuid::nil()).is_err());
+    }
+
+    fn window(from: &str, to: &str) -> super::super::dto::MetricResultsPeriod {
+        super::super::dto::MetricResultsPeriod {
+            from: from.to_owned(),
+            to: to.to_owned(),
+        }
+    }
+
+    #[test]
+    fn shape_keeps_extra_windows_in_request_order() {
+        let mut req = shape_request(
+            vec!["019e27bc-dec0-7626-81a9-c5524662a6a9"],
+            "2026-02-01",
+            "2026-02-28",
+            vec!["ai.x"],
+        );
+        req.windows = vec![window("2026-01-01", "2026-01-31")];
+
+        let Ok(shape) = validate_request_shape(&req, Uuid::nil()) else {
+            panic!("expected the shape to validate");
+        };
+
+        assert_eq!(shape.windows.len(), 1);
+        assert_eq!(shape.windows[0].from, day("2026-01-01"));
+        assert_eq!(shape.windows[0].to, day("2026-01-31"));
+    }
+
+    #[test]
+    fn shape_rejects_a_reversed_window() {
+        let mut req = shape_request(
+            vec!["019e27bc-dec0-7626-81a9-c5524662a6a9"],
+            "2026-02-01",
+            "2026-02-28",
+            vec!["ai.x"],
+        );
+        req.windows = vec![window("2026-01-31", "2026-01-01")];
+
+        assert!(validate_request_shape(&req, Uuid::nil()).is_err());
+    }
+
+    #[test]
+    fn shape_rejects_more_windows_than_the_cap() {
+        let mut req = shape_request(
+            vec!["019e27bc-dec0-7626-81a9-c5524662a6a9"],
+            "2026-02-01",
+            "2026-02-28",
+            vec!["ai.x"],
+        );
+        req.windows = (0..=MAX_WINDOWS)
+            .map(|_| window("2026-01-01", "2026-01-31"))
+            .collect();
+
         assert!(validate_request_shape(&req, Uuid::nil()).is_err());
     }
 
@@ -1423,6 +1523,7 @@ mod tests {
             },
             from: day("2026-01-01"),
             to: day("2026-03-31"),
+            windows: Vec::new(),
             metrics: vec![ValidatedMetricRequest {
                 def,
                 filters: vec![],
@@ -1456,6 +1557,7 @@ mod tests {
             },
             from: day("2025-07-21"),
             to: day("2026-07-20"),
+            windows: Vec::new(),
             metrics: (0..4)
                 .map(|_| ValidatedMetricRequest {
                     def: def.clone(),
@@ -1489,6 +1591,7 @@ mod tests {
             },
             from: day("2026-01-01"),
             to: day("2026-01-31"),
+            windows: Vec::new(),
             metrics: vec![ValidatedMetricRequest {
                 def: median_definition(),
                 filters: vec![],
@@ -1517,6 +1620,7 @@ mod tests {
             },
             from: day("2026-01-01"),
             to: day("2026-01-31"),
+            windows: Vec::new(),
             metrics: vec![ValidatedMetricRequest {
                 def,
                 filters: vec![],

--- a/src/frontend/src/api/metric-results-client.ts
+++ b/src/frontend/src/api/metric-results-client.ts
@@ -33,10 +33,11 @@ export interface MetricResultsRequest {
   entity: MetricResultsEntity;
   period: { from: string; to: string };
   /**
-   * Extra windows served in the same response, in request order. The `period`
-   * and `breakdown` views carry them; every other view answers over `period`.
+   * A second window answered in the same response — what a delta is measured
+   * against. The `period` and `breakdown` views carry it; every other view
+   * answers over `period`.
    */
-  windows?: Array<{ from: string; to: string }>;
+  compare_to?: { from: string; to: string };
   metrics: MetricRequest[];
 }
 
@@ -159,8 +160,8 @@ export interface PeriodView {
   values: Array<{
     entity_id: string;
     value: number | null;
-    /** One entry per requested extra window, in request order. */
-    windows?: Array<number | null>;
+    /** The same reading over `compare_to`; absent when none was asked for. */
+    compare_to?: number | null;
   }>;
 }
 
@@ -192,12 +193,12 @@ export interface PeerView {
   }>;
 }
 
-export interface BreakdownWindowValue {
+export interface BreakdownComparisonValue {
   value: number | null;
   /**
-   * Whether a standalone request over that window would have returned this
-   * group at all. Independent of `value`: a ratio over a group that IS in the
-   * window reads null whenever its denominator is zero.
+   * Whether a standalone request over the comparison window would have
+   * returned this group at all. Independent of `value`: a ratio over a group
+   * that IS in the window reads null whenever its denominator is zero.
    */
   present: boolean;
 }
@@ -211,8 +212,8 @@ export interface BreakdownView {
     value: number | null;
     /** Whether the group has observations inside the primary period. */
     present?: boolean;
-    /** One entry per requested extra window, in request order. */
-    windows?: BreakdownWindowValue[];
+    /** This group's reading over `compare_to`. */
+    compare_to?: BreakdownComparisonValue;
   }>;
 }
 

--- a/src/frontend/src/api/metric-results-client.ts
+++ b/src/frontend/src/api/metric-results-client.ts
@@ -192,6 +192,16 @@ export interface PeerView {
   }>;
 }
 
+export interface BreakdownWindowValue {
+  value: number | null;
+  /**
+   * Whether a standalone request over that window would have returned this
+   * group at all. Independent of `value`: a ratio over a group that IS in the
+   * window reads null whenever its denominator is zero.
+   */
+  present: boolean;
+}
+
 export interface BreakdownView {
   view: "breakdown";
   dimensions: string[];
@@ -199,8 +209,10 @@ export interface BreakdownView {
     entity_id: string;
     dimensions: MetricDimension[];
     value: number | null;
+    /** Whether the group has observations inside the primary period. */
+    present?: boolean;
     /** One entry per requested extra window, in request order. */
-    windows?: Array<number | null>;
+    windows?: BreakdownWindowValue[];
   }>;
 }
 

--- a/src/frontend/src/api/metric-results-client.ts
+++ b/src/frontend/src/api/metric-results-client.ts
@@ -32,6 +32,11 @@ export type MetricResultsEntity =
 export interface MetricResultsRequest {
   entity: MetricResultsEntity;
   period: { from: string; to: string };
+  /**
+   * Extra windows served in the same response, in request order. The `period`
+   * and `breakdown` views carry them; every other view answers over `period`.
+   */
+  windows?: Array<{ from: string; to: string }>;
   metrics: MetricRequest[];
 }
 
@@ -151,7 +156,12 @@ export type MetricResultView =
 
 export interface PeriodView {
   view: "period";
-  values: Array<{ entity_id: string; value: number | null }>;
+  values: Array<{
+    entity_id: string;
+    value: number | null;
+    /** One entry per requested extra window, in request order. */
+    windows?: Array<number | null>;
+  }>;
 }
 
 export interface TimeseriesView {
@@ -189,6 +199,8 @@ export interface BreakdownView {
     entity_id: string;
     dimensions: MetricDimension[];
     value: number | null;
+    /** One entry per requested extra window, in request order. */
+    windows?: Array<number | null>;
   }>;
 }
 

--- a/src/frontend/src/components/portal/tenant-lens-view/index.test.tsx
+++ b/src/frontend/src/components/portal/tenant-lens-view/index.test.tsx
@@ -21,7 +21,6 @@ import type {
 type HookResult = {
   byKey: Map<string, NormalizedMetricResult>;
   previousByKey: Map<string, NormalizedMetricResult> | null;
-  windowsByKey: Array<Map<string, NormalizedMetricResult>>;
   isPending: boolean;
   isFetching: boolean;
   isError: boolean;
@@ -32,7 +31,6 @@ function emptyResult(): HookResult {
   return {
     byKey: new Map(),
     previousByKey: null,
-    windowsByKey: [],
     isPending: false,
     isFetching: false,
     isError: false,
@@ -47,7 +45,7 @@ const mocks = vi.hoisted(() => ({
     collection: MetricCollectionConfig;
     entity: MetricCollectionEntity;
     range: DateRange;
-    windows: readonly DateRange[];
+    compareTo: DateRange | undefined;
   }>,
   setCalls: [] as Array<{
     collections: ReadonlyArray<{ key: string; collection: MetricCollectionConfig }>;
@@ -73,21 +71,19 @@ vi.mock("@/queries/metric-results", () => ({
     collection: MetricCollectionConfig,
     entity: MetricCollectionEntity,
     range: DateRange,
-    options?: { windows?: readonly DateRange[] }
+    options?: { compareTo?: DateRange }
   ) => {
-    const windows = options?.windows ?? [];
-    mocks.calls.push({ collection, entity, range, windows });
-    // The half windows ride the primary range now, so a windowed call answers
-    // with one `windowsByKey` entry per window from the same fixtures.
-    if (windows.length > 0) {
+    const compareTo = options?.compareTo;
+    mocks.calls.push({ collection, entity, range, compareTo });
+    // Both halves come from one call now: the range is the second half and the
+    // comparison window the first, each answered from the same fixtures.
+    if (compareTo) {
       const result = emptyResult();
       result.byKey =
         mocks.rangeResults.get(`${range.from}..${range.to}`)?.byKey ?? new Map();
-      result.windowsByKey = windows.map(
-        (window) =>
-          mocks.rangeResults.get(`${window.from}..${window.to}`)?.byKey ??
-          new Map()
-      );
+      result.previousByKey =
+        mocks.rangeResults.get(`${compareTo.from}..${compareTo.to}`)?.byKey ??
+        new Map();
       return result;
     }
     return range.from === PORTAL_RANGE.from && range.to === PORTAL_RANGE.to
@@ -921,14 +917,12 @@ describe("TenantLensView", () => {
     mocks.rangeResults.set(SECOND_HALF, secondHalf);
 
     render(<TenantLensView config={config} />);
-    // Both halves come from ONE request: the first half is its period and the
-    // second its only extra window, so nothing computes a third aggregate over
+    // Both halves come from ONE request: the second half is its period and the
+    // first its comparison window, so nothing computes a third aggregate over
     // the whole range that no section reads.
     expect(mocks.calls).toHaveLength(2);
-    expect(mocks.calls[1].range).toEqual({ from: "2026-03-01", to: "2026-03-15" });
-    expect(mocks.calls[1].windows).toEqual([
-      { from: "2026-03-16", to: "2026-03-31" },
-    ]);
+    expect(mocks.calls[1].range).toEqual({ from: "2026-03-16", to: "2026-03-31" });
+    expect(mocks.calls[1].compareTo).toEqual({ from: "2026-03-01", to: "2026-03-15" });
     expect(mocks.calls[1].collection.metrics).toEqual([
       {
         key: "ci.gate_pass_rate",

--- a/src/frontend/src/components/portal/tenant-lens-view/index.test.tsx
+++ b/src/frontend/src/components/portal/tenant-lens-view/index.test.tsx
@@ -21,6 +21,7 @@ import type {
 type HookResult = {
   byKey: Map<string, NormalizedMetricResult>;
   previousByKey: Map<string, NormalizedMetricResult> | null;
+  windowsByKey: Array<Map<string, NormalizedMetricResult>>;
   isPending: boolean;
   isFetching: boolean;
   isError: boolean;
@@ -31,6 +32,7 @@ function emptyResult(): HookResult {
   return {
     byKey: new Map(),
     previousByKey: null,
+    windowsByKey: [],
     isPending: false,
     isFetching: false,
     isError: false,
@@ -45,6 +47,7 @@ const mocks = vi.hoisted(() => ({
     collection: MetricCollectionConfig;
     entity: MetricCollectionEntity;
     range: DateRange;
+    windows: readonly DateRange[];
   }>,
   setCalls: [] as Array<{
     collections: ReadonlyArray<{ key: string; collection: MetricCollectionConfig }>;
@@ -69,11 +72,22 @@ vi.mock("@/queries/metric-results", () => ({
   useMetricCollection: (
     collection: MetricCollectionConfig,
     entity: MetricCollectionEntity,
-    range: DateRange
+    range: DateRange,
+    options?: { windows?: readonly DateRange[] }
   ) => {
-    mocks.calls.push({ collection, entity, range });
-    const half = mocks.rangeResults.get(`${range.from}..${range.to}`);
-    if (half) return half;
+    const windows = options?.windows ?? [];
+    mocks.calls.push({ collection, entity, range, windows });
+    // The half windows ride the primary range now, so a windowed call answers
+    // with one `windowsByKey` entry per window from the same fixtures.
+    if (windows.length > 0) {
+      const result = emptyResult();
+      result.windowsByKey = windows.map(
+        (window) =>
+          mocks.rangeResults.get(`${window.from}..${window.to}`)?.byKey ??
+          new Map()
+      );
+      return result;
+    }
     return range.from === PORTAL_RANGE.from && range.to === PORTAL_RANGE.to
       ? mocks.result
       : emptyResult();
@@ -264,13 +278,12 @@ describe("TenantLensView", () => {
   it("requests the lens over a tenant entity with per-section views", () => {
     render(<TenantLensView config={CONFIG} />);
 
-    // Main + the two half-window hooks (disabled: empty collections).
-    expect(mocks.calls).toHaveLength(3);
+    // Main + the halves hook (disabled: empty collection).
+    expect(mocks.calls).toHaveLength(2);
     for (const call of mocks.calls) {
       expect(call.entity).toEqual({ type: "tenant" });
     }
     expect(mocks.calls[1].collection.metrics).toHaveLength(0);
-    expect(mocks.calls[2].collection.metrics).toHaveLength(0);
     // No conflicting views → no extra collections.
     expect(mocks.setCalls[0].collections).toHaveLength(0);
 
@@ -906,9 +919,14 @@ describe("TenantLensView", () => {
     mocks.rangeResults.set(SECOND_HALF, secondHalf);
 
     render(<TenantLensView config={config} />);
-    // The month split at its midpoint, the odd day to the second half.
-    expect(mocks.calls[1].range).toEqual({ from: "2026-03-01", to: "2026-03-15" });
-    expect(mocks.calls[2].range).toEqual({ from: "2026-03-16", to: "2026-03-31" });
+    // Both halves are windows on ONE request, the month split at its midpoint
+    // with the odd day going to the second half.
+    expect(mocks.calls).toHaveLength(2);
+    expect(mocks.calls[1].range).toEqual(PORTAL_RANGE);
+    expect(mocks.calls[1].windows).toEqual([
+      { from: "2026-03-01", to: "2026-03-15" },
+      { from: "2026-03-16", to: "2026-03-31" },
+    ]);
     expect(mocks.calls[1].collection.metrics).toEqual([
       {
         key: "ci.gate_pass_rate",

--- a/src/frontend/src/components/portal/tenant-lens-view/index.test.tsx
+++ b/src/frontend/src/components/portal/tenant-lens-view/index.test.tsx
@@ -81,6 +81,8 @@ vi.mock("@/queries/metric-results", () => ({
     // with one `windowsByKey` entry per window from the same fixtures.
     if (windows.length > 0) {
       const result = emptyResult();
+      result.byKey =
+        mocks.rangeResults.get(`${range.from}..${range.to}`)?.byKey ?? new Map();
       result.windowsByKey = windows.map(
         (window) =>
           mocks.rangeResults.get(`${window.from}..${window.to}`)?.byKey ??
@@ -919,12 +921,12 @@ describe("TenantLensView", () => {
     mocks.rangeResults.set(SECOND_HALF, secondHalf);
 
     render(<TenantLensView config={config} />);
-    // Both halves are windows on ONE request, the month split at its midpoint
-    // with the odd day going to the second half.
+    // Both halves come from ONE request: the first half is its period and the
+    // second its only extra window, so nothing computes a third aggregate over
+    // the whole range that no section reads.
     expect(mocks.calls).toHaveLength(2);
-    expect(mocks.calls[1].range).toEqual(PORTAL_RANGE);
+    expect(mocks.calls[1].range).toEqual({ from: "2026-03-01", to: "2026-03-15" });
     expect(mocks.calls[1].windows).toEqual([
-      { from: "2026-03-01", to: "2026-03-15" },
       { from: "2026-03-16", to: "2026-03-31" },
     ]);
     expect(mocks.calls[1].collection.metrics).toEqual([

--- a/src/frontend/src/components/portal/tenant-lens-view/index.tsx
+++ b/src/frontend/src/components/portal/tenant-lens-view/index.tsx
@@ -86,25 +86,26 @@ export function TenantLensView({ config }: { config: TenantLensConfig }) {
   // are windows on ONE request: their breakdowns read the same rows, so the
   // slope sections no longer cost a request each (#2651).
   const halvesCollection = halfRanges ? plan.halves : EMPTY_COLLECTION;
+  // The FIRST half is the request's own period and the second its only extra
+  // window: asking over the whole range instead would compute a third aggregate
+  // per metric that no section reads.
   const halfWindows = useMemo(
-    () => (halfRanges ? [halfRanges.first, halfRanges.second] : []),
+    () => (halfRanges ? [halfRanges.second] : []),
     [halfRanges]
   );
   const halves = useMetricCollection(
     halvesCollection,
     { type: "tenant" },
-    dateRange,
+    halfRanges?.first ?? dateRange,
     { windows: halfWindows }
   );
 
   const resolve: ResolveView = (need) => {
     const location = plan.locate(need);
     if (!location) return undefined;
-    if (location.at === "first-half") {
-      return halves.windowsByKey[0]?.get(need.metric);
-    }
+    if (location.at === "first-half") return halves.byKey.get(need.metric);
     if (location.at === "second-half") {
-      return halves.windowsByKey[1]?.get(need.metric);
+      return halves.windowsByKey[0]?.get(need.metric);
     }
     const byKey =
       location.index === 0

--- a/src/frontend/src/components/portal/tenant-lens-view/index.tsx
+++ b/src/frontend/src/components/portal/tenant-lens-view/index.tsx
@@ -86,27 +86,24 @@ export function TenantLensView({ config }: { config: TenantLensConfig }) {
   // are windows on ONE request: their breakdowns read the same rows, so the
   // slope sections no longer cost a request each (#2651).
   const halvesCollection = halfRanges ? plan.halves : EMPTY_COLLECTION;
-  // The FIRST half is the request's own period and the second its only extra
+  // The SECOND half is the request's own period and the first its comparison
   // window: asking over the whole range instead would compute a third aggregate
-  // per metric that no section reads.
-  const halfWindows = useMemo(
-    () => (halfRanges ? [halfRanges.second] : []),
-    [halfRanges]
-  );
+  // per metric that no section reads, and this way round the comparison window
+  // really is the earlier one.
   const halves = useMetricCollection(
     halvesCollection,
     { type: "tenant" },
-    halfRanges?.first ?? dateRange,
-    { windows: halfWindows }
+    halfRanges?.second ?? dateRange,
+    { compareTo: halfRanges?.first }
   );
 
   const resolve: ResolveView = (need) => {
     const location = plan.locate(need);
     if (!location) return undefined;
-    if (location.at === "first-half") return halves.byKey.get(need.metric);
-    if (location.at === "second-half") {
-      return halves.windowsByKey[0]?.get(need.metric);
+    if (location.at === "first-half") {
+      return halves.previousByKey?.get(need.metric);
     }
+    if (location.at === "second-half") return halves.byKey.get(need.metric);
     const byKey =
       location.index === 0
         ? main.byKey

--- a/src/frontend/src/components/portal/tenant-lens-view/index.tsx
+++ b/src/frontend/src/components/portal/tenant-lens-view/index.tsx
@@ -82,24 +82,30 @@ export function TenantLensView({ config }: { config: TenantLensConfig }) {
     dateRange
   );
   // Halves stay disabled (empty collection) when the window is too short to
-  // split — the slope/momentum sections then suppress themselves.
+  // split — the slope/momentum sections then suppress themselves. Both halves
+  // are windows on ONE request: their breakdowns read the same rows, so the
+  // slope sections no longer cost a request each (#2651).
   const halvesCollection = halfRanges ? plan.halves : EMPTY_COLLECTION;
-  const firstHalf = useMetricCollection(
-    halvesCollection,
-    { type: "tenant" },
-    halfRanges?.first ?? dateRange
+  const halfWindows = useMemo(
+    () => (halfRanges ? [halfRanges.first, halfRanges.second] : []),
+    [halfRanges]
   );
-  const secondHalf = useMetricCollection(
+  const halves = useMetricCollection(
     halvesCollection,
     { type: "tenant" },
-    halfRanges?.second ?? dateRange
+    dateRange,
+    { windows: halfWindows }
   );
 
   const resolve: ResolveView = (need) => {
     const location = plan.locate(need);
     if (!location) return undefined;
-    if (location.at === "first-half") return firstHalf.byKey.get(need.metric);
-    if (location.at === "second-half") return secondHalf.byKey.get(need.metric);
+    if (location.at === "first-half") {
+      return halves.windowsByKey[0]?.get(need.metric);
+    }
+    if (location.at === "second-half") {
+      return halves.windowsByKey[1]?.get(need.metric);
+    }
     const byKey =
       location.index === 0
         ? main.byKey
@@ -107,12 +113,7 @@ export function TenantLensView({ config }: { config: TenantLensConfig }) {
     return byKey?.get(need.metric);
   };
 
-  if (
-    main.isPending ||
-    collectionSetPending(extras) ||
-    firstHalf.isPending ||
-    secondHalf.isPending
-  ) {
+  if (main.isPending || collectionSetPending(extras) || halves.isPending) {
     return (
       <div className="flex flex-col gap-6 p-6">
         <Skeleton className="h-8 w-64" />
@@ -125,12 +126,9 @@ export function TenantLensView({ config }: { config: TenantLensConfig }) {
       </div>
     );
   }
-  const failed = [
-    main,
-    ...extras.values(),
-    firstHalf,
-    secondHalf,
-  ].filter((result) => result.isError);
+  const failed = [main, ...extras.values(), halves].filter(
+    (result) => result.isError
+  );
   if (failed.length > 0) {
     return (
       <div className="mx-auto w-full max-w-md p-8">

--- a/src/frontend/src/lib/metrics/collection.test.ts
+++ b/src/frontend/src/lib/metrics/collection.test.ts
@@ -17,9 +17,9 @@ import {
   mergeNormalizedResults,
   normalizeMetricResult,
   normalizeMetricResults,
+  projectComparison,
   projectPrimary,
   projectViews,
-  projectWindow,
   resolveBucket,
   type MetricCollectionConfig,
 } from "@/lib/metrics/collection";
@@ -82,31 +82,25 @@ describe("buildMetricCollectionRequest", () => {
     ]);
   });
 
-  it("omits windows entirely when none were asked for", () => {
-    // The field is absent, not `[]`: an unwindowed request keeps the exact
-    // wire form it had before windows existed.
+  it("omits the comparison window entirely when none was asked for", () => {
+    // The field is absent, not null: an uncompared request keeps the exact
+    // wire form it had before comparison windows existed.
     const request = buildMetricCollectionRequest(
       COLLECTION,
       { type: "person", ids: ["alice@example.com"] },
       RANGE
     );
-    expect("windows" in request).toBe(false);
+    expect("compare_to" in request).toBe(false);
   });
 
-  it("carries extra windows in request order", () => {
+  it("carries the comparison window", () => {
     const request = buildMetricCollectionRequest(
       COLLECTION,
       { type: "person", ids: ["alice@example.com"] },
       RANGE,
-      [
-        { from: "2026-05-01", to: "2026-05-31" },
-        { from: "2026-04-01", to: "2026-04-30" },
-      ]
+      { from: "2026-05-01", to: "2026-05-31" }
     );
-    expect(request.windows).toEqual([
-      { from: "2026-05-01", to: "2026-05-31" },
-      { from: "2026-04-01", to: "2026-04-30" },
-    ]);
+    expect(request.compare_to).toEqual({ from: "2026-05-01", to: "2026-05-31" });
   });
 });
 
@@ -116,7 +110,7 @@ describe("buildMetricCollectionRequest", () => {
  * to the standalone request it replaced: rows are chosen by `present`, never by
  * whether the value happens to be null.
  */
-describe("a windowed breakdown's row set", () => {
+describe("a compared breakdown's row set", () => {
   /** `org/a` only in the primary period (ratio null there), `org/b` only in the window. */
   const disjoint = (): Map<string, NormalizedMetricResult> =>
     new Map([
@@ -138,14 +132,14 @@ describe("a windowed breakdown's row set", () => {
                 dimensions: [{ key: "repository", value: "org/a" }],
                 value: null,
                 present: true,
-                windows: [{ value: null, present: false }],
+                compare_to: { value: null, present: false },
               },
               {
                 entity_id: "t",
                 dimensions: [{ key: "repository", value: "org/b" }],
                 value: null,
                 present: false,
-                windows: [{ value: 20, present: true }],
+                compare_to: { value: 20, present: true },
               },
             ],
           },
@@ -156,9 +150,9 @@ describe("a windowed breakdown's row set", () => {
   const repositories = (result: NormalizedMetricResult | undefined) =>
     result?.breakdown?.values.map((row) => row.dimensions[0]?.value);
 
-  it("gives a window only the groups that window had", () => {
+  it("gives the comparison window only the groups it had", () => {
     // A standalone request over the window would have returned org/b alone.
-    const projected = projectWindow(disjoint(), 0).get("ci.gate_pass_rate");
+    const projected = projectComparison(disjoint()).get("ci.gate_pass_rate");
     expect(repositories(projected)).toEqual(["org/b"]);
     expect(projected?.breakdown?.values[0]?.value).toBe(20);
   });
@@ -172,7 +166,7 @@ describe("a windowed breakdown's row set", () => {
     expect(primary?.breakdown?.values[0]?.value).toBeNull();
   });
 
-  it("leaves an unwindowed response untouched", () => {
+  it("leaves an uncompared response untouched", () => {
     const plain = new Map([
       [
         "git.commits",
@@ -201,7 +195,7 @@ describe("a windowed breakdown's row set", () => {
   });
 });
 
-describe("projectWindow", () => {
+describe("projectComparison", () => {
   const windowed = (): Map<string, NormalizedMetricResult> =>
     new Map([
       [
@@ -215,7 +209,7 @@ describe("projectWindow", () => {
           direction: "higher_is_better",
           period: {
             view: "period",
-            values: [{ entity_id: "a", value: 9, windows: [4, 2] }],
+            values: [{ entity_id: "a", value: 9, compare_to: 2 }],
           },
           peer: {
             view: "peer",
@@ -236,27 +230,21 @@ describe("projectWindow", () => {
       ],
     ]);
 
-  it("reads the window at its own index as the value", () => {
+  it("reads the comparison window as the value", () => {
     expect(
-      projectWindow(windowed(), 1).get("git.commits")?.period?.values[0]?.value
+      projectComparison(windowed()).get("git.commits")?.period?.values[0]?.value
     ).toBe(2);
   });
 
-  it("answers null for a window the row never carried", () => {
-    expect(
-      projectWindow(windowed(), 5).get("git.commits")?.period?.values[0]?.value
-    ).toBeNull();
-  });
-
-  it("drops the views a window does not carry", () => {
+  it("drops the views the comparison window does not carry", () => {
     // Keeping `peer` would answer the primary period's standing under a
     // previous-period label — a mispairing no consumer could detect.
-    expect(projectWindow(windowed(), 0).get("git.commits")?.peer).toBeUndefined();
+    expect(projectComparison(windowed()).get("git.commits")?.peer).toBeUndefined();
   });
 
   it("leaves the source map untouched", () => {
     const source = windowed();
-    projectWindow(source, 0);
+    projectComparison(source);
     expect(source.get("git.commits")?.period?.values[0]?.value).toBe(9);
   });
 });

--- a/src/frontend/src/lib/metrics/collection.test.ts
+++ b/src/frontend/src/lib/metrics/collection.test.ts
@@ -17,6 +17,7 @@ import {
   mergeNormalizedResults,
   normalizeMetricResult,
   normalizeMetricResults,
+  projectPrimary,
   projectViews,
   projectWindow,
   resolveBucket,
@@ -106,6 +107,97 @@ describe("buildMetricCollectionRequest", () => {
       { from: "2026-05-01", to: "2026-05-31" },
       { from: "2026-04-01", to: "2026-04-30" },
     ]);
+  });
+});
+
+/**
+ * A windowed breakdown groups over every window at once, so its row set is the
+ * union of them. These cases pin the rule that makes a projected window equal
+ * to the standalone request it replaced: rows are chosen by `present`, never by
+ * whether the value happens to be null.
+ */
+describe("a windowed breakdown's row set", () => {
+  /** `org/a` only in the primary period (ratio null there), `org/b` only in the window. */
+  const disjoint = (): Map<string, NormalizedMetricResult> =>
+    new Map([
+      [
+        "ci.gate_pass_rate",
+        {
+          metric_key: "ci.gate_pass_rate",
+          label: "Pass rate",
+          unit: null,
+          computation: "ratio",
+          format: "percent",
+          direction: "higher_is_better",
+          breakdown: {
+            view: "breakdown",
+            dimensions: ["repository"],
+            values: [
+              {
+                entity_id: "t",
+                dimensions: [{ key: "repository", value: "org/a" }],
+                value: null,
+                present: true,
+                windows: [{ value: null, present: false }],
+              },
+              {
+                entity_id: "t",
+                dimensions: [{ key: "repository", value: "org/b" }],
+                value: null,
+                present: false,
+                windows: [{ value: 20, present: true }],
+              },
+            ],
+          },
+        } satisfies NormalizedMetricResult,
+      ],
+    ]);
+
+  const repositories = (result: NormalizedMetricResult | undefined) =>
+    result?.breakdown?.values.map((row) => row.dimensions[0]?.value);
+
+  it("gives a window only the groups that window had", () => {
+    // A standalone request over the window would have returned org/b alone.
+    const projected = projectWindow(disjoint(), 0).get("ci.gate_pass_rate");
+    expect(repositories(projected)).toEqual(["org/b"]);
+    expect(projected?.breakdown?.values[0]?.value).toBe(20);
+  });
+
+  it("keeps a present group whose value is genuinely null", () => {
+    // org/a IS in the primary period; its ratio is null because the
+    // denominator is zero. Dropping it would lose a row the standalone
+    // request returns — which is why presence cannot be read off the value.
+    const primary = projectPrimary(disjoint()).get("ci.gate_pass_rate");
+    expect(repositories(primary)).toEqual(["org/a"]);
+    expect(primary?.breakdown?.values[0]?.value).toBeNull();
+  });
+
+  it("leaves an unwindowed response untouched", () => {
+    const plain = new Map([
+      [
+        "git.commits",
+        {
+          metric_key: "git.commits",
+          label: "Commits",
+          unit: null,
+          computation: "sum",
+          format: "integer",
+          direction: "higher_is_better",
+          breakdown: {
+            view: "breakdown",
+            dimensions: ["repository"],
+            values: [
+              {
+                entity_id: "t",
+                dimensions: [{ key: "repository", value: "org/a" }],
+                value: 0,
+              },
+            ],
+          },
+        } satisfies NormalizedMetricResult,
+      ],
+    ]);
+    expect(projectPrimary(plain).get("git.commits")).toBe(plain.get("git.commits"));
   });
 });
 

--- a/src/frontend/src/lib/metrics/collection.test.ts
+++ b/src/frontend/src/lib/metrics/collection.test.ts
@@ -18,6 +18,7 @@ import {
   normalizeMetricResult,
   normalizeMetricResults,
   projectViews,
+  projectWindow,
   resolveBucket,
   type MetricCollectionConfig,
 } from "@/lib/metrics/collection";
@@ -78,6 +79,93 @@ describe("buildMetricCollectionRequest", () => {
       },
       { view: "breakdown", dimensions: ["tool"] },
     ]);
+  });
+
+  it("omits windows entirely when none were asked for", () => {
+    // The field is absent, not `[]`: an unwindowed request keeps the exact
+    // wire form it had before windows existed.
+    const request = buildMetricCollectionRequest(
+      COLLECTION,
+      { type: "person", ids: ["alice@example.com"] },
+      RANGE
+    );
+    expect("windows" in request).toBe(false);
+  });
+
+  it("carries extra windows in request order", () => {
+    const request = buildMetricCollectionRequest(
+      COLLECTION,
+      { type: "person", ids: ["alice@example.com"] },
+      RANGE,
+      [
+        { from: "2026-05-01", to: "2026-05-31" },
+        { from: "2026-04-01", to: "2026-04-30" },
+      ]
+    );
+    expect(request.windows).toEqual([
+      { from: "2026-05-01", to: "2026-05-31" },
+      { from: "2026-04-01", to: "2026-04-30" },
+    ]);
+  });
+});
+
+describe("projectWindow", () => {
+  const windowed = (): Map<string, NormalizedMetricResult> =>
+    new Map([
+      [
+        "git.commits",
+        {
+          metric_key: "git.commits",
+          label: "Commits",
+          unit: null,
+          computation: "sum",
+          format: "integer",
+          direction: "higher_is_better",
+          period: {
+            view: "period",
+            values: [{ entity_id: "a", value: 9, windows: [4, 2] }],
+          },
+          peer: {
+            view: "peer",
+            values: [
+              {
+                entity_id: "a",
+                target_value: 9,
+                p25: 1,
+                median: 5,
+                p75: 8,
+                min: 0,
+                max: 10,
+                n: 7,
+              },
+            ],
+          },
+        } satisfies NormalizedMetricResult,
+      ],
+    ]);
+
+  it("reads the window at its own index as the value", () => {
+    expect(
+      projectWindow(windowed(), 1).get("git.commits")?.period?.values[0]?.value
+    ).toBe(2);
+  });
+
+  it("answers null for a window the row never carried", () => {
+    expect(
+      projectWindow(windowed(), 5).get("git.commits")?.period?.values[0]?.value
+    ).toBeNull();
+  });
+
+  it("drops the views a window does not carry", () => {
+    // Keeping `peer` would answer the primary period's standing under a
+    // previous-period label — a mispairing no consumer could detect.
+    expect(projectWindow(windowed(), 0).get("git.commits")?.peer).toBeUndefined();
+  });
+
+  it("leaves the source map untouched", () => {
+    const source = windowed();
+    projectWindow(source, 0);
+    expect(source.get("git.commits")?.period?.values[0]?.value).toBe(9);
   });
 });
 

--- a/src/frontend/src/lib/metrics/collection.ts
+++ b/src/frontend/src/lib/metrics/collection.ts
@@ -147,7 +147,7 @@ export function buildMetricCollectionRequest(
   collection: MetricCollectionConfig,
   entity: MetricCollectionEntity,
   period: DateRange,
-  windows: readonly DateRange[] = []
+  compareTo?: DateRange
 ): MetricResultsRequest {
   return {
     entity:
@@ -155,7 +155,7 @@ export function buildMetricCollectionRequest(
         ? { type: "person", ids: entity.ids }
         : { type: "tenant" },
     period,
-    ...(windows.length ? { windows: windows.map((w) => ({ ...w })) } : {}),
+    ...(compareTo ? { compare_to: { ...compareTo } } : {}),
     metrics: collection.metrics.map((metric) => ({
       metric_key: metric.key,
       ...(metric.filters?.length ? { filters: metric.filters } : {}),
@@ -246,21 +246,20 @@ export function normalizeMetricResult(
 }
 
 /**
- * One extra window read as if it had been its own request: the window's value
- * takes the place of `value`, and the views that never carry a window
- * (`peer`, `timeseries`, `histogram`, `rollup`) are dropped rather than
- * repeated — reading them here would silently answer over the primary period.
- * This is what lets a window feed the same selectors a separate request did.
+ * The comparison window read as if it had been its own request: its value takes
+ * the place of `value`, and the views that never carry a window (`peer`,
+ * `timeseries`, `histogram`, `rollup`) are dropped rather than repeated —
+ * reading them here would silently answer over the primary period. This is what
+ * lets the window feed the same selectors a separate request did.
  *
- * A windowed breakdown groups over every window at once, so its row set is the
- * union of them; `present` says which rows each window actually had, and a row
- * the window never had is dropped here. Presence cannot be read off the value:
- * a ratio over a group that IS in the window is null whenever its denominator
- * is zero, and dropping that row would lose one a standalone request returns.
+ * A compared breakdown groups over both windows at once, so its row set is the
+ * union of them; `present` says which rows the window actually had, and a row
+ * it never had is dropped here. Presence cannot be read off the value: a ratio
+ * over a group that IS in the window is null whenever its denominator is zero,
+ * and dropping that row would lose one a standalone request returns.
  */
-export function projectWindow(
-  results: Map<string, NormalizedMetricResult>,
-  windowIndex: number
+export function projectComparison(
+  results: Map<string, NormalizedMetricResult>
 ): Map<string, NormalizedMetricResult> {
   const out = new Map<string, NormalizedMetricResult>();
   for (const [key, result] of results) {
@@ -278,7 +277,7 @@ export function projectWindow(
         ...result.period,
         values: result.period.values.map((value) => ({
           entity_id: value.entity_id,
-          value: value.windows?.[windowIndex] ?? null,
+          value: value.compare_to ?? null,
         })),
       };
     }
@@ -286,9 +285,11 @@ export function projectWindow(
       projected.breakdown = {
         ...result.breakdown,
         values: result.breakdown.values.flatMap((row) => {
-          const window = row.windows?.[windowIndex];
+          const window = row.compare_to;
           if (!window?.present) return [];
-          return [{ ...row, value: window.value, present: undefined, windows: undefined }];
+          return [
+            { ...row, value: window.value, present: undefined, compare_to: undefined },
+          ];
         }),
       };
     }
@@ -298,9 +299,9 @@ export function projectWindow(
 }
 
 /**
- * The primary period of a windowed response, read the same way: its breakdown
- * row set is the union across windows too, so the groups the primary period
- * never had are dropped. A response without windows is returned untouched.
+ * The primary period of a compared response, read the same way: its breakdown
+ * row set is the union of both windows too, so the groups the primary period
+ * never had are dropped. An uncompared response is returned untouched.
  */
 export function projectPrimary(
   results: Map<string, NormalizedMetricResult>
@@ -318,7 +319,7 @@ export function projectPrimary(
         values: result.breakdown.values.flatMap((row) =>
           row.present === false
             ? []
-            : [{ ...row, present: undefined, windows: undefined }]
+            : [{ ...row, present: undefined, compare_to: undefined }]
         ),
       },
     });

--- a/src/frontend/src/lib/metrics/collection.ts
+++ b/src/frontend/src/lib/metrics/collection.ts
@@ -146,7 +146,8 @@ function exhaustive(value: never): never {
 export function buildMetricCollectionRequest(
   collection: MetricCollectionConfig,
   entity: MetricCollectionEntity,
-  period: DateRange
+  period: DateRange,
+  windows: readonly DateRange[] = []
 ): MetricResultsRequest {
   return {
     entity:
@@ -154,6 +155,7 @@ export function buildMetricCollectionRequest(
         ? { type: "person", ids: entity.ids }
         : { type: "tenant" },
     period,
+    ...(windows.length ? { windows: windows.map((w) => ({ ...w })) } : {}),
     metrics: collection.metrics.map((metric) => ({
       metric_key: metric.key,
       ...(metric.filters?.length ? { filters: metric.filters } : {}),
@@ -241,6 +243,51 @@ export function normalizeMetricResult(
   }
 
   return normalized;
+}
+
+/**
+ * One extra window read as if it had been its own request: the window's value
+ * takes the place of `value`, and the views that never carry a window
+ * (`peer`, `timeseries`, `histogram`, `rollup`) are dropped rather than
+ * repeated — reading them here would silently answer over the primary period.
+ * This is what lets a window feed the same selectors a separate request did.
+ */
+export function projectWindow(
+  results: Map<string, NormalizedMetricResult>,
+  windowIndex: number
+): Map<string, NormalizedMetricResult> {
+  const out = new Map<string, NormalizedMetricResult>();
+  for (const [key, result] of results) {
+    const projected: NormalizedMetricResult = {
+      ...result,
+      period: undefined,
+      timeseries: undefined,
+      peer: undefined,
+      breakdown: undefined,
+      rollup: undefined,
+      histogram: undefined,
+    };
+    if (result.period) {
+      projected.period = {
+        ...result.period,
+        values: result.period.values.map((value) => ({
+          entity_id: value.entity_id,
+          value: value.windows?.[windowIndex] ?? null,
+        })),
+      };
+    }
+    if (result.breakdown) {
+      projected.breakdown = {
+        ...result.breakdown,
+        values: result.breakdown.values.map((value) => ({
+          ...value,
+          value: value.windows?.[windowIndex] ?? null,
+        })),
+      };
+    }
+    out.set(key, projected);
+  }
+  return out;
 }
 
 export function normalizeMetricResults(

--- a/src/frontend/src/lib/metrics/collection.ts
+++ b/src/frontend/src/lib/metrics/collection.ts
@@ -251,6 +251,12 @@ export function normalizeMetricResult(
  * (`peer`, `timeseries`, `histogram`, `rollup`) are dropped rather than
  * repeated — reading them here would silently answer over the primary period.
  * This is what lets a window feed the same selectors a separate request did.
+ *
+ * A windowed breakdown groups over every window at once, so its row set is the
+ * union of them; `present` says which rows each window actually had, and a row
+ * the window never had is dropped here. Presence cannot be read off the value:
+ * a ratio over a group that IS in the window is null whenever its denominator
+ * is zero, and dropping that row would lose one a standalone request returns.
  */
 export function projectWindow(
   results: Map<string, NormalizedMetricResult>,
@@ -279,13 +285,43 @@ export function projectWindow(
     if (result.breakdown) {
       projected.breakdown = {
         ...result.breakdown,
-        values: result.breakdown.values.map((value) => ({
-          ...value,
-          value: value.windows?.[windowIndex] ?? null,
-        })),
+        values: result.breakdown.values.flatMap((row) => {
+          const window = row.windows?.[windowIndex];
+          if (!window?.present) return [];
+          return [{ ...row, value: window.value, present: undefined, windows: undefined }];
+        }),
       };
     }
     out.set(key, projected);
+  }
+  return out;
+}
+
+/**
+ * The primary period of a windowed response, read the same way: its breakdown
+ * row set is the union across windows too, so the groups the primary period
+ * never had are dropped. A response without windows is returned untouched.
+ */
+export function projectPrimary(
+  results: Map<string, NormalizedMetricResult>
+): Map<string, NormalizedMetricResult> {
+  const out = new Map<string, NormalizedMetricResult>();
+  for (const [key, result] of results) {
+    if (!result.breakdown?.values.some((row) => row.present !== undefined)) {
+      out.set(key, result);
+      continue;
+    }
+    out.set(key, {
+      ...result,
+      breakdown: {
+        ...result.breakdown,
+        values: result.breakdown.values.flatMap((row) =>
+          row.present === false
+            ? []
+            : [{ ...row, present: undefined, windows: undefined }]
+        ),
+      },
+    });
   }
   return out;
 }

--- a/src/frontend/src/queries/member-grid.test.tsx
+++ b/src/frontend/src/queries/member-grid.test.tsx
@@ -18,8 +18,8 @@ vi.mock("@/api/metric-results-client", async (orig) => ({
 
 const mock = vi.mocked(queryMetricResults);
 
-// Every requested view echoed back, with a distinct value per extra window so
-// the trend arrows have real data to read.
+// Every requested view echoed back, with a comparison reading so the trend
+// arrows have real data.
 function respond(req: MetricResultsRequest): MetricResultsResponse {
   if (req.entity.type !== "person") throw new Error("person request expected");
   const ids = req.entity.ids;
@@ -39,9 +39,7 @@ function respond(req: MetricResultsRequest): MetricResultsResponse {
               values: ids.map((id) => ({
                 entity_id: id,
                 value: 1,
-                ...(req.windows?.length
-                  ? { windows: req.windows.map((_, index) => 10 + index) }
-                  : {}),
+                ...(req.compare_to ? { compare_to: 10 } : {}),
               })),
             }
           : {
@@ -100,7 +98,8 @@ describe("useMemberGridData", () => {
     });
 
     // One request, carrying period + peer over the range and the previous
-    // period as a window — not a second fetch over a shifted range.
+    // period as its comparison window — not a second fetch over a shifted
+    // range.
     expect(mock).toHaveBeenCalledTimes(1);
     const req = mock.mock.calls[0]![0];
     expect(req.period.from).toBe(RANGE.from);
@@ -108,7 +107,7 @@ describe("useMemberGridData", () => {
       "period",
       "peer",
     ]);
-    expect(req.windows).toEqual([{ from: "2026-03-01", to: "2026-03-30" }]);
+    expect(req.compare_to).toEqual({ from: "2026-03-01", to: "2026-03-30" });
     expect(
       result.current.previousByKey.get("git.commits")?.period?.values[0]?.value,
     ).toBe(10);

--- a/src/frontend/src/queries/member-grid.test.tsx
+++ b/src/frontend/src/queries/member-grid.test.tsx
@@ -18,8 +18,8 @@ vi.mock("@/api/metric-results-client", async (orig) => ({
 
 const mock = vi.mocked(queryMetricResults);
 
-// Every requested view echoed back so the current (period+peer) and previous
-// (period-only) twins both resolve to real data.
+// Every requested view echoed back, with a distinct value per extra window so
+// the trend arrows have real data to read.
 function respond(req: MetricResultsRequest): MetricResultsResponse {
   if (req.entity.type !== "person") throw new Error("person request expected");
   const ids = req.entity.ids;
@@ -36,7 +36,13 @@ function respond(req: MetricResultsRequest): MetricResultsResponse {
         v.view === "period"
           ? {
               view: "period",
-              values: ids.map((id) => ({ entity_id: id, value: 1 })),
+              values: ids.map((id) => ({
+                entity_id: id,
+                value: 1,
+                ...(req.windows?.length
+                  ? { windows: req.windows.map((_, index) => 10 + index) }
+                  : {}),
+              })),
             }
           : {
               view: "peer",
@@ -75,7 +81,7 @@ describe("useMemberGridData", () => {
     mock.mockImplementation(async (req) => respond(req));
   });
 
-  it("returns the current byKey and the previous-period twin, keyed once", async () => {
+  it("serves the grid and its trend arrows from one request", async () => {
     const { result } = renderHook(
       () =>
         useMemberGridData(
@@ -93,19 +99,19 @@ describe("useMemberGridData", () => {
       expect(result.current.previousByKey.has("git.commits")).toBe(true);
     });
 
-    // Current fetch requests period + peer; the previous twin requests period
-    // only (trends compare values, not standings).
-    const viewsFor = (from: string) =>
-      mock.mock.calls
-        .map((c) => c[0])
-        .find((r) => r.period.from === from)
-        ?.metrics[0]?.views.map((v) => v.view);
-    expect(viewsFor(RANGE.from)).toEqual(["period", "peer"]);
-    // The previous range differs from the current; its twin is period-only.
-    const prevCall = mock.mock.calls
-      .map((c) => c[0])
-      .find((r) => r.period.from !== RANGE.from);
-    expect(prevCall?.metrics[0]?.views.map((v) => v.view)).toEqual(["period"]);
+    // One request, carrying period + peer over the range and the previous
+    // period as a window — not a second fetch over a shifted range.
+    expect(mock).toHaveBeenCalledTimes(1);
+    const req = mock.mock.calls[0]![0];
+    expect(req.period.from).toBe(RANGE.from);
+    expect(req.metrics[0]?.views.map((v) => v.view)).toEqual([
+      "period",
+      "peer",
+    ]);
+    expect(req.windows).toEqual([{ from: "2026-03-01", to: "2026-03-30" }]);
+    expect(
+      result.current.previousByKey.get("git.commits")?.period?.values[0]?.value,
+    ).toBe(10);
   });
 
   it("is pending with no entities and does no fetch", () => {

--- a/src/frontend/src/queries/member-grid.ts
+++ b/src/frontend/src/queries/member-grid.ts
@@ -33,12 +33,10 @@ const EMPTY = new Map<string, NormalizedMetricResult>();
 
 /**
  * Data for a members grid over any metric collection: the collection's
- * metrics for the roster (period + peer), plus a previous-period period-only
- * twin for the trend arrows — trends compare values, not standings, so the
- * peer view would be dead weight there (and its rows would tighten chunking
- * for no gain). Both requests chunk large rosters via
- * `useMetricCollectionSet`. Pass a stable `collection` reference (module
- * constant or memo) — it keys the query.
+ * metrics for the roster (period + peer) plus the previous period as an extra
+ * window on the same request, which is what the trend arrows read. Large
+ * rosters chunk via `useMetricCollectionSet`. Pass a stable `collection`
+ * reference (module constant or memo) — it keys the query.
  */
 export function useMemberGridData(
   collection: MetricCollectionConfig,
@@ -46,38 +44,31 @@ export function useMemberGridData(
   range: DateRange,
   period: PeriodValue,
 ): MemberGridData {
-  const currentCollections = useMemo<readonly KeyedCollection[]>(
-    () => [{ key: GRID_KEY, collection: projectViews(collection, ["period", "peer"]) }],
+  const collections = useMemo<readonly KeyedCollection[]>(
+    () => [
+      {
+        key: GRID_KEY,
+        collection: projectViews(collection, ["period", "peer"]),
+      },
+    ],
     [collection],
   );
-  const previousCollections = useMemo<readonly KeyedCollection[]>(
-    () => [{ key: GRID_KEY, collection: projectViews(collection, ["period"]) }],
-    [collection],
-  );
-
-  const current = useMetricCollectionSet(currentCollections, entity, range);
-  const previousRange = useMemo(
-    () => previousPeriodRange(range, period),
+  const windows = useMemo(
+    () => [previousPeriodRange(range, period)],
     [range, period],
   );
-  const previous = useMetricCollectionSet(
-    previousCollections,
-    entity,
-    previousRange,
-  );
 
-  const cur = current.get(GRID_KEY);
-  const prev = previous.get(GRID_KEY);
+  const set = useMetricCollectionSet(collections, entity, range, windows);
+  const grid = set.get(GRID_KEY);
 
   return {
-    byKey: cur?.byKey ?? EMPTY,
-    previousByKey: prev?.byKey ?? EMPTY,
-    isPending: cur?.isPending ?? false,
-    isFetching: (cur?.isFetching ?? false) || (prev?.isFetching ?? false),
-    isError: cur?.isError ?? false,
+    byKey: grid?.byKey ?? EMPTY,
+    previousByKey: grid?.windowsByKey[0] ?? EMPTY,
+    isPending: grid?.isPending ?? false,
+    isFetching: grid?.isFetching ?? false,
+    isError: grid?.isError ?? false,
     refetch: () => {
-      cur?.refetch();
-      prev?.refetch();
+      grid?.refetch();
     },
   };
 }

--- a/src/frontend/src/queries/member-grid.ts
+++ b/src/frontend/src/queries/member-grid.ts
@@ -53,17 +53,17 @@ export function useMemberGridData(
     ],
     [collection],
   );
-  const windows = useMemo(
-    () => [previousPeriodRange(range, period)],
+  const compareTo = useMemo(
+    () => previousPeriodRange(range, period),
     [range, period],
   );
 
-  const set = useMetricCollectionSet(collections, entity, range, windows);
+  const set = useMetricCollectionSet(collections, entity, range, compareTo);
   const grid = set.get(GRID_KEY);
 
   return {
     byKey: grid?.byKey ?? EMPTY,
-    previousByKey: grid?.windowsByKey[0] ?? EMPTY,
+    previousByKey: grid?.previousByKey ?? EMPTY,
     isPending: grid?.isPending ?? false,
     isFetching: grid?.isFetching ?? false,
     isError: grid?.isError ?? false,

--- a/src/frontend/src/queries/metric-results.test.tsx
+++ b/src/frontend/src/queries/metric-results.test.tsx
@@ -64,7 +64,15 @@ function respond(req: MetricResultsRequest): MetricResultsResponse {
             }
           : {
               view: "period",
-              values: ids.map((id) => ({ entity_id: id, value: 1 })),
+              values: ids.map((id) => ({
+                entity_id: id,
+                value: 1,
+                // Distinct per window so a projection reading the wrong index
+                // cannot pass by coincidence.
+                ...(req.windows?.length
+                  ? { windows: req.windows.map((_, index) => 10 + index) }
+                  : {}),
+              })),
             },
       ),
     })),
@@ -127,7 +135,7 @@ describe("useMetricCollection", () => {
     expect(result.current.isError).toBe(false);
   });
 
-  it("normalizes the current result and skips the previous twin by default", async () => {
+  it("normalizes the current result and asks for no extra window by default", async () => {
     const { result } = renderHook(
       () => useMetricCollection(COLLECTION, ENTITY, RANGE),
       { wrapper: wrapper() },
@@ -138,14 +146,41 @@ describe("useMetricCollection", () => {
     expect(mock).toHaveBeenCalledTimes(1);
   });
 
-  it("fires the previous-period twin and exposes previousByKey", async () => {
+  it("serves the previous period as a window on the one request", async () => {
     const { result } = renderHook(
       () => useMetricCollection(COLLECTION, ENTITY, RANGE, { previousPeriod: "month" }),
       { wrapper: wrapper() },
     );
-    await waitFor(() => expect(result.current.previousByKey).not.toBeNull());
-    expect(result.current.previousByKey?.get("m")).toBeDefined();
-    expect(mock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock.mock.calls[0]![0].windows).toEqual([
+      { from: "2026-05-01", to: "2026-05-30" },
+    ]);
+    expect(
+      result.current.previousByKey?.get("m")?.period?.values[0]?.value,
+    ).toBe(10);
+  });
+
+  it("reads each extra window back at its own index", async () => {
+    const windows = [
+      { from: "2026-05-01", to: "2026-05-15" },
+      { from: "2026-05-16", to: "2026-05-31" },
+    ];
+    const { result } = renderHook(
+      () => useMetricCollection(COLLECTION, ENTITY, RANGE, { windows }),
+      { wrapper: wrapper() },
+    );
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(result.current.windowsByKey).toHaveLength(2);
+    expect(result.current.windowsByKey[0]?.get("m")?.period?.values[0]?.value).toBe(10);
+    expect(result.current.windowsByKey[1]?.get("m")?.period?.values[0]?.value).toBe(11);
+    // A window carries no standing: reading `peer` here would answer over the
+    // primary period instead.
+    expect(result.current.windowsByKey[0]?.get("m")?.peer).toBeUndefined();
+    expect(result.current.previousByKey).toBeNull();
   });
 
   it("surfaces errors and leaves byKey empty", async () => {

--- a/src/frontend/src/queries/metric-results.test.tsx
+++ b/src/frontend/src/queries/metric-results.test.tsx
@@ -67,11 +67,7 @@ function respond(req: MetricResultsRequest): MetricResultsResponse {
               values: ids.map((id) => ({
                 entity_id: id,
                 value: 1,
-                // Distinct per window so a projection reading the wrong index
-                // cannot pass by coincidence.
-                ...(req.windows?.length
-                  ? { windows: req.windows.map((_, index) => 10 + index) }
-                  : {}),
+                ...(req.compare_to ? { compare_to: 10 } : {}),
               })),
             },
       ),
@@ -135,7 +131,7 @@ describe("useMetricCollection", () => {
     expect(result.current.isError).toBe(false);
   });
 
-  it("normalizes the current result and asks for no extra window by default", async () => {
+  it("normalizes the current result and asks for no comparison by default", async () => {
     const { result } = renderHook(
       () => useMetricCollection(COLLECTION, ENTITY, RANGE),
       { wrapper: wrapper() },
@@ -146,7 +142,7 @@ describe("useMetricCollection", () => {
     expect(mock).toHaveBeenCalledTimes(1);
   });
 
-  it("serves the previous period as a window on the one request", async () => {
+  it("serves the previous period as the comparison window of one request", async () => {
     const { result } = renderHook(
       () => useMetricCollection(COLLECTION, ENTITY, RANGE, { previousPeriod: "month" }),
       { wrapper: wrapper() },
@@ -154,33 +150,29 @@ describe("useMetricCollection", () => {
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
     expect(mock).toHaveBeenCalledTimes(1);
-    expect(mock.mock.calls[0]![0].windows).toEqual([
-      { from: "2026-05-01", to: "2026-05-30" },
-    ]);
+    expect(mock.mock.calls[0]![0].compare_to).toEqual({
+      from: "2026-05-01",
+      to: "2026-05-30",
+    });
     expect(
       result.current.previousByKey?.get("m")?.period?.values[0]?.value,
     ).toBe(10);
   });
 
-  it("reads each extra window back at its own index", async () => {
-    const windows = [
-      { from: "2026-05-01", to: "2026-05-15" },
-      { from: "2026-05-16", to: "2026-05-31" },
-    ];
+  it("reads an explicit comparison window back through previousByKey", async () => {
+    const compareTo = { from: "2026-05-01", to: "2026-05-15" };
     const { result } = renderHook(
-      () => useMetricCollection(COLLECTION, ENTITY, RANGE, { windows }),
+      () => useMetricCollection(COLLECTION, ENTITY, RANGE, { compareTo }),
       { wrapper: wrapper() },
     );
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
     expect(mock).toHaveBeenCalledTimes(1);
-    expect(result.current.windowsByKey).toHaveLength(2);
-    expect(result.current.windowsByKey[0]?.get("m")?.period?.values[0]?.value).toBe(10);
-    expect(result.current.windowsByKey[1]?.get("m")?.period?.values[0]?.value).toBe(11);
-    // A window carries no standing: reading `peer` here would answer over the
+    expect(mock.mock.calls[0]![0].compare_to).toEqual(compareTo);
+    expect(result.current.previousByKey?.get("m")?.period?.values[0]?.value).toBe(10);
+    // The window carries no standing: reading `peer` here would answer over the
     // primary period instead.
-    expect(result.current.windowsByKey[0]?.get("m")?.peer).toBeUndefined();
-    expect(result.current.previousByKey).toBeNull();
+    expect(result.current.previousByKey?.get("m")?.peer).toBeUndefined();
   });
 
   it("surfaces errors and leaves byKey empty", async () => {

--- a/src/frontend/src/queries/metric-results.ts
+++ b/src/frontend/src/queries/metric-results.ts
@@ -17,6 +17,7 @@ import {
   entityChunkSize,
   mergeNormalizedResults,
   normalizeMetricResults,
+  projectPrimary,
   projectWindow,
   type MetricCollectionConfig,
   type MetricCollectionEntity,
@@ -158,21 +159,21 @@ export function useMetricCollection(
     placeholderData: options?.keepPreviousData ? keepPreviousData : undefined,
   });
 
-  const byKey = useMemo(
+  // INVARIANT: both projections read the RAW response. A windowed breakdown
+  // groups over every window at once, so filtering the primary first would hide
+  // the groups that belong only to a comparison window — the very rows those
+  // windows exist to carry.
+  const served = useMemo(
     () => normalizeMetricResults(current.data?.metrics),
     [current.data]
   );
+  const byKey = useMemo(() => projectPrimary(served), [served]);
   // One window's values, read as if they had been their own request — a period
   // and its comparison window now stand or fall together, so there is no
-  // mispairing to guard against.
-  const windowCount = windows.length;
-  const windowsByKey = useMemo(
-    () =>
-      Array.from({ length: windowCount }, (_, index) =>
-        projectWindow(byKey, index)
-      ),
-    [byKey, windowCount]
-  );
+  // mispairing to guard against. Left for the compiler to memoize: `windows` is
+  // built in this render, so a hand-written dependency on it cannot be
+  // preserved (`react-hooks/preserve-manual-memoization`).
+  const windowsByKey = windows.map((_, index) => projectWindow(served, index));
   const previousByKey = options?.previousPeriod
     ? (windowsByKey[0] ?? null)
     : null;
@@ -322,10 +323,9 @@ export function useMetricCollectionSet(
   for (const [key, maps] of chunkMaps) {
     const entry = out.get(key);
     if (!entry) continue;
-    entry.byKey = mergeNormalizedResults(maps);
-    entry.windowsByKey = windows.map((_, index) =>
-      projectWindow(entry.byKey, index)
-    );
+    const served = mergeNormalizedResults(maps);
+    entry.byKey = projectPrimary(served);
+    entry.windowsByKey = windows.map((_, index) => projectWindow(served, index));
   }
   return out;
 }

--- a/src/frontend/src/queries/metric-results.ts
+++ b/src/frontend/src/queries/metric-results.ts
@@ -17,6 +17,7 @@ import {
   entityChunkSize,
   mergeNormalizedResults,
   normalizeMetricResults,
+  projectWindow,
   type MetricCollectionConfig,
   type MetricCollectionEntity,
   type NormalizedMetricResult,
@@ -47,18 +48,25 @@ function useMetricGate(): (metricKey: string) => boolean {
 
 export interface MetricCollectionOptions {
   /**
-   * When set, a twin query fetches the same collection over the previous
-   * period of the same kind (the period value drives week/month/quarter/year
-   * shift semantics in `previousPeriodRange`). Consumers derive deltas from
-   * `previousByKey`.
+   * When set, the request carries the previous period of the same kind as an
+   * extra window (the period value drives week/month/quarter/year shift
+   * semantics in `previousPeriodRange`). Consumers derive deltas from
+   * `previousByKey`. Sugar for a single entry in `windows`.
    */
   previousPeriod?: PeriodValue;
+  /**
+   * Extra windows served in the same request, in order; read them back through
+   * `windowsByKey` at the same index. Ignored when `previousPeriod` is set.
+   */
+  windows?: readonly DateRange[];
   keepPreviousData?: boolean;
 }
 
 export interface MetricCollectionResult {
   byKey: Map<string, NormalizedMetricResult>;
   previousByKey: Map<string, NormalizedMetricResult> | null;
+  /** One entry per requested extra window, in request order. */
+  windowsByKey: Array<Map<string, NormalizedMetricResult>>;
   isPending: boolean;
   isFetching: boolean;
   isError: boolean;
@@ -85,7 +93,8 @@ function queryKeyFor(
   entity: MetricCollectionEntity,
   ids: string[],
   range: DateRange,
-  metrics: MetricRequest[]
+  metrics: MetricRequest[],
+  windows: readonly DateRange[] = []
 ) {
   // The derived `metrics` array rides in the key, so key and payload are
   // provably coherent — no hand-maintained collection identity to forget to
@@ -97,6 +106,7 @@ function queryKeyFor(
     range.from,
     range.to,
     metrics,
+    windows,
   ] as const;
 }
 
@@ -118,7 +128,19 @@ export function useMetricCollection(
   );
   const canonicalEntity: MetricCollectionEntity =
     entity.type === "person" ? { type: "person", ids } : { type: "tenant" };
-  const request = buildMetricCollectionRequest(asked, canonicalEntity, range);
+  // The previous period rides along as an extra window instead of a twin
+  // request: it reads the same rows the primary aggregate already scans, so a
+  // delta arrow no longer costs a second round trip, a second authorization and
+  // a second query slot (#2651).
+  const windows = options?.previousPeriod
+    ? [previousPeriodRange(range, options.previousPeriod)]
+    : (options?.windows ?? []);
+  const request = buildMetricCollectionRequest(
+    asked,
+    canonicalEntity,
+    range,
+    windows
+  );
   // Neither an empty entity list nor an empty metric list is a request the
   // backend can answer — it rejects both with 400 invalid_argument. So the
   // query stays disabled, and because `refetch()` bypasses `enabled`, the
@@ -130,59 +152,42 @@ export function useMetricCollection(
     Boolean(range.from && range.to);
 
   const current = useQuery({
-    queryKey: queryKeyFor(entity, ids, range, request.metrics),
+    queryKey: queryKeyFor(entity, ids, range, request.metrics, windows),
     queryFn: () => queryMetricResults(request),
     enabled,
     placeholderData: options?.keepPreviousData ? keepPreviousData : undefined,
   });
 
-  const previousRange = options?.previousPeriod
-    ? previousPeriodRange(range, options.previousPeriod)
-    : null;
-  const previousRequest = previousRange
-    ? buildMetricCollectionRequest(asked, canonicalEntity, previousRange)
-    : null;
-  const previous = useQuery({
-    // Sentinel key when no previous period is requested: the disabled twin
-    // must never alias the current query's cache entry.
-    queryKey: previousRequest
-      ? queryKeyFor(
-          entity,
-          ids,
-          previousRange ?? range,
-          previousRequest.metrics
-        )
-      : (["metric-results", "previous-disabled"] as const),
-    queryFn: () => queryMetricResults(previousRequest ?? request),
-    enabled: enabled && previousRequest !== null,
-  });
-
-  const hasPrevious = previousRequest !== null;
   const byKey = useMemo(
     () => normalizeMetricResults(current.data?.metrics),
     [current.data]
   );
-  // Deltas pair two periods; a failed twin yields "no delta" rather than a
-  // silently mispaired one. Both queries reset together on a period change, so
-  // the previous twin is absent (not stale) while it reloads — nothing to
-  // mispair against.
-  const previousUsable = hasPrevious && !previous.isError;
-  const previousData = previousUsable ? previous.data : undefined;
-  const previousByKey = useMemo(
-    () => (previousData ? normalizeMetricResults(previousData.metrics) : null),
-    [previousData]
+  // One window's values, read as if they had been their own request — a period
+  // and its comparison window now stand or fall together, so there is no
+  // mispairing to guard against.
+  const windowCount = windows.length;
+  const windowsByKey = useMemo(
+    () =>
+      Array.from({ length: windowCount }, (_, index) =>
+        projectWindow(byKey, index)
+      ),
+    [byKey, windowCount]
   );
+  const previousByKey = options?.previousPeriod
+    ? (windowsByKey[0] ?? null)
+    : null;
 
   return {
     byKey,
     previousByKey,
+    windowsByKey,
     // Pending while the catalog resolves too: the request is coming, so the
     // screen must show a skeleton rather than an empty state it would replace
     // a moment later.
     isPending:
       (current.isPending && enabled) ||
       (entitySelected(entity, ids) && catalog.isPending),
-    isFetching: current.isFetching || (hasPrevious && previous.isFetching),
+    isFetching: current.isFetching,
     // Defensive: `ids` and `range` both ride in the query key, so today a
     // disabled query cannot be holding an error from an enabled one. Kept so
     // that a future key change cannot resurrect "Unable to load" for a
@@ -194,7 +199,6 @@ export function useMetricCollection(
       // see the note on `enabled` above.
       if (!enabled) return;
       void current.refetch();
-      if (hasPrevious) void previous.refetch();
     },
   };
 }
@@ -215,13 +219,14 @@ export function collectionSetPending(
 /**
  * One query per collection for a dynamic list (e.g. every metrics-backed
  * group in the registry) — `useQueries`, so the list length can change
- * without violating hook rules. No previous-period twin here; only the KPI
- * row compares periods.
+ * without violating hook rules. `windows` rides every request in the set and
+ * reads back per collection through `windowsByKey`.
  */
 export function useMetricCollectionSet(
   collections: readonly KeyedCollection[],
   entity: MetricCollectionEntity,
-  range: DateRange
+  range: DateRange,
+  windows: readonly DateRange[] = []
 ): Map<string, MetricCollectionResult> {
   const ids = canonicalEntityIds(entity);
   const catalog = useAvailableMetricKeys();
@@ -252,7 +257,8 @@ export function useMetricCollectionSet(
         entity.type === "person"
           ? { type: "person", ids: chunkIds }
           : { type: "tenant" },
-        range
+        range,
+        windows
       );
       return {
         key,
@@ -269,7 +275,7 @@ export function useMetricCollectionSet(
 
   const results = useQueries({
     queries: requests.map(({ request, chunkIds, active }) => ({
-      queryKey: queryKeyFor(entity, chunkIds, range, request.metrics),
+      queryKey: queryKeyFor(entity, chunkIds, range, request.metrics, windows),
       queryFn: () => queryMetricResults(request),
       enabled: active,
     })),
@@ -295,6 +301,7 @@ export function useMetricCollectionSet(
     out.set(key, {
       byKey: new Map(),
       previousByKey: null,
+      windowsByKey: [],
       // Pending covers the catalog wait too — otherwise a screen reads "no
       // data" for the moment before its requests are even allowed to fire.
       isPending:
@@ -314,7 +321,11 @@ export function useMetricCollectionSet(
   });
   for (const [key, maps] of chunkMaps) {
     const entry = out.get(key);
-    if (entry) entry.byKey = mergeNormalizedResults(maps);
+    if (!entry) continue;
+    entry.byKey = mergeNormalizedResults(maps);
+    entry.windowsByKey = windows.map((_, index) =>
+      projectWindow(entry.byKey, index)
+    );
   }
   return out;
 }

--- a/src/frontend/src/queries/metric-results.ts
+++ b/src/frontend/src/queries/metric-results.ts
@@ -52,7 +52,7 @@ export interface MetricCollectionOptions {
    * When set, the request carries the previous period of the same kind as an
    * extra window (the period value drives week/month/quarter/year shift
    * semantics in `previousPeriodRange`). Consumers derive deltas from
-   * `previousByKey`. Sugar for a single entry in `windows`.
+   * `previousByKey`. Shorthand for a `compareTo` range.
    */
   previousPeriod?: PeriodValue;
   /**

--- a/src/frontend/src/queries/metric-results.ts
+++ b/src/frontend/src/queries/metric-results.ts
@@ -17,8 +17,8 @@ import {
   entityChunkSize,
   mergeNormalizedResults,
   normalizeMetricResults,
+  projectComparison,
   projectPrimary,
-  projectWindow,
   type MetricCollectionConfig,
   type MetricCollectionEntity,
   type NormalizedMetricResult,
@@ -56,18 +56,18 @@ export interface MetricCollectionOptions {
    */
   previousPeriod?: PeriodValue;
   /**
-   * Extra windows served in the same request, in order; read them back through
-   * `windowsByKey` at the same index. Ignored when `previousPeriod` is set.
+   * The window to compare against, served in the same request and read back
+   * through `previousByKey`. Ignored when `previousPeriod` is set, which is
+   * sugar for it.
    */
-  windows?: readonly DateRange[];
+  compareTo?: DateRange;
   keepPreviousData?: boolean;
 }
 
 export interface MetricCollectionResult {
   byKey: Map<string, NormalizedMetricResult>;
+  /** The comparison window's values, or null when none was requested. */
   previousByKey: Map<string, NormalizedMetricResult> | null;
-  /** One entry per requested extra window, in request order. */
-  windowsByKey: Array<Map<string, NormalizedMetricResult>>;
   isPending: boolean;
   isFetching: boolean;
   isError: boolean;
@@ -95,7 +95,7 @@ function queryKeyFor(
   ids: string[],
   range: DateRange,
   metrics: MetricRequest[],
-  windows: readonly DateRange[] = []
+  compareTo?: DateRange
 ) {
   // The derived `metrics` array rides in the key, so key and payload are
   // provably coherent — no hand-maintained collection identity to forget to
@@ -107,7 +107,7 @@ function queryKeyFor(
     range.from,
     range.to,
     metrics,
-    windows,
+    compareTo ?? null,
   ] as const;
 }
 
@@ -129,18 +129,18 @@ export function useMetricCollection(
   );
   const canonicalEntity: MetricCollectionEntity =
     entity.type === "person" ? { type: "person", ids } : { type: "tenant" };
-  // The previous period rides along as an extra window instead of a twin
-  // request: it reads the same rows the primary aggregate already scans, so a
-  // delta arrow no longer costs a second round trip, a second authorization and
-  // a second query slot (#2651).
-  const windows = options?.previousPeriod
-    ? [previousPeriodRange(range, options.previousPeriod)]
-    : (options?.windows ?? []);
+  // The comparison window rides along inside the request instead of a twin
+  // one: it reads the same rows the primary aggregate already scans, so a delta
+  // arrow no longer costs a second round trip, a second authorization and a
+  // second query slot (#2651).
+  const compareTo = options?.previousPeriod
+    ? previousPeriodRange(range, options.previousPeriod)
+    : options?.compareTo;
   const request = buildMetricCollectionRequest(
     asked,
     canonicalEntity,
     range,
-    windows
+    compareTo
   );
   // Neither an empty entity list nor an empty metric list is a request the
   // backend can answer — it rejects both with 400 invalid_argument. So the
@@ -153,35 +153,29 @@ export function useMetricCollection(
     Boolean(range.from && range.to);
 
   const current = useQuery({
-    queryKey: queryKeyFor(entity, ids, range, request.metrics, windows),
+    queryKey: queryKeyFor(entity, ids, range, request.metrics, compareTo),
     queryFn: () => queryMetricResults(request),
     enabled,
     placeholderData: options?.keepPreviousData ? keepPreviousData : undefined,
   });
 
-  // INVARIANT: both projections read the RAW response. A windowed breakdown
-  // groups over every window at once, so filtering the primary first would hide
-  // the groups that belong only to a comparison window — the very rows those
-  // windows exist to carry.
+  // INVARIANT: both projections read the RAW response. A compared breakdown
+  // groups over both windows at once, so filtering the primary first would hide
+  // the groups that belong only to the comparison window — the very rows it
+  // exists to carry.
   const served = useMemo(
     () => normalizeMetricResults(current.data?.metrics),
     [current.data]
   );
   const byKey = useMemo(() => projectPrimary(served), [served]);
-  // One window's values, read as if they had been their own request — a period
-  // and its comparison window now stand or fall together, so there is no
-  // mispairing to guard against. Left for the compiler to memoize: `windows` is
-  // built in this render, so a hand-written dependency on it cannot be
-  // preserved (`react-hooks/preserve-manual-memoization`).
-  const windowsByKey = windows.map((_, index) => projectWindow(served, index));
-  const previousByKey = options?.previousPeriod
-    ? (windowsByKey[0] ?? null)
-    : null;
+  // The comparison window's values, read as if they had been their own request
+  // — a period and its comparison now stand or fall together, so there is no
+  // mispairing to guard against.
+  const previousByKey = compareTo ? projectComparison(served) : null;
 
   return {
     byKey,
     previousByKey,
-    windowsByKey,
     // Pending while the catalog resolves too: the request is coming, so the
     // screen must show a skeleton rather than an empty state it would replace
     // a moment later.
@@ -220,14 +214,14 @@ export function collectionSetPending(
 /**
  * One query per collection for a dynamic list (e.g. every metrics-backed
  * group in the registry) — `useQueries`, so the list length can change
- * without violating hook rules. `windows` rides every request in the set and
- * reads back per collection through `windowsByKey`.
+ * without violating hook rules. `compareTo` rides every request in the set and
+ * reads back per collection through `previousByKey`.
  */
 export function useMetricCollectionSet(
   collections: readonly KeyedCollection[],
   entity: MetricCollectionEntity,
   range: DateRange,
-  windows: readonly DateRange[] = []
+  compareTo?: DateRange
 ): Map<string, MetricCollectionResult> {
   const ids = canonicalEntityIds(entity);
   const catalog = useAvailableMetricKeys();
@@ -259,7 +253,7 @@ export function useMetricCollectionSet(
           ? { type: "person", ids: chunkIds }
           : { type: "tenant" },
         range,
-        windows
+        compareTo
       );
       return {
         key,
@@ -276,7 +270,7 @@ export function useMetricCollectionSet(
 
   const results = useQueries({
     queries: requests.map(({ request, chunkIds, active }) => ({
-      queryKey: queryKeyFor(entity, chunkIds, range, request.metrics, windows),
+      queryKey: queryKeyFor(entity, chunkIds, range, request.metrics, compareTo),
       queryFn: () => queryMetricResults(request),
       enabled: active,
     })),
@@ -302,7 +296,6 @@ export function useMetricCollectionSet(
     out.set(key, {
       byKey: new Map(),
       previousByKey: null,
-      windowsByKey: [],
       // Pending covers the catalog wait too — otherwise a screen reads "no
       // data" for the moment before its requests are even allowed to fire.
       isPending:
@@ -325,7 +318,7 @@ export function useMetricCollectionSet(
     if (!entry) continue;
     const served = mergeNormalizedResults(maps);
     entry.byKey = projectPrimary(served);
-    entry.windowsByKey = windows.map((_, index) => projectWindow(served, index));
+    entry.previousByKey = compareTo ? projectComparison(served) : null;
   }
   return out;
 }

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -58,6 +58,23 @@ class AiSettingsResponse(BaseModel):
     system_prompt: str
 
 
+class BreakdownWindowValueDto(BaseModel):
+    """
+    One group's reading over one extra window.
+
+    `value` and `present` are independent: a ratio over a group that IS in the
+    window reads NULL whenever its denominator is zero, so absence cannot be
+    inferred from the value. A reader that wants what a standalone request over
+    this window would have returned keeps the rows with `present` and renders
+    their `value` as it stands, NULL included.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    present: bool
+    value: float | None = None
+
+
 class Bucket(StrEnum):
     day = 'day'
     week = 'week'
@@ -965,8 +982,9 @@ class BreakdownValueDto(BaseModel):
     )
     dimensions: list[MetricDimensionDto]
     entity_id: str
+    present: bool | None = Field(None, description='Whether this group has any observation inside the primary period.\nPresent only on a windowed response, where the group set spans every\nwindow and a reader has to know which of them each group belongs to.')
     value: float | None = None
-    windows: list[float | None] | None = Field(None, description='One entry per requested extra window, in request order; empty when the\nrequest asked for none.')
+    windows: list[BreakdownWindowValueDto] | None = Field(None, description='One entry per requested extra window, in request order; empty when the\nrequest asked for none.')
 
 
 class ConnectorHealth(BaseModel):

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -60,12 +60,12 @@ class AiSettingsResponse(BaseModel):
 
 class BreakdownWindowValueDto(BaseModel):
     """
-    One group's reading over one extra window.
+    One group's reading over the comparison window.
 
     `value` and `present` are independent: a ratio over a group that IS in the
     window reads NULL whenever its denominator is zero, so absence cannot be
     inferred from the value. A reader that wants what a standalone request over
-    this window would have returned keeps the rows with `present` and renders
+    that window would have returned keeps the rows with `present` and renders
     their `value` as it stands, NULL included.
     """
     model_config = ConfigDict(
@@ -693,9 +693,9 @@ class PeriodValueDto(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
+    compare_to: float | None = Field(None, description='The same reading over `compare_to`; absent when the request asked for no\ncomparison window, and null when it asked but the entity has no value\nthere.')
     entity_id: str
     value: float | None = None
-    windows: list[float | None] | None = Field(None, description='One entry per requested extra window, in request order; empty when the\nrequest asked for none, keeping the single-window wire form unchanged.')
 
 
 class Problem(BaseModel):
@@ -980,11 +980,11 @@ class BreakdownValueDto(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
+    compare_to: BreakdownWindowValueDto | None = None
     dimensions: list[MetricDimensionDto]
     entity_id: str
     present: bool | None = Field(None, description='Whether this group has any observation inside the primary period.\nPresent only on a windowed response, where the group set spans every\nwindow and a reader has to know which of them each group belongs to.')
     value: float | None = None
-    windows: list[BreakdownWindowValueDto] | None = Field(None, description='One entry per requested extra window, in request order; empty when the\nrequest asked for none.')
 
 
 class ConnectorHealth(BaseModel):
@@ -1213,10 +1213,10 @@ class MetricResultsRequest(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
+    compare_to: MetricResultsPeriod | None = None
     entity: MetricResultsEntity
     metrics: list[MetricRequest]
     period: MetricResultsPeriod
-    windows: list[MetricResultsPeriod] | None = Field(None, description='Extra windows served alongside `period` in the same response, in request\norder. Carried by the `period` and `breakdown` views only; every other\nview kind answers over `period` alone.')
 
 
 class MetricSnapshot(BaseModel):

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -678,6 +678,7 @@ class PeriodValueDto(BaseModel):
     )
     entity_id: str
     value: float | None = None
+    windows: list[float | None] | None = Field(None, description='One entry per requested extra window, in request order; empty when the\nrequest asked for none, keeping the single-window wire form unchanged.')
 
 
 class Problem(BaseModel):
@@ -965,6 +966,7 @@ class BreakdownValueDto(BaseModel):
     dimensions: list[MetricDimensionDto]
     entity_id: str
     value: float | None = None
+    windows: list[float | None] | None = Field(None, description='One entry per requested extra window, in request order; empty when the\nrequest asked for none.')
 
 
 class ConnectorHealth(BaseModel):
@@ -1196,6 +1198,7 @@ class MetricResultsRequest(BaseModel):
     entity: MetricResultsEntity
     metrics: list[MetricRequest]
     period: MetricResultsPeriod
+    windows: list[MetricResultsPeriod] | None = Field(None, description='Extra windows served alongside `period` in the same response, in request\norder. Carried by the `period` and `breakdown` views only; every other\nview kind answers over `period` alone.')
 
 
 class MetricSnapshot(BaseModel):

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -693,7 +693,7 @@ class PeriodValueDto(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    compare_to: float | None = Field(None, description='The same reading over `compare_to`; absent when the request asked for no\ncomparison window, and null when it asked but the entity has no value\nthere.')
+    compare_to: float | None = Field(None, description='The same reading over `compare_to`. Omitted both when no comparison\nwindow was asked for and when the entity has no value in it — the two\nare not distinguished on the wire, and a reader that asked knows which\ncase it is in.')
     entity_id: str
     value: float | None = None
 


### PR DESCRIPTION
Closes #2651.

**Why.** Opening a dashboard sent every data request twice — once for the chosen period and once for the period before it — so a small "vs last period" arrow cost as much as the tile it sits on.

**What changed.** `POST /v1/metric-results` accepts `compare_to: {from, to}`, answered by the `period` and `breakdown` views as a second conditional aggregate in the same query. The frontend reads a delta's previous period out of the primary response instead of firing a twin request. The org lens' `slope`/`momentum` halves ride the same mechanism: the second half is the request's period, the first its comparison window.

**One comparison window, not a list.** Every caller compares against exactly one range, and a list bought nothing but index arithmetic on both sides of the wire. Widening it later is the same edit as narrowing it now.

**Only `period` and `breakdown` carry it; other views answer over `period`.** A KPI collection asks for period + peer in one request, so rejecting the mix would make the field unusable where it is needed — and a previous period's peer standing is read by nobody. The scanned range is therefore a property of the VIEW (`ScanScope`), not of the request: a peer aggregate carries no window term of its own, so a widened scan would have folded both ranges into one target value and built its percentiles on that. A regression test pins it — for `peer`, `timeseries`, `rollup`, `histogram` and `ranking` the compiled SQL and its bound parameters are identical with and without `compare_to`, down to the identity-resolving subquery; for `period` and `breakdown` they differ.

**The scan is a disjunction of the two ranges, never `min(from)..max(to)`.** An envelope reads every day between them and lets the aggregates discard it. This is reachable from the UI, not hypothetical: `period` and a custom range coexist in the portal's URL, so `?period=year&from=…&to=…` compares a week against the same week a year earlier.

**A compared breakdown reports presence separately from the value.** It groups over both windows at once, so its row set is the union of them, and the value cannot say which window a group belongs to: a ratio over a group that IS in the window reads NULL whenever its denominator is zero. `countIf(<window>) > 0` carries that fact; the projections pick rows by presence and render the value as it stands, NULL included. The aggregate expressions are untouched, so a projected window equals a standalone request over it in both row set and values.

**A compared breakdown stages its aggregates under `staged_*`.** An inner column aliased `value` is what a sibling aggregate's argument resolves to, which ClickHouse rejects as an aggregate inside an aggregate. A live test caught that; SQL-text assertions could not.

## Measured

On a throwaway table carrying the real observations DDL — `PARTITION BY toYYYYMM(metric_date)`, `metric_date` last in the sort key — 3.65M rows, 51 parts, best of three runs.

One request against the two it replaces, over adjacent windows (every window pair the product actually sends):

| | rows read | best |
|---|---|---|
| two sequential requests, one person | 8 192 + 11 964 | 4 + 4 ms |
| one compared request, one person | 20 156 | 4 ms |
| two sequential requests, 500-person roster | 70 500 + 78 000 | 9 + 12 ms |
| one compared request, 500-person roster | 148 000 | 14 ms |

Same rows either way; the saving is the second scan's setup, and above it the second round trip, authorization and query slot. The extra conditional aggregate does not show: over one 300k-row scan, 1 aggregate 9 ms, 2 aggregates 9 ms, 4 aggregates 9 ms.

The disjunction, against the envelope it replaced, over the year-apart pair a portal URL can produce (`EXPLAIN indexes=1`):

| | rows read | bytes | parts | granules | best |
|---|---|---|---|---|---|
| envelope | 983 000 | 46.2 MiB | 14 / 51 | 117 | 16 ms |
| disjunction | 140 500 | 2.07 MiB | 2 / 51 | 18 | 9 ms |

A wider gap widens the ratio: over four years the same comparison reads 80 of 99 parts against 2. Adjacent windows read identically under both, so the disjunction costs nothing where it changes nothing. Kept as a SQL-shape assertion rather than a live test — a DDL-and-`EXPLAIN` gate against a shared ClickHouse is too brittle to stand in CI.

The response also shrinks, because a metric's envelope and a breakdown's dimension tuples go over the wire once instead of twice: the five-tile KPI row 8 968 B → 4 564 B (−49%), a 50-repository breakdown 18 290 B → 11 995 B (−34%).

**Verified.** A request with no comparison window compiles byte-identical SQL. On CI's pinned 1.95.0: `cargo fmt -- --check`, `clippy --all-targets --all-features -D warnings`, and `cargo test --all-features` (669 tests). 6 live tests against a local ClickHouse 25.7.5, including a breakdown whose two groups occupy different windows, one present with a NULL ratio. Frontend `pnpm lint`, `pnpm typecheck`, `vitest run --project=unit`. Two Storybook-in-chromium files under `metric-views` fail locally and fail identically on a clean `main`, so they are this environment rather than this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Analytics results now support optional comparison date ranges in the same request as the primary period.
  - Period metrics include comparison values, including unavailable readings.
  - Breakdown metrics show comparison values and whether groups were present in each window, even when values are null.
  - Previous-period trends in metric views and grids now load through a single request.
- **Bug Fixes**
  - Improved handling of missing comparison data and groups that exist without a measurable value.
- **Validation**
  - Comparison ranges are validated for valid ordering and supported duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->