### PR TITLE
feat(github): record links between work items as intervals, and re-key the Projects V2 relations

### DIFF
--- a/docs/domain/task-tracking/specs/feature-github-projects/DESIGN.md
+++ b/docs/domain/task-tracking/specs/feature-github-projects/DESIGN.md
@@ -14,7 +14,7 @@ those findings.
   - [2.2 Field catalogue](#22-field-catalogue)
   - [2.3 Cards](#23-cards)
   - [2.4 Timeline additions](#24-timeline-additions)
-- [3. Why a day sits in two row keys](#3-why-a-day-sits-in-two-row-keys)
+- [3. Where the history of a board lives](#3-where-the-history-of-a-board-lives)
 - [4. The incremental filter and its silent failure](#4-the-incremental-filter-and-its-silent-failure)
 - [5. Identity: what a board status is called](#5-identity-what-a-board-status-is-called)
 - [6. Board status is not the issue's state](#6-board-status-is-not-the-issues-state)
@@ -74,21 +74,27 @@ have no issue behind them and no identity outside the board.
 event resolvable at all: every board defines its own status field, and an issue
 on several boards interleaves all their status events in this one timeline.
 
-## 3. Why a day sits in two row keys
+## 3. Where the history of a board lives
 
-GitHub keeps no history of a board field, an option rename, or a non-status card
-value. `ProjectV2Item` and each field value carry `updatedAt`, which says when a
-value was last touched and never what it was before. A succession of snapshots
-is therefore the only possible record, and the day in the key is what makes one:
-bronze is a `ReplacingMergeTree` keyed on `unique_key`, so a re-collection
-inside one day replaces its row while a new day adds one.
+GitHub keeps no history of a board field, an option rename, or a non-status
+card value. `ProjectV2Item` and each field value carry `updatedAt`, which says
+when a value was last touched and never what it was before. A succession of
+observations is therefore the only possible record.
 
-The two keys take their day from different places, and the difference matters.
-`project_items` uses the card's own `updatedAt`, so re-reading an unchanged card
-inside the overlap window rewrites the same row — the stream is a change log,
-not a daily dump. `project_fields` uses the collection day, because a field's
-`updatedAt` is not guaranteed to move when one of its options is renamed, and
-catching renames is the whole point of keeping the catalogue's history.
+Both bronze relations are keyed on the ENTITY — a board field, a card — so the
+`ReplacingMergeTree` collapses each re-collection onto the current state, and
+the record of change is built above them by the shared SCD2 macros:
+`github__project_fields_snapshot` and `github__project_items_snapshot` append a
+version only when a tracked column actually moves, and
+`github__project_fields_history` turns the field catalogue's versions into a
+per-attribute change log.
+
+An earlier revision of this design put the collection day into `unique_key`
+instead. That defeats the collapse: bronze stops holding the present and
+accumulates one row per entity per day whether anything changed or not, which
+is what `union_by_tag` warns against in as many words — *never encode the
+version into `unique_key`* (ADR-0001, ADR-0004). The macros already existed and
+do the job better, because they write nothing on a day when nothing changed.
 
 ## 4. The incremental filter and its silent failure
 
@@ -217,3 +223,6 @@ destination stream on a state clear. Card field values cannot be backfilled.
   operator-facing layout; workflow definitions likely need elevated permission.
 - **Membership in silver**, if a measure ever wants "which boards was this on".
 - **Iteration field values** are collected but nothing reads them.
+- **Per-board-field card history.** `github__project_items_snapshot` versions
+  the whole `field_values_json` blob, so a change is visible but not attributed
+  to a single board field. Splitting it belongs with the first consumer.

--- a/docs/domain/task-tracking/specs/feature-work-item-links/DESIGN.md
+++ b/docs/domain/task-tracking/specs/feature-work-item-links/DESIGN.md
@@ -1,0 +1,129 @@
+# Technical Design — Links Between Work Items
+
+Collecting the links GitHub records between issues, and between an issue and a
+pull request, so that the links in force over any interval can be read back.
+
+<!-- toc -->
+
+- [1. What a link is here](#1-what-a-link-is-here)
+- [2. Two sources, because one is not enough](#2-two-sources-because-one-is-not-enough)
+- [3. Storage: intervals, not a current set](#3-storage-intervals-not-a-current-set)
+- [4. Reading it](#4-reading-it)
+- [5. Edges that are bounds rather than facts](#5-edges-that-are-bounds-rather-than-facts)
+- [6. Both directions are stored](#6-both-directions-are-stored)
+- [7. Deferred](#7-deferred)
+
+<!-- tocstop -->
+
+## 1. What a link is here
+
+Six kinds, in one vocabulary:
+
+| `link_type` | Meaning | Target |
+|---|---|---|
+| `parent` | the item's parent | issue |
+| `sub_issue` | the item is the parent of the target | issue |
+| `blocked_by` | the target blocks the item | issue |
+| `blocking` | the item blocks the target | issue |
+| `duplicate_of` | the item was marked a duplicate of the target | issue or pull request |
+| `connected` | a manual connection | issue or pull request |
+| `closed_by_pr` | the target pull request closes the item | pull request |
+
+A target carries its own repository, because a link may cross repositories and
+an issue number alone identifies nothing.
+
+## 2. Two sources, because one is not enough
+
+**The timeline** emits twelve link event types, each a pure delta: it names the
+link that appeared or disappeared and never the set that resulted. Hierarchy
+and dependency links always emit a matching pair, so folding adds against
+removes reconstructs the set exactly — a claim checked against real data, where
+seven additions and two removals reconciled with the count the vendor reports.
+
+**The snapshot** — `closedByPullRequestsReferences` and the hierarchy
+connections on the issue — states what is true now and carries no history.
+
+Neither alone is enough, and the split is not a preference:
+
+- Hierarchy and dependency links fold exactly, so the timeline rules them.
+- A pull request closing an issue does NOT reliably reach the timeline. It may
+  arrive as a `ConnectedEvent`, as a `CrossReferencedEvent` that reports
+  `willCloseTarget: false`, or not at all, while the connection states it
+  plainly. So that kind is observed, never folded.
+
+No link type is ever built from both sources, because their precision differs
+and a consumer that averaged them would be comparing a second to a sync.
+
+## 3. Storage: intervals, not a current set
+
+`silver.class_task_links` holds one row per link OCCURRENCE:
+
+| column | meaning |
+|---|---|
+| `valid_from` | when the link appeared |
+| `valid_to` | when it went away; NULL while it is still there |
+| `valid_from_known` | 1 when the vendor stated the moment; 0 when it is a lower bound |
+| `evidence` | `event` (folded from add/remove) or `observation` (bounded by first and last seen) |
+
+A link removed and re-added later is two rows. `valid_from` is therefore part
+of the key — as the identity of an occurrence, not as a version of one row,
+which is the thing `union_by_tag` forbids (ADR-0001, ADR-0004).
+
+Intervals are built by pairing each addition with the nearest removal that
+follows it, in ClickHouse an `ASOF LEFT JOIN`. One property of that join drives
+a guard: an ASOF join that matches nothing yields the column type's DEFAULT
+rather than NULL, so an unclosed interval would read as closed at the epoch —
+a real date, which every range query would believe.
+`assert_link_intervals_are_sane` refuses that shape, along with an interval
+that ends before it begins.
+
+## 4. Reading it
+
+The links in force over a window:
+
+```sql
+SELECT * FROM silver.class_task_links FINAL
+WHERE valid_from < :to AND (valid_to IS NULL OR valid_to > :from)
+```
+
+The links as of an instant is the same predicate with one point. The links now
+is `valid_to IS NULL`.
+
+## 5. Edges that are bounds rather than facts
+
+`valid_from_known = 0` marks a lower bound, and there are two ways to get one:
+
+- **A removal with no addition.** The link was created before anything
+  collected. Dropping the row would report a link that never existed;
+  inventing a start would report a date nobody observed. The interval is left
+  open at the bottom and flagged.
+- **An observed link.** First-seen is not first-true — the link may predate the
+  first snapshot that carried it.
+
+Filtering these out silently drops the oldest links, which are exactly the ones
+a long window asks about.
+
+## 6. Both directions are stored
+
+One action writes two events: a parent records `SubIssueAdded`, its child
+records `ParentIssueAdded`, at the same instant. Both are kept, so a link
+appears once from each side.
+
+Deduplicating to a canonical direction would make the parent's history depend
+on whether the child was collected, and the two ends can live in different
+repositories — one of which the token may not be able to read at all.
+
+## 7. Deferred
+
+- **Cross-references.** `CrossReferencedEvent` is a mention, not a link: it has
+  no removal counterpart, so it is a point in time and not an interval. It
+  belongs in an event relation, not this one.
+- **The pull-request side of a connection.** `closingIssuesReferences` states
+  the same link from the other end; collecting it would duplicate what the
+  issue side already carries.
+- **Jira.** The link sets are already in bronze inside the raw `fields` blob,
+  and the changelog carries their history — but items whose `fieldId` is empty
+  are dropped before staging, which is where link changes are likely to land.
+  Confirming that, and mapping Jira's link vocabulary onto the one above, is
+  its own change.
+- **A consumer.** Nothing in gold reads this yet.

--- a/src/ingestion/connectors/git/github/README.md
+++ b/src/ingestion/connectors/git/github/README.md
@@ -25,7 +25,8 @@ feeds the shared `class_git_*` silver models.
 | pull_request_review_comments | `/repos/{r}/pulls/comments` | updated_at, server-side `since` |
 | issues | `/repos/{r}/issues` | updated_at, server-side `since`; PRs filtered out |
 | projects_v2 | GraphQL `organization.projectsV2` | full refresh |
-| project_fields | GraphQL `ProjectV2.fields`, per board | full refresh, one row per (field, collection day) |
+| issue_links | GraphQL `repository.issues` link connections | updated_at, newest-first data feed |
+| project_fields | GraphQL `ProjectV2.fields`, per board | full refresh, one row per board field |
 | project_items | GraphQL `ProjectV2.items`, per board | card `updatedAt`, server-side `updated:>=DATE` (day granularity) |
 | issue_fields | GraphQL `organization.issueFields` | full refresh |
 | issue_types | GraphQL `organization.issueTypes` | full refresh |
@@ -64,12 +65,22 @@ is therefore `%Y-%m-%d`, so a timestamp cannot reach the query string, and
 re-read on every sync by design: the row key carries the day the card changed,
 so a re-read rewrites the same row.
 
-**Why a collection day sits in the board keys.** GitHub keeps no history of a
-board field, an option rename, or a non-status card value. `updatedAt` says
-when a value was last touched and never what it was before, so a succession of
-snapshots is the only record — the day in the key makes each sync's view its
-own row while a re-collection inside one day replaces it. Status history is the
+**Where board history lives.** GitHub keeps no history of a board field, an
+option rename, or a non-status card value, so a succession of observations is
+the only record. Both board relations are keyed on the entity, so bronze holds
+the present and the RMT collapses each re-collection onto it; the record of
+change is the SCD2 snapshot above them (`*_snapshot`, `project_fields_history`),
+which writes nothing on a day when nothing changed. Status history is the
 exception: it comes from the issue timeline and is retroactively recoverable.
+
+**Links between work items are collected two ways, because one is not enough.**
+Hierarchy and dependency links emit a matching add/remove pair on the timeline,
+so their history folds exactly. A pull request closing an issue does not: the
+timeline may report it as a connection, as a cross-reference that claims it
+will NOT close the issue, or not at all, while `closedByPullRequestsReferences`
+states it plainly. So `issue_links` observes the sets and the timeline supplies
+the events, and `silver.class_task_links` records which evidence bounded each
+interval.
 
 **Board status is not the issue's state.** An issue is open or closed; a board
 column is a separate field, one per board, and the two are bound separately.

--- a/src/ingestion/connectors/git/github/README.md
+++ b/src/ingestion/connectors/git/github/README.md
@@ -62,8 +62,8 @@ GraphQL error, so a typo reads as "nothing changed": a green sync, an empty
 stream, and no way to tell it from a quiet week. The cursor's `datetime_format`
 is therefore `%Y-%m-%d`, so a timestamp cannot reach the query string, and
 `assert_boards_yield_cards` catches the outcome if one ever does. One day is
-re-read on every sync by design: the row key carries the day the card changed,
-so a re-read rewrites the same row.
+re-read on every sync by design, and that is free: the row key is the card, so
+a re-read collapses onto the row already there.
 
 **Where board history lives.** GitHub keeps no history of a board field, an
 option rename, or a non-status card value, so a succession of observations is

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -2436,6 +2436,171 @@ streams:
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.org | replace(':', '%3A') }}:project:{{ (record.get('id') or '') | replace(':', '%3A') }}
 
+  # ── Issue links, current state (GitHub GraphQL) ─────────────────────────
+  # One row per issue carrying every link it holds right now, each set as JSON.
+  #
+  # This exists because the timeline is NOT sufficient for every link kind.
+  # Hierarchy and dependency links emit a matching add/remove pair, so their
+  # history folds exactly. A pull request that closes an issue does not: the
+  # link is stated by `closedByPullRequestsReferences`, and the timeline may
+  # carry a ConnectedEvent for it, a CrossReferencedEvent that even reports
+  # `willCloseTarget: false`, or nothing at all. Observation is the only
+  # reliable source for that kind, so both sources feed one interval model and
+  # each interval records which evidence produced it.
+  #
+  # Repository-scoped rather than per issue: the timeline stream already spends
+  # one call per issue, and this needs no such precision — one page carries
+  # fifty issues with all their link sets.
+  - type: DeclarativeStream
+    name: issue_links
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          item_number: {type: [integer, "null"]}
+          updated_at: {type: [string, "null"]}
+          parent_json: {type: [string, "null"]}
+          sub_issues_json: {type: [string, "null"]}
+          blocked_by_json: {type: [string, "null"]}
+          blocking_json: {type: [string, "null"]}
+          closed_by_pull_requests_json: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        error_handler: *graphql_error_handler_repo_scoped
+        path: /graphql
+        http_method: POST
+        request_body_json:
+          query: |
+            query($owner: String!, $name: String!, $cursor: String) {
+              repository(owner: $owner, name: $name) {
+                issues(first: 50, after: $cursor, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    number updatedAt
+                    parent { number repository { nameWithOwner } }
+                    subIssues(first: 50) { totalCount nodes { number repository { nameWithOwner } } }
+                    blockedBy(first: 50) { totalCount nodes { number repository { nameWithOwner } } }
+                    blocking(first: 50) { totalCount nodes { number repository { nameWithOwner } } }
+                    closedByPullRequestsReferences(first: 20) { totalCount nodes { number repository { nameWithOwner } } }
+                  }
+                }
+              }
+            }
+          variables:
+            owner: "{{ stream_partition.repo_full_name.split('/')[0] }}"
+            name: "{{ stream_partition.repo_full_name.split('/')[1] }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, repository, issues, nodes]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ ((((response.get('data') or {}).get('repository') or {}).get('issues') or {}).get('pageInfo') or {}).get('endCursor') }}"
+          stop_condition: "{{ not ((((response.get('data') or {}).get('repository') or {}).get('issues') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: full_name
+            partition_field: repo_full_name
+            stream: *repositories_all_parent
+    # Newest-first data feed on the issue's own `updated_at`: a sweep of every
+    # issue in every repository on every sync would be the most expensive query
+    # this connector makes, and the GraphQL point budget does not have room for
+    # it — one page here carries fifty issues with five connections each.
+    #
+    # The cost is that a link removed WITHOUT otherwise touching the issue is
+    # observed late. That is survivable because it only affects the link kinds
+    # observed rather than folded: hierarchy and dependency changes emit
+    # timeline events, which this stream is not the source for.
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config['github_start_date'] }}"
+        datetime_format: "%Y-%m-%d"
+      is_data_feed: true
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_partition.repo_full_name }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [item_number]
+            value: "{{ record.get('number') or 0 }}"
+            value_type: integer
+          - type: AddedFieldDefinition
+            path: [updated_at]
+            value: "{{ record.get('updatedAt') or '' }}"
+            value_type: string
+          # Each set is kept as the vendor states it. Exploding into rows is the
+          # staging model's job, and a JSON column keeps the stream one row per
+          # issue however many links it holds.
+          - type: AddedFieldDefinition
+            path: [parent_json]
+            value: "{{ (record.get('parent') or {}) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [sub_issues_json]
+            value: "{{ ((record.get('subIssues') or {}).get('nodes') or []) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [blocked_by_json]
+            value: "{{ ((record.get('blockedBy') or {}).get('nodes') or []) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [blocking_json]
+            value: "{{ ((record.get('blocking') or {}).get('nodes') or []) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [closed_by_pull_requests_json]
+            value: "{{ ((record.get('closedByPullRequestsReferences') or {}).get('nodes') or []) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:issue_links:{{ record.get('number') }}
+      - type: RemoveFields
+        # Hoisted above; the camelCase and nested originals stay out of bronze.
+        field_pointers:
+          - [number]
+          - [updatedAt]
+          - [parent]
+          - [subIssues]
+          - [blockedBy]
+          - [blocking]
+          - [closedByPullRequestsReferences]
+
   # ── Projects V2 field catalogue (GitHub GraphQL) ─────────────────────────
   # Every board's own field definitions. A board field is NOT shared: two
   # projects' same-named `Status` are different fields with different ids, and
@@ -2447,10 +2612,11 @@ streams:
   # by display name only, so resolving that name to an option id happens
   # through the options of the board's own field.
   #
-  # `snapshot_date` is part of the key on purpose. GitHub keeps no history of a
-  # field or an option rename, so the only record of one is a succession of
-  # snapshots — a re-collection inside one day replaces its row, a new day adds
-  # one. Without it a rename erases the name every earlier event carries.
+  # Keyed on (board, field) so bronze holds the CURRENT catalogue and the
+  # ReplacingMergeTree collapses each re-collection onto it. GitHub keeps no
+  # history of a field or an option rename, and the record of one is built
+  # downstream by `github__project_fields_snapshot` — the shared SCD2 macro,
+  # which appends a version only when a tracked column actually changes.
   - type: DeclarativeStream
     name: project_fields
     primary_key:
@@ -2466,7 +2632,6 @@ streams:
           source_id: {type: [string, "null"]}
           data_source: {type: [string, "null"]}
           collected_at: {type: [string, "null"]}
-          snapshot_date: {type: [string, "null"]}
           project_id: {type: [string, "null"]}
           project_number: {type: [integer, "null"]}
           field_id: {type: [string, "null"]}
@@ -2548,10 +2713,6 @@ streams:
       - type: AddFields
         fields:
           - type: AddedFieldDefinition
-            path: [snapshot_date]
-            value: "{{ now_utc().strftime('%Y-%m-%d') }}"
-            value_type: string
-          - type: AddedFieldDefinition
             path: [project_id]
             value: "{{ stream_partition.project_id }}"
             value_type: string
@@ -2606,7 +2767,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:project:{{ (stream_partition.project_id or '') | replace(':', '%3A') }}:field:{{ (record.get('id') or '') | replace(':', '%3A') }}:{{ now_utc().strftime('%Y-%m-%d') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:project:{{ (stream_partition.project_id or '') | replace(':', '%3A') }}:field:{{ (record.get('id') or '') | replace(':', '%3A') }}
       - type: RemoveFields
         # Hoisted above; the camelCase and nested originals stay out of bronze.
         field_pointers:
@@ -2622,19 +2783,19 @@ streams:
           - [configuration]
 
   # ── Projects V2 cards (GitHub GraphQL) ──────────────────────────────────
-  # One row per (card x day the card changed), carrying the card's current
-  # field values. Two reasons this stream exists rather than riding the issue
-  # streams:
+  # One row per card, carrying its current field values. Two reasons this
+  # stream exists rather than riding the issue streams:
   #
   # 1. Moving a card does NOT bump the issue's `updated_at`, and the timeline
   #    stream is a substream of an issue window cursored on exactly that. Board
   #    movement on an otherwise untouched issue is invisible without a
   #    board-side cursor.
   # 2. No API exposes the history of a non-status board field. `updatedAt` says
-  #    when a value was last touched, never what it was before, so the only
-  #    record is a succession of snapshots — hence the day in the key. The day
-  #    comes from the card's own `updatedAt`, so re-reading an unchanged card
-  #    inside the overlap window rewrites its row instead of adding one.
+  #    when a value was last touched, never what it was before, so the record
+  #    has to be built from successive observations — which is
+  #    `github__project_items_snapshot`'s job, not this stream's. Here the key
+  #    is the card, so bronze holds its current state and a re-read inside the
+  #    overlap window collapses onto it.
   #
   # INVARIANT: the incremental filter is built from a DATE and nothing else.
   # `items(query:)` filters server-side on the card's update date, but its
@@ -2761,8 +2922,8 @@ streams:
         - "%Y-%m-%dT%H:%M:%SZ"
         - "%Y-%m-%dT%H:%M:%S%z"
       # The server filter is coarser than the cursor, so a day is re-read on
-      # every sync. That is deliberate rather than tolerated: the row key
-      # carries the day the card changed, so a re-read rewrites the same row.
+      # every sync. That is free: the row key is the card, so a re-read
+      # collapses onto the row already there.
       #
       # A client-side cut is NOT used here. The CDK applies it in the record
       # selector, before the transformations that rename `updatedAt` to
@@ -2837,7 +2998,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:project:{{ (stream_partition.project_id or '') | replace(':', '%3A') }}:item:{{ (record.get('id') or '') | replace(':', '%3A') }}:{{ (record.get('updatedAt') or '')[:10] }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:project:{{ (stream_partition.project_id or '') | replace(':', '%3A') }}:item:{{ (record.get('id') or '') | replace(':', '%3A') }}
       - type: RemoveFields
         # Hoisted above; the camelCase and nested originals stay out of bronze.
         field_pointers:
@@ -3822,6 +3983,10 @@ streams:
           project_id: {type: [string, "null"]}
           project_number: {type: [integer, "null"]}
           was_automated: {type: [boolean, "null"]}
+          link_target_type: {type: [string, "null"]}
+          link_target_number: {type: [integer, "null"]}
+          link_target_repo_full_name: {type: [string, "null"]}
+          is_cross_repository: {type: [boolean, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -3837,7 +4002,7 @@ streams:
             query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
               repository(owner: $owner, name: $name) {
                 issue(number: $number) {
-                  timelineItems(first: 100, after: $cursor, itemTypes: [ASSIGNED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, CLOSED_EVENT, REOPENED_EVENT, ISSUE_TYPE_CHANGED_EVENT, ISSUE_FIELD_CHANGED_EVENT, PROJECT_V2_ITEM_STATUS_CHANGED_EVENT, ADDED_TO_PROJECT_V2_EVENT, REMOVED_FROM_PROJECT_V2_EVENT]) {
+                  timelineItems(first: 100, after: $cursor, itemTypes: [ASSIGNED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, CLOSED_EVENT, REOPENED_EVENT, ISSUE_TYPE_CHANGED_EVENT, ISSUE_FIELD_CHANGED_EVENT, PROJECT_V2_ITEM_STATUS_CHANGED_EVENT, ADDED_TO_PROJECT_V2_EVENT, REMOVED_FROM_PROJECT_V2_EVENT, SUB_ISSUE_ADDED_EVENT, SUB_ISSUE_REMOVED_EVENT, PARENT_ISSUE_ADDED_EVENT, PARENT_ISSUE_REMOVED_EVENT, BLOCKED_BY_ADDED_EVENT, BLOCKED_BY_REMOVED_EVENT, BLOCKING_ADDED_EVENT, BLOCKING_REMOVED_EVENT, CONNECTED_EVENT, DISCONNECTED_EVENT, MARKED_AS_DUPLICATE_EVENT, UNMARKED_AS_DUPLICATE_EVENT]) {
                     pageInfo { hasNextPage endCursor }
                     nodes {
                       __typename
@@ -3869,6 +4034,24 @@ streams:
                       # when. The card snapshot states only the present.
                       ... on AddedToProjectV2Event { id createdAt actor { login ... on User { databaseId } } project { id number } wasAutomated }
                       ... on RemovedFromProjectV2Event { id createdAt actor { login ... on User { databaseId } } project { id number } wasAutomated }
+                      # Links between work items. Each is a pure DELTA — the
+                      # event names the link that appeared or disappeared and
+                      # never the set that resulted, so the set at any moment
+                      # is a fold. Both ends of one link emit their own event
+                      # with the same timestamp: a parent records SubIssue*,
+                      # its child records ParentIssue*.
+                      ... on SubIssueAddedEvent { id createdAt actor { login ... on User { databaseId } } subIssue { number repository { nameWithOwner } } }
+                      ... on SubIssueRemovedEvent { id createdAt actor { login ... on User { databaseId } } subIssue { number repository { nameWithOwner } } }
+                      ... on ParentIssueAddedEvent { id createdAt actor { login ... on User { databaseId } } parent { number repository { nameWithOwner } } }
+                      ... on ParentIssueRemovedEvent { id createdAt actor { login ... on User { databaseId } } parent { number repository { nameWithOwner } } }
+                      ... on BlockedByAddedEvent { id createdAt actor { login ... on User { databaseId } } blockingIssue { number repository { nameWithOwner } } }
+                      ... on BlockedByRemovedEvent { id createdAt actor { login ... on User { databaseId } } blockingIssue { number repository { nameWithOwner } } }
+                      ... on BlockingAddedEvent { id createdAt actor { login ... on User { databaseId } } blockedIssue { number repository { nameWithOwner } } }
+                      ... on BlockingRemovedEvent { id createdAt actor { login ... on User { databaseId } } blockedIssue { number repository { nameWithOwner } } }
+                      ... on ConnectedEvent { id createdAt actor { login ... on User { databaseId } } isCrossRepository subject { __typename ... on Issue { number repository { nameWithOwner } } ... on PullRequest { number repository { nameWithOwner } } } }
+                      ... on DisconnectedEvent { id createdAt actor { login ... on User { databaseId } } isCrossRepository subject { __typename ... on Issue { number repository { nameWithOwner } } ... on PullRequest { number repository { nameWithOwner } } } }
+                      ... on MarkedAsDuplicateEvent { id createdAt actor { login ... on User { databaseId } } isCrossRepository canonical { __typename ... on Issue { number repository { nameWithOwner } } ... on PullRequest { number repository { nameWithOwner } } } }
+                      ... on UnmarkedAsDuplicateEvent { id createdAt actor { login ... on User { databaseId } } isCrossRepository canonical { __typename ... on Issue { number repository { nameWithOwner } } ... on PullRequest { number repository { nameWithOwner } } } }
                     }
                   }
                 }
@@ -4086,6 +4269,30 @@ streams:
             path: [was_automated]
             value: "{{ record.get('wasAutomated') or false }}"
             value_type: boolean
+          # The other end of a link. Every link event names it under its own
+          # key — `subIssue`, `parent`, `blockingIssue`, `blockedIssue`,
+          # `subject`, `canonical` — so the target collapses into one set of
+          # columns here, and which link it was stays the event type's job.
+          - type: AddedFieldDefinition
+            path: [link_target_number]
+            value: "{{ (record.get('subIssue') or record.get('parent') or record.get('blockingIssue') or record.get('blockedIssue') or record.get('subject') or record.get('canonical') or {}).get('number') or 0 }}"
+            value_type: integer
+          - type: AddedFieldDefinition
+            path: [link_target_repo_full_name]
+            value: "{{ ((record.get('subIssue') or record.get('parent') or record.get('blockingIssue') or record.get('blockedIssue') or record.get('subject') or record.get('canonical') or {}).get('repository') or {}).get('nameWithOwner') or '' }}"
+            value_type: string
+          # Only the connect and duplicate pairs can point at a pull request.
+          # Hierarchy and dependency links are issue-to-issue by construction
+          # and state no __typename of their own.
+          - type: AddedFieldDefinition
+            path: [link_target_type]
+            value: >-
+              {{ (record.get('subIssue') or record.get('parent') or record.get('blockingIssue') or record.get('blockedIssue') or record.get('subject') or record.get('canonical') or {}).get('__typename') or ('Issue' if (record.get('subIssue') or record.get('parent') or record.get('blockingIssue') or record.get('blockedIssue') or record.get('subject') or record.get('canonical') or {}) else '') }}
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [is_cross_repository]
+            value: "{{ record.get('isCrossRepository') or false }}"
+            value_type: boolean
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
@@ -4109,6 +4316,15 @@ streams:
           - [newOptions]
           - [previousStatus]
           - [status]
+          - [project]
+          - [wasAutomated]
+          - [subIssue]
+          - [parent]
+          - [blockingIssue]
+          - [blockedIssue]
+          - [subject]
+          - [canonical]
+          - [isCrossRepository]
     # Formal cursor: no request option is injected and nothing is filtered, so
     # every enumerated issue's timeline is always emitted in full. It exists to
     # make the stream stateful, which is what lets incremental_dependency carry
@@ -4213,6 +4429,7 @@ metadata:
     pull_request_commits: false
     pull_request_diff_stats: false
     issues: false
+    issue_links: false
     projects_v2: false
     project_fields: false
     project_items: false

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -2474,6 +2474,10 @@ streams:
           blocked_by_json: {type: [string, "null"]}
           blocking_json: {type: [string, "null"]}
           closed_by_pull_requests_json: {type: [string, "null"]}
+          sub_issues_total: {type: [integer, "null"]}
+          blocked_by_total: {type: [integer, "null"]}
+          blocking_total: {type: [integer, "null"]}
+          closed_by_pull_requests_total: {type: [integer, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -2586,6 +2590,27 @@ streams:
             path: [closed_by_pull_requests_json]
             value: "{{ ((record.get('closedByPullRequestsReferences') or {}).get('nodes') or []) | tojson }}"
             value_type: string
+          # The vendor's own count for each set, kept beside the nodes. A
+          # nested connection cannot be paginated from a declarative manifest,
+          # so a set larger than its page silently loses its tail — storing
+          # the count is what lets `assert_issue_link_sets_are_complete` say
+          # so out loud instead.
+          - type: AddedFieldDefinition
+            path: [sub_issues_total]
+            value: "{{ (record.get('subIssues') or {}).get('totalCount') or 0 }}"
+            value_type: integer
+          - type: AddedFieldDefinition
+            path: [blocked_by_total]
+            value: "{{ (record.get('blockedBy') or {}).get('totalCount') or 0 }}"
+            value_type: integer
+          - type: AddedFieldDefinition
+            path: [blocking_total]
+            value: "{{ (record.get('blocking') or {}).get('totalCount') or 0 }}"
+            value_type: integer
+          - type: AddedFieldDefinition
+            path: [closed_by_pull_requests_total]
+            value: "{{ (record.get('closedByPullRequestsReferences') or {}).get('totalCount') or 0 }}"
+            value_type: integer
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-

--- a/src/ingestion/connectors/git/github/dbt/github__bronze_promoted.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__bronze_promoted.sql
@@ -28,6 +28,7 @@
 {% do promote_bronze_to_rmt(table='bronze_github.issues',                      order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_github.projects_v2',                 order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_github.issue_fields',                order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_github.issue_links',                 order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_github.project_fields',              order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_github.project_items',               order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_github.issue_types',                 order_by='unique_key') %}

--- a/src/ingestion/connectors/git/github/dbt/github__issue_link_events.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__issue_link_events.sql
@@ -1,0 +1,80 @@
+-- depends_on: {{ ref('github__bronze_promoted') }}
+{{ config(
+    materialized='view',
+    alias='github__issue_link_events',
+    schema='staging',
+    tags=['github', 'staging']
+) }}
+
+-- Every link between work items that appeared or disappeared, as a delta.
+--
+-- A link event states only what changed, never the set that resulted, so the
+-- links an issue held at a given moment are a fold over these rows. That fold
+-- is `github__task_links`; this model only normalises the vendor's twelve
+-- event types into one shape.
+--
+-- Both ends of a link emit their own event at the same instant — a parent
+-- records SubIssue*, its child records ParentIssue* — so a link appears twice
+-- in this table, once from each side, and each side is true on its own terms.
+-- Deduplicating to a single canonical direction would make the parent's
+-- history depend on whether the child was collected.
+
+WITH linked AS (
+    SELECT
+        COALESCE(source_id, '')                                 AS insight_source_id,
+        COALESCE(tenant_id, '')                                 AS tenant_id,
+        COALESCE(event_id, '')                                  AS event_id,
+        COALESCE(event_type, '')                                AS event_type,
+        parseDateTimeBestEffortOrNull(event_at)                 AS event_at,
+        concat(COALESCE(repo_full_name, ''), '#', toString(COALESCE(item_number, 0))) AS id_readable,
+        COALESCE(actor_login, '')                               AS actor_login,
+        toString(COALESCE(actor_id, 0))                         AS actor_id,
+        COALESCE(link_target_type, '')                          AS target_type_raw,
+        COALESCE(link_target_repo_full_name, '')                AS target_repo,
+        COALESCE(link_target_number, 0)                         AS target_number,
+        COALESCE(is_cross_repository, false)                    AS is_cross_repository,
+        _airbyte_extracted_at
+    FROM {{ source('bronze_github', 'issue_timeline_events') }} FINAL
+    WHERE event_type IN (
+        'SubIssueAddedEvent', 'SubIssueRemovedEvent',
+        'ParentIssueAddedEvent', 'ParentIssueRemovedEvent',
+        'BlockedByAddedEvent', 'BlockedByRemovedEvent',
+        'BlockingAddedEvent', 'BlockingRemovedEvent',
+        'ConnectedEvent', 'DisconnectedEvent',
+        'MarkedAsDuplicateEvent', 'UnmarkedAsDuplicateEvent'
+    )
+)
+
+SELECT
+    CAST(concat(insight_source_id, '-github-link-', event_id) AS String)    AS unique_key,
+    CAST(insight_source_id AS String)                                      AS insight_source_id,
+    CAST(tenant_id AS String)                                              AS tenant_id,
+    CAST('github' AS String)                                               AS data_source,
+    CAST(id_readable AS String)                                            AS id_readable,
+    CAST(event_id AS String)                                               AS event_id,
+    assumeNotNull(event_at)                                                AS event_at,
+    CAST(multiIf(
+        event_type IN ('SubIssueAddedEvent', 'SubIssueRemovedEvent'),           'sub_issue',
+        event_type IN ('ParentIssueAddedEvent', 'ParentIssueRemovedEvent'),     'parent',
+        event_type IN ('BlockedByAddedEvent', 'BlockedByRemovedEvent'),         'blocked_by',
+        event_type IN ('BlockingAddedEvent', 'BlockingRemovedEvent'),           'blocking',
+        event_type IN ('MarkedAsDuplicateEvent', 'UnmarkedAsDuplicateEvent'),   'duplicate_of',
+        'connected'
+    ) AS String)                                                           AS link_type,
+    -- The vendor spells the direction in the type name and nowhere else.
+    CAST(if(
+        event_type IN ('SubIssueRemovedEvent', 'ParentIssueRemovedEvent',
+                       'BlockedByRemovedEvent', 'BlockingRemovedEvent',
+                       'DisconnectedEvent', 'UnmarkedAsDuplicateEvent'),
+        'remove', 'add') AS String)                                        AS link_action,
+    CAST(if(lower(target_type_raw) = 'pullrequest', 'pull_request', 'issue') AS String) AS target_type,
+    CAST(concat(target_repo, '#', toString(target_number)) AS String)      AS target_readable,
+    CAST(is_cross_repository AS Bool)                                      AS is_cross_repository,
+    CAST(nullIf(actor_login, '') AS Nullable(String))                      AS actor_display,
+    CAST(nullIf(actor_id, '0') AS Nullable(String))                        AS actor_id,
+    toDateTime64(_airbyte_extracted_at, 3)                                 AS collected_at,
+    CAST(toUnixTimestamp64Milli(toDateTime64(_airbyte_extracted_at, 3)) AS UInt64) AS _version
+FROM linked
+-- A link event with no target is a payload the query did not ask for; keeping
+-- it would put a row with no other end into the fold.
+WHERE event_at IS NOT NULL AND target_number != 0

--- a/src/ingestion/connectors/git/github/dbt/github__issue_link_events.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__issue_link_events.sql
@@ -27,6 +27,7 @@ WITH linked AS (
         COALESCE(event_type, '')                                AS event_type,
         parseDateTimeBestEffortOrNull(event_at)                 AS event_at,
         concat(COALESCE(repo_full_name, ''), '#', toString(COALESCE(item_number, 0))) AS id_readable,
+        COALESCE(repo_full_name, '')                            AS source_repo,
         COALESCE(actor_login, '')                               AS actor_login,
         toString(COALESCE(actor_id, 0))                         AS actor_id,
         COALESCE(link_target_type, '')                          AS target_type_raw,
@@ -69,7 +70,11 @@ SELECT
         'remove', 'add') AS String)                                        AS link_action,
     CAST(if(lower(target_type_raw) = 'pullrequest', 'pull_request', 'issue') AS String) AS target_type,
     CAST(concat(target_repo, '#', toString(target_number)) AS String)      AS target_readable,
-    CAST(is_cross_repository AS Bool)                                      AS is_cross_repository,
+    -- Derived, not read: only the connect and duplicate pairs report
+    -- `isCrossRepository`, so trusting the vendor flag would call every
+    -- cross-repository parent, sub-issue or dependency a same-repository one.
+    -- The two repositories are on the row either way.
+    CAST(source_repo != target_repo AS Bool)                               AS is_cross_repository,
     CAST(nullIf(actor_login, '') AS Nullable(String))                      AS actor_display,
     CAST(nullIf(actor_id, '0') AS Nullable(String))                        AS actor_id,
     toDateTime64(_airbyte_extracted_at, 3)                                 AS collected_at,

--- a/src/ingestion/connectors/git/github/dbt/github__issue_links_snapshot.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__issue_links_snapshot.sql
@@ -1,0 +1,25 @@
+-- depends_on: {{ ref('github__bronze_promoted') }}
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    schema='staging',
+    tags=['github']
+) }}
+
+-- SCD2 snapshot of the link sets an issue holds — appends a version only when
+-- one of them changes.
+--
+-- Bronze keeps the present, so it cannot answer when a link first appeared.
+-- For hierarchy and dependency links the timeline answers that exactly and
+-- this model is redundant. For a pull request that closes an issue it is the
+-- only answer there is: that link has no reliable event, so the interval model
+-- bounds it by when it was first and last observed here.
+
+{{ snapshot(
+    source_ref=source('bronze_github', 'issue_links'),
+    unique_key_col='unique_key',
+    check_cols=[
+        'parent_json', 'sub_issues_json', 'blocked_by_json', 'blocking_json',
+        'closed_by_pull_requests_json'
+    ]
+) }}

--- a/src/ingestion/connectors/git/github/dbt/github__project_fields_history.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__project_fields_history.sql
@@ -1,0 +1,26 @@
+-- depends_on: {{ ref('github__bronze_promoted') }}
+{{ config(
+    materialized='table',
+    schema='staging',
+    tags=['github']
+) }}
+
+-- Field-level change log of a board's field catalogue, derived from the
+-- snapshot: one row per changed attribute per version transition, carrying
+-- `old_value` and `new_value`.
+--
+-- This is what answers "when did that column stop being called X" — the
+-- question a status value keyed on a name cannot answer on its own, because
+-- the catalogue only ever states the present.
+--
+-- `entity_id` is the board field's node id, which is globally unique across
+-- boards, so it needs no board prefix to stay distinct.
+
+{{ fields_history(
+    snapshot_ref=ref('github__project_fields_snapshot'),
+    entity_id_col='field_id',
+    fields=[
+        'field_name', 'data_type', 'is_multi', 'is_mirror', 'is_issue_field',
+        'options_json', 'configuration_json'
+    ]
+) }}

--- a/src/ingestion/connectors/git/github/dbt/github__project_fields_snapshot.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__project_fields_snapshot.sql
@@ -1,0 +1,26 @@
+-- depends_on: {{ ref('github__bronze_promoted') }}
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    schema='staging',
+    tags=['github']
+) }}
+
+-- SCD2 snapshot of every board's field catalogue — appends a version only when
+-- a tracked column actually changes.
+--
+-- GitHub exposes no history for a board field: no timeline event fires when a
+-- field is renamed, an option is renamed, or a select gains a column. Bronze
+-- therefore holds only what is true now, and this is the only record that it
+-- was ever different. `options_json` is tracked as a whole because an option
+-- rename is a change to the set, and the set is what a status mapping is
+-- authored against.
+
+{{ snapshot(
+    source_ref=source('bronze_github', 'project_fields'),
+    unique_key_col='unique_key',
+    check_cols=[
+        'field_name', 'data_type', 'is_multi', 'is_mirror', 'is_issue_field',
+        'options_json', 'configuration_json'
+    ]
+) }}

--- a/src/ingestion/connectors/git/github/dbt/github__project_items_snapshot.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__project_items_snapshot.sql
@@ -1,0 +1,29 @@
+-- depends_on: {{ ref('github__bronze_promoted') }}
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    schema='staging',
+    tags=['github']
+) }}
+
+-- SCD2 snapshot of board cards — appends a version only when the card's
+-- tracked state changes.
+--
+-- Status history comes from the issue timeline and does NOT depend on this
+-- model. Every OTHER board field value does: no API exposes their history, and
+-- `updatedAt` says when a value was last touched but never what it was before.
+-- Successive versions here are the only way to see one change.
+--
+-- `field_values_json` is tracked whole, so a version appears when any board
+-- field on the card moves. Splitting that into one row per (card, field)
+-- belongs in the model that first has a consumer for it — pinning the value
+-- shape now would fix a contract nothing reads yet.
+
+{{ snapshot(
+    source_ref=source('bronze_github', 'project_items'),
+    unique_key_col='unique_key',
+    check_cols=[
+        'is_archived', 'content_type', 'content_number', 'content_repo_full_name',
+        'field_values_json'
+    ]
+) }}

--- a/src/ingestion/connectors/git/github/dbt/github__task_links.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__task_links.sql
@@ -1,0 +1,214 @@
+-- depends_on: {{ ref('github__bronze_promoted') }}
+{{ config(
+    materialized='table',
+    alias='github__task_links',
+    schema='staging',
+    tags=['github', 'staging', 'silver:class_task_links']
+) }}
+
+-- One row per link OCCURRENCE, with the interval it held: `valid_from` when it
+-- appeared, `valid_to` when it went away, NULL while it is still there. The
+-- question this answers is "which links existed between two dates", which is a
+-- range predicate and nothing more:
+--
+--   WHERE valid_from < :to AND (valid_to IS NULL OR valid_to > :from)
+--
+-- INVARIANT: `valid_from` belongs to the KEY, not to a version. A link removed
+-- and re-added later is two occurrences and two rows, and both are current
+-- facts about different intervals — unlike a snapshot version, which would be
+-- the same fact restated (ADR-0001, ADR-0004).
+--
+-- `evidence` says how the interval was established, because the two sources
+-- differ in precision and a consumer must not average them:
+--   `event`       — an add/remove pair from the issue timeline. Exact to the
+--                   second, and the vendor's own record of the change.
+--   `observation` — the link was seen present in successive snapshots. The
+--                   bounds are first-seen and last-seen, so the true edges lie
+--                   somewhere between two syncs.
+--
+-- Which source rules which link type is not a preference. Hierarchy and
+-- dependency links emit a matching add/remove pair, so they fold exactly. A
+-- pull request closing an issue does not: the timeline may report it as a
+-- connection, as a cross-reference that claims it will NOT close the issue, or
+-- not at all, while `closedByPullRequestsReferences` states it plainly. So
+-- that one kind is observed and the rest are folded, and no link type is ever
+-- built from both.
+
+WITH events AS (
+    SELECT
+        insight_source_id, tenant_id, id_readable, link_type, link_action,
+        target_type, target_readable, is_cross_repository, actor_display, actor_id,
+        event_at, event_id, collected_at
+    FROM {{ ref('github__issue_link_events') }}
+),
+
+adds AS (
+    SELECT * FROM events WHERE link_action = 'add'
+),
+
+removes AS (
+    SELECT
+        insight_source_id, id_readable, link_type, target_readable,
+        event_at                                                AS removed_at,
+        actor_display                                           AS removed_by,
+        -- INVARIANT: an ASOF LEFT JOIN that matches nothing yields the column
+        -- TYPE'S DEFAULT, not NULL — an unclosed interval would read as closed
+        -- at the epoch, which is a date, and every range query would believe
+        -- it. This flag is how the join says "no match" out loud.
+        toUInt8(1)                                              AS matched
+    FROM events WHERE link_action = 'remove'
+),
+
+-- ASOF pairs every add with the nearest remove that follows it in the same
+-- link. A strict `<` is deliberate: an add and a remove sharing one timestamp
+-- are not a closed interval, they are a collection artefact, and pairing them
+-- would report a link that existed for zero seconds.
+event_intervals AS (
+    SELECT
+        a.insight_source_id                                     AS insight_source_id,
+        a.tenant_id                                             AS tenant_id,
+        a.id_readable                                           AS id_readable,
+        a.link_type                                             AS link_type,
+        a.target_type                                           AS target_type,
+        a.target_readable                                       AS target_readable,
+        a.is_cross_repository                                   AS is_cross_repository,
+        a.event_at                                              AS valid_from,
+        toUInt8(1)                                              AS valid_from_known,
+        if(r.matched = 1, toNullable(r.removed_at), NULL)       AS valid_to,
+        a.actor_display                                         AS added_by,
+        if(r.matched = 1, r.removed_by, CAST(NULL AS Nullable(String))) AS removed_by,
+        'event'                                                 AS evidence,
+        a.event_id                                              AS origin_event_id,
+        a.collected_at                                          AS collected_at
+    FROM adds AS a
+    ASOF LEFT JOIN removes AS r
+        ON a.insight_source_id = r.insight_source_id
+        AND a.id_readable = r.id_readable
+        AND a.link_type = r.link_type
+        AND a.target_readable = r.target_readable
+        AND a.event_at < r.removed_at
+),
+
+-- A removal whose addition predates everything collected. Dropping it would
+-- report the link as never having existed; inventing a start would report a
+-- date nobody observed. The interval is left open at the bottom and flagged,
+-- so a range query still finds it and a reader still knows the edge is a
+-- bound rather than a fact.
+orphan_removes AS (
+    SELECT
+        insight_source_id                                       AS insight_source_id,
+        tenant_id                                               AS tenant_id,
+        id_readable                                             AS id_readable,
+        link_type                                               AS link_type,
+        target_type                                             AS target_type,
+        target_readable                                         AS target_readable,
+        is_cross_repository                                     AS is_cross_repository,
+        toDateTime64(0, 3)                                      AS valid_from,
+        toUInt8(0)                                              AS valid_from_known,
+        first_at                                                AS valid_to,
+        CAST(NULL AS Nullable(String))                          AS added_by,
+        first_actor                                             AS removed_by,
+        'event'                                                 AS evidence,
+        ''                                                      AS origin_event_id,
+        collected_at                                            AS collected_at
+    FROM (
+        SELECT
+            insight_source_id,
+            id_readable,
+            link_type,
+            target_readable,
+            any(tenant_id)                                             AS tenant_id,
+            argMin(link_action, (event_at, event_id))                  AS first_action,
+            min(event_at)                                              AS first_at,
+            argMin(target_type, (event_at, event_id))                  AS target_type,
+            argMin(is_cross_repository, (event_at, event_id))          AS is_cross_repository,
+            argMin(actor_display, (event_at, event_id))                AS first_actor,
+            max(collected_at)                                          AS collected_at
+        FROM events
+        GROUP BY insight_source_id, id_readable, link_type, target_readable
+    )
+    -- The earliest event of a link being a removal means its addition happened
+    -- before anything collected. Any later add/remove pair in the same link is
+    -- already handled by the ASOF pairing above.
+    WHERE first_action = 'remove'
+),
+
+-- Observation side: one row per (issue, closing pull request) per snapshot
+-- version, so the version timestamps bound the link.
+pr_observations AS (
+    SELECT
+        COALESCE(s.source_id, '')                               AS insight_source_id,
+        COALESCE(s.tenant_id, '')                               AS tenant_id,
+        concat(COALESCE(s.repo_full_name, ''), '#', toString(COALESCE(s.item_number, 0))) AS id_readable,
+        concat(
+            JSONExtractString(JSONExtractRaw(link_raw, 'repository'), 'nameWithOwner'),
+            '#', toString(JSONExtractInt(link_raw, 'number'))
+        )                                                       AS target_readable,
+        s._tracked_at                                           AS observed_at
+    FROM (
+        SELECT *, arrayJoin(JSONExtractArrayRaw(COALESCE(closed_by_pull_requests_json, '[]'))) AS link_raw
+        FROM {{ ref('github__issue_links_snapshot') }}
+    ) AS s
+),
+
+latest_observation AS (
+    SELECT insight_source_id, id_readable, max(observed_at) AS last_version_at
+    FROM pr_observations GROUP BY insight_source_id, id_readable
+),
+
+pr_intervals AS (
+    SELECT
+        o.insight_source_id                                     AS insight_source_id,
+        any(o.tenant_id)                                        AS tenant_id,
+        o.id_readable                                           AS id_readable,
+        'closed_by_pr'                                          AS link_type,
+        'pull_request'                                          AS target_type,
+        o.target_readable                                       AS target_readable,
+        false                                                   AS is_cross_repository,
+        min(o.observed_at)                                      AS valid_from,
+        -- First SEEN, not first true: the link may predate the first snapshot
+        -- that carried it, so the lower edge is a bound like an orphan's.
+        toUInt8(0)                                              AS valid_from_known,
+        -- Still in the newest version of this issue's links -> still there.
+        if(max(o.observed_at) = any(l.last_version_at), CAST(NULL AS Nullable(DateTime64(3))), max(o.observed_at)) AS valid_to,
+        CAST(NULL AS Nullable(String))                          AS added_by,
+        CAST(NULL AS Nullable(String))                          AS removed_by,
+        'observation'                                           AS evidence,
+        ''                                                      AS origin_event_id,
+        max(o.observed_at)                                      AS collected_at
+    FROM pr_observations AS o
+    INNER JOIN latest_observation AS l
+        ON l.insight_source_id = o.insight_source_id AND l.id_readable = o.id_readable
+    GROUP BY o.insight_source_id, o.id_readable, o.target_readable
+),
+
+every_interval AS (
+    SELECT * FROM event_intervals
+    UNION ALL
+    SELECT * FROM orphan_removes
+    UNION ALL
+    SELECT * FROM pr_intervals
+)
+
+SELECT
+    CAST(concat(
+        insight_source_id, '-github-', id_readable, '-', link_type, '-',
+        target_readable, '-', toString(toUnixTimestamp64Milli(valid_from))
+    ) AS String)                                                AS unique_key,
+    CAST(insight_source_id AS String)                           AS insight_source_id,
+    CAST('github' AS String)                                    AS data_source,
+    CAST(id_readable AS String)                                 AS id_readable,
+    CAST(link_type AS String)                                   AS link_type,
+    CAST(target_type AS Enum8('issue' = 1, 'pull_request' = 2)) AS target_type,
+    CAST(target_readable AS String)                             AS target_readable,
+    CAST(is_cross_repository AS Bool)                           AS is_cross_repository,
+    valid_from                                                  AS valid_from,
+    valid_from_known                                            AS valid_from_known,
+    valid_to                                                    AS valid_to,
+    CAST(added_by AS Nullable(String))                          AS added_by,
+    CAST(removed_by AS Nullable(String))                        AS removed_by,
+    CAST(evidence AS Enum8('event' = 1, 'observation' = 2))     AS evidence,
+    CAST(nullIf(origin_event_id, '') AS Nullable(String))       AS origin_event_id,
+    toDateTime64(collected_at, 3)                               AS collected_at,
+    CAST(toUnixTimestamp64Milli(toDateTime64(collected_at, 3)) AS UInt64) AS _version
+FROM every_interval

--- a/src/ingestion/connectors/git/github/dbt/github__task_links.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__task_links.sql
@@ -51,6 +51,7 @@ removes AS (
         insight_source_id, id_readable, link_type, target_readable,
         event_at                                                AS removed_at,
         actor_display                                           AS removed_by,
+        collected_at                                            AS removed_collected_at,
         -- INVARIANT: an ASOF LEFT JOIN that matches nothing yields the column
         -- TYPE'S DEFAULT, not NULL — an unclosed interval would read as closed
         -- at the epoch, which is a date, and every range query would believe
@@ -79,7 +80,11 @@ event_intervals AS (
         if(r.matched = 1, r.removed_by, CAST(NULL AS Nullable(String))) AS removed_by,
         'event'                                                 AS evidence,
         a.event_id                                              AS origin_event_id,
-        a.collected_at                                          AS collected_at
+        -- INVARIANT: the newest evidence behind the row, not the addition's.
+        -- `_version` derives from this and `class_task_links` is incremental on
+        -- it, so a row whose only change is that it CLOSED would be filtered
+        -- out and the interval would stay open in silver forever.
+        if(r.matched = 1, greatest(a.collected_at, r.removed_collected_at), a.collected_at) AS collected_at
     FROM adds AS a
     ASOF LEFT JOIN removes AS r
         ON a.insight_source_id = r.insight_source_id
@@ -144,6 +149,7 @@ pr_observations AS (
             JSONExtractString(JSONExtractRaw(link_raw, 'repository'), 'nameWithOwner'),
             '#', toString(JSONExtractInt(link_raw, 'number'))
         )                                                       AS target_readable,
+        COALESCE(s.repo_full_name, '')                          AS source_repo,
         s._tracked_at                                           AS observed_at
     FROM (
         SELECT *, arrayJoin(JSONExtractArrayRaw(COALESCE(closed_by_pull_requests_json, '[]'))) AS link_raw
@@ -151,9 +157,18 @@ pr_observations AS (
     ) AS s
 ),
 
+-- INVARIANT: the newest version of an issue's links, taken from the snapshot
+-- itself and NOT from `pr_observations`. A version whose link set is empty
+-- produces no observation row, so deriving the latest version from the
+-- observations would take the last version that still HAD a link — and every
+-- link removed by emptying the set would read as still open.
 latest_observation AS (
-    SELECT insight_source_id, id_readable, max(observed_at) AS last_version_at
-    FROM pr_observations GROUP BY insight_source_id, id_readable
+    SELECT
+        COALESCE(source_id, '')                                 AS insight_source_id,
+        concat(COALESCE(repo_full_name, ''), '#', toString(COALESCE(item_number, 0))) AS id_readable,
+        max(_tracked_at)                                        AS last_version_at
+    FROM {{ ref('github__issue_links_snapshot') }}
+    GROUP BY insight_source_id, id_readable
 ),
 
 pr_intervals AS (
@@ -164,7 +179,9 @@ pr_intervals AS (
         'closed_by_pr'                                          AS link_type,
         'pull_request'                                          AS target_type,
         o.target_readable                                       AS target_readable,
-        false                                                   AS is_cross_repository,
+        -- The closing pull request may live in another repository, so this is
+        -- a comparison and not a constant.
+        any(o.source_repo) != splitByChar('#', o.target_readable)[1] AS is_cross_repository,
         min(o.observed_at)                                      AS valid_from,
         -- First SEEN, not first true: the link may predate the first snapshot
         -- that carried it, so the lower edge is a bound like an orphan's.
@@ -175,7 +192,10 @@ pr_intervals AS (
         CAST(NULL AS Nullable(String))                          AS removed_by,
         'observation'                                           AS evidence,
         ''                                                      AS origin_event_id,
-        max(o.observed_at)                                      AS collected_at
+        -- The issue's newest version, for the same reason: a link closes
+        -- because a LATER observation no longer carries it, and that evidence
+        -- has to move `_version` or silver never sees the closure.
+        any(l.last_version_at)                                  AS collected_at
     FROM pr_observations AS o
     INNER JOIN latest_observation AS l
         ON l.insight_source_id = o.insight_source_id AND l.id_readable = o.id_readable

--- a/src/ingestion/connectors/git/github/dbt/schema.yml
+++ b/src/ingestion/connectors/git/github/dbt/schema.yml
@@ -23,6 +23,7 @@ sources:
       - name: issues
       - name: projects_v2
       - name: issue_fields
+      - name: issue_links
       - name: project_fields
       - name: project_items
       - name: issue_types

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -23,7 +23,19 @@ name: github
 #   collected after the change — recovering them for history means clearing the
 #   `issue_timeline_events` cursor and re-walking, which is a rollout step, not
 #   a version bump.
-version: "6.1.0"
+# 7.0.0: work-item links, and a correction to how the two Projects V2 streams
+#   are keyed. MAJOR for the keys: `project_fields` and `project_items` no
+#   longer carry a collection day in `unique_key`, so bronze holds the present
+#   and the ReplacingMergeTree collapses onto it, with history moved to the
+#   shared SCD2 snapshot macros (ADR-0001, ADR-0004 forbid a version in the
+#   key). Rows written under the old day-keyed scheme cannot collapse onto the
+#   new ones and must be dropped: TRUNCATE both bronze relations before the
+#   first sync on this version. `project_fields` also loses `snapshot_date`;
+#   the column survives on existing installations as NULL because nothing
+#   drops a bronze column.
+#   Additive alongside: a new `issue_links` stream, twelve link event types on
+#   `issue_timeline_events`, and four columns for the link target.
+version: "7.0.0"
 schedule: "0 */4 * * *"
 workflow: sync
 

--- a/src/ingestion/connectors/git/github/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github/tests/test_github_streams.py
@@ -1503,10 +1503,11 @@ def test_project_fields_mark_the_issue_mirrors(http_mocker: HttpMocker) -> None:
 
 
 @freezegun.freeze_time(_FROZEN)
-def test_project_fields_key_carries_the_snapshot_day(http_mocker: HttpMocker) -> None:
-    """GitHub keeps no history of an option rename, so a succession of daily
-    snapshots is the only record of one. Without the day in the key a rename
-    erases the name every earlier status event carries."""
+def test_project_fields_key_is_the_field_so_bronze_holds_the_present(http_mocker: HttpMocker) -> None:
+    """Bronze states what is true now and the ReplacingMergeTree collapses each
+    re-collection onto it. History belongs to the SCD2 snapshot downstream, not
+    to the row key: keying by day would keep every version permanently current
+    (ADR-0001, ADR-0004)."""
     config = GithubConfigBuilder().build()
     _mock_projects_parent(http_mocker, [{"id": "PVT_1", "number": 40}])
     http_mocker.post(
@@ -1539,8 +1540,9 @@ def test_project_fields_key_carries_the_snapshot_day(http_mocker: HttpMocker) ->
 
     assert not output.errors
     key = output.records[0].record.data["unique_key"]
-    assert key.endswith(":project:PVT_1:field:F_est:2026-07-01"), key
-    assert output.records[0].record.data["snapshot_date"] == "2026-07-01"
+    assert key.endswith(":project:PVT_1:field:F_est"), key
+    assert "2026-07-01" not in key, "a collection day in the key would defeat the RMT collapse"
+    assert "snapshot_date" not in output.records[0].record.data
 
 
 @freezegun.freeze_time(_FROZEN)
@@ -1655,11 +1657,10 @@ def test_project_items_drop_a_draft_card_but_keep_an_unreadable_one(http_mocker:
 
 
 @freezegun.freeze_time(_FROZEN)
-def test_project_item_key_carries_the_day_the_card_changed(http_mocker: HttpMocker) -> None:
-    """No API exposes the history of a non-status board field, so the record is
-    a succession of snapshots. The day comes from the card's own updatedAt, so
-    re-reading an unchanged card inside the overlap window rewrites its row
-    instead of adding one."""
+def test_project_item_key_is_the_card_so_a_re_read_collapses(http_mocker: HttpMocker) -> None:
+    """The cursor re-reads a day on every sync by design. That is free only
+    while the key is the card itself: the re-read collapses onto the row
+    already there instead of appending a version."""
     config = GithubConfigBuilder().build()
     _mock_projects_parent(http_mocker, [{"id": "PVT_1", "number": 40}])
     http_mocker.post(
@@ -1689,9 +1690,8 @@ def test_project_item_key_carries_the_day_the_card_changed(http_mocker: HttpMock
 
     assert not output.errors
     keys = [r.record.data["unique_key"] for r in output.records]
-    assert keys[0].endswith(":project:PVT_1:item:PVTI_1:2026-06-20")
-    assert keys[1].endswith(":project:PVT_1:item:PVTI_1:2026-06-21")
-    assert keys[0] != keys[1], "one row per day the card changed, not one row ever"
+    assert keys[0].endswith(":project:PVT_1:item:PVTI_1")
+    assert keys[0] == keys[1], "the same card twice is the same row, whatever day it moved"
     first = output.records[0].record.data
     assert first["content_number"] == 7
     assert first["content_repo_full_name"] == "acme/app"
@@ -1819,3 +1819,181 @@ def test_status_change_names_the_board_it_happened_on(http_mocker: HttpMocker) -
     assert by_event["E_removed"]["project_id"] == "PVT_2"
     assert by_event["E_added"]["new_value"] == ""
     _no_literal_none(output.records)
+
+
+def _issue_links_body(cursor: str | None = None) -> dict:
+    return _graphql_body("issue_links", {"owner": "acme", "name": "app"}, cursor)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_link_events_collapse_six_payload_shapes_into_one_target(http_mocker: HttpMocker) -> None:
+    """Each link event names the other end under its own key — subIssue,
+    parent, blockingIssue, blockedIssue, subject, canonical. Downstream has to
+    fold adds against removes, which it cannot do while the target's location
+    depends on which of the twelve types carried it."""
+    config = GithubConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps([_repo()]), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(f"{GH_URL}/repos/acme/app/issues", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps([{"id": 901, "number": 7, "updated_at": "2026-06-20T00:00:00Z"}]), status_code=200
+        ),
+    )
+    actor = {"login": "alice", "databaseId": 1001}
+    other = {"number": 11, "repository": {"nameWithOwner": "acme/app"}}
+    cross = {"number": 3, "repository": {"nameWithOwner": "acme/other"}}
+    nodes = [
+        {
+            "__typename": "SubIssueAddedEvent",
+            "id": "L1",
+            "createdAt": "2026-06-01T00:00:00Z",
+            "actor": actor,
+            "subIssue": other,
+        },
+        {
+            "__typename": "SubIssueRemovedEvent",
+            "id": "L2",
+            "createdAt": "2026-06-02T00:00:00Z",
+            "actor": actor,
+            "subIssue": other,
+        },
+        {
+            "__typename": "ParentIssueAddedEvent",
+            "id": "L3",
+            "createdAt": "2026-06-03T00:00:00Z",
+            "actor": actor,
+            "parent": cross,
+        },
+        {
+            "__typename": "BlockedByAddedEvent",
+            "id": "L4",
+            "createdAt": "2026-06-04T00:00:00Z",
+            "actor": actor,
+            "blockingIssue": other,
+        },
+        {
+            "__typename": "BlockingAddedEvent",
+            "id": "L5",
+            "createdAt": "2026-06-05T00:00:00Z",
+            "actor": actor,
+            "blockedIssue": other,
+        },
+        {
+            "__typename": "ConnectedEvent",
+            "id": "L6",
+            "createdAt": "2026-06-06T00:00:00Z",
+            "actor": actor,
+            "isCrossRepository": False,
+            "subject": {"__typename": "PullRequest", "number": 42, "repository": {"nameWithOwner": "acme/app"}},
+        },
+        {
+            "__typename": "MarkedAsDuplicateEvent",
+            "id": "L7",
+            "createdAt": "2026-06-07T00:00:00Z",
+            "actor": actor,
+            "isCrossRepository": True,
+            "canonical": {"__typename": "Issue", "number": 9, "repository": {"nameWithOwner": "acme/other"}},
+        },
+    ]
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_issue_timeline_body()),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "issue": {
+                                "timelineItems": {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": nodes}
+                            }
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "issue_timeline_events", config)
+
+    assert not output.errors
+    by_event = {r.record.data["event_id"]: r.record.data for r in output.records}
+    assert set(by_event) == {"L1", "L2", "L3", "L4", "L5", "L6", "L7"}
+    for event_id in ("L1", "L2", "L4", "L5"):
+        assert by_event[event_id]["link_target_number"] == 11, event_id
+        assert by_event[event_id]["link_target_repo_full_name"] == "acme/app", event_id
+        assert by_event[event_id]["link_target_type"] == "Issue", event_id
+    # A hierarchy link may cross repositories, so the target's repository is
+    # part of its identity and not decoration.
+    assert by_event["L3"]["link_target_repo_full_name"] == "acme/other"
+    # Only the connect and duplicate pairs state a __typename of their own.
+    assert by_event["L6"]["link_target_type"] == "PullRequest"
+    assert by_event["L6"]["link_target_number"] == 42
+    assert by_event["L7"]["link_target_type"] == "Issue"
+    assert by_event["L7"]["is_cross_repository"] is True
+    # An event that is not a link leaves the columns empty rather than guessing.
+    _no_literal_none(output.records)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_issue_links_snapshot_carries_every_link_set(http_mocker: HttpMocker) -> None:
+    """A pull request that closes an issue has no reliable event — the timeline
+    may call it a connection, a cross-reference that claims it will NOT close
+    the issue, or say nothing. Observing the connection is the only way to know
+    it, so the snapshot must carry it alongside the sets the timeline does
+    cover."""
+    config = GithubConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps([_repo()]), status_code=200),
+    )
+    node = {
+        "number": 7,
+        "updatedAt": "2026-06-20T10:00:00Z",
+        "parent": {"number": 1, "repository": {"nameWithOwner": "acme/app"}},
+        "subIssues": {
+            "totalCount": 2,
+            "nodes": [
+                {"number": 8, "repository": {"nameWithOwner": "acme/app"}},
+                {"number": 9, "repository": {"nameWithOwner": "acme/other"}},
+            ],
+        },
+        "blockedBy": {"totalCount": 1, "nodes": [{"number": 5, "repository": {"nameWithOwner": "acme/app"}}]},
+        "blocking": {"totalCount": 0, "nodes": []},
+        "closedByPullRequestsReferences": {
+            "totalCount": 1,
+            "nodes": [{"number": 42, "repository": {"nameWithOwner": "acme/app"}}],
+        },
+    }
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_issue_links_body()),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "issues": {"pageInfo": {"hasNextPage": False, "endCursor": None}, "nodes": [node]}
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "issue_links", config)
+
+    assert not output.errors
+    row = output.records[0].record.data
+    assert row["item_number"] == 7
+    assert row["repo_full_name"] == "acme/app"
+    assert json.loads(row["parent_json"])["number"] == 1
+    assert [n["number"] for n in json.loads(row["sub_issues_json"])] == [8, 9]
+    assert [n["number"] for n in json.loads(row["blocked_by_json"])] == [5]
+    assert json.loads(row["blocking_json"]) == [], "an empty set is empty, never absent"
+    assert [n["number"] for n in json.loads(row["closed_by_pull_requests_json"])] == [42]
+    assert row["unique_key"].endswith(":acme/app:issue_links:7")
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "issue_links", strict=True)

--- a/src/ingestion/connectors/git/github/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github/tests/test_github_streams.py
@@ -1994,6 +1994,12 @@ def test_issue_links_snapshot_carries_every_link_set(http_mocker: HttpMocker) ->
     assert [n["number"] for n in json.loads(row["blocked_by_json"])] == [5]
     assert json.loads(row["blocking_json"]) == [], "an empty set is empty, never absent"
     assert [n["number"] for n in json.loads(row["closed_by_pull_requests_json"])] == [42]
+    # The vendor's own counts travel with the sets: a nested connection cannot
+    # be paginated here, so the count is the only way a truncated set is
+    # visible at all.
+    assert row["sub_issues_total"] == 2
+    assert row["blocking_total"] == 0
+    assert row["closed_by_pull_requests_total"] == 1
     assert row["unique_key"].endswith(":acme/app:issue_links:7")
     _no_literal_none(output.records)
     assert_records_conform(output.records, _CONNECTOR, "issue_links", strict=True)

--- a/src/ingestion/dbt/tests/task/README.md
+++ b/src/ingestion/dbt/tests/task/README.md
@@ -28,6 +28,7 @@ tag, add `config(tags=['task_tracker'])` as a SQL comment at the top of each tes
 | `assert_initial_traceable_to_bronze` | Silver initial row with no matching `bronze_jira.jira_issue` |
 | `assert_initial_is_earliest_per_issue_field` | `event_at` of initial row later than first changelog |
 | `assert_value_id_type_consistent` | Same field_id classified with different `value_id_type`s across runs |
+| `assert_link_intervals_are_sane` | A link interval that ends before it begins, or one closed at the epoch — the value an unmatched ASOF join yields instead of NULL |
 | `assert_one_field_per_role` | Two vendor fields bound to one metric role — consumers merge them rather than choose, and `precedence` is not read yet |
 | `assert_boards_yield_cards` | Projects V2 boards and board events collected, cards not — the date filter on `items(query:)` is being rejected silently |
 

--- a/src/ingestion/dbt/tests/task/README.md
+++ b/src/ingestion/dbt/tests/task/README.md
@@ -28,6 +28,7 @@ tag, add `config(tags=['task_tracker'])` as a SQL comment at the top of each tes
 | `assert_initial_traceable_to_bronze` | Silver initial row with no matching `bronze_jira.jira_issue` |
 | `assert_initial_is_earliest_per_issue_field` | `event_at` of initial row later than first changelog |
 | `assert_value_id_type_consistent` | Same field_id classified with different `value_id_type`s across runs |
+| `assert_issue_link_sets_are_complete` | A link set collected with fewer members than the vendor states — a nested connection cut off at its page boundary |
 | `assert_link_intervals_are_sane` | A link interval that ends before it begins, or one closed at the epoch — the value an unmatched ASOF join yields instead of NULL |
 | `assert_one_field_per_role` | Two vendor fields bound to one metric role — consumers merge them rather than choose, and `precedence` is not read yet |
 | `assert_boards_yield_cards` | Projects V2 boards and board events collected, cards not — the date filter on `items(query:)` is being rejected silently |

--- a/src/ingestion/dbt/tests/task/assert_issue_link_sets_are_complete.sql
+++ b/src/ingestion/dbt/tests/task/assert_issue_link_sets_are_complete.sql
@@ -1,0 +1,35 @@
+-- A link set that was cut off at its page boundary.
+--
+-- `issue_links` reads five nested GraphQL connections, and a declarative
+-- manifest cannot paginate a nested connection: it asks for a page and takes
+-- what it gets. An issue with more sub-issues, dependencies or closing pull
+-- requests than the page holds therefore loses its tail — and loses it
+-- SILENTLY, which is the part that matters. `github__task_links` would then
+-- report fewer links than exist and give no sign that anything is missing.
+--
+-- The vendor states the true size of each set, so the two are compared here.
+-- Firing means the page has to grow, or the stream has to move to a component
+-- that can follow a nested cursor.
+
+WITH sets AS (
+    SELECT
+        COALESCE(source_id, '')                                 AS insight_source_id,
+        concat(COALESCE(repo_full_name, ''), '#', toString(COALESCE(item_number, 0))) AS id_readable,
+        arrayJoin([
+            ('sub_issues',   JSONLength(COALESCE(sub_issues_json, '[]')),             COALESCE(sub_issues_total, 0)),
+            ('blocked_by',   JSONLength(COALESCE(blocked_by_json, '[]')),             COALESCE(blocked_by_total, 0)),
+            ('blocking',     JSONLength(COALESCE(blocking_json, '[]')),               COALESCE(blocking_total, 0)),
+            ('closed_by_pr', JSONLength(COALESCE(closed_by_pull_requests_json, '[]')), COALESCE(closed_by_pull_requests_total, 0))
+        ]) AS s
+    FROM {{ source('bronze_github', 'issue_links') }} FINAL
+)
+
+SELECT
+    insight_source_id,
+    id_readable,
+    s.1 AS link_set,
+    s.2 AS collected,
+    s.3 AS stated_by_vendor
+FROM sets
+WHERE s.2 < s.3
+LIMIT 100

--- a/src/ingestion/dbt/tests/task/assert_link_intervals_are_sane.sql
+++ b/src/ingestion/dbt/tests/task/assert_link_intervals_are_sane.sql
@@ -1,0 +1,33 @@
+-- An interval that cannot have happened.
+--
+-- Three shapes, and the second is why this test exists. ClickHouse answers an
+-- ASOF LEFT JOIN that matched nothing with the column TYPE'S DEFAULT rather
+-- than NULL, so a link that was never removed reads as removed at the epoch —
+-- a date, which every range query believes. The same failure has already been
+-- shipped twice in this repository under a different aggregate, so it is
+-- guarded here rather than reasoned about.
+--
+--   1. `valid_to` at or before `valid_from` — the link ended before it began.
+--   2. `valid_to` at the epoch — the unmatched-join default leaking through.
+--   3. `valid_from` at the epoch while `valid_from_known = 1` — the row claims
+--      the vendor stated a moment that is the sentinel for "unknown".
+
+SELECT
+    insight_source_id,
+    data_source,
+    id_readable,
+    link_type,
+    target_readable,
+    valid_from,
+    valid_to,
+    valid_from_known,
+    multiIf(
+        valid_to IS NOT NULL AND valid_to <= valid_from, 'ends before it begins',
+        valid_to = toDateTime64(0, 3),                   'closed at the epoch: an unmatched join default',
+        'valid_from is the unknown sentinel but is marked known'
+    ) AS finding
+FROM {{ ref('class_task_links') }} FINAL
+WHERE (valid_to IS NOT NULL AND valid_to <= valid_from)
+   OR valid_to = toDateTime64(0, 3)
+   OR (valid_from = toDateTime64(0, 3) AND valid_from_known = 1)
+LIMIT 100

--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -77,6 +77,41 @@ for migration in "$SCRIPT_DIR/migrations"/*.sql; do
   run_ch < "$migration"
 done
 
+echo "=== Healing GitHub Projects V2 bronze keys ==="
+# Both relations were briefly keyed with the collection day inside `unique_key`.
+# That keeps every observation permanently current instead of collapsing onto
+# the entity — the shape `union_by_tag` names outright (ADR-0001, ADR-0004).
+#
+# The rows cannot be repaired in place, because the key IS the identity: a
+# day-keyed row and its entity-keyed replacement are different rows forever, and
+# no merge will ever reconcile them. Bronze is derivable from the API, so the
+# stale generation is dropped instead.
+#
+# Guarded on the stale rows themselves, so this is a no-op on a fresh cluster
+# and a no-op on the second deploy. It must run BEFORE dbt: the SCD2 snapshots
+# above these tables key on `unique_key`, and a day-keyed row would enter them
+# as its own entity and stay there.
+#
+# `project_fields` is full refresh, so the next sync rewrites it whole.
+# `project_items` is cursored, so it refills as the cursor advances — clearing
+# that stream's state makes it immediate. Nothing reads either relation yet, so
+# the gap costs nothing either way.
+heal_github_project_day_keys() {
+  local table="$1" stale
+  ch_table_exists bronze_github "${table}" || return 0
+  stale="$(printf "SELECT count() FROM bronze_github.%s WHERE match(unique_key, ':[0-9]{4}-[0-9]{2}-[0-9]{2}$')" \
+    "${table}" | _ch_http_query | tr -d '[:space:]')"
+  [[ "${stale}" =~ ^[0-9]+$ ]] || return 0
+  [[ "${stale}" -gt 0 ]] || return 0
+  echo "  bronze_github.${table}: ${stale} day-keyed row(s) — dropping, the connector refills them"
+  run_ch <<SQL
+TRUNCATE TABLE bronze_github.${table};
+SQL
+}
+
+heal_github_project_day_keys project_fields
+heal_github_project_day_keys project_items
+
 echo "=== Healing AI staging contract schemas ==="
 # Physical column order must equal the model's SELECT order (positional
 # incremental inserts, positional union). Labels left the contract (they

--- a/src/ingestion/scripts/connectors-ddl/github.sql
+++ b/src/ingestion/scripts/connectors-ddl/github.sql
@@ -194,6 +194,31 @@ ORDER BY unique_key
 SETTINGS allow_nullable_key = 1, index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS bronze_github.issue_links
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `repo_full_name` Nullable(String),
+    `item_number` Nullable(Int64),
+    `updated_at` Nullable(String),
+    `parent_json` Nullable(String),
+    `sub_issues_json` Nullable(String),
+    `blocked_by_json` Nullable(String),
+    `blocking_json` Nullable(String),
+    `closed_by_pull_requests_json` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_github.issue_timeline_events
 (
     `_airbyte_raw_id` String,
@@ -226,7 +251,11 @@ CREATE TABLE IF NOT EXISTS bronze_github.issue_timeline_events
     `new_options_json` Nullable(String),
     `project_id` Nullable(String),
     `project_number` Nullable(Int64),
-    `was_automated` Nullable(Bool)
+    `was_automated` Nullable(Bool),
+    `link_target_type` Nullable(String),
+    `link_target_number` Nullable(Int64),
+    `link_target_repo_full_name` Nullable(String),
+    `is_cross_repository` Nullable(Bool)
 )
 ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
 ORDER BY unique_key
@@ -310,7 +339,6 @@ CREATE TABLE IF NOT EXISTS bronze_github.project_fields
     `source_id` Nullable(String),
     `data_source` Nullable(String),
     `collected_at` Nullable(String),
-    `snapshot_date` Nullable(String),
     `project_id` Nullable(String),
     `project_number` Nullable(Int64),
     `field_id` Nullable(String),

--- a/src/ingestion/scripts/connectors-ddl/github.sql
+++ b/src/ingestion/scripts/connectors-ddl/github.sql
@@ -212,7 +212,11 @@ CREATE TABLE IF NOT EXISTS bronze_github.issue_links
     `sub_issues_json` Nullable(String),
     `blocked_by_json` Nullable(String),
     `blocking_json` Nullable(String),
-    `closed_by_pull_requests_json` Nullable(String)
+    `closed_by_pull_requests_json` Nullable(String),
+    `sub_issues_total` Nullable(Int64),
+    `blocked_by_total` Nullable(Int64),
+    `blocking_total` Nullable(Int64),
+    `closed_by_pull_requests_total` Nullable(Int64)
 )
 ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
 ORDER BY unique_key

--- a/src/ingestion/scripts/connectors-ddl/silver.sql
+++ b/src/ingestion/scripts/connectors-ddl/silver.sql
@@ -947,6 +947,31 @@ ORDER BY unique_key
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS silver.class_task_links
+(
+    `unique_key` String,
+    `insight_source_id` String,
+    `data_source` String,
+    `id_readable` String,
+    `link_type` String,
+    `target_type` Enum8('issue' = 1, 'pull_request' = 2),
+    `target_readable` String,
+    `is_cross_repository` Bool,
+    `valid_from` DateTime64(3),
+    `valid_from_known` UInt8,
+    `valid_to` Nullable(DateTime64(3)),
+    `added_by` Nullable(String),
+    `removed_by` Nullable(String),
+    `evidence` Enum8('event' = 1, 'observation' = 2),
+    `origin_event_id` Nullable(String),
+    `collected_at` DateTime64(3),
+    `_version` UInt64
+)
+ENGINE = ReplacingMergeTree(_version)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS silver.class_task_projects
 (
     `unique_key` Nullable(String),

--- a/src/ingestion/silver/task-tracking/class_task_links.sql
+++ b/src/ingestion/silver/task-tracking/class_task_links.sql
@@ -1,0 +1,43 @@
+-- depends_on: {{ ref('github__task_links') }}
+{{ config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key='unique_key',
+    schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
+    tags=['silver']
+) }}
+
+-- Unified, source-neutral record of the links between work items, as
+-- INTERVALS rather than as a current set: one row per link occurrence, open at
+-- `valid_from`, closed at `valid_to`, still open when `valid_to` is NULL.
+--
+-- Reading the links that existed over a window is a range predicate:
+--
+--   WHERE valid_from < :to AND (valid_to IS NULL OR valid_to > :from)
+--
+-- and the links as of an instant is the same predicate with one point.
+--
+-- Both directions of a link are stored. A parent-child pair produces a
+-- `sub_issue` row on the parent and a `parent` row on the child, because each
+-- side is a fact about that side and collecting one issue must not depend on
+-- having collected the other.
+--
+-- `evidence` distinguishes an interval folded from the vendor's own add and
+-- remove events from one bounded by successive observations. A consumer that
+-- mixes them without noticing is comparing a second-accurate edge with one
+-- that is only known to a sync, so the column is not decoration.
+--
+-- `valid_from_known = 0` marks a lower bound rather than a fact: the link was
+-- already there when collection began, or was only ever seen in a snapshot.
+-- Filtering it out silently drops the oldest links, which are exactly the ones
+-- a long window asks about.
+
+SELECT * FROM (
+    {{ union_by_tag('silver:class_task_links') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/task-tracking/schema.yml
+++ b/src/ingestion/silver/task-tracking/schema.yml
@@ -108,6 +108,52 @@ models:
         tests:
           - not_null
 
+  - name: class_task_links
+    description: >
+      Links between work items as INTERVALS, one row per link occurrence: `valid_from` when it appeared,
+      `valid_to` when it went away, NULL while it is still there. The links over a window are a range
+      predicate — `valid_from < :to AND (valid_to IS NULL OR valid_to > :from)` — and the links at an
+      instant are the same predicate with one point. A link removed and re-added is two rows, so
+      `valid_from` is part of the key rather than a version of one row. Both directions are stored: a
+      parent-child pair yields a `sub_issue` row on the parent and a `parent` row on the child.
+    columns:
+      - name: insight_source_id
+        tests:
+          - not_null
+      - name: id_readable
+        description: "The item the link belongs to, as the tracker addresses it (`owner/repo#12`)."
+        tests:
+          - not_null
+      - name: link_type
+        description: "parent | sub_issue | blocked_by | blocking | duplicate_of | connected | closed_by_pr."
+        tests:
+          - not_null
+      - name: target_type
+        description: "What sits at the other end: issue | pull_request."
+      - name: target_readable
+        description: "The other end, addressed the same way. Carries its own repository, because a link may cross repositories."
+        tests:
+          - not_null
+      - name: valid_from
+        description: "When the link appeared. A lower bound rather than a fact when `valid_from_known = 0`."
+        tests:
+          - not_null
+      - name: valid_to
+        description: "When it went away; NULL while it is still there."
+      - name: valid_from_known
+        description: >
+          1 when the vendor stated the moment the link appeared. 0 when the link was already there before
+          collection began, or is known only from successive observations — the interval is still usable,
+          but its lower edge is a bound. Filtering these out drops the oldest links.
+      - name: evidence
+        description: >
+          `event` — folded from the vendor's own add and remove events, exact to the second.
+          `observation` — bounded by first-seen and last-seen across snapshots, so each edge lies between
+          two syncs. No link type is ever built from both, because their precision differs.
+        tests:
+          - accepted_values:
+              values: ['event', 'observation']
+
   - name: class_task_statuses
     description: "Unified, source-neutral status dimension. Maps each source status id to the reconciled lifecycle `status_category` (new/in_progress/done/undefined). Jira derives it from statusCategory; YouTrack from the State bundle `isResolved` flag. Gold detects a closed task via `status_category='done'` — never a localized status name (issue #1541)."
     columns:

--- a/src/ingestion/silver/task-tracking/schema.yml
+++ b/src/ingestion/silver/task-tracking/schema.yml
@@ -117,7 +117,15 @@ models:
       `valid_from` is part of the key rather than a version of one row. Both directions are stored: a
       parent-child pair yields a `sub_issue` row on the parent and a `parent` row on the child.
     columns:
+      - name: unique_key
+        description: "Source, item, link type, target and `valid_from` — the occurrence, not the link."
+        tests:
+          - not_null
       - name: insight_source_id
+        tests:
+          - not_null
+      - name: data_source
+        description: "Vendor that recorded the link; `github` today."
         tests:
           - not_null
       - name: id_readable
@@ -153,6 +161,16 @@ models:
         tests:
           - accepted_values:
               values: ['event', 'observation']
+      - name: is_cross_repository
+        description: "The two ends live in different repositories. Derived by comparing them, because only some event types report it."
+      - name: added_by
+        description: "Who created the link, where the vendor names an actor; NULL for an observed link or an addition that predates collection."
+      - name: removed_by
+        description: "Who removed it; NULL while the link is still there."
+      - name: origin_event_id
+        description: "The vendor event the interval was folded from; NULL for an observed interval."
+      - name: collected_at
+        description: "When the evidence behind this row was collected."
 
   - name: class_task_statuses
     description: "Unified, source-neutral status dimension. Maps each source status id to the reconciled lifecycle `status_category` (new/in_progress/done/undefined). Jira derives it from statusCategory; YouTrack from the State bundle `isResolved` flag. Gold detects a closed task via `status_category='done'` — never a localized status name (issue #1541)."

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_github.issue_links.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_github.issue_links.yaml
@@ -1,6 +1,6 @@
-# Mirrors the bronze_github.project_fields DDL in scripts/connectors-ddl/github.sql.
+# Mirrors the bronze_github.issue_links DDL in scripts/connectors-ddl/github.sql.
 schemas:
-  bronze_github.project_fields:
+  bronze_github.issue_links:
     $schema: http://json-schema.org/draft-07/schema#
     type: object
     additionalProperties: false
@@ -20,17 +20,12 @@ schemas:
       source_id: *id001
       data_source: *id001
       collected_at: *id001
-      project_id: *id001
-      project_number: &id002
+      repo_full_name: *id001
+      item_number:
         type: integer
-      field_id: *id001
-      field_database_id: *id001
-      field_name: *id001
-      data_type: *id001
-      is_multi: &id003
-        type: boolean
-      is_mirror: *id003
-      is_issue_field: *id003
-      options_json: *id001
-      configuration_json: *id001
-      field_updated_at: *id001
+      updated_at: *id001
+      parent_json: *id001
+      sub_issues_json: *id001
+      blocked_by_json: *id001
+      blocking_json: *id001
+      closed_by_pull_requests_json: *id001

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_github.issue_links.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_github.issue_links.yaml
@@ -29,3 +29,8 @@ schemas:
       blocked_by_json: *id001
       blocking_json: *id001
       closed_by_pull_requests_json: *id001
+      sub_issues_total: &id002
+        type: integer
+      blocked_by_total: *id002
+      blocking_total: *id002
+      closed_by_pull_requests_total: *id002

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_github.issue_timeline_events.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_github.issue_timeline_events.yaml
@@ -57,3 +57,16 @@ schemas:
         type:
         - boolean
         - 'null'
+      link_target_type: &id004
+        type:
+        - string
+        - 'null'
+      link_target_number:
+        type:
+        - integer
+        - 'null'
+      link_target_repo_full_name: *id004
+      is_cross_repository:
+        type:
+        - boolean
+        - 'null'

--- a/src/ingestion/tests/e2e/metrics/templates/github_task.yaml
+++ b/src/ingestion/tests/e2e/metrics/templates/github_task.yaml
@@ -194,7 +194,6 @@ templates:
     source_id: github-test
     data_source: github
     collected_at: "2026-03-01T00:00:00Z"
-    snapshot_date: "2026-03-01"
     project_id: PVT_board1
     project_number: 40
     field_id: PVTSSF_board1_status


### PR DESCRIPTION
Refs #2908. Two separable changes: a fix to how the Projects V2 relations are keyed, and link collection built on top of it.

**Why.** Nothing was collected about how work items relate — which issue blocked which, what an epic contained, which pull request closed an issue. Separately, both board relations shipped with the collection day inside `unique_key`, which stops the ReplacingMergeTree ever collapsing them.

**What changed.** Links come from twelve new timeline event types plus a new `issue_links` stream, and land in `silver.class_task_links` as INTERVALS — `valid_from`, `valid_to` NULL while the link is still there — so the links held over a window are a range predicate. The board relations are re-keyed on the entity, with history moved to the shared `snapshot()` / `fields_history()` macros. Mechanism in `feature-work-item-links/DESIGN.md` and `feature-github-projects/DESIGN.md` §3.

**Two sources, never mixed.** Hierarchy and dependency links emit matching add/remove pairs and fold exactly; a pull request closing an issue reaches the timeline as a connection, as a cross-reference claiming it will NOT close the issue, or not at all. So that kind is observed and the rest are folded, and `evidence` records which bounded each interval.

**`valid_from` is part of the key, and is not the mistake this PR fixes.** A link removed and re-added is two occurrences and two rows — the identity of an occurrence, not a version of one row. The day-in-key it replaces was the latter, which `union_by_tag` forbids outright (ADR-0001, ADR-0004).

**Old rows heal themselves.** A guarded step in `apply-ch-migrations.sh` drops the day-keyed generation where it exists, so it no-ops on a fresh cluster and on the second deploy. It cannot be repaired in place: the key is the identity, so a day-keyed row and its replacement are different rows forever.

**Out of scope.** A gold consumer, cross-references (a mention has no removal, so it is a point and not an interval), and the Jira side — recorded in `DESIGN.md` §7.

**Verified.** 38 mock tests; both new queries read against the live GitHub API; eight dbt models built against ClickHouse with the interval semantics checked over a seeded history, where a re-added link yields two rows and point and range queries answer as designed; e2e metrics 86/86. One gap: no metric reads links, so their correctness rests on those queries rather than on a fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub work-item link tracking for parent, sub-issue, blocking, duplicate, and pull-request relationships.
  * Added time-bounded link history, including both relationship directions and evidence sources.
  * Added GitHub Projects field and card history tracking.
* **Improvements**
  * Expanded timeline event support for relationship changes and cross-repository targets.
  * Updated Projects data handling so repeated collections reflect current state while preserving history.
* **Maintenance**
  * Added migration safeguards and validation for incomplete link sets and invalid relationship intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->