### PR TITLE
docs(frontend): publish the 31 August release notes

### DIFF
--- a/src/frontend/src/components/portal/manage-view.test.tsx
+++ b/src/frontend/src/components/portal/manage-view.test.tsx
@@ -158,7 +158,7 @@ describe("Manage · What's new", () => {
 
     expect(screen.getByText("Insight · What's new")).toBeInTheDocument();
     expect(
-      screen.getByText("We've moved to the new interface for good"),
+      screen.getByText("The pages the portal has now")
     ).toBeInTheDocument();
     expect(screen.queryByRole("banner")).not.toBeInTheDocument();
   });
@@ -170,7 +170,7 @@ describe("Manage · Connector health", () => {
     render(<ManageView item="connector-health" />);
 
     expect(
-      screen.queryByTestId("connector-health-pane"),
+      screen.queryByTestId("connector-health-pane")
     ).not.toBeInTheDocument();
     // A gate rendering nothing at all would satisfy the line above, and would
     // leave a non-admin on a blank screen with nothing to act on.
@@ -217,9 +217,7 @@ describe("identities gate", () => {
     render(<ManageView item="identities" />);
 
     expect(screen.getByRole("alert")).toHaveTextContent(/admin surface/i);
-    expect(
-      screen.queryByText(/under construction/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/under construction/i)).not.toBeInTheDocument();
   });
 
   it("never flashes the console while the role check is in flight", () => {
@@ -227,9 +225,7 @@ describe("identities gate", () => {
     render(<ManageView item="identities" />);
 
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/under construction/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/under construction/i)).not.toBeInTheDocument();
   });
 
   it("opens for an admin", () => {

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -114,76 +114,133 @@
   "whats_new": {
     "nav_label": "What's new",
     "eyebrow": "Insight · What's new",
-    "title": "What's new · 31 July 2026",
+    "title": "What's new · 31 August 2026",
     "stamp": {
       "release_label": "Release",
-      "release": "0.4.69",
+      "release": "0.6.12",
       "highlights_label": "Highlights",
-      "highlights": "5 improvements",
+      "highlights": "13 improvements",
       "focus_label": "Focus",
-      "focus": "the new interface, two new pages"
+      "focus": "more data coming in, and the new UI over it"
     },
     "improvements_label": "Improvements you'll notice",
     "sections": {
       "new_ui": {
         "title": "New UI"
       },
-      "dashboards": {
-        "title": "Dashboards"
+      "git": {
+        "title": "Git"
       },
       "connectors": {
-        "title": "Platform"
+        "title": "Connectors"
+      },
+      "identity": {
+        "title": "Identity"
+      },
+      "data_health": {
+        "title": "Data health"
+      },
+      "reports": {
+        "title": "Reports"
+      },
+      "sign_in": {
+        "title": "Sign-in"
       }
     },
     "items": {
-      "new_interface": {
-        "title": "We've moved to the new interface for good",
-        "description_html": "Until now the new interface was an option in the sidebar. Now it's what Insight looks like."
+      "new_pages": {
+        "title": "The pages the portal has now",
+        "description_html": "The portal replaced the old sidebar app, and what it holds today is <strong>Overview, Directions, Person, People, AI & Cost and a Report builder</strong> — plus a Manage area carrying <strong>the Metric catalog, Connector health, Identities and Platform usage.</strong>"
       },
-      "activity_over_time": {
-        "title": "Activity over time, by repository",
-        "description_html": "A new table and chart in Git output: commits, merged pull requests and lines, <strong>split by repository</strong> and grouped by day, week or month to match the period you picked. The 10 busiest repositories are listed, the rest roll up into “Other”, and the totals always add up. Switch between chart and table, and <strong>download it as CSV or Excel.</strong>"
+      "drilldown": {
+        "title": "See the records behind a number",
+        "description_html": "Drill-down was added: <strong>open a metric and see the commits, pull requests and tasks behind the number.</strong>"
       },
-      "metric_catalog": {
-        "title": "Metric catalog",
-        "description_html": "A new page in the sidebar lists every metric we report: what it means, its unit, which breakdowns it supports, and <strong>when it last had data.</strong> If a chart looks empty, that last column usually explains why."
+      "git_proxy": {
+        "title": "Git data comes through our own proxy",
+        "description_html": "Git collection ran through the vendor connector and gave out on big repositories. It now goes through <strong>our own proxy, which handles larger repositories.</strong>"
       },
-      "honest_no_data": {
-        "title": "“No data” instead of a misleading zero",
-        "description_html": "Collaboration, task delivery and wiki now measure the same way as Git and AI. Where something isn't measured yet, <strong>you'll see “no data” rather than a zero that looks like a real result.</strong>"
+      "default_branch": {
+        "title": "Git output split by what reached the default branch",
+        "description_html": "Commits and lines counted everything pushed anywhere, so abandoned work read like delivered work. Every Git total is now <strong>paired with how much of it reached the default branch.</strong>"
       },
-      "steadier_data": {
-        "title": "Steadier data across your connectors",
-        "description_html": "Connector fixes across <strong>Jira, Bitbucket, Zoom, Claude and Microsoft 365</strong>, plus the data preparation behind them, so syncs finish and resume where they stopped instead of stalling."
-      }
-    },
-    "coming": {
-      "label": "Coming next",
-      "sections": {
-        "trust": {
-          "title": "Trust"
-        },
-        "platform": {
-          "title": "Platform"
-        }
+      "bamboohr": {
+        "title": "BambooHR: every custom field, without naming them",
+        "description_html": "Custom fields had to be configured one by one to be collected. <strong>All of them now come across on their own,</strong> and the sync completes on the fields the API key can read instead of failing on the ones it cannot."
       },
-      "items": {
-        "drill_down": {
-          "title": "See the records behind a number",
-          "description_html": "Right now a metric group shows trends, distributions and peer standing, but not the records themselves. We're building the next step: the actual commits, pull requests and tasks behind a number, with a link straight to the source."
-        },
-        "people_matching": {
-          "title": "Better people matching",
-          "description_html": "Work by someone whose email doesn't match still isn't attributed, which can leave some Git and Jira metrics incomplete. Better matching is in flight."
-        },
-        "role_cohorts": {
-          "title": "Compare like with like",
-          "description_html": "A person is currently compared against their whole department. Role-based comparison is planned: peers whose role is expected to do the same kind of work."
-        }
+      "jira": {
+        "title": "Jira: the whole data set, not just open issues",
+        "description_html": "Collection now covers <strong>deleted and trashed issues, projects access was lost to, deleted worklogs, every custom field, board columns and estimation fields, and project leads.</strong> A deletion and a lost permission used to look identical — both simply silence — and are now told apart and kept as history. Story points are read from the instance's own field metadata rather than one hardcoded field id."
+      },
+      "github": {
+        "title": "GitHub: issues, boards and file-level changes",
+        "description_html": "The GitHub connector was rebuilt. It now collects <strong>Issues and Projects V2 boards as task delivery, and file-level changes identified by their content,</strong> with commits and pull requests attributed through the account that authored them."
+      },
+      "bitbucket": {
+        "title": "Bitbucket: moved onto the git proxy",
+        "description_html": "The Bitbucket connector was replaced. <strong>It reads through the git proxy now,</strong> and repositories can be left out by name pattern."
+      },
+      "claude_team": {
+        "title": "Claude Team: seats and spend collected",
+        "description_html": "Claude Team is now a connector like any other. <strong>Seats, per-person usage and the billed spend</strong> arrive on their own sync."
+      },
+      "identity_resolution": {
+        "title": "Identity resolution",
+        "description_html": "One person turns up as several accounts — GitHub, Jira, BambooHR, Claude — and their work was counted as several people. Those accounts are now <strong>matched to one person,</strong> and where the match is not certain, <strong>an operator decides it by hand under Manage → Identities.</strong>"
+      },
+      "data_health": {
+        "title": "Data health — when each source last synced",
+        "description_html": "Nothing said whether the data behind a chart was current. <strong>Connector health now lists every source with the state of its last sync,</strong> as reported by the process that ran it, so a connector that stalled says so instead of going quiet."
+      },
+      "reports": {
+        "title": "Take any metric away as a file",
+        "description_html": "A new Report builder lets you <strong>pick the metrics, the people and the period, and download the result</strong> as CSV or Excel."
+      },
+      "github_login": {
+        "title": "Sign in with GitHub",
+        "description_html": "Getting into Insight meant being provisioned first. <strong>GitHub sign-in works now.</strong>"
       }
     },
     "history_label": "Earlier releases",
     "history": {
+      "release_2026_07_31": {
+        "title": "What's new — 31 July 2026",
+        "release": "0.4.69",
+        "summary": "5 improvements · the new interface, two new pages",
+        "sections": {
+          "new_ui": {
+            "title": "New UI"
+          },
+          "dashboards": {
+            "title": "Dashboards"
+          },
+          "connectors": {
+            "title": "Platform"
+          }
+        },
+        "items": {
+          "new_interface": {
+            "title": "We've moved to the new interface for good",
+            "description_html": "Until now the new interface was an option in the sidebar. Now it's what Insight looks like."
+          },
+          "activity_over_time": {
+            "title": "Activity over time, by repository",
+            "description_html": "A new table and chart in Git output: commits, merged pull requests and lines, <strong>split by repository</strong> and grouped by day, week or month to match the period you picked. The 10 busiest repositories are listed, the rest roll up into “Other”, and the totals always add up. Switch between chart and table, and <strong>download it as CSV or Excel.</strong>"
+          },
+          "metric_catalog": {
+            "title": "Metric catalog",
+            "description_html": "A new page in the sidebar lists every metric we report: what it means, its unit, which breakdowns it supports, and <strong>when it last had data.</strong> If a chart looks empty, that last column usually explains why."
+          },
+          "honest_no_data": {
+            "title": "“No data” instead of a misleading zero",
+            "description_html": "Collaboration, task delivery and wiki now measure the same way as Git and AI. Where something isn't measured yet, <strong>you'll see “no data” rather than a zero that looks like a real result.</strong>"
+          },
+          "steadier_data": {
+            "title": "Steadier data across your connectors",
+            "description_html": "Connector fixes across <strong>Jira, Bitbucket, Zoom, Claude and Microsoft 365</strong>, plus the data preparation behind them, so syncs finish and resume where they stopped instead of stalling."
+          }
+        }
+      },
       "release_2026_07_13": {
         "title": "What's new — 13 July 2026",
         "release": "0.3.42",
@@ -245,7 +302,7 @@
         }
       }
     },
-    "footer": "Insight · what's new · 31 July 2026"
+    "footer": "Insight · what's new · 31 August 2026"
   },
   "auth": {
     "loginFailedAccessDenied": "Your account is not authorized to access this application. Contact your administrator if you believe this is a mistake.",

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -150,55 +150,55 @@
     "items": {
       "new_pages": {
         "title": "The pages the portal has now",
-        "description_html": "The portal replaced the old sidebar app, and what it holds today is <strong>Overview, Directions, Person, People, AI & Cost and a Report builder</strong> — plus a Manage area carrying <strong>the Metric catalog, Connector health, Identities and Platform usage.</strong>"
+        "description_html": "The portal replaced the old sidebar app. It holds Overview, Directions, Person, People, AI & Cost and a Report builder, plus a Manage area with the Metric catalog, Connector health, Identities and Platform usage."
       },
       "drilldown": {
         "title": "See the records behind a number",
-        "description_html": "Drill-down was added: <strong>open a metric and see the commits, pull requests and tasks behind the number.</strong>"
+        "description_html": "Drill-down was added: open a metric and see the commits, pull requests and tasks behind the number."
       },
       "git_proxy": {
         "title": "Git data comes through our own proxy",
-        "description_html": "Git collection ran through the vendor connector and gave out on big repositories. It now goes through <strong>our own proxy, which handles larger repositories.</strong>"
+        "description_html": "Git collection ran through the vendor connector and gave out on big repositories. It now goes through our own proxy, which handles larger repositories."
       },
       "default_branch": {
         "title": "Git output split by what reached the default branch",
-        "description_html": "Commits and lines counted everything pushed anywhere, so abandoned work read like delivered work. Every Git total is now <strong>paired with how much of it reached the default branch.</strong>"
+        "description_html": "Commits and lines counted everything pushed anywhere, so abandoned work read like delivered work. Every Git total is now paired with how much of it reached the default branch."
       },
       "bamboohr": {
         "title": "BambooHR: every custom field, without naming them",
-        "description_html": "Custom fields had to be configured one by one to be collected. <strong>All of them now come across on their own,</strong> and the sync completes on the fields the API key can read instead of failing on the ones it cannot."
+        "description_html": "Custom fields had to be configured one by one. They now come across on their own, and the sync completes on the fields the API key can read instead of failing on the ones it cannot."
       },
       "jira": {
         "title": "Jira: the whole data set, not just open issues",
-        "description_html": "Collection now covers <strong>deleted and trashed issues, projects access was lost to, deleted worklogs, every custom field, board columns and estimation fields, and project leads.</strong> A deletion and a lost permission used to look identical — both simply silence — and are now told apart and kept as history. Story points are read from the instance's own field metadata rather than one hardcoded field id."
+        "description_html": "Collection now covers deleted and trashed issues, projects access was lost to, deleted worklogs, custom fields, board columns and estimation fields, and project leads. A deletion and a lost permission used to look the same — both silence — and are now told apart."
       },
       "github": {
         "title": "GitHub: issues, boards and file-level changes",
-        "description_html": "The GitHub connector was rebuilt. It now collects <strong>Issues and Projects V2 boards as task delivery, and file-level changes identified by their content,</strong> with commits and pull requests attributed through the account that authored them."
+        "description_html": "The GitHub connector was rebuilt. It now collects Issues and Projects V2 boards as task delivery, and file-level changes identified by their content."
       },
       "bitbucket": {
         "title": "Bitbucket: moved onto the git proxy",
-        "description_html": "The Bitbucket connector was replaced. <strong>It reads through the git proxy now,</strong> and repositories can be left out by name pattern."
+        "description_html": "The Bitbucket connector was replaced. It reads through the git proxy now, and repositories can be left out by name pattern."
       },
       "claude_team": {
         "title": "Claude Team: seats and spend collected",
-        "description_html": "Claude Team is now a connector like any other. <strong>Seats, per-person usage and the billed spend</strong> arrive on their own sync."
+        "description_html": "Claude Team is now a connector like any other. Seats, per-person usage and the billed spend arrive on their own sync."
       },
       "identity_resolution": {
         "title": "Identity resolution",
-        "description_html": "One person turns up as several accounts — GitHub, Jira, BambooHR, Claude — and their work was counted as several people. Those accounts are now <strong>matched to one person,</strong> and where the match is not certain, <strong>an operator decides it by hand under Manage → Identities.</strong>"
+        "description_html": "One person turns up as several accounts — GitHub, Jira, BambooHR, Claude — and their work was counted as several people. Those accounts are now matched to one person, and where the match is not certain an operator decides it under Manage → Identities."
       },
       "data_health": {
         "title": "Data health — when each source last synced",
-        "description_html": "Nothing said whether the data behind a chart was current. <strong>Connector health now lists every source with the state of its last sync,</strong> as reported by the process that ran it, so a connector that stalled says so instead of going quiet."
+        "description_html": "Nothing said whether the data behind a chart was current. Connector health lists each source with the state of its last sync, so a connector that stalled says so instead of going quiet."
       },
       "reports": {
         "title": "Take any metric away as a file",
-        "description_html": "A new Report builder lets you <strong>pick the metrics, the people and the period, and download the result</strong> as CSV or Excel."
+        "description_html": "A new Report builder lets you pick the metrics, the people and the period, and download the result as CSV or Excel."
       },
       "github_login": {
         "title": "Sign in with GitHub",
-        "description_html": "Getting into Insight meant being provisioned first. <strong>GitHub sign-in works now.</strong>"
+        "description_html": "Getting into Insight meant being provisioned first. GitHub sign-in works now."
       }
     },
     "history_label": "Earlier releases",

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -117,7 +117,7 @@
     "title": "What's new · 31 August 2026",
     "stamp": {
       "release_label": "Release",
-      "release": "0.6.12",
+      "release": "26.08",
       "highlights_label": "Highlights",
       "highlights": "13 improvements",
       "focus_label": "Focus",

--- a/src/frontend/src/screens/whats-new.test.tsx
+++ b/src/frontend/src/screens/whats-new.test.tsx
@@ -50,7 +50,7 @@ describe("WhatsNewScreen", () => {
     expect(
       screen.getByRole("heading", { name: "What's new · 31 August 2026" })
     ).toBeInTheDocument();
-    expect(screen.getByText("0.6.12")).toBeInTheDocument();
+    expect(screen.getByText("26.08")).toBeInTheDocument();
     expect(screen.getByText("13 improvements")).toBeInTheDocument();
     expect(
       screen.getByText("more data coming in, and the new UI over it")

--- a/src/frontend/src/screens/whats-new.test.tsx
+++ b/src/frontend/src/screens/whats-new.test.tsx
@@ -153,4 +153,32 @@ describe("WhatsNewScreen", () => {
       ).toBeInTheDocument();
     }
   });
+
+  it("carries the July 31 release's own sections and entries", async () => {
+    const user = userEvent.setup();
+    renderScreen();
+
+    const entry = screen.getByRole("button", {
+      name: /What's new — 31 July 2026/,
+    });
+    await user.click(entry);
+
+    const archived = within(entry.parentElement as HTMLElement);
+    for (const title of ["New UI", "Dashboards", "Platform"]) {
+      expect(
+        archived.getByRole("heading", { name: title })
+      ).toBeInTheDocument();
+    }
+    for (const title of [
+      "We've moved to the new interface for good",
+      "Activity over time, by repository",
+      "Metric catalog",
+      "“No data” instead of a misleading zero",
+      "Steadier data across your connectors",
+    ]) {
+      expect(
+        archived.getByRole("heading", { name: title })
+      ).toBeInTheDocument();
+    }
+  });
 });

--- a/src/frontend/src/screens/whats-new.test.tsx
+++ b/src/frontend/src/screens/whats-new.test.tsx
@@ -48,12 +48,12 @@ describe("WhatsNewScreen", () => {
   it("renders the release header and stamp", () => {
     renderScreen();
     expect(
-      screen.getByRole("heading", { name: "What's new · 31 July 2026" })
+      screen.getByRole("heading", { name: "What's new · 31 August 2026" })
     ).toBeInTheDocument();
-    expect(screen.getByText("0.4.69")).toBeInTheDocument();
-    expect(screen.getByText("5 improvements")).toBeInTheDocument();
+    expect(screen.getByText("0.6.12")).toBeInTheDocument();
+    expect(screen.getByText("13 improvements")).toBeInTheDocument();
     expect(
-      screen.getByText("the new interface, two new pages")
+      screen.getByText("more data coming in, and the new UI over it")
     ).toBeInTheDocument();
   });
 
@@ -62,15 +62,25 @@ describe("WhatsNewScreen", () => {
     // "Platform" names a section in both the release and Coming next, so scope
     // the assertions to the release card.
     const release = within(sectionFor("Improvements you'll notice"));
-    for (const title of ["New UI", "Dashboards", "Platform"]) {
+    for (const title of [
+      "New UI",
+      "Sign-in",
+      "Git",
+      "Connectors",
+      "Identity",
+      "Data health",
+      "Reports",
+    ]) {
       expect(release.getByRole("heading", { name: title })).toBeInTheDocument();
     }
     for (const title of [
-      "We've moved to the new interface for good",
-      "Activity over time, by repository",
-      "Metric catalog",
-      "“No data” instead of a misleading zero",
-      "Steadier data across your connectors",
+      "The pages the portal has now",
+      "Git data comes through our own proxy",
+      "Git output split by what reached the default branch",
+      "Jira: the whole data set, not just open issues",
+      "Data health — when each source last synced",
+      "See the records behind a number",
+      "Claude Team: seats and spend collected",
     ]) {
       expect(release.getByRole("heading", { name: title })).toBeInTheDocument();
     }
@@ -82,33 +92,14 @@ describe("WhatsNewScreen", () => {
   it("renders the connector entry under the Platform section", () => {
     renderScreen();
     expect(
-      screen.getByText(/plus the data preparation behind them/)
+      screen.getByText(/as reported by the process that ran it/)
     ).toBeInTheDocument();
   });
 
-  it("states today's limitation inside each coming-next entry", () => {
+  it("carries no forward-looking section", () => {
     renderScreen();
-    const coming = within(sectionFor("Coming next"));
-    // Coming next is grouped and connected like the release above it.
-    for (const title of ["Trust", "Platform"]) {
-      expect(coming.getByRole("heading", { name: title })).toBeInTheDocument();
-    }
-    for (const title of [
-      "See the records behind a number",
-      "Better people matching",
-      "Compare like with like",
-    ]) {
-      expect(coming.getByRole("heading", { name: title })).toBeInTheDocument();
-    }
-    // The separate "still on our list" callout is gone; the limitations it
-    // listed have to survive inside the entries that address them.
+    expect(screen.queryByText("Coming next")).not.toBeInTheDocument();
     expect(screen.queryByText("Still on our list")).not.toBeInTheDocument();
-    expect(
-      screen.getByText(/email doesn't match still isn't attributed/)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/but not the records themselves/)
-    ).toBeInTheDocument();
   });
 
   it("keeps earlier releases on the page, collapsed", async () => {
@@ -116,6 +107,9 @@ describe("WhatsNewScreen", () => {
     renderScreen();
 
     expect(screen.getByText("Earlier releases")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /What's new — 31 July 2026/ })
+    ).toHaveTextContent("0.4.69");
     const entry = screen.getByRole("button", {
       name: /What's new — 13 July 2026/,
     });
@@ -141,10 +135,12 @@ describe("WhatsNewScreen", () => {
     const user = userEvent.setup();
     renderScreen();
 
-    await user.click(
-      screen.getByRole("button", { name: /What's new — 13 July 2026/ })
-    );
+    const entry = screen.getByRole("button", {
+      name: /What's new — 13 July 2026/,
+    });
+    await user.click(entry);
 
+    const archived = within(entry.parentElement as HTMLElement);
     for (const title of [
       "Team dashboards",
       "Git & code reviews",
@@ -152,7 +148,9 @@ describe("WhatsNewScreen", () => {
       "Collaboration",
       "AI adoption",
     ]) {
-      expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
+      expect(
+        archived.getByRole("heading", { name: title })
+      ).toBeInTheDocument();
     }
   });
 });

--- a/src/frontend/src/screens/whats-new.test.tsx
+++ b/src/frontend/src/screens/whats-new.test.tsx
@@ -89,10 +89,10 @@ describe("WhatsNewScreen", () => {
     expect(screen.queryByText("Git output")).not.toBeInTheDocument();
   });
 
-  it("renders the connector entry under the Platform section", () => {
+  it("renders the data-health entry", () => {
     renderScreen();
     expect(
-      screen.getByText(/as reported by the process that ran it/)
+      screen.getByText(/lists each source with the state of its last sync/)
     ).toBeInTheDocument();
   });
 

--- a/src/frontend/src/screens/whats-new.tsx
+++ b/src/frontend/src/screens/whats-new.tsx
@@ -12,29 +12,32 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
 // Each section is one row of the release card, styled like the archived
 // releases below: its name sits in the left column, its entries on the right.
 const RELEASE_SECTIONS = [
-  { id: "new_ui", itemKeys: ["new_interface"] },
+  { id: "new_ui", itemKeys: ["new_pages", "drilldown"] },
+  { id: "git", itemKeys: ["git_proxy", "default_branch"] },
   {
-    id: "dashboards",
-    itemKeys: ["activity_over_time", "metric_catalog", "honest_no_data"],
+    id: "connectors",
+    itemKeys: ["bamboohr", "jira", "github", "bitbucket", "claude_team"],
   },
-  { id: "connectors", itemKeys: ["steadier_data"] },
-] as const;
-
-// Each entry states today's limitation before the plan that addresses it —
-// there is no separate "still on our list" section, which only restated these.
-// Grouped and rendered like a release, so what is coming reads the same way as
-// what shipped.
-const COMING_SECTIONS = [
-  { id: "trust", itemKeys: ["drill_down"] },
-  { id: "platform", itemKeys: ["people_matching", "role_cohorts"] },
+  { id: "identity", itemKeys: ["identity_resolution"] },
+  { id: "data_health", itemKeys: ["data_health"] },
+  { id: "reports", itemKeys: ["reports"] },
+  { id: "sign_in", itemKeys: ["github_login"] },
 ] as const;
 
 // Past releases stay on the page so a reader can see the whole history, newest
-// first, and are grouped into sections the same way the current one is. Each
-// entry keeps the improvements it announced; its "still on our list" and
-// "coming next" lists are not repeated, since the current release's lists
-// supersede them.
+// first, and are grouped into sections the same way the current one is.
 const PAST_RELEASES = [
+  {
+    id: "release_2026_07_31",
+    sections: [
+      { id: "new_ui", itemKeys: ["new_interface"] },
+      {
+        id: "dashboards",
+        itemKeys: ["activity_over_time", "metric_catalog", "honest_no_data"],
+      },
+      { id: "connectors", itemKeys: ["steadier_data"] },
+    ],
+  },
   {
     id: "release_2026_07_13",
     sections: [
@@ -192,18 +195,6 @@ export function WhatsNewBody() {
           </h3>
           <div className="mt-3 divide-y overflow-hidden rounded-lg border bg-card">
             <ReleaseSections baseKey="whats_new" sections={RELEASE_SECTIONS} />
-          </div>
-        </section>
-
-        <section>
-          <h3 className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
-            {t("whats_new.coming.label")}
-          </h3>
-          <div className="mt-3 divide-y overflow-hidden rounded-lg border bg-card">
-            <ReleaseSections
-              baseKey="whats_new.coming"
-              sections={COMING_SECTIONS}
-            />
           </div>
         </section>
 


### PR DESCRIPTION
**Why.** The page still announced 31 July / 0.4.69 after a month of shipped work, and the top item of its own Coming next — metric drill-down — landed on 08-13.

**What changed.** A 31 August / 26.08 entry, 13 improvements across New UI, Git, Connectors, Identity, Data health, Reports and Sign-in. The 31 July entry moves into Earlier releases with its items intact.

**The page list is read off `ZoneContent` and `ManageView`, not the nav.** Surfaces that fall through to "Not built yet" — Scorecard, Roles & taxonomy, Data exclusions, Org snapshots, Group and Scorecard management, MCP servers, Config & setup — are not claimed.

**Coming next is removed, not restated.** Its entries had either shipped or were not commitments worth publishing. Restoring it is one const and one section.

**Verified.** `pnpm test` 2276 passed, `pnpm lint` and `tsc -b` clean; rendered at `/portal?zone=manage&item=whats-new` against a local dev server on seeded data.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-2939-assets/before.png" width="420"> | <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-2939-assets/after.png" width="420"> |
