### PR TITLE
fix(ingestion): record a sync still in flight

### DIFF
--- a/docs/components/backend/analytics/specs/connector-health/DESIGN.md
+++ b/docs/components/backend/analytics/specs/connector-health/DESIGN.md
@@ -272,10 +272,12 @@ by `argMax` over
 
 Every component earns its place, and each closes a wrong answer that was measured first:
 
-- **`coalesce(job_updated_at, ts)`** — NULLs sort last in ClickHouse in BOTH directions, so a
-  job the mover gave no update stamp for does not merely lose the comparison: a different,
-  older job wins it, and the page presents a stale success as the current state. Falling back
-  to when the row was recorded places the job by a real recorded moment instead.
+- **`coalesce(job_updated_at, ts)`** — a defence against a NULL this writer no longer produces
+  and a reader cannot survive. Rows recorded before the placement rule settled still hold one,
+  and NULLs sort last in ClickHouse in BOTH directions: such a row does not merely lose the
+  comparison, a different and older job wins it, and the page presents a stale success as the
+  current state. Falling back to when the row was recorded places it by a real recorded moment
+  instead.
 - **`toUInt64OrZero(job_id)`** — the mover's ids are numbers stored as text, so comparing them
   as text makes `"9"` newer than `"10"`.
 - **the terminal flag** — within one job a final row outranks a provisional one whatever the

--- a/docs/components/backend/analytics/specs/connector-health/DESIGN.md
+++ b/docs/components/backend/analytics/specs/connector-health/DESIGN.md
@@ -210,7 +210,7 @@ them, so an absent-value type would buy nothing and cost a nullable read on the 
 out-of-range one — it clamps a `DateTime64` and wraps a `UInt64`. A year-1000 stamp lands as
 1900 and a count above 2^64 lands as a different number, and the page would label both as
 what the mover reported. A stamp or a count the column cannot hold is therefore treated as
-absent, and a job whose update stamp is unusable is not recorded at all.
+absent, and a job carrying no usable moment at all is not recorded.
 
 **Resolution.** The summary takes, per connector, the newest `sync.completed` by the mover's
 own last-update stamp for the job; the configured set is the membership of the newest *sealed*
@@ -230,8 +230,8 @@ page shows it as a state it could not read. It is also not terminal: coverage fa
 a status the sweep could not read is one it keeps re-reading until it becomes one it can.
 
 **Two timestamps, kept apart.** `started_at` is when the mover says the sync began, and is
-absent for a job it has not started. `job_updated_at` is the mover's own last-update stamp for
-the job, which is the field the listing is ordered and filtered by — and therefore the axis
+absent for a job it has not started. `job_updated_at` is the mover's last word about the job
+— its last update, or its start when the mover has not updated it — which is the field the listing is ordered and filtered by — and therefore the axis
 the sweep's own watermark moves along. Substituting one for the other would report a start
 that never happened and still leave the cursor on the wrong axis.
 
@@ -253,10 +253,18 @@ bounded by that same watermark and so cannot filter them out; and a capped pass 
 short of the newest jobs while still sealing, leaving the page dated as freshly checked on
 facts it never reached.
 
-**`job_updated_at` is never NULL on a sync row.** The listing is ordered by it, so a job the
-mover returns always carries one; the column is nullable only because snapshot and seal rows
-are not about a job at all. A job the mover returns without an update stamp is one the planner
-cannot place in time, so it is skipped and logged rather than written with a NULL.
+**A job in flight carries no update stamp at all**, only a start — the mover reports an
+update once it has one to report. Refusing such an entry costs the state the page exists for:
+the connector reads as last synced whenever it last finished, while a sync is in flight or
+stuck. So the planner falls back to the start, and the fallback is not a guess — the listing
+places such an entry around its start, serving it when the filter begins at or before that
+moment and withholding it when the filter begins after. Recording the start therefore keeps
+the watermark on the axis the filter runs on.
+
+**`job_updated_at` is never NULL on a sync row.** Every entry the mover returns carries one of
+the two stamps; the column is nullable only because snapshot and seal rows are not about a job
+at all. An entry carrying neither is one the planner cannot place in time, so it is skipped and
+logged rather than written with a NULL.
 
 **The resolution is one aggregate over an ordering tuple.** Per connector the newest row wins
 by `argMax` over
