### PR TITLE
feat(gitops): scrape cAdvisor and kube-state-metrics via Alloy

### DIFF
--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -161,6 +161,16 @@ ALLOY_RELEASE    ?= alloy
 ALLOY_CHART      ?= grafana/alloy
 ALLOY_VERSION    ?= 1.12.1     # app v1.19.2
 
+# Second Alloy release for METRICS collection (kubelet/cAdvisor +
+# kube-state-metrics → VictoriaMetrics). Same chart and version as the log
+# collector so the config dialect is identical; single-replica Deployment
+# because every scrape target is cluster-wide.
+ALLOY_METRICS_RELEASE ?= alloy-metrics
+
+KUBE_STATE_METRICS_RELEASE ?= kube-state-metrics
+KUBE_STATE_METRICS_CHART   ?= prometheus-community/kube-state-metrics
+KUBE_STATE_METRICS_VERSION ?= 8.4.1   # app v2.20.0
+
 GRAFANA_RELEASE  ?= grafana
 # grafana/grafana is deprecated (frozen 2026-01-30); development moved to
 # grafana-community/helm-charts. Alloy still lives in the old repo.
@@ -231,6 +241,8 @@ help:
 	@echo "  make system-loki ENV=$(ENV)               }"
 	@echo "  make system-tempo ENV=$(ENV)              }"
 	@echo "  make system-alloy ENV=$(ENV)              } L2 — observability (LGTM, bundled mode)."
+	@echo "  make system-kube-state-metrics ENV=$(ENV) }"
+	@echo "  make system-alloy-metrics ENV=$(ENV)      }   (infra metrics → VictoriaMetrics)"
 	@echo "  make system-grafana ENV=$(ENV)            }"
 	@echo "  make system-status ENV=$(ENV)             Show what's installed in insight-infra"
 	@echo "  make provision-ci ENV=$(ENV)      Provision the namespace-scoped CI deploy credential"
@@ -637,6 +649,8 @@ system: inventory-present vpn-up kube-ctx
 	$(call _run_if_enabled,system.loki,system-loki)
 	$(call _run_if_enabled,system.tempo,system-tempo)
 	$(call _run_if_enabled,system.alloy,system-alloy)
+	$(call _run_if_enabled,system.kubeStateMetrics,system-kube-state-metrics)
+	$(call _run_if_enabled,system.alloyMetrics,system-alloy-metrics)
 	$(call _run_if_enabled,system.grafana,system-grafana)
 	@echo "$(C_GRN)system complete$(C_RST) → $(NS_INFRA)"
 
