### PR TITLE
fix(security): clear the open image and lockfile CVEs

### DIFF
--- a/src/backend/services/gateway/Dockerfile
+++ b/src/backend/services/gateway/Dockerfile
@@ -25,7 +25,8 @@ FROM openresty/openresty:1.31.1.1-2-alpine
 #     correlation ids. Alpine ships only libuuid.so.1, but the FFI loader wants
 #     libuuid.so, so symlink it.
 # opm needs perl + curl to fetch the modules; those are build-only, dropped after.
-RUN apk add --no-cache libuuid \
+RUN apk upgrade --no-cache libcrypto3 libssl3 \
+    && apk add --no-cache libuuid \
     && apk add --no-cache --virtual .opm-deps perl curl \
     && opm get ledgetech/lua-resty-http \
     && opm get bungle/lua-resty-uuid \

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -28,6 +28,8 @@ FROM nginxinc/nginx-unprivileged:1.31-alpine
 # before the runtime stage.
 USER root
 
+RUN apk upgrade --no-cache libcrypto3 libssl3
+
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -99,7 +99,9 @@
       "fast-uri": ">=3.1.4 <4",
       "brace-expansion@5": ">=5.0.9 <6",
       "brace-expansion@1": ">=1.1.18 <2",
-      "brace-expansion@2": ">=2.1.4 <3"
+      "brace-expansion@2": ">=2.1.4 <3",
+      "uuid@8": ">=11.1.1 <12",
+      "@babel/core": ">=7.29.6 <8"
     }
   },
   "msw": {

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -15,6 +15,8 @@ overrides:
   brace-expansion@5: '>=5.0.9 <6'
   brace-expansion@1: '>=1.1.18 <2'
   brace-expansion@2: '>=2.1.4 <3'
+  uuid@8: '>=11.1.1 <12'
+  '@babel/core': '>=7.29.6 <8'
 
 importers:
 
@@ -215,32 +217,16 @@ packages:
     resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
     engines: {node: ^22.13.0 || >=24.0.0}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/compat-data@7.29.3':
-    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.29.7':
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/core@7.29.7':
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.29.1':
-    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.8':
@@ -251,10 +237,6 @@ packages:
     resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-compilation-targets@7.29.7':
     resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
@@ -263,11 +245,7 @@ packages:
     resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
@@ -277,25 +255,15 @@ packages:
     resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.28.6':
-    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-module-imports@7.29.7':
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.6':
-    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
 
   '@babel/helper-module-transforms@7.29.7':
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/helper-optimise-call-expression@7.29.7':
     resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
@@ -309,7 +277,7 @@ packages:
     resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
@@ -335,10 +303,6 @@ packages:
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.29.2':
-    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
@@ -357,31 +321,31 @@ packages:
     resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-syntax-typescript@7.29.7':
     resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-modules-commonjs@7.29.7':
     resolution: {integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/plugin-transform-typescript@7.29.7':
     resolution: {integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/preset-typescript@7.29.7':
     resolution: {integrity: sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '>=7.29.6 <8'
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -393,10 +357,6 @@ packages:
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.29.0':
-    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.8':
@@ -1262,7 +1222,7 @@ packages:
     resolution: {integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==}
     engines: {node: '>=22.12.0 || ^24.0.0'}
     peerDependencies:
-      '@babel/core': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/core': '>=7.29.6 <8'
       '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
       '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
       rolldown: ^1.0.0-rc.5
@@ -4317,9 +4277,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   validate-npm-package-name@7.0.2:
@@ -4560,41 +4519,13 @@ snapshots:
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.3': {}
-
   '@babel/compat-data@7.29.7': {}
-
-  '@babel/core@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.3
-      '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.8
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/core@7.29.7':
     dependencies:
@@ -4616,14 +4547,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.29.1':
-    dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.8
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
-
   '@babel/generator@7.29.8':
     dependencies:
       '@babel/parser': 7.29.8
@@ -4635,14 +4558,6 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.29.7':
     dependencies:
       '@babel/types': 7.29.8
-
-  '@babel/helper-compilation-targets@7.28.6':
-    dependencies:
-      '@babel/compat-data': 7.29.3
-      '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.8
-      lru-cache: 5.1.1
-      semver: 6.3.1
 
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
@@ -4665,8 +4580,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-globals@7.28.0': {}
-
   '@babel/helper-globals@7.29.7': {}
 
   '@babel/helper-member-expression-to-functions@7.29.7':
@@ -4676,26 +4589,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.28.6':
-    dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-imports@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4739,11 +4636,6 @@ snapshots:
   '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.29.7': {}
-
-  '@babel/helpers@7.29.2':
-    dependencies:
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.8
 
   '@babel/helpers@7.29.7':
     dependencies:
@@ -4807,18 +4699,6 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
-
-  '@babel/traverse@7.29.0':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.3
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.8
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.29.8':
     dependencies:
@@ -6747,7 +6627,7 @@ snapshots:
 
   eslint-plugin-react-hooks@7.1.1(eslint@10.8.1(jiti@2.7.0)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.3
       eslint: 10.8.1(jiti@2.7.0)
       hermes-parser: 0.25.1
@@ -6854,7 +6734,7 @@ snapshots:
       saxes: 5.0.1
       tmp: 0.2.7
       unzipper: 0.10.14
-      uuid: 8.3.2
+      uuid: 11.1.1
 
   execa@5.1.1:
     dependencies:
@@ -8515,7 +8395,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@8.3.2: {}
+  uuid@11.1.1: {}
 
   validate-npm-package-name@7.0.2: {}
 

--- a/src/ingestion/connectors/ai/claude-team-invoices/Dockerfile
+++ b/src/ingestion/connectors/ai/claude-team-invoices/Dockerfile
@@ -7,8 +7,9 @@ RUN pip install /airbyte/integration_code
 # CVE-2026-33231, CVE-2026-54293) but only uses it in the file-based
 # unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
-# tooling unused at runtime (CVE-2026-34591, CVE-2026-42305).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 \
+# tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
+# arrives with the base image's keyring stack (SecretStorage).
+RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.0 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/ai/claude-team-invoices/Dockerfile
+++ b/src/ingestion/connectors/ai/claude-team-invoices/Dockerfile
@@ -8,8 +8,9 @@ RUN pip install /airbyte/integration_code
 # unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
 # tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
-# arrives with the base image's keyring stack (SecretStorage).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.0 \
+# arrives with the base image's keyring stack (SecretStorage); its wheel
+# bundles OpenSSL, and 50.0.1 is the first built against 4.0.2 (CVE-2026-63072).
+RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.1 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/crm/hubspot/Dockerfile
+++ b/src/ingestion/connectors/crm/hubspot/Dockerfile
@@ -7,8 +7,9 @@ RUN pip install --no-cache-dir /airbyte/integration_code
 # CVE-2026-33231, CVE-2026-54293) but only uses it in the file-based
 # unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
-# tooling unused at runtime (CVE-2026-34591, CVE-2026-42305).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 \
+# tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
+# arrives with the base image's keyring stack (SecretStorage).
+RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.0 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/crm/hubspot/Dockerfile
+++ b/src/ingestion/connectors/crm/hubspot/Dockerfile
@@ -8,8 +8,9 @@ RUN pip install --no-cache-dir /airbyte/integration_code
 # unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
 # tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
-# arrives with the base image's keyring stack (SecretStorage).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.0 \
+# arrives with the base image's keyring stack (SecretStorage); its wheel
+# bundles OpenSSL, and 50.0.1 is the first built against 4.0.2 (CVE-2026-63072).
+RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.1 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/git/gitlab/Dockerfile
+++ b/src/ingestion/connectors/git/gitlab/Dockerfile
@@ -7,8 +7,9 @@ RUN pip install /airbyte/integration_code
 # CVE-2026-33231, CVE-2026-54293) but only uses it in the file-based
 # unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
-# tooling unused at runtime (CVE-2026-34591, CVE-2026-42305).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 \
+# tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
+# arrives with the base image's keyring stack (SecretStorage).
+RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.0 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/git/gitlab/Dockerfile
+++ b/src/ingestion/connectors/git/gitlab/Dockerfile
@@ -8,8 +8,9 @@ RUN pip install /airbyte/integration_code
 # unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
 # tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
-# arrives with the base image's keyring stack (SecretStorage).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.0 \
+# arrives with the base image's keyring stack (SecretStorage); its wheel
+# bundles OpenSSL, and 50.0.1 is the first built against 4.0.2 (CVE-2026-63072).
+RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.1 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/hr-directory/active-directory/Dockerfile
+++ b/src/ingestion/connectors/hr-directory/active-directory/Dockerfile
@@ -7,8 +7,9 @@ RUN pip install /airbyte/integration_code
 # CVE-2026-33231, CVE-2026-54293) but only uses it in the file-based
 # unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
-# tooling unused at runtime (CVE-2026-34591, CVE-2026-42305).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 \
+# tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
+# arrives with the base image's keyring stack (SecretStorage).
+RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.0 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/hr-directory/active-directory/Dockerfile
+++ b/src/ingestion/connectors/hr-directory/active-directory/Dockerfile
@@ -8,8 +8,9 @@ RUN pip install /airbyte/integration_code
 # unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
 # tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
-# arrives with the base image's keyring stack (SecretStorage).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.0 \
+# arrives with the base image's keyring stack (SecretStorage); its wheel
+# bundles OpenSSL, and 50.0.1 is the first built against 4.0.2 (CVE-2026-63072).
+RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.1 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/hr-directory/bamboohr/Dockerfile
+++ b/src/ingestion/connectors/hr-directory/bamboohr/Dockerfile
@@ -7,8 +7,9 @@ RUN pip install /airbyte/integration_code
 # CVE-2026-33231, CVE-2026-54293) but only uses it in the file-based
 # unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
-# tooling unused at runtime (CVE-2026-34591, CVE-2026-42305).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 \
+# tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
+# arrives with the base image's keyring stack (SecretStorage).
+RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.0 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/hr-directory/bamboohr/Dockerfile
+++ b/src/ingestion/connectors/hr-directory/bamboohr/Dockerfile
@@ -8,8 +8,9 @@ RUN pip install /airbyte/integration_code
 # unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
 # tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
-# arrives with the base image's keyring stack (SecretStorage).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.0 \
+# arrives with the base image's keyring stack (SecretStorage); its wheel
+# bundles OpenSSL, and 50.0.1 is the first built against 4.0.2 (CVE-2026-63072).
+RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.1 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/tools/seed/Dockerfile
+++ b/src/ingestion/tools/seed/Dockerfile
@@ -27,6 +27,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # curl + bash: scripts/create-bronze-placeholders.sh and
 # scripts/apply-ch-migrations.sh use both, and slim ships dash and no curl.
 RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends curl bash \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/ingestion/tools/seed/pyproject.toml
+++ b/src/ingestion/tools/seed/pyproject.toml
@@ -34,7 +34,9 @@ dependencies = [
 # The silver step's environment for a host run outside the toolbox image:
 # `apply-ch-migrations.sh` writes a profiles.yml with PyYAML (which dbt-core
 # pulls in) and then runs dbt itself.
-silver = ["dbt-clickhouse"]
+# INVARIANT: floored. Resolving this extra together with `dev` walks
+# dbt-clickhouse back to 1.2.2 (2022) without it, and >=1.10 does not resolve.
+silver = ["dbt-clickhouse>=1.9"]
 dev = [
     # dbt-core 1.12 raised its own cap to pathspec<1.1 (dbt-labs/dbt-core#12385),
     # so a current mypy resolves again. Below 2.0 it would pull pathspec<1.0 and

--- a/src/ingestion/tools/toolbox/Dockerfile
+++ b/src/ingestion/tools/toolbox/Dockerfile
@@ -1,17 +1,17 @@
 FROM python:3.12-slim
 
 # System tools
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && \
+    apt-get install -y --no-install-recommends \
     curl gettext-base jq gnupg lsb-release && \
     rm -rf /var/lib/apt/lists/*
 
-# Node.js (for JWT token generation). npm is upgraded in place: the one the
-# distro package carries lags its own release line, and its bundled dependency
-# tree is what the image scan reports.
+# Node.js (for JWT token generation). Nothing in this image installs a package,
+# and npm's own bundled dependency tree is what the image scan reports against.
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
-    npm install -g npm@latest && \
     npm cache clean --force && \
+    rm -rf /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx && \
     rm -rf /var/lib/apt/lists/*
 
 # yq (YAML processor)


### PR DESCRIPTION
Closes #2120.

**Why.** 24 of the 44 open Trivy alerts on `main` are high, and #2487 sets zero high as the release bar. Half of them describe a dependency graph nothing installs.

**What changed.** One lever per source: a floor on the seeder's `dbt-clickhouse` extra, an OS package refresh at build time in the four images whose base tags lag their own distribution, `cryptography==50.0.1` pinned over the airbyte base, and `uuid@8` / `@babel/core` pnpm overrides.

**The seeder floor is the whole lockfile half.** `uv` resolves that extra with `dev`, and mypy's `pathspec>=1.0` against dbt-core's `pathspec<0.13` walks `dbt-clickhouse` back to 1.2.2 (2022). `>=1.10` has no solution. #2120's own fix landed already and changed nothing.

**npm is removed from the toolbox rather than upgraded — a deliberate change to that image.** `npm@latest` still ships every vulnerable version, and nothing in the image installs a package. Reverting costs four highs.

**cryptography 50.0.1 misses the seven-day quarantine by four days.** Its wheel bundles OpenSSL; 50.0.0's is 4.0.1, which CVE-2026-63072 affects. `exclude-newer` guards automatic resolution, not a reviewed pin.

Alerts 44 → 6. Highs 24 → 0.

**Out of scope.** setuptools 80.10.2 in six generated connector locks — airbyte-cdk caps it below 81, and the images ship 78.1.1 whatever the lock resolves.

**Verified.** Gateway, seed, toolbox and the active-directory connector built and smoke-tested; `uv lock` reproduced before and after; frontend typecheck, build, lint and 2276 unit tests pass locally.
