### PR TITLE
test(usage): cover the usage report's counts, attribution and privacy

### DIFF
--- a/src/frontend/src/components/portal/platform-usage.test.tsx
+++ b/src/frontend/src/components/portal/platform-usage.test.tsx
@@ -60,9 +60,10 @@ const SUMMARY = {
   since: "2026-08-01",
   until: "2026-08-03",
   totals: { visits: 5, visitors: 2, page_views: 9 },
+  // A day nobody opened the product is ABSENT: the server groups by the days it
+  // has rows for and fills nothing, so a zero row is a shape it cannot emit.
   by_day: [
     { day: "2026-08-01", visits: 3, visitors: 2 },
-    { day: "2026-08-02", visits: 0, visitors: 0 },
     { day: "2026-08-03", visits: 2, visitors: 1 },
   ],
   by_person: [],
@@ -224,6 +225,19 @@ describe("PlatformUsage", () => {
       "2026-08-02",
       "2026-08-03",
     ]);
+  });
+
+  // #2573 scenario 5 — the server omits a quiet day entirely, so this zero is
+  // the component's own doing.
+  it("draws a day nobody used the product as a zero", () => {
+    render(<PlatformUsage />);
+
+    const rows = JSON.parse(
+      screen.getByTestId("plot").getAttribute("data-rows") ?? "[]",
+    ) as Array<{ day: string; visits: number }>;
+    const quiet = rows.find((row) => row.day === "2026-08-02");
+
+    expect(quiet).toEqual({ day: "2026-08-02", visits: 0, visitors: 0 });
   });
 
   it("reads feedback over the very window the numbers above it cover", () => {

--- a/src/frontend/src/telemetry.test.ts
+++ b/src/frontend/src/telemetry.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({ logEvent: vi.fn() }));
+const mocks = vi.hoisted(() => ({ logEvent: vi.fn(), createTelemetry: vi.fn() }));
 
 vi.mock("@gears-frontx/telemetry", () => {
   const service = {
@@ -9,7 +9,8 @@ vi.mock("@gears-frontx/telemetry", () => {
     logEvent: mocks.logEvent,
     destroy: () => {},
   };
-  return { createTelemetry: () => service };
+  mocks.createTelemetry.mockImplementation(() => service);
+  return { createTelemetry: mocks.createTelemetry };
 });
 
 vi.mock("@/api/usage-client", () => ({
@@ -104,5 +105,26 @@ describe("scopeLabel", () => {
         attrFilter: { key: "department", value: "Engineering" },
       }),
     ).toBe("attr:department");
+  });
+});
+
+describe("a session opened on somebody else's behalf", () => {
+  // #2573 scenario 11 — a fresh module, because a collector another test already
+  // started would short-circuit the guard under test and pass for that reason.
+  it("starts no collector and sends nothing, for either person", async () => {
+    vi.resetModules();
+    mocks.createTelemetry.mockClear();
+    mocks.logEvent.mockClear();
+
+    const telemetry = await import("./telemetry");
+    await telemetry.startUsageTelemetry({
+      personId: "p1",
+      impersonatorEmail: "operator@example.com",
+    } as unknown as Parameters<typeof startUsageTelemetry>[0]);
+    telemetry.recordPageView("/portal/people");
+    telemetry.recordUsageEvent("drill", "git.commits");
+
+    expect(mocks.createTelemetry).not.toHaveBeenCalled();
+    expect(mocks.logEvent).not.toHaveBeenCalled();
   });
 });

--- a/tests/stand/api/analytics/test_usage.py
+++ b/tests/stand/api/analytics/test_usage.py
@@ -201,6 +201,84 @@ def test_a_beacon_carrying_no_session_is_not_a_visit(
     )
 
 
+def _figures_for(summary: UsageSummaryResponse, person_id: str) -> tuple[int, int]:
+    """That person's (visits, page_views) in this summary. (0, 0) when absent."""
+    for person in summary.by_person:
+        if person.person_id == person_id:
+            return person.visits, person.page_views
+    return 0, 0
+
+
+@pytest.mark.requires_seed("dev_lead", "admin_operator")
+@pytest.mark.security
+def test_the_sender_owns_the_visit_whoever_the_message_names(
+    lead_session: PersonaSession, admin_operator_session: PersonaSession
+) -> None:
+    """#2573 scenario 9 — the session decides whose visit it is, not the body.
+
+    The message names a second person everywhere a handler could be tempted to
+    read an identity from: beside the record, inside its data, and in the meta
+    the batch shares. The wire type declares none of these, and serde drops what
+    it does not declare — which is the property under test, not an accident to
+    rely on silently.
+    """
+    if not _config(lead_session.client).enabled:
+        pytest.skip("this instance does not record usage")
+
+    admin = admin_operator_session.client
+    day = _today()
+    sender = lead_session.person.uuid
+    named = admin_operator_session.person.uuid
+    assert sender != named, "the sender and the person named must differ"
+
+    before = _summary(admin, day)
+    before_sender = _figures_for(before, sender)
+    before_named = _figures_for(before, named)
+
+    tag = f"{scratch.SCRATCH_PREFIX}-{scratch.RUN_TAG}-impostor"
+    path = f"/portal/{tag}"
+    claimed: JsonValue = {
+        "meta": {"person_id": named, "user_id": named},
+        "records": [
+            {
+                "name": "page_view",
+                "context_session_id": tag,
+                "context_app_name": "insight-stand-tests",
+                "context_app_version": "0",
+                "person_id": named,
+                "user_id": named,
+                "email": admin_operator_session.email,
+                "data": {
+                    "path": path,
+                    "person_id": named,
+                    "email": admin_operator_session.email,
+                },
+            }
+        ],
+    }
+    accepted = lead_session.client.post(
+        EVENTS,
+        content=json.dumps(claimed),
+        headers={"Content-Type": SDK_CONTENT_TYPE},
+    )
+    assert accepted.status_code == 204, accepted.text[:300]
+
+    wait_until(
+        lambda: path in {page.path for page in _summary(admin, day).by_page},
+        timeout_s=20,
+        description="the page view claiming to be somebody else to reach the summary",
+    )
+
+    after = _summary(admin, day)
+    assert _figures_for(after, sender) == (before_sender[0] + 1, before_sender[1] + 1), (
+        f"the sender was not credited: {before_sender} -> {_figures_for(after, sender)}"
+    )
+    assert _figures_for(after, named) == before_named, (
+        f"the person the message named gained activity they did not make: "
+        f"{before_named} -> {_figures_for(after, named)}"
+    )
+
+
 @pytest.mark.security
 def test_the_summary_is_refused_without_the_admin_grant(api: ApiClient) -> None:
     """Admin-only is enforced by the service, not by hiding the nav entry.

--- a/tests/stand/ui/flows.py
+++ b/tests/stand/ui/flows.py
@@ -119,21 +119,25 @@ def collect_rows(table: Locator) -> list[list[str]]:
     return _scrolled(table, read)
 
 
-def collect_page_rows(usage: PlatformUsagePage) -> list[tuple[str, str]]:
-    """Every row of "What they opened" as (the name shown, the path recorded).
+#: "What they opened" renders Page | Views | People.
+_VIEWS_CELL = 1
+
+
+def collect_page_rows(usage: PlatformUsagePage) -> list[tuple[str, str, int]]:
+    """Every row of "What they opened" as (the name shown, the path, the views).
 
     The path exists only in a hover tooltip.
     """
 
-    def read(index: int) -> tuple[str, str]:
+    def read(index: int) -> tuple[str, str, int]:
         # Two tooltips can be mounted at once; wait for zero before the next hover.
         usage.header(PAGES_TABLE).hover()
         expect(usage.tooltips()).to_have_count(0)
         row = usage.row_at(PAGES_TABLE, index)
-        label = usage.page_cell(row).inner_text().strip()
+        cells = [text.strip() for text in row.locator('[data-slot="table-cell"]').all_inner_texts()]
         usage.page_label(row).hover()
         expect(usage.tooltips()).to_have_count(1)
-        return label, usage.tooltips().inner_text().strip()
+        return cells[0], usage.tooltips().inner_text().strip(), int(cells[_VIEWS_CELL])
 
     return _scrolled(usage.table(PAGES_TABLE), read)
 

--- a/tests/stand/ui/test_platform_usage.py
+++ b/tests/stand/ui/test_platform_usage.py
@@ -3,7 +3,12 @@
 The browser is the only writer this feature has: `session_start` comes from the
 frontx SDK in the page and page views from `recordPageView` in `main.tsx`, so no
 API test can prove the shipped SPA emits anything. Usage events are append-only
-on a shared stand, so the assertion is a subset, not an equality.
+on a shared stand, so every assertion here is a delta around one sweep, never an
+equality on what the tables hold.
+
+Three promises share that one sweep (#2573 scenarios 1, 3 and 4). A browser
+session is the most expensive thing this suite spends, so the fixture pays for
+it once and each test states one promise against it.
 """
 
 from __future__ import annotations
@@ -23,16 +28,33 @@ PERSON, VISITS, PAGES = 0, 1, 2
 #: The sweep must not walk unbuilt zones, whatever the app default is.
 SHOW_PLANNED_OFF = "window.localStorage.setItem('insight.portal.showPlanned', 'false')"
 
+#: The admin's own re-reading of this page records screens for the whole run, and
+#: all of them are in the zone a lead is never offered.
+ADMIN_ZONE = "/portal/manage"
+
+#: A cold sign-in records these before the sweep begins.
+COLD_START = ("/", "/portal")
+
+#: Opening a zone can compose a deeper screen name than the sweep reports for
+#: that navigation — a direction opens with a lens (#2648) — so a swept screen
+#: stands for everything recorded beneath it.
+
 
 @dataclass(frozen=True)
 class Swept:
     screens: list[str]
-    #: "What they opened", as (the name shown, the path recorded) per row.
-    opened: list[tuple[str, str]]
+    #: "What they opened", as (the name shown, the path recorded, the views) per row.
+    opened: list[tuple[str, str, int]]
+    #: The sweeper's own Visits and Pages figures, before and after.
+    visits: tuple[int, int]
+    pages: tuple[int, int]
+    #: Views per recorded path, before and after.
+    views_before: dict[str, int]
+    views_after: dict[str, int]
 
     @property
     def paths(self) -> list[str]:
-        return [path for _, path in self.opened]
+        return [path for _, path, _ in self.opened]
 
 
 def _portal_context(browser: Browser, base_url: str) -> BrowserContext:
@@ -62,19 +84,20 @@ def swept(
     usage = PlatformUsagePage(admin_page)
     usage.go()
     expect(usage.chart_heading()).to_be_visible()
-    # Baseline before the sweep: the table is append-only and the stand is shared.
-    before = _pages_recorded_for(usage, lead.person.display_name)
+    # Baseline before the sweep: the tables are append-only and the stand is shared.
+    before_visits, before_pages = _figures_for(usage, lead.person.display_name)
+    views_before = _views_by_path(usage)
 
     lead_context = _portal_context(browser, base_url)
     lead_page = lead_context.new_page()
     sign_in(lead_page, base_url, lead)
     screens = sweep_portal(lead_page)
-    assert screens, "the sweep opened nothing — the assertion below would be vacuous"
+    assert screens, "the sweep opened nothing — the assertions below would be vacuous"
 
     # The SDK flushes on a 5s timer and nothing re-sends on unload, so the
     # sweeper's context stays open until its events land.
     wait_until(
-        lambda: _pages_recorded_for(usage, lead.person.display_name) >= before + len(screens),
+        lambda: _pages_recorded_for(usage, lead.person.display_name) >= before_pages + len(screens),
         timeout_s=45,
         description=(
             f"the {len(screens)} screens {lead.person.display_name} opened to reach the summary"
@@ -82,7 +105,35 @@ def swept(
     )
     lead_context.close()
 
-    return Swept(screens=screens, opened=collect_page_rows(usage))
+    after_visits, after_pages = _figures_for(usage, lead.person.display_name)
+    # One read, two uses: a second pass over this virtualized table starts from
+    # wherever the first left it scrolled and comes back short.
+    opened = collect_page_rows(usage)
+    return Swept(
+        screens=screens,
+        opened=opened,
+        visits=(before_visits, after_visits),
+        pages=(before_pages, after_pages),
+        views_before=views_before,
+        views_after={path: views for _, path, views in opened},
+    )
+
+
+def _people_row(usage: PlatformUsagePage, display_name: str) -> list[str] | None:
+    for row in collect_rows(usage.table(PEOPLE_TABLE)):
+        if row[PERSON] == display_name:
+            return row
+    return None
+
+
+def _figures_for(usage: PlatformUsagePage, display_name: str) -> tuple[int, int]:
+    """That person's (Visits, Pages), as the page shows them now. (0, 0) when absent."""
+    row = _people_row(usage, display_name)
+    return (int(row[VISITS]), int(row[PAGES])) if row else (0, 0)
+
+
+def _views_by_path(usage: PlatformUsagePage) -> dict[str, int]:
+    return {path: views for _, path, views in collect_page_rows(usage)}
 
 
 def _pages_recorded_for(usage: PlatformUsagePage, display_name: str) -> int:
@@ -92,17 +143,83 @@ def _pages_recorded_for(usage: PlatformUsagePage, display_name: str) -> int:
     gateway's `auth_per_ip` limiter.
     """
     revisit_usage(usage.page)
-    for row in collect_rows(usage.table(PEOPLE_TABLE)):
-        if row[PERSON] == display_name:
-            return int(row[PAGES])
-    return 0
+    return _figures_for(usage, display_name)[1]
 
 
 @pytest.mark.requires_seed("dev_lead", "admin_operator")
+@pytest.mark.stand_smoke
 @pytest.mark.reliability
 def test_every_screen_the_sweep_opened_is_listed(swept: Swept) -> None:
+    """#2573 scenario 3 — every screen a reader opened reaches the report by name.
+
+    Marked `stand_smoke`: this is the post-deploy gate's "the shipped SPA still
+    reports what it opened", the one claim no API test can make for it.
+    """
     missing = [screen for screen in swept.screens if screen not in swept.paths]
     assert not missing, (
         f"{len(missing)} of the {len(swept.screens)} screens opened are absent from "
         f"'{PAGES_TABLE}': {missing}. Listed: {sorted(set(swept.paths))}"
+    )
+
+
+@pytest.mark.requires_seed("dev_lead", "admin_operator")
+@pytest.mark.stand_smoke
+@pytest.mark.reliability
+def test_the_sweep_counts_as_one_sitting(swept: Swept) -> None:
+    """#2573 scenario 1 — a sitting is one visit however many screens it opens.
+
+    Read off the sweeper's own row, so the admin's polling cannot confound it.
+    Marked `stand_smoke`: it shares the gate's sweep and costs it no browser.
+    """
+    before_visits, after_visits = swept.visits
+    before_pages, after_pages = swept.pages
+    assert after_visits - before_visits == 1, (
+        f"one uninterrupted sitting over {len(swept.screens)} screens counted as "
+        f"{after_visits - before_visits} visits, not 1"
+    )
+    assert after_pages - before_pages >= len(swept.screens), (
+        f"the Pages figure rose by {after_pages - before_pages} over a sweep that "
+        f"opened {len(swept.screens)} screens"
+    )
+
+
+@pytest.mark.requires_seed("dev_lead", "admin_operator")
+@pytest.mark.stand_smoke
+@pytest.mark.reliability
+def test_each_screen_carries_its_own_count(swept: Swept) -> None:
+    """#2573 scenario 4 — the number beside a screen counts that screen alone.
+
+    Both halves are needed: that every screen opened moved says the column
+    counts something, and that a screen nobody opened did not move says it is
+    not a figure the whole table shares.
+    Marked `stand_smoke`: it shares the gate's sweep and costs it no browser.
+    """
+    stalled = [
+        screen
+        for screen in swept.screens
+        if swept.views_after.get(screen, 0) <= swept.views_before.get(screen, 0)
+    ]
+    assert not stalled, (
+        f"{len(stalled)} of the {len(swept.screens)} screens opened kept the same Views "
+        f"figure across the sweep: "
+        f"{ {s: (swept.views_before.get(s, 0), swept.views_after.get(s, 0)) for s in stalled} }"
+    )
+
+    unopened = [
+        path
+        for path in swept.views_before
+        if not any(path.startswith(screen) for screen in swept.screens)
+        and not path.startswith(ADMIN_ZONE)
+        and path not in COLD_START
+    ]
+    if not unopened:
+        pytest.skip("the sweep opened every screen already listed — nothing to compare against")
+    moved = {
+        path: (swept.views_before[path], swept.views_after.get(path, 0))
+        for path in unopened
+        if swept.views_after.get(path, 0) != swept.views_before[path]
+    }
+    assert not moved, (
+        f"{len(moved)} screens nobody opened during the sweep changed their Views figure, "
+        f"so the column is not counting per screen: {moved}"
     )


### PR DESCRIPTION
Refs #2573.

**Why.** Usage monitoring shipped with its round trip tested and its meaning not: what counts as one visit, what the number beside a screen counts, who a visit is credited to, and what the browser must refuse to send were all unasserted.

**What changed.** Five checks, one per unguarded promise, each mutation-controlled — the behaviour was broken and only that check went red. A 50-screen sweep moves the sweeper's Visits figure by one; crediting the person a message names instead of its sender fails at `(8, 162) == (9, 163)`; removing the view-as guard reddens 1 test of 114.

**The two browser checks ride the sweep that already existed, and join the smoke lane.** They cost no new browser session, and are the first UI tests in a gate that was API-only.

**The sitting check moves from stand-api to stand-ui.** The visit is minted by the SDK in the page, so only a real browser produces the sitting under test.

**No check for AC-7, deliberately.** Every usage row comes from a signed-in person's browser, and on a seeded stand every such person is named — the only unnamed subject I could produce came from calling the service directly from inside the cluster, which is no path a user has. AC-7 needs restating on #2573 rather than a test.

**Verified.** Stand suite 461 passed, 1 skipped, 2 xfailed; frontend unit 2278 across 230 files, on a locally installed stand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved usage attribution so activity is credited to the session owner, preventing misleading identity data.
  - Ensured quiet days appear as zero-usage entries in platform usage reporting.
  - Improved analytics accuracy for visits, pages, and per-screen views.
  - Prevented telemetry collection and event emission for sessions opened on behalf of another person.

- **Tests**
  - Added coverage for usage attribution, quiet-day display, telemetry privacy, and reliable analytics counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->