@@ -619,7 +627,7 @@ customer extracts, which must never carry service rows.
 | `event` | `LowCardinality(String)` | `sync.completed` \| `connector.configured` \| `sweep.completed` |
 | `status` | `LowCardinality(String)` | on a sync row, the mover's own word or `unknown`; empty elsewhere |
 | `started_at` | `Nullable(DateTime64(3, 'UTC'))` | when the mover says the sync began; NULL for a job it has not started |
-| `job_updated_at` | `Nullable(DateTime64(3, 'UTC'))` | the mover's last-update stamp for the job — the axis the watermark moves along, and the field the listing is ordered and filtered by; never NULL on a sync row |
+| `job_updated_at` | `Nullable(DateTime64(3, 'UTC'))` | the mover's last word about the job — its last update, or its start while it is still in flight. The axis the watermark moves along and the field the listing is ordered and filtered by; never NULL on a sync row |
 | `duration_ms` | `Nullable(UInt64)` | between the mover's own start and end stamps; NULL while a job is in flight and where either stamp is missing, which a zero could not express |
 | `records_reported` | `Nullable(UInt64)` | the mover's own count; NULL where it reported none |
 

--- a/src/backend/services/analytics/src/domain/connector_health/read.rs
+++ b/src/backend/services/analytics/src/domain/connector_health/read.rs
@@ -81,9 +81,10 @@ static READ_INTERVAL_SQL: LazyLock<String> = LazyLock::new(|| {
 /// Four components, each earning its place:
 ///
 /// * `coalesce(job_updated_at, ts)` — the axis the ledger places jobs along,
-///   falling back to when the row was recorded. A NULL here would be worse than
-///   a fallback: ClickHouse sorts NULLs last in BOTH directions, so a job the
-///   mover gave no update stamp for would not merely lose the comparison — a
+///   falling back to when the row was recorded. The writer no longer leaves a
+///   NULL here, but rows recorded before the placement rule settled still hold
+///   one and a reader cannot survive it: ClickHouse sorts NULLs last in BOTH
+///   directions, so such a row would not merely lose the comparison — a
 ///   different, older job would win it, and the page would present a stale
 ///   success as the current state.
 /// * `toUInt64OrZero(job_id)` — the mover's ids are numbers stored as text, so

--- a/src/ingestion/reconcile-connectors/python/sweep/plan.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/plan.py
@@ -11,8 +11,10 @@ ISO-8601 duration, so both are parsed rather than cast.
 
 INVARIANT: the entry carries no creation time. The listing accepts a creation
 filter but never reports one, so reading a job's moment from anything other
-than its last-update stamp refuses every entry — indistinguishable, from the
-page, from a mover that has run no syncs at all.
+than the stamps it does carry refuses every entry — indistinguishable, from the
+page, from a mover that has run no syncs at all. Nor does every entry carry
+every stamp it does report: a job still running can arrive with a start and no
+update at all.
 """
 
 from __future__ import annotations
@@ -96,13 +98,24 @@ def moment(stamp: object) -> str | None:
 
 
 def entry_moment(entry: Mapping[str, Any]) -> str | None:
-    """One listing entry's last-update moment, in the ledger's own form.
+    """Where one listing entry sits on the axis the ledger orders jobs along.
 
-    The single reader of that field: the watermark is compared against it, the
-    listing is filtered by it and the planner records it, and the three must
-    never disagree about which of an entry's stamps places it.
+    The mover's last word about the job — its last update, or its start when the
+    mover has not updated it yet. A job still running can carry no update stamp
+    at all, and refusing it would drop the one state the page most needs to
+    show: the connector reads as last synced whenever it last finished, while a
+    sync is in flight or stuck.
+
+    The fallback is not a guess. The listing itself places such an entry around
+    its start — it serves the entry when filtered from that moment and withholds
+    it when filtered from after — so recording the start keeps the watermark on
+    the same axis the filter runs on.
+
+    INVARIANT: the watermark is compared against this, the listing is filtered
+    by it and the planner records it, and the three must never disagree about
+    which of an entry's stamps places it.
     """
-    return moment(entry.get("lastUpdatedAt"))
+    return moment(entry.get("lastUpdatedAt")) or moment(entry.get("startTime"))
 
 
 def as_listing_stamp(recorded: str | None) -> str | None:
@@ -233,9 +246,9 @@ def sync_row(
     # SAFETY: the summary resolves the newest sync per connector along this
     # column, and a row without it can never win that comparison. Recording it
     # anyway would hide the connector rather than the row.
-    updated = entry_moment(entry)
-    if updated is None:
-        return Skipped(job_id, "job carries no readable update time")
+    placed = entry_moment(entry)
+    if placed is None:
+        return Skipped(job_id, "job carries no readable moment")
 
     return {
         "tick_id": tick_id,
@@ -244,7 +257,7 @@ def sync_row(
         "event": SYNC_COMPLETED,
         "status": vocab.normalise(entry.get("status")),
         "started_at": moment(entry.get("startTime")),
-        "job_updated_at": updated,
+        "job_updated_at": placed,
         "duration_ms": duration_ms(entry.get("duration")),
         "records_reported": records_reported(entry),
     }

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
@@ -64,6 +64,16 @@ def _ch_stamp(iso: str) -> str:
     return iso.replace("T", " ").replace("Z", "") + ".000"
 
 
+def _placed(entry: dict) -> datetime:
+    """Where the real listing places an entry for its own filter.
+
+    Its last update, or its start when it has none: a job in flight was
+    measured to be served when the filter starts at or before its start, and
+    withheld when the filter starts after it.
+    """
+    return _parse_iso(entry.get("lastUpdatedAt") or entry["startTime"])
+
+
 #: Every parameter the sweep is allowed to send. A name outside it is a filter
 #: the real listing would silently ignore.
 _LISTING_PARAMETERS = frozenset(
@@ -90,12 +100,22 @@ def _closed_job(index: int) -> dict:
 
 
 def _running_job() -> dict:
-    """No start, no duration, no count — the mover has nothing to report yet."""
+    """A job in flight, in the shape the listing serves one.
+
+    It has started and it carries no update stamp at all — the mover reports
+    one only once it has something to update. A stub that hands out an update
+    stamp here tests a shape the listing never sends, and lets a planner that
+    refuses the real one pass.
+    """
     return {
         "jobId": 999,
         "connectionId": CONNECTION,
+        "jobType": "sync",
         "status": "running",
-        "lastUpdatedAt": _stamp(8),
+        "startTime": _stamp(8),
+        "duration": "PT46M18S",
+        "bytesSynced": 0,
+        "rowsSynced": 0,
     }
 
 
@@ -153,9 +173,7 @@ class _StubMover:
                     # as raw strings is what let a wrongly-formatted watermark
                     # look like a working filter.
                     edge = _parse_iso(since)
-                    entries = [
-                        e for e in entries if _parse_iso(e["lastUpdatedAt"]) >= edge
-                    ]
+                    entries = [e for e in entries if _placed(e) >= edge]
                 offset = int(flat.get("offset", "0"))
                 window = entries[offset : offset + stub.page_size]
 
@@ -351,17 +369,24 @@ class SweptRowsLandAndResolve(unittest.TestCase):
         self.assertEqual(summary[0]["job_id"], "999")
         self.assertEqual(summary[0]["status"], "failed")
 
-    def test_an_unfinished_job_stores_no_start_and_no_duration(self) -> None:
+    def test_a_job_in_flight_is_recorded_and_placed_at_its_start(self) -> None:
+        """The listing sends a running job with a start and no update stamp.
+
+        Refusing it for the missing stamp costs the state the page exists for:
+        the connector would read as last synced whenever it last finished,
+        while a sync is in flight or stuck.
+        """
         with _StubMover():
             self._tick("tick-a")
 
         running = _rows(
-            f"SELECT started_at, duration_ms, records_reported FROM {TABLE} "
+            f"SELECT status, toString(started_at) AS started, "
+            f"toString(job_updated_at) AS placed FROM {TABLE} "
             "WHERE event = 'sync.completed' AND job_id = '999'"
         )
-        self.assertIsNone(running[0]["started_at"])
-        self.assertIsNone(running[0]["duration_ms"])
-        self.assertIsNone(running[0]["records_reported"])
+        self.assertEqual(len(running), 1, "the job in flight must be recorded")
+        self.assertEqual(running[0]["status"], "running")
+        self.assertEqual(running[0]["placed"], running[0]["started"])
 
     def test_no_connectors_records_nothing_at_all(self) -> None:
         """An empty configured set is indistinguishable from "all removed"."""

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
@@ -100,14 +100,16 @@ class StatusKeepsTheMoversWord(unittest.TestCase):
 
 
 class AJobMustBePlaceable(unittest.TestCase):
-    def test_a_job_with_no_update_time_is_refused(self) -> None:
+    def test_a_job_with_neither_stamp_readable_is_refused(self) -> None:
+        """Both, because either one places the job. A case that blanks only the
+        update stamp stops testing the refusal the moment a fallback exists."""
         for absent in (None, 0, -1, "yesterday", True):
             with self.subTest(absent=absent):
                 planned = plan.sync_row(
-                    entry(lastUpdatedAt=absent), CONNECTORS, TICK
+                    entry(lastUpdatedAt=absent, startTime=absent), CONNECTORS, TICK
                 )
                 self.assertIsInstance(
-                    planned, plan.Skipped, f"should refuse lastUpdatedAt={absent!r}"
+                    planned, plan.Skipped, f"should refuse both stamps = {absent!r}"
                 )
 
     def test_a_job_with_no_identity_is_refused(self) -> None:
@@ -119,8 +121,10 @@ class AJobMustBePlaceable(unittest.TestCase):
         self.assertIsInstance(planned, plan.Skipped)
 
     def test_a_refusal_carries_its_reason(self) -> None:
-        planned = plan.sync_row(entry(lastUpdatedAt=None), CONNECTORS, TICK)
-        self.assertIn("update time", planned.reason)
+        planned = plan.sync_row(
+            entry(lastUpdatedAt=None, startTime=None), CONNECTORS, TICK
+        )
+        self.assertIn("moment", planned.reason)
 
 
 class AbsenceIsNotZero(unittest.TestCase):
@@ -195,7 +199,11 @@ class WhatIsRead(unittest.TestCase):
     def test_an_epoch_number_is_not_a_stamp(self) -> None:
         """The listing sends strings. A number here would be a different
         endpoint's shape, and guessing at it would date every job to 1970."""
-        planned = plan.sync_row(entry(lastUpdatedAt=1_700_000_000), CONNECTORS, TICK)
+        planned = plan.sync_row(
+            entry(lastUpdatedAt=1_700_000_000, startTime=1_700_000_000),
+            CONNECTORS,
+            TICK,
+        )
         self.assertIsInstance(planned, plan.Skipped)
 
     def test_the_duration_is_read_as_an_iso_8601_duration(self) -> None:
@@ -244,7 +252,10 @@ class CoverageSkipsWhatIsClosed(unittest.TestCase):
 
     def test_refusals_are_reported_beside_the_rows(self) -> None:
         planned = plan.plan_syncs(
-            [entry(), entry(jobId=7, lastUpdatedAt=None)], CONNECTORS, TICK, frozenset()
+            [entry(), entry(jobId=7, lastUpdatedAt=None, startTime=None)],
+            CONNECTORS,
+            TICK,
+            frozenset(),
         )
         self.assertEqual(len(planned.rows), 1)
         self.assertEqual(len(planned.skipped), 1)
@@ -299,12 +310,67 @@ class TheListingsOwnShape(unittest.TestCase):
     def test_a_creation_stamp_does_not_place_a_job(self) -> None:
         """The listing filters on creation and reports none, so an entry
         carrying only a creation stamp is one the mover cannot have sent."""
-        invented = {k: v for k, v in entry().items() if k != "lastUpdatedAt"}
+        invented = {
+            k: v for k, v in entry().items() if k not in ("lastUpdatedAt", "startTime")
+        }
         invented["createdAt"] = "2026-08-27T08:00:00Z"
 
         planned = plan.sync_row(invented, CONNECTORS, TICK)
 
         self.assertIsInstance(planned, plan.Skipped)
+
+
+class AJobStillRunningIsPlaceable(unittest.TestCase):
+    """A running job can arrive with a start and no update stamp at all.
+
+    Refusing it costs the one state the page most needs: the connector reads as
+    last synced whenever it last finished, while a sync is in flight or stuck.
+    The whole page exists to tell those apart.
+    """
+
+    #: A running job as the listing serves one: started, not finished, nothing
+    #: reported yet, and no update stamp.
+    RUNNING = {
+        "jobId": 9001,
+        "connectionId": CONNECTION,
+        "jobType": "sync",
+        "status": "running",
+        "startTime": "2026-08-27T08:00:30Z",
+        "duration": "PT46M18S",
+        "bytesSynced": 0,
+        "rowsSynced": 0,
+    }
+
+    def test_it_is_recorded_rather_than_skipped(self) -> None:
+        planned = plan.sync_row(self.RUNNING, CONNECTORS, TICK)
+
+        self.assertNotIsInstance(planned, plan.Skipped, planned)
+        self.assertEqual(planned["status"], "running")
+
+    def test_it_is_placed_at_its_start(self) -> None:
+        """The listing places such an entry around its start — it serves the
+        entry when filtered from that moment and withholds it when filtered
+        from after — so the ledger must place it there too, or the watermark
+        and the filter part company."""
+        planned = plan.sync_row(self.RUNNING, CONNECTORS, TICK)
+
+        self.assertEqual(planned["job_updated_at"], "2026-08-27 08:00:30.000")
+
+    def test_an_update_stamp_still_wins_when_there_is_one(self) -> None:
+        """The fallback must not outrank the field it stands in for."""
+        self.assertEqual(row()["job_updated_at"], "2026-08-27 08:02:52.000")
+
+    def test_it_outranks_the_finished_job_it_follows(self) -> None:
+        """A sync that started after the last one finished is the newer fact,
+        and the summary orders along the same column the planner writes."""
+        finished = entry(jobId=8900, lastUpdatedAt="2026-08-27T07:00:00Z")
+        planned = plan.plan_syncs(
+            [finished, self.RUNNING], CONNECTORS, TICK, frozenset()
+        )
+
+        placed = {r["job_id"]: r["job_updated_at"] for r in planned.rows}
+        self.assertEqual(len(placed), 2)
+        self.assertGreater(placed["9001"], placed["8900"])
 
 
 class AnIgnoredFilterIsVisible(unittest.TestCase):

--- a/src/ingestion/scripts/migrations/20260827000000_connector-sync-history.sql
+++ b/src/ingestion/scripts/migrations/20260827000000_connector-sync-history.sql
@@ -11,10 +11,10 @@
 -- job at all, and is never NULL on a sync row — the read surface orders jobs
 -- along it, and a row without it cannot be placed among them.
 --
--- `job_updated_at` is the mover's own last-update stamp for the job, not a
--- creation time: the listing does not report when a job was created, and it is
--- also the field the listing filters on, so the sweep reads back exactly the
--- field it asks by.
+-- `job_updated_at` is the mover's last word about the job — its last update, or
+-- its start while it is still in flight — never a creation time: the listing
+-- does not report when a job was created, and it is also the field the listing
+-- filters on, so the sweep reads back exactly the field it asks by.
 --
 -- Spec: docs/components/backend/analytics/specs/connector-health.
 


### PR DESCRIPTION
**Why.** A connector with a sync in progress read as last synced whenever it last *finished*. Telling those apart is what the page is for, and a stuck sync was the case it hid.

**What changed.** A job in flight carries a start and no update stamp at all — the mover reports an update once it has one — and the planner placed jobs by the update stamp alone, so it refused every such entry. The moment now falls back to the job's start.

**The fallback is measured, not assumed.** The listing places such an entry around its start: it serves the entry when the filter begins at or before that moment and withholds it when the filter begins after. Recording the start keeps the watermark on the axis the filter runs on.

**The stub served the opposite shape** — a running job with an update stamp and no start — which is how a planner that refuses the real one passed. It now serves the shape the listing sends and filters by the same rule the planner places by. Eight tests that blanked only the update stamp stopped proving their own names once a fallback existed; they blank both now.

Fed a stand's real listing through the planner: **899 rows where 898 were**, the one difference being the job in flight, placed at its start. Remaining skips are jobs on deleted connections.

**Out of scope.** Such a job reports `rowsSynced: 0`, so the page shows `0` rather than `—` while it runs. Left alone deliberately: the PRD defines that column as the count *the mover states*, and substituting absence would interpret the source instead of copying it.

**Verified.** 75 ingestion tests (e2e against a throwaway ClickHouse), 721 backend, `clippy -D warnings`, `fmt`, `ruff check`. Mutation-checked: removing the fallback fails three of the new tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Running jobs without an update timestamp are now recorded using their start time.
  * Jobs are skipped only when neither a start time nor an update timestamp is available.
  * Job ordering and sync history now remain consistent for in-progress jobs.

* **Documentation**
  * Clarified how job timestamps are selected and recorded, including behavior for running jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->