### PR TITLE
feat(ai-cost): read the billed months on the AI & Cost screen

### DIFF
--- a/src/frontend/src/components/portal/ai-cost-view.test.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.test.tsx
@@ -47,6 +47,14 @@ const mocks = vi.hoisted(() => ({
     isError: false,
     refetch: vi.fn(),
   },
+  // Wide enough to hold two billing months' first days, which is what the
+  // month-grain metrics are anchored to. A test needing the other case — a
+  // window inside one month — narrows it and empties the monthly result, since
+  // the collection hook is mocked and does no filtering of its own.
+  period: {
+    period: "quarter",
+    dateRange: { from: "2026-06-01", to: "2026-07-31" },
+  },
 }));
 
 vi.mock("@/auth", () => ({
@@ -90,7 +98,7 @@ vi.mock("@/queries/metric-results", () => ({
       : mocks.tools,
 }));
 vi.mock("@/hooks/use-portal-period", () => ({
-  usePortalPeriod: () => ({ period: "week", dateRange: { from: "2026-07-20", to: "2026-07-26" } }),
+  usePortalPeriod: () => mocks.period,
 }));
 
 
@@ -211,9 +219,15 @@ beforeEach(() => {
     ])],
   ]);
   mocks.monthly.isError = false;
-  // Two billing months. July carries both facts — a $40 seat and a $160 one, and
-  // the usage billed on top of them. June carries only billed usage: no invoice
-  // priced its tier, which is absence rather than a $0 seat.
+  mocks.period = {
+    period: "quarter",
+    dateRange: { from: "2026-06-01", to: "2026-07-31" },
+  };
+  // Two billing months, both of whose first days the window above holds — the
+  // only shape in which a month-anchored metric answers at all. July carries
+  // both facts: a $40 seat and a $160 one, and the usage billed on top of them.
+  // June carries only billed usage, because no invoice priced its tier — which
+  // is absence rather than a $0 seat.
   mocks.monthly.byKey = new Map([
     ["ai.seat_cost", monthlySeries("ai.seat_cost", [
       [pid("a"), "2026-07-01", 40],
@@ -368,6 +382,29 @@ describe("AiCostView", () => {
     expect(within(june).getByText("$2")).toBeInTheDocument();
     expect(within(june).getByText("—")).toBeInTheDocument();
     expect(within(june).queryByText("$0")).not.toBeInTheDocument();
+  });
+
+  it("says a window inside one month holds no billing month, rather than showing none", () => {
+    // The portal opens on a week. Both month-grain metrics are anchored to the
+    // first day of the month they bill for, so a week inside a month answers
+    // with nothing at all — the state a reader meets by default, and the one
+    // the section's own caveat is written for.
+    mocks.period = {
+      period: "week",
+      dateRange: { from: "2026-07-20", to: "2026-07-26" },
+    };
+    mocks.monthly.byKey = new Map([
+      ["ai.seat_cost", monthlySeries("ai.seat_cost", [])],
+      ["ai.extra_usage_cost", monthlySeries("ai.extra_usage_cost", [])],
+    ]);
+
+    render(<AiCostView item={null} />);
+
+    expect(screen.getByText("Billed by month")).toBeInTheDocument();
+    expect(
+      screen.getByText(/No invoiced months in this period/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Jul 2026")).not.toBeInTheDocument();
   });
 
   it("surfaces a failed monthly request instead of calling the period uninvoiced", () => {

--- a/src/frontend/src/components/portal/ai-cost-view.test.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@tanstack/react-router", async () => {
 
 import { portalRouter } from "@/test/portal-router";
 
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
@@ -32,6 +32,14 @@ const mocks = vi.hoisted(() => ({
     refetch: vi.fn(),
   },
   tools: {
+    byKey: new Map<string, NormalizedMetricResult>(),
+    previousByKey: null,
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+  monthly: {
     byKey: new Map<string, NormalizedMetricResult>(),
     previousByKey: null,
     isPending: false,
@@ -72,7 +80,15 @@ vi.mock("@/queries/team-view", () => ({
   useTeamMembers: () => ({ data: mocks.members, isPending: false, isLoading: false, isError: false, refetch: vi.fn() }),
 }));
 vi.mock("@/queries/member-grid", () => ({ useMemberGridData: () => mocks.grid }));
-vi.mock("@/queries/metric-results", () => ({ useMetricCollection: () => mocks.tools }));
+// The view takes two collections through one hook. Dispatching on the requested
+// keys keeps them apart, so a failing per-tool request cannot stand in for a
+// failing monthly one and each section is asserted on its own data.
+vi.mock("@/queries/metric-results", () => ({
+  useMetricCollection: (collection: { metrics: Array<{ key: string }> }) =>
+    collection.metrics.some((m) => m.key === "ai.seat_cost")
+      ? mocks.monthly
+      : mocks.tools,
+}));
 vi.mock("@/hooks/use-portal-period", () => ({
   usePortalPeriod: () => ({ period: "week", dateRange: { from: "2026-07-20", to: "2026-07-26" } }),
 }));
@@ -124,6 +140,43 @@ function toolBreakdown(
   } as unknown as NormalizedMetricResult;
 }
 
+/** A month-bucketed result: one series per entity, one point per billing month. */
+function monthlySeries(
+  key: string,
+  rows: Array<[string, string, number | null]>,
+): NormalizedMetricResult {
+  const byEntity = new Map<
+    string,
+    Array<{ bucket_start: string; value: number | null }>
+  >();
+  for (const [entity_id, bucket_start, value] of rows) {
+    const points = byEntity.get(entity_id) ?? [];
+    points.push({ bucket_start, value });
+    byEntity.set(entity_id, points);
+  }
+  return {
+    ...metric(key, []),
+    format: "currency",
+    unit: "USD",
+    timeseries: {
+      view: "timeseries",
+      bucket: "month",
+      series: [...byEntity].map(([entity_id, points]) => ({
+        entity_id,
+        dimensions: [],
+        points,
+      })),
+    },
+  } as unknown as NormalizedMetricResult;
+}
+
+/** The table row a label sits in — so a money assertion is scoped to one month. */
+function row(label: string): HTMLElement {
+  const found = screen.getByText(label).closest("tr");
+  if (!found) throw new Error(`no table row holds ${label}`);
+  return found as HTMLElement;
+}
+
 // Roster entity ids are person UUIDs (identity cutover).
 const LABELS = ["a", "b", "c", "d"];
 const IDS = LABELS.map(pid);
@@ -155,6 +208,21 @@ beforeEach(() => {
       [pid("a"), "claude_code", 600],
       [pid("b"), "chatgpt", 300],
       [pid("c"), "chatgpt", 100],
+    ])],
+  ]);
+  mocks.monthly.isError = false;
+  // Two billing months. July carries both facts — a $40 seat and a $160 one, and
+  // the usage billed on top of them. June carries only billed usage: no invoice
+  // priced its tier, which is absence rather than a $0 seat.
+  mocks.monthly.byKey = new Map([
+    ["ai.seat_cost", monthlySeries("ai.seat_cost", [
+      [pid("a"), "2026-07-01", 40],
+      [pid("b"), "2026-07-01", 160],
+    ])],
+    ["ai.extra_usage_cost", monthlySeries("ai.extra_usage_cost", [
+      [pid("a"), "2026-07-01", 3],
+      [pid("b"), "2026-07-01", 7],
+      [pid("a"), "2026-06-01", 2],
     ])],
   ]);
   act(() => {
@@ -278,6 +346,38 @@ describe("AiCostView", () => {
     expect(screen.getByText("Unable to load the per-tool breakdown")).toBeInTheDocument();
     expect(
       screen.queryByText(/No per-tool breakdown for this period/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reads a month's seat fee and billed usage side by side, never their sum", () => {
+    render(<AiCostView item={null} />);
+    expect(screen.getByText("Billed by month")).toBeInTheDocument();
+    const july = row("Jul 2026");
+    expect(within(july).getByText("$200")).toBeInTheDocument();
+    expect(within(july).getByText("$10")).toBeInTheDocument();
+    // $210 is a figure the vendor never charged: the seat fee and the usage
+    // billed on top of it answer different questions.
+    expect(screen.queryByText("$210")).not.toBeInTheDocument();
+  });
+
+  it("says a month carries no seat fee rather than calling it $0", () => {
+    // June has billed usage but no invoice priced its tier. An unpriced tier is
+    // absence, and a printed $0 would claim the vendor charged nothing for it.
+    render(<AiCostView item={null} />);
+    const june = row("Jun 2026");
+    expect(within(june).getByText("$2")).toBeInTheDocument();
+    expect(within(june).getByText("—")).toBeInTheDocument();
+    expect(within(june).queryByText("$0")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a failed monthly request instead of calling the period uninvoiced", () => {
+    mocks.monthly.isError = true;
+    render(<AiCostView item={null} />);
+    expect(
+      screen.getByText("Unable to load the monthly billing figures"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No invoiced months in this period/),
     ).not.toBeInTheDocument();
   });
 

--- a/src/frontend/src/components/portal/ai-cost-view.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.tsx
@@ -16,7 +16,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
-import { formatMetricValue } from "@/lib/format";
+import { formatDate, formatMetricValue, NO_METRIC_VALUE } from "@/lib/format";
 import { GROUPS } from "@/lib/insight/groups";
 import {
   availableSlices,
@@ -48,6 +48,11 @@ const COST_KEY = "ai.cost";
 // INVARIANT: the per-day metric. The cumulative one is anchored to the first day
 // of its billing month and returns nothing for a window inside a month.
 const ACTUAL_COST_KEY = "ai.daily_approximate_extra_usage_cost";
+// INVARIANT: month-grain billing facts, each anchored to the first day of the
+// month it bills for. They are read at month buckets in their own section — a
+// row that totals a window would drop any month whose first day it misses.
+const SEAT_COST_KEY = "ai.seat_cost";
+const BILLED_MONTH_KEY = "ai.extra_usage_cost";
 const LINES_KEY = "ai.accepted_lines";
 const DAYS_KEY = "ai.active_days";
 /** Grid columns for the cost-leaders scan. */
@@ -87,6 +92,15 @@ interface ToolRow {
   actualTracked: boolean;
 }
 
+/** One "Billed by month" row: two billing facts of one month, never summed. */
+interface MonthlyBillRow {
+  month: string;
+  seatCost: number;
+  seatCostSeen: boolean;
+  billed: number;
+  billedSeen: boolean;
+}
+
 /** A person's reading of a metric, or null where they have none. */
 function reading(
   r: NormalizedMetricResult | undefined,
@@ -111,6 +125,28 @@ function aggregateByTool(
       bucket.sum += row.value;
       if (row.value > 0) bucket.users.add(id);
       out.set(tool, bucket);
+    }
+  }
+  return out;
+}
+
+/**
+ * Sum a month-bucketed metric across members, keyed by the bucket's first day.
+ * A month absent from the map had no reading, which is what lets the renderer
+ * print "—" instead of a $0 nobody measured.
+ */
+function aggregateByMonth(
+  result: NormalizedMetricResult | undefined,
+  memberIds: readonly string[],
+): Map<string, number> {
+  const out = new Map<string, number>();
+  if (!result) return out;
+  for (const id of memberIds) {
+    for (const series of forEntity(result, id).series) {
+      for (const point of series.points) {
+        if (point.value == null) continue;
+        out.set(point.bucket_start, (out.get(point.bucket_start) ?? 0) + point.value);
+      }
     }
   }
   return out;
@@ -175,6 +211,15 @@ export function AiCostView({ item }: { item: string | null }) {
     }),
     [],
   );
+  const monthlyCollection = useMemo<MetricCollectionConfig>(
+    () => ({
+      metrics: [SEAT_COST_KEY, BILLED_MONTH_KEY].map((key) => ({
+        key,
+        views: [{ view: "timeseries" as const, bucket: "month" as const }],
+      })),
+    }),
+    [],
+  );
 
   const grid = useMemberGridData(
     memberIds.length ? gridCollection : EMPTY_COLLECTION,
@@ -184,6 +229,11 @@ export function AiCostView({ item }: { item: string | null }) {
   );
   const toolData = useMetricCollection(
     memberIds.length ? toolCollection : EMPTY_COLLECTION,
+    { type: "person", ids: memberIds },
+    dateRange,
+  );
+  const monthlyData = useMetricCollection(
+    memberIds.length ? monthlyCollection : EMPTY_COLLECTION,
     { type: "person", ids: memberIds },
     dateRange,
   );
@@ -237,6 +287,24 @@ export function AiCostView({ item }: { item: string | null }) {
       })
       .sort((a, b) => b.lines - a.lines);
   }, [toolData.byKey, memberIds]);
+
+  const monthlyRows = useMemo<MonthlyBillRow[]>(() => {
+    const seat = aggregateByMonth(monthlyData.byKey.get(SEAT_COST_KEY), memberIds);
+    const billed = aggregateByMonth(
+      monthlyData.byKey.get(BILLED_MONTH_KEY),
+      memberIds,
+    );
+    const months = new Set([...seat.keys(), ...billed.keys()]);
+    return [...months]
+      .sort((a, b) => b.localeCompare(a))
+      .map((month) => ({
+        month,
+        seatCost: seat.get(month) ?? 0,
+        seatCostSeen: seat.has(month),
+        billed: billed.get(month) ?? 0,
+        billedSeen: billed.has(month),
+      }));
+  }, [monthlyData.byKey, memberIds]);
 
   // Data-driven slice options + the active slice's cohort accessor. The slice
   // is global (portal-store) so it re-cohorts every view at once.
@@ -481,6 +549,14 @@ export function AiCostView({ item }: { item: string | null }) {
         </p>
       </section>
 
+      <BilledMonthsSection
+        rows={monthlyRows}
+        seatR={monthlyData.byKey.get(SEAT_COST_KEY)}
+        billedR={monthlyData.byKey.get(BILLED_MONTH_KEY)}
+        isPending={monthlyData.isPending}
+        isError={monthlyData.isError}
+      />
+
       {/* Cost leaders */}
       <section className="flex flex-col gap-3">
         <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
@@ -541,6 +617,91 @@ function FunnelSection({ funnel }: { funnel: { label: string; n: number }[] }) {
       <p className="text-xs text-muted-foreground">
         Stages from AI active-days; “active”/“heavy” cuts are the median and
         top-quartile day counts among people who used AI this period.
+      </p>
+    </section>
+  );
+}
+
+/**
+ * Billed by month — the two facts the vendor bills a month for, side by side:
+ * the seat fee taken from the invoice, and the usage billed on top of it. There
+ * is deliberately no total column: the two answer different questions and
+ * adding them would report a figure the vendor never charged.
+ */
+function BilledMonthsSection({
+  rows,
+  seatR,
+  billedR,
+  isPending,
+  isError,
+}: {
+  rows: MonthlyBillRow[];
+  seatR: NormalizedMetricResult | undefined;
+  billedR: NormalizedMetricResult | undefined;
+  isPending: boolean;
+  isError: boolean;
+}) {
+  const money = (
+    value: number,
+    seen: boolean,
+    r: NormalizedMetricResult | undefined,
+  ) =>
+    seen
+      ? formatMetricValue(value, r?.format ?? "currency", r?.unit ?? "USD")
+      : NO_METRIC_VALUE;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        Billed by month
+      </p>
+      {isError ? (
+        <ComingSoon
+          state="error"
+          label="Unable to load the monthly billing figures"
+        />
+      ) : isPending ? (
+        <CenteredSpinner className="min-h-32" />
+      ) : rows.length ? (
+        <div className="overflow-x-auto rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Billing month</TableHead>
+                <TableHead className="text-right">Seat cost</TableHead>
+                <TableHead className="text-right">Extra usage billed</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((r) => (
+                <TableRow key={r.month}>
+                  <TableCell className="font-medium">
+                    {formatDate(r.month, "MMM yyyy")}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {money(r.seatCost, r.seatCostSeen, seatR)}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {money(r.billed, r.billedSeen, billedR)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ) : (
+        <ComingSoon
+          variant="card"
+          state="empty"
+          label="No invoiced months in this period. Seat cost and extra usage are facts of a whole billing month, so a window that misses a month's first day returns neither."
+        />
+      )}
+      <p className="text-xs text-muted-foreground">
+        Subscription and overusage, side by side and never added: the seat fee is
+        what a seat costs before any usage, and the billed extra usage is what
+        the vendor charged on top of it once the usage that fee included ran out.
+        Each is a fact of the whole month rather than a rate sliced to the
+        selected window. A tier the invoice does not price reads “—”, not $0.
       </p>
     </section>
   );


### PR DESCRIPTION
Refs #2942.

**Do not merge as an answer to #2942 — that issue has been reframed.** The need there is monthly statistics in general: the same parameters with a monthly cut in place of the daily one, available for every metric. This branch builds a section for two cost keys, which is the narrow reading it was written against.

**Open rather than closed.** It stands as a worked reference for the monthly reading of these two metrics while the general shape is decided. What ships against #2942 is the product owner's call.

**Why.** `ai.seat_cost` has been served since #2671 and shown on no screen; the monthly `ai.extra_usage_cost` was shown on none either. So what a seat costs could not be read anywhere in the product.

**What changed.** A **new "Billed by month" section on the AI & Cost screen** — `Billing month | Seat cost | Extra usage billed`, one row per billing month, both figures read at month buckets.

**No total column, deliberately.** The seat fee and the usage billed on top of it answer different questions; adding them reports a figure the vendor never charged. One line to add if a reader asks for a sum.

**A section of its own rather than the existing rows.** Both metrics are anchored to the first day of the month they bill for, so a row that totals a window drops any month whose first day it misses — which is why the surrounding sections take only the per-day distribution. The new section carries that caveat in place, and a window holding no month start says so.

**Split out of #2928.** No frontend consumer asked for this, so it waits on its own rather than riding the data-path checks that shipped there.

**Verified.** `tsc -b` clean, `eslint . --max-warnings 0` clean, and 16/16 in `ai-cost-view.test.tsx` — four of them new: a month's two figures side by side with no sum of them anywhere, a month with no seat fee reading as absent rather than `$0`, a window inside one month showing the empty state a reader meets when the portal opens, and a failed monthly request saying so instead of calling the period uninvoiced.

The suite takes two metric collections through one hook, so its mock now dispatches on the requested keys — without that a failing per-tool request stands in for a failing monthly one and the new section asserts nothing.

**Not run.** `tests/stand/ui` — no browser journey covers this section, and no screenshot of it exists yet. Someone should look at it before this merges.

