### PR TITLE
docs(e2e): correct the tenant-metrics default in the rig comment

### DIFF
--- a/src/ingestion/tests/e2e/lib/analytics.py
+++ b/src/ingestion/tests/e2e/lib/analytics.py
@@ -208,9 +208,9 @@ class AnalyticsProcess:
                         "clickhouse_url": "",
                         "clickhouse_database": "insight",
                         "identity_url": "",
-                        # Tenant metrics ship enabled (issue #2803 decision 1);
-                        # the rig mirrors the shipped default so the CI-family
-                        # tenant-entity tests exercise the real read path.
+                        # Tenant metrics ship disabled (opt-in per installation);
+                        # the rig diverges from that default so the CI-family
+                        # tenant-entity tests have a read path at all.
                         "metric_catalog": {"tenant_metrics_enabled": True},
                     }
                 },


### PR DESCRIPTION
**Why.** The e2e rig's comment states that tenant metrics ship enabled and that the rig mirrors the shipped default. Both halves are wrong since the flag became opt-in, so a reader checking whether CI metrics are live in an installation gets the opposite answer.

**What changed.** The comment now states the real default and that the rig deliberately diverges from it. Comment only — `tenant_metrics_enabled: True` in the rig is unchanged and still correct.

**Verified.** `tenantMetricsEnabled`/`tenant_metrics_enabled` is `false` in `charts/insight/values.yaml`, the analytics subchart values and `config/insight.yaml`; the rig is the only surface setting it true. Pre-commit ruff green; no behaviour to test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the default status of tenant metrics and the configuration used for CI testing.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->