### PR TITLE
feat(gitops): deploy Tempo and wire log-to-trace correlation

### DIFF
--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -140,7 +140,7 @@ ARGO_RBAC_TMPL   ?= bootstrap/argo-rbac.yaml.template
 ARGO_WORKFLOW_SA ?= argo-workflow
 
 # Observability stack (LGTM). Installed only when the bundled stack is
-# enabled via inventory.system.{victoriametrics,loki,alloy,grafana};
+# enabled via inventory.system.{victoriametrics,loki,tempo,alloy,grafana};
 # otherwise the host cluster collects from stdout and these targets are
 # skipped.
 # Chart versions verified latest via `helm search repo <repo>/<chart>
@@ -150,6 +150,12 @@ LOKI_RELEASE     ?= loki
 # as grafana-community/loki (same manifests, renumbered versions).
 LOKI_CHART       ?= grafana-community/loki
 LOKI_VERSION     ?= 18.11.4    # app 3.7.7
+
+TEMPO_RELEASE    ?= tempo
+# grafana/tempo is frozen like grafana/grafana and grafana/loki; the OSS
+# chart continues as grafana-community/tempo.
+TEMPO_CHART      ?= grafana-community/tempo
+TEMPO_VERSION    ?= 2.3.0      # app 2.10.8
 
 ALLOY_RELEASE    ?= alloy
 ALLOY_CHART      ?= grafana/alloy
@@ -223,6 +229,7 @@ help:
 	@echo "  make system-argo ENV=$(ENV)               }   (Argo Workflows = chart + supplemental RBAC apply)"
 	@echo "  make system-victoriametrics ENV=$(ENV)    }"
 	@echo "  make system-loki ENV=$(ENV)               }"
+	@echo "  make system-tempo ENV=$(ENV)              }"
 	@echo "  make system-alloy ENV=$(ENV)              } L2 — observability (LGTM, bundled mode)."
 	@echo "  make system-grafana ENV=$(ENV)            }"
 	@echo "  make system-status ENV=$(ENV)             Show what's installed in insight-infra"
@@ -628,6 +635,7 @@ system: inventory-present vpn-up kube-ctx
 	$(call _run_if_enabled,system.argoWorkflows,system-argo)
 	$(call _run_if_enabled,system.victoriametrics,system-victoriametrics)
 	$(call _run_if_enabled,system.loki,system-loki)
+	$(call _run_if_enabled,system.tempo,system-tempo)
 	$(call _run_if_enabled,system.alloy,system-alloy)
 	$(call _run_if_enabled,system.grafana,system-grafana)
 	@echo "$(C_GRN)system complete$(C_RST) → $(NS_INFRA)"
@@ -729,10 +737,10 @@ system-redpanda-console: vpn-up kube-ctx
 		--wait --timeout 5m
 
 # ── Observability (LGTM) ────────────────────────────────────────────────
-# VictoriaMetrics (metrics store) + Loki (log store) + Alloy (DaemonSet
-# collector) + Grafana (UI). Install order matters: stores first (Alloy/
-# Grafana point at them), then Alloy, then Grafana. `make system` honours
-# that ordering via the chain above.
+# VictoriaMetrics (metrics store) + Loki (log store) + Tempo (trace store)
+# + Alloy (DaemonSet collector) + Grafana (UI). Install order matters:
+# stores first (Alloy/Grafana point at them), then Alloy, then Grafana.
+# `make system` honours that ordering via the chain above.
 # No required creds in the baseline (single-tenant, no auth); the optional-
 # secrets helper picks up a sealed `grafana-creds` if an env adds one.
 .PHONY: system-victoriametrics
@@ -753,6 +761,16 @@ system-loki: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(LOKI_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,loki) \
+		--wait --timeout 10m
+
+.PHONY: system-tempo
+system-tempo: vpn-up kube-ctx
+	@$(call _helm_repo_add,grafana-community,https://grafana-community.github.io/helm-charts)
+	$(call _apply_optional_system_secrets,tempo)
+	helm upgrade --install $(TEMPO_RELEASE) $(TEMPO_CHART) \
+		--namespace $(NS_INFRA) --create-namespace \
+		--version $(TEMPO_VERSION) $(HELM_EXTRA_FLAGS) \
+		$(call _system_values_args,tempo) \
 		--wait --timeout 10m
 
 .PHONY: system-alloy

--- a/deploy/gitops/environments/functional-ci/inventory.yaml
+++ b/deploy/gitops/environments/functional-ci/inventory.yaml
@@ -43,6 +43,7 @@ system:
   argoWorkflows: false
   victoriametrics: false
   loki: false
+  tempo: false
   alloy: false
   grafana: false
 

--- a/deploy/gitops/environments/local/inventory.yaml.template
+++ b/deploy/gitops/environments/local/inventory.yaml.template
@@ -47,11 +47,12 @@ system:
   airbyte:         true
   argoWorkflows:   true
   # Observability (LGTM). Off for local dev — flip on to self-host
-  # VictoriaMetrics/Loki/Alloy/Grafana, and point the umbrella's
+  # VictoriaMetrics/Loki/Tempo/Alloy/Grafana, and point the umbrella's
   # observability.otlp.endpoint (environments/<env>/values.yaml) at this
   # stack's Alloy. See system/README.md "Observability".
   victoriametrics: false
   loki:            false
+  tempo:           false
   alloy:           false
   grafana:         false
 

--- a/deploy/gitops/environments/test-stand/inventory.yaml
+++ b/deploy/gitops/environments/test-stand/inventory.yaml
@@ -210,6 +210,7 @@ system:
   # would self-host an LGTM stack that nothing points at.
   victoriametrics: false
   loki: false
+  tempo: false
   alloy: false
   grafana: false
 

--- a/deploy/gitops/system/README.md
+++ b/deploy/gitops/system/README.md
@@ -23,23 +23,26 @@ model and full workflow.
 | `airbyte/` | `airbyte/airbyte` | `airbyte` | not in baseline (uses embedded Postgres+MinIO); prod overlay needs S3 creds |
 | `argo-workflows/` | `argo/argo-workflows` | `argo-workflows` | not in baseline |
 | `victoriametrics/` | `vm/victoria-metrics-single` | `victoriametrics` | not in baseline |
-| `loki/` | `grafana/loki` | `loki` | not in baseline (single-tenant, no auth) |
+| `loki/` | `grafana-community/loki` | `loki` | not in baseline (single-tenant, no auth) |
+| `tempo/` | `grafana-community/tempo` | `tempo` | not in baseline |
 | `alloy/` | `grafana/alloy` | `alloy` | not in baseline |
-| `grafana/` | `grafana/grafana` | `grafana` | not in baseline (chart auto-gens admin pw; per-env overlay may seal `grafana-creds`) |
+| `grafana/` | `grafana-community/grafana` | `grafana` | not in baseline (chart auto-gens admin pw; per-env overlay may seal `grafana-creds`) |
 
-### Observability (victoriametrics / loki / alloy / grafana)
+### Observability (victoriametrics / loki / tempo / alloy / grafana)
 
 These are the bundled observability stack: VictoriaMetrics stores metrics
 (PromQL-compatible, remote-write receiver at `/api/v1/write`), Loki stores
-logs, Alloy collects, Grafana serves both — provisioned as the fixed-uid
-datasources `vm` and `loki` so dashboards reference them portably. Two
-independent decisions, mirroring the managed-vs-bundled choice for the data
-stores above:
+logs, Tempo stores traces (OTLP ingest on `tempo:4317`/`4318`), Alloy
+collects, Grafana serves all three — provisioned as the fixed-uid
+datasources `vm`, `loki` and `tempo` so dashboards reference them portably;
+a `trace_id` in a JSON log line links to the trace via Loki's
+`derivedFields`. Two independent decisions, mirroring the
+managed-vs-bundled choice for the data stores above:
 
 1. **Install the bundled stack?** — the
-   `inventory.system.{victoriametrics,loki,alloy,grafana}` toggles. On =
-   self-host the stack in `insight-infra`. Off = don't (the cluster already
-   runs observability, or stdout is enough).
+   `inventory.system.{victoriametrics,loki,tempo,alloy,grafana}` toggles.
+   On = self-host the stack in `insight-infra`. Off = don't (the cluster
+   already runs observability, or stdout is enough).
 2. **Where do services export?** — the umbrella's `observability.otlp.endpoint`
    (`environments/<env>/values.yaml`). Point it at this stack's Alloy when the
    toggles are on; at your own collector for an external one; leave it empty

--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -42,13 +42,14 @@ initChownData:
   enabled: false
 
 # Loki wired as the default datasource so Explore works out of the box,
