### PR TITLE
fix(gold): give git_metric_evidence the headroom its inputs now need

### DIFF
--- a/src/ingestion/dbt/macros/metric_serving_table.sql
+++ b/src/ingestion/dbt/macros/metric_serving_table.sql
@@ -1,4 +1,4 @@
-{% macro metric_serving_query_settings(join_use_nulls=none) %}
+{% macro metric_serving_query_settings(join_use_nulls=none, query_settings_overrides=none) %}
     {% set settings = {
         'max_memory_usage': 2147483648,
         'max_threads': 2,
@@ -15,10 +15,16 @@
     {% if join_use_nulls is not none %}
         {% do settings.update({'join_use_nulls': join_use_nulls}) %}
     {% endif %}
+    {# A model whose inputs outgrew the shared ceiling raises its own rather
+       than lifting it for every serving table: the cap is what keeps one heavy
+       build from starving the rest of the gold run. #}
+    {% if query_settings_overrides %}
+        {% do settings.update(query_settings_overrides) %}
+    {% endif %}
     {{ return(settings) }}
 {% endmacro %}
 
-{% macro metric_serving_table(include_record_id, join_use_nulls=none) %}
+{% macro metric_serving_table(include_record_id, join_use_nulls=none, query_settings_overrides=none) %}
     {% set order_by = [
         'tenant_id',
         'source_key',
@@ -37,12 +43,19 @@
         partition_by='toYYYYMM(metric_date)',
         schema=var('gold_database'),
         tags=['gold'],
-        query_settings=metric_serving_query_settings(join_use_nulls=join_use_nulls)
+        query_settings=metric_serving_query_settings(
+            join_use_nulls=join_use_nulls,
+            query_settings_overrides=query_settings_overrides
+        )
     ) }}
 {% endmacro %}
 
-{% macro metric_evidence_table(join_use_nulls=none) %}
-    {{ metric_serving_table(true, join_use_nulls=join_use_nulls) }}
+{% macro metric_evidence_table(join_use_nulls=none, query_settings_overrides=none) %}
+    {{ metric_serving_table(
+        true,
+        join_use_nulls=join_use_nulls,
+        query_settings_overrides=query_settings_overrides
+    ) }}
 {% endmacro %}
 
 {% macro metric_observations_table() %}

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -1,4 +1,16 @@
-{{ metric_evidence_table(join_use_nulls=1) }}
+{# 3 GiB, and spill thresholds to match: this build outgrew the shared 2 GiB
+   ceiling and failed the post-upgrade migration hook with MEMORY_LIMIT_EXCEEDED,
+   taking the whole deploy down with it. Same pairing the other heavy gold
+   models carry (task_issue_state, task_status_spans, account_attribute_values).
+   Raising the ceiling buys headroom, not a cure — the inputs keep growing. #}
+{{ metric_evidence_table(
+    join_use_nulls=1,
+    query_settings_overrides={
+        'max_memory_usage': 3221225472,
+        'max_bytes_before_external_group_by': 805306368,
+        'max_bytes_before_external_sort': 805306368
+    }
+) }}
 
 -- Resolution happens at READ time, and account-first: a row naming its author's
 -- account (pull requests) resolves through that binding, everything else


### PR DESCRIPTION
**Why.** `git_metric_evidence` outgrew the 2 GiB ceiling the shared serving-table macro applies and now fails with `MEMORY_LIMIT_EXCEEDED`. It builds inside the post-upgrade migration hook, so the blast radius is every deploy: dbt exits non-zero, the hook job exhausts its backoff, and Helm rolls the release back — whatever else that release carried.

**What changed.** The model asks for 3 GiB with 768 MiB spill thresholds, the same pairing `task_issue_state`, `task_status_spans` and `account_attribute_values` already carry. The macro grows an optional `query_settings_overrides` argument to allow it, threaded the way `join_use_nulls` already is.

**The shared ceiling stays where it is.** Only the model that outgrew it opts out, because the cap is what stops one heavy build from starving the rest of the gold run.

**This is headroom, not a cure.** The inputs keep growing, and the next model to cross the line fails the same way, taking a deploy with it. Worth a follow-up on the build itself.

**Verified.** Reproduced on a live cluster: re-running the hook job surfaced the exact failure, and the model's inputs are small enough (largest ~180 MiB on disk) that the new ceiling plus disk spilling has real margin. Not built end-to-end locally — dbt here cannot run the gold chain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable query-setting overrides for metric serving and evidence tables.
  * Individual models can now increase resource limits when needed without changing shared defaults.
  * The Git metric evidence build now uses higher memory and processing thresholds to support larger workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->