### PR TITLE
chore(gitops): community Grafana chart, refreshed pins, persistence recipe

### DIFF
--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -146,8 +146,10 @@ ARGO_WORKFLOW_SA ?= argo-workflow
 # Chart versions verified latest via `helm search repo <repo>/<chart>
 # --versions` (bump deliberately, same discipline as the pins above).
 LOKI_RELEASE     ?= loki
-LOKI_CHART       ?= grafana/loki
-LOKI_VERSION     ?= 7.3.0      # app 3.6.12
+# grafana/loki now tracks Grafana Enterprise Logs; the OSS chart continues
+# as grafana-community/loki (same manifests, renumbered versions).
+LOKI_CHART       ?= grafana-community/loki
+LOKI_VERSION     ?= 18.11.4    # app 3.7.7
 
 ALLOY_RELEASE    ?= alloy
 ALLOY_CHART      ?= grafana/alloy
@@ -155,7 +157,7 @@ ALLOY_VERSION    ?= 1.12.1     # app v1.19.2
 
 GRAFANA_RELEASE  ?= grafana
 # grafana/grafana is deprecated (frozen 2026-01-30); development moved to
-# grafana-community/helm-charts. Loki and Alloy still live in the old repo.
+# grafana-community/helm-charts. Alloy still lives in the old repo.
 GRAFANA_CHART    ?= grafana-community/grafana
 GRAFANA_VERSION  ?= 13.0.0     # app 13.2.0
 
@@ -745,7 +747,7 @@ system-victoriametrics: vpn-up kube-ctx
 
 .PHONY: system-loki
 system-loki: vpn-up kube-ctx
-	@$(call _helm_repo_add,grafana,https://grafana.github.io/helm-charts)
+	@$(call _helm_repo_add,grafana-community,https://grafana-community.github.io/helm-charts)
 	$(call _apply_optional_system_secrets,loki)
 	helm upgrade --install $(LOKI_RELEASE) $(LOKI_CHART) \
 		--namespace $(NS_INFRA) --create-namespace \

--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -147,15 +147,17 @@ ARGO_WORKFLOW_SA ?= argo-workflow
 # --versions` (bump deliberately, same discipline as the pins above).
 LOKI_RELEASE     ?= loki
 LOKI_CHART       ?= grafana/loki
-LOKI_VERSION     ?= 7.0.0      # app 3.6.7
+LOKI_VERSION     ?= 7.3.0      # app 3.6.12
 
 ALLOY_RELEASE    ?= alloy
 ALLOY_CHART      ?= grafana/alloy
-ALLOY_VERSION    ?= 1.9.0      # app v1.16.3
+ALLOY_VERSION    ?= 1.12.1     # app v1.19.2
 
 GRAFANA_RELEASE  ?= grafana
-GRAFANA_CHART    ?= grafana/grafana
-GRAFANA_VERSION  ?= 10.5.15    # app 12.3.1
+# grafana/grafana is deprecated (frozen 2026-01-30); development moved to
+# grafana-community/helm-charts. Loki and Alloy still live in the old repo.
+GRAFANA_CHART    ?= grafana-community/grafana
+GRAFANA_VERSION  ?= 13.0.0     # app 13.2.0
 
 # Metrics store — PromQL-compatible, remote-write receiver built in at
 # /api/v1/write (always on, no flag needed).
@@ -763,7 +765,7 @@ system-alloy: vpn-up kube-ctx
 
 .PHONY: system-grafana
 system-grafana: vpn-up kube-ctx
-	@$(call _helm_repo_add,grafana,https://grafana.github.io/helm-charts)
+	@$(call _helm_repo_add,grafana-community,https://grafana-community.github.io/helm-charts)
 	$(call _apply_optional_system_secrets,grafana)
 	helm upgrade --install $(GRAFANA_RELEASE) $(GRAFANA_CHART) \
 		--namespace $(NS_INFRA) --create-namespace \

--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -27,8 +27,11 @@
 # An env where people also author dashboards in the UI can keep them by
 # enabling a PVC in its overlay — paired with Recreate, or problem 1 above
 # returns (problem 2 cannot: every provisioned datasource now has a uid):
-#   deploymentStrategy: { type: Recreate }
+#   deploymentStrategy: { type: Recreate, rollingUpdate: null }
 #   persistence: { enabled: true, size: 10Gi }
+# (rollingUpdate: null is required on an existing install — server-side
+# apply keeps the old rollingUpdate block otherwise, and the API forbids
+# it alongside Recreate.)
 persistence:
   enabled: false
 

--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -24,6 +24,11 @@
 #      uid-bearing provisioning on restart and crash-loops grafana.
 # Anything worth keeping lives in git, not in grafana.db. The admin
 # password is re-applied from the Secret on each start, so it stays stable.
+# An env where people also author dashboards in the UI can keep them by
+# enabling a PVC in its overlay — paired with Recreate, or problem 1 above
+# returns (problem 2 cannot: every provisioned datasource now has a uid):
+#   deploymentStrategy: { type: Recreate }
+#   persistence: { enabled: true, size: 10Gi }
 persistence:
   enabled: false
 

--- a/deploy/gitops/system/loki/values.yaml
+++ b/deploy/gitops/system/loki/values.yaml
@@ -1,7 +1,7 @@
 ##
 ## Loki — log store for the L2 system layer (observability `bundled` mode).
 ##
-## Chart: grafana/loki   (https://grafana.github.io/helm-charts)
+## Chart: grafana-community/loki   (https://grafana-community.github.io/helm-charts)
 ## Pin in Makefile: LOKI_VERSION
 ## Release: `loki` in namespace `insight-infra`.
 ##


### PR DESCRIPTION
**Why.** `helm upgrade` warns "this chart is deprecated": `grafana/grafana` was frozen on 2026-01-30 at Grafana 12.3.1. The persistence comment also read as if a PVC were simply unsafe, without saying how to opt in.

**What changed.** Grafana now installs from `grafana-community/grafana` 13.0.0 (app 13.2.0, the chart's continuation); Loki moves to `grafana-community/loki` 18.11.4 (app 3.7.7 — the old repo's chart now tracks Enterprise Logs; rendered StatefulSet identity is unchanged, so it upgrades in place); Alloy 1.9.0→1.12.1 stays in the original repo. The persistence comment carries the safe per-env recipe: `deploymentStrategy: {type: Recreate, rollingUpdate: null}` + a PVC, explaining why the two documented hazards no longer apply (`rollingUpdate: null` is required on an existing install — server-side apply otherwise keeps the old block, which the API forbids alongside Recreate).

**Verified.** `helm template` of the base values (plus a persistence overlay) against all three bumped charts renders cleanly — strategy, fixed-uid datasources, and PVC come out as intended. Not deployed from this branch.