-# VictoriaMetrics as the PromQL datasource for metrics. Fixed uids so
-# provisioned dashboards can reference them on any environment. Tempo gets
-# added here in the tracing phase; `derivedFields` will then map
-# `trace_id` → a Tempo link for log↔trace correlation.
+# VictoriaMetrics as the PromQL datasource for metrics, Tempo as the trace
+# store. Fixed uids so provisioned dashboards can reference them on any
+# environment. Loki's `derivedFields` turn a `trace_id` in a JSON log line
+# into a Tempo link (log → trace correlation).
 # INVARIANT: helm REPLACES lists — a per-env overlay that touches
-# `datasources` must restate every entry below, and the uids (`loki`, `vm`)
-# must stay what they are or every provisioned dashboard panel goes dark.
+# `datasources` must restate every entry below, and the uids (`loki`, `vm`,
+# `tempo`) must stay what they are or every provisioned dashboard panel
+# goes dark.
 datasources:
   datasources.yaml:
     apiVersion: 1
@@ -61,6 +62,21 @@ datasources:
         isDefault: true
         jsonData:
           maxLines: 1000
+          # `$$` because datasource provisioning expands $VAR env refs —
+          # Grafana needs to receive the literal `${__value.raw}`.
+          derivedFields:
+            - name: TraceID
+              datasourceUid: tempo
+              matcherRegex: '"trace_id"\s*:\s*"([0-9a-fA-F]+)"'
+              url: '$${__value.raw}'
+              urlDisplayLabel: Trace
+
+      - name: Tempo
+        uid: tempo
+        type: tempo
+        access: proxy
+        url: http://tempo.insight-infra.svc.cluster.local:3200
+        isDefault: false
 
       - name: VictoriaMetrics
         uid: vm

--- a/deploy/gitops/system/tempo/values.yaml
+++ b/deploy/gitops/system/tempo/values.yaml
@@ -1,0 +1,37 @@
+##
+## Tempo — trace store for the L2 system layer (observability `bundled`
+## mode). Single-binary (monolithic) chart.
+##
+## Chart: grafana-community/tempo   (https://grafana-community.github.io/helm-charts)
+## Pin in Makefile: TEMPO_VERSION
+## Release: `tempo` in namespace `insight-infra`.
+##
+## Per-env overrides go in environments/<env>/tempo-values.yaml.
+##
+## Endpoints other components use:
+##   OTLP push:  tempo.insight-infra.svc.cluster.local:4317 (gRPC) / 4318 (HTTP)
+##   Query API:  http://tempo.insight-infra.svc.cluster.local:3200 (Grafana datasource)
+##
+## Receivers stay at the chart default (OTLP + Jaeger): the chart's port
+## templates hard-require the jaeger block, and an emptied protocol map
+## renders a config Tempo refuses to start on. Nothing here emits Jaeger;
+## the extra listeners are ClusterIP-internal.
+##
+## SCOPE: dev / single-tenant baseline — one replica, node-local
+## filesystem storage, NO HA. For production move to object storage
+## (S3/GCS) and the distributed chart.
+##
+
+tempo:
+  # Same window as the Loki baseline (7d): a log line's trace link should
+  # resolve for as long as the log line itself is queryable.
+  retention: 168h
+
+  # No anonymous usage phone-home from a shared infra namespace.
+  reportingEnabled: false
+
+# Blocks + WAL live under /var/tempo — persist it or every restart drops
+# the whole trace store.
+persistence:
+  enabled: true
+  size: 10Gi


### PR DESCRIPTION
Closes #2885.

**Why.** The bundled observability stack stores logs and metrics but has no trace store — a trace pushed over OTLP has nowhere to land, and a trace id in a log line links to nothing.

**What changed.** A `system-tempo` L2 target pinning `grafana-community/tempo` 2.3.0 (monolithic mode, OTLP ingest on 4317/4318, 7d retention, 10Gi PVC), a fixed-uid `tempo` Grafana datasource, and Loki `derivedFields` that turn a `trace_id` in a JSON log line into a Tempo link.

**Receivers stay at the chart default (OTLP + Jaeger).** The chart's port templates hard-require the jaeger block, and an emptied protocol map renders a config Tempo refuses to start on; the extra listeners are ClusterIP-internal. Trivial to revisit if the chart grows a toggle.

**Out of scope.** Services still export no traces (`OTEL_TRACES_EXPORTER` stays `none` in platform-config) — flipping the emitter is a separate issue in the observability EPIC.

**Verified.** `helm template` of the pinned chart against the new values renders the OTLP ports, `block_retention: 168h` and the StatefulSet PVC; `make help` and all touched inventories parse. Not exercised against a cluster.