@@ -781,6 +795,28 @@ system-alloy: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(ALLOY_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,alloy) \
+		--wait --timeout 5m
+
+# Infra metrics: kube-state-metrics first (alloy-metrics scrapes it),
+# then the alloy-metrics scraper. Both remote-write into VictoriaMetrics.
+.PHONY: system-kube-state-metrics
+system-kube-state-metrics: vpn-up kube-ctx
+	@$(call _helm_repo_add,prometheus-community,https://prometheus-community.github.io/helm-charts)
+	$(call _apply_optional_system_secrets,kube-state-metrics)
+	helm upgrade --install $(KUBE_STATE_METRICS_RELEASE) $(KUBE_STATE_METRICS_CHART) \
+		--namespace $(NS_INFRA) --create-namespace \
+		--version $(KUBE_STATE_METRICS_VERSION) $(HELM_EXTRA_FLAGS) \
+		$(call _system_values_args,kube-state-metrics) \
+		--wait --timeout 5m
+
+.PHONY: system-alloy-metrics
+system-alloy-metrics: vpn-up kube-ctx
+	@$(call _helm_repo_add,grafana,https://grafana.github.io/helm-charts)
+	$(call _apply_optional_system_secrets,alloy-metrics)
+	helm upgrade --install $(ALLOY_METRICS_RELEASE) $(ALLOY_CHART) \
+		--namespace $(NS_INFRA) --create-namespace \
+		--version $(ALLOY_VERSION) $(HELM_EXTRA_FLAGS) \
+		$(call _system_values_args,alloy-metrics) \
 		--wait --timeout 5m
 
 .PHONY: system-grafana

--- a/deploy/gitops/environments/functional-ci/inventory.yaml
+++ b/deploy/gitops/environments/functional-ci/inventory.yaml
@@ -45,6 +45,8 @@ system:
   loki: false
   tempo: false
   alloy: false
+  kubeStateMetrics: false
+  alloyMetrics: false
   grafana: false
 
 secrets:

--- a/deploy/gitops/environments/local/inventory.yaml.template
+++ b/deploy/gitops/environments/local/inventory.yaml.template
@@ -54,6 +54,10 @@ system:
   loki:            false
   tempo:           false
   alloy:           false
+  # Infra metrics (kubelet/cAdvisor + kube-state-metrics → VictoriaMetrics).
+  # Needs victoriametrics on.
+  kubeStateMetrics: false
+  alloyMetrics:     false
   grafana:         false
 
 # ─── Secrets (drives `make seal`) ──────────────────────────────────────

--- a/deploy/gitops/environments/test-stand/inventory.yaml
+++ b/deploy/gitops/environments/test-stand/inventory.yaml
@@ -212,6 +212,8 @@ system:
   loki: false
   tempo: false
   alloy: false
+  kubeStateMetrics: false
+  alloyMetrics: false
   grafana: false
 
 # ─── Secrets (drives `make seal`) ──────────────────────────────────────

--- a/deploy/gitops/system/README.md
+++ b/deploy/gitops/system/README.md
@@ -26,9 +26,11 @@ model and full workflow.
 | `loki/` | `grafana-community/loki` | `loki` | not in baseline (single-tenant, no auth) |
 | `tempo/` | `grafana-community/tempo` | `tempo` | not in baseline |
 | `alloy/` | `grafana/alloy` | `alloy` | not in baseline |
+| `kube-state-metrics/` | `prometheus-community/kube-state-metrics` | `kube-state-metrics` | not in baseline |
+| `alloy-metrics/` | `grafana/alloy` | `alloy-metrics` | not in baseline |
 | `grafana/` | `grafana-community/grafana` | `grafana` | not in baseline (chart auto-gens admin pw; per-env overlay may seal `grafana-creds`) |
 
-### Observability (victoriametrics / loki / tempo / alloy / grafana)
+### Observability (victoriametrics / loki / tempo / alloy / kube-state-metrics / alloy-metrics / grafana)
 
 These are the bundled observability stack: VictoriaMetrics stores metrics
 (PromQL-compatible, remote-write receiver at `/api/v1/write`), Loki stores
@@ -39,11 +41,24 @@ to VictoriaMetrics and forwarding the traces to Tempo — and Grafana
 serves all three — provisioned as the fixed-uid
 datasources `vm`, `loki` and `tempo` so dashboards reference them portably;
 a `trace_id` in a JSON log line links to the trace via Loki's
-`derivedFields`. Two independent decisions, mirroring the
+`derivedFields`.
+
+**Infra metrics (kube-state-metrics / alloy-metrics).** Service health
+without touching the services: `alloy-metrics` is a second Alloy release
+(single-replica Deployment — every target is cluster-wide, so a DaemonSet
+would scrape each once per node) that pull-scrapes the kubelet's cAdvisor
+(per-container CPU / memory / network) and the `kube-state-metrics` release
+(pod readiness, container restarts, OOMKills, deployment status),
+remote-writing both into VictoriaMetrics. Enable them together with
+`inventory.system.{kubeStateMetrics,alloyMetrics}`; they need
+`victoriametrics` on to have somewhere to write.
+
+Two independent decisions, mirroring the
 managed-vs-bundled choice for the data stores above:
 
 1. **Install the bundled stack?** — the
-   `inventory.system.{victoriametrics,loki,tempo,alloy,grafana}` toggles.
+   `inventory.system.{victoriametrics,loki,tempo,alloy,kubeStateMetrics,alloyMetrics,grafana}`
+   toggles.
    On = self-host the stack in `insight-infra`. Off = don't (the cluster
    already runs observability, or stdout is enough).
 2. **Where do services export?** — the umbrella's `observability.otlp.endpoint`
@@ -73,8 +88,11 @@ kubectl -n insight-infra get secret grafana -o jsonpath='{.data.admin-password}'
 # Explore → Loki:
 {namespace="insight"}            # service logs
 {component="reconcile-loop"}     # reconcile ticks
-# Explore → VictoriaMetrics (PromQL; empty until a collector remote-writes):
+# Explore → VictoriaMetrics (PromQL; empty until a collector remote-writes —
+# alloy-metrics fills it with per-pod series when enabled):
 up
+container_memory_working_set_bytes{namespace="insight"}
+kube_pod_container_status_restarts_total{namespace="insight"}
 ```
 
 Putting Grafana behind auth is a tracked follow-up: seal a `grafana-creds`

--- a/deploy/gitops/system/alloy-metrics/values.yaml
+++ b/deploy/gitops/system/alloy-metrics/values.yaml
@@ -1,0 +1,128 @@
+##
+## Grafana Alloy — METRICS collector. Second, independent release alongside
+## the `alloy` log/OTLP collector, on the same chart and version so the
+## config dialect is identical. It pull-scrapes what the push pipeline
+## cannot see: the kubelet's cAdvisor (per-container CPU / memory / network
+## for every workload, no application change required) and
+## kube-state-metrics (pod readiness, restarts, OOMKills, deployment
+## status), remote-writing both into VictoriaMetrics.
+##
+## Chart: grafana/alloy
+## Pin in Makefile: ALLOY_VERSION (shared with the log collector)
+## Release: `alloy-metrics` in namespace `insight-infra`.
+##
+## Deployment rather than DaemonSet: every target is discovered
+## cluster-wide, so one replica scrapes the whole cluster; a DaemonSet
+## would scrape every target once per node.
+##
+## Per-env overrides go in environments/<env>/alloy-metrics-values.yaml.
+## `configMap.content` is a single string that helm REPLACES rather than
+## merges — an env that needs extra scrape jobs or series pruning carries
+## the whole config in its overlay.
+##
+
+controller:
+  type: deployment
+  replicas: 1
+
+alloy:
+  clustering:
+    enabled: false
+  resources:
+    requests: { cpu: 100m, memory: 256Mi }
+    limits:   { cpu: "1",  memory: 1Gi }
+  configMap:
+    content: |-
+      // ── Kubelet — cAdvisor + resource metrics ──────────────────────────
+      // Per-container CPU / memory / network for every pod on every node.
+      // The chart's ClusterRole already grants nodes + nodes/metrics +
+      // nonResourceURLs:/metrics, which authorises scraping the kubelet
+      // DIRECTLY on :10250 — the API-server proxy path would need
+      // `nodes/proxy`, which it does not grant. The kubelet's serving cert
+      // is typically self-signed for the node IP, hence insecure_skip_verify.
+      discovery.kubernetes "nodes" {
+        role = "node"
+      }
+
+      discovery.relabel "kubelet" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+      }
+
+      prometheus.scrape "cadvisor" {
+        targets           = discovery.relabel.kubelet.output
+        job_name          = "kubelet-cadvisor"
+        scheme            = "https"
+        metrics_path      = "/metrics/cadvisor"
+        scrape_interval   = "30s"
+        bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        tls_config {
+          insecure_skip_verify = true
+        }
+        forward_to = [prometheus.relabel.drop_noise.receiver]
+      }
+
+      prometheus.scrape "kubelet_resource" {
+        targets           = discovery.relabel.kubelet.output
+        job_name          = "kubelet-resource"
+        scheme            = "https"
+        metrics_path      = "/metrics/resource"
+        scrape_interval   = "30s"
+        bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        tls_config {
+          insecure_skip_verify = true
+        }
+        forward_to = [prometheus.relabel.drop_noise.receiver]
+      }
+
+      // ── kube-state-metrics — object state ──────────────────────────────
+      // Static target: the system-kube-state-metrics release in this
+      // namespace (fullnameOverride pins the Service name).
+      prometheus.scrape "kube_state_metrics" {
+        targets = [
+          {"__address__" = "kube-state-metrics.insight-infra.svc.cluster.local:8080", "job" = "kube-state-metrics"},
+        ]
+        scrape_interval = "30s"
+        forward_to      = [prometheus.relabel.drop_noise.receiver]
+      }
+
+      // ── Series-level pruning, then remote_write ─────────────────────────
+      prometheus.relabel "drop_noise" {
+        // kubelet /metrics/resource re-exports cAdvisor's container_cpu/
+        // memory families under job=kubelet-resource — with both jobs
+        // stored, every sum() across them double-counts. cAdvisor stays the
+        // single source for container_* series.
+        rule {
+          source_labels = ["__name__", "job"]
+          regex         = "container_[^;]*;kubelet-resource"
+          action        = "drop"
+        }
+        // Container-scoped families are emitted twice: once per container
+        // and once as a pod-level roll-up with container="". Drop the
+        // roll-up. The families are listed explicitly rather than matched
+        // as `container_.*` because container_network_* is ONLY ever
+        // pod-level (it legitimately has container="") — a blanket rule
+        // would delete every network series.
+        rule {
+          source_labels = ["__name__", "container"]
+          regex         = "container_(cpu|memory|fs|blkio|file|last_seen|processes|sockets|start_time|spec|tasks|threads|ulimits)[^;]*;"
+          action        = "drop"
+        }
+        // The host's systemd slice tree is not a workload.
+        rule {
+          source_labels = ["id"]
+          regex         = "/system\\.slice.*|/user\\.slice.*|/init\\.scope"
+          action        = "drop"
+        }
+
+        forward_to = [prometheus.remote_write.victoriametrics.receiver]
+      }
+
+      prometheus.remote_write "victoriametrics" {
+        endpoint {
+          url = "http://victoriametrics-server.insight-infra.svc.cluster.local:8428/api/v1/write"
+        }
+      }

--- a/deploy/gitops/system/kube-state-metrics/values.yaml
+++ b/deploy/gitops/system/kube-state-metrics/values.yaml
@@ -1,0 +1,54 @@
+##
+## kube-state-metrics — Kubernetes object state as metrics: pod readiness,
+## container restarts, OOMKills, deployment/statefulset status. The
+## `alloy-metrics` release scrapes it over the Service on :8080 and
+## remote-writes into VictoriaMetrics.
+##
+## Chart: prometheus-community/kube-state-metrics
+## Pin in Makefile: KUBE_STATE_METRICS_VERSION
+## Release: `kube-state-metrics` in namespace `insight-infra`.
+##
+## Per-env overrides go in environments/<env>/kube-state-metrics-values.yaml
+## — custom-resource metrics (e.g. Argo Workflow phase) belong there, since
+## the CRDs present differ per cluster.
+##
+
+# The alloy-metrics scrape config addresses the Service by this exact name;
+# don't let a release-name change move it.
+fullnameOverride: kube-state-metrics
+
+replicas: 1
+
+resources:
+  requests: { cpu: 20m,  memory: 64Mi }
+  limits:   { cpu: 200m, memory: 256Mi }
+
+service:
+  type: ClusterIP
+
+# Only the collectors that answer a question the dashboards ask. The chart's
+# default set covers ~35 resources (certificatesigningrequests, leases,
+# ingressclasses, volumeattachments, …) whose series would be pure noise.
+collectors:
+  - cronjobs
+  - daemonsets
+  - deployments
+  - jobs
+  - namespaces
+  - nodes
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - replicasets
+  - statefulsets
+
+# Cluster-wide: the workloads live in `insight`, the data stores in
+# `insight-infra`.
+namespaces: ""
+
+selfMonitor:
+  enabled: false
+
+prometheus:
+  monitor:
+    enabled: false # no prometheus-operator assumed; alloy-metrics scrapes statically


### PR DESCRIPTION
Closes #2887.

**Why.** The bundled stack only sees what services push over OTLP — VictoriaMetrics holds no per-pod CPU/memory/restart series, so container and deployment health on a stand is invisible in Grafana.

**What changed.** Two new L2 releases: `kube-state-metrics`, and `alloy-metrics` — a single-replica Alloy Deployment on the shared `ALLOY_VERSION` pin that scrapes the kubelet's cAdvisor + `/metrics/resource` directly on :10250 and the kube-state-metrics Service, remote-writing both into VictoriaMetrics. Inventory toggles (`system.{kubeStateMetrics,alloyMetrics}`, off everywhere in-repo like the rest of the bundled stack) and `make system-*` targets wire them into `make system`.

**A second release, Deployment, not the existing `alloy` DaemonSet.** Every scrape target is cluster-wide, so a DaemonSet would scrape each once per node — and a separate release keeps a metrics config change from restarting log collection. Trivial to fold back in later.

**A relabel stage drops the three known noise sources.** `container_*` re-exported by `/metrics/resource` (with both jobs stored, every `sum()` double-counts), the pod-level `container=""` roll-ups (families enumerated — `container_network_*` is only ever pod-level and must survive), and the host systemd slice tree.

**Out of scope.** Per-env series pruning of one-shot pods and custom-resource metrics (Argo Workflow phase) — both belong in per-env overlays; Grafana dashboards over these series are a separate EPIC item.

**Verified.** Rendered config passes `alloy validate` on the pinned app v1.19.2; both charts `helm template` cleanly with the baseline values; the alloy chart's ClusterRole grants `nodes/metrics` + `/metrics` in the rendered manifests, so direct kubelet scraping is authorised.
