### PR TITLE
fix(gitops-sample): inventory-driven Gateway namespaces; admit previews; unbreak test-stand

### DIFF
--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -49,6 +49,7 @@ INVENTORY        := environments/$(ENV)/inventory.yaml
 KUBE_CTX         ?= $(shell yq -r '.kubeContext // ""' $(INVENTORY) 2>/dev/null)
 NS_APP           ?= $(shell yq -r '.namespaces.services // "insight"'        $(INVENTORY) 2>/dev/null)
 NS_INFRA         ?= $(shell yq -r '.namespaces.infra    // "insight-infra"'  $(INVENTORY) 2>/dev/null)
+NS_PREVIEWS      ?= $(shell yq -r '.namespaces.previews // "insight-previews"' $(INVENTORY) 2>/dev/null)
 RELEASE          ?= $(shell yq -r '.release             // "insight"'        $(INVENTORY) 2>/dev/null)
 
 # Back-compat alias for older targets still referencing NAMESPACE.
@@ -264,7 +265,7 @@ help:
 	@echo
 	@echo "Resolved values (inventory + CLI/env overrides):"
 	@echo "  ENV=$(ENV)  KUBE_CTX=$(KUBE_CTX)  RELEASE=$(RELEASE)"
-	@echo "  NS_APP=$(NS_APP)  NS_INFRA=$(NS_INFRA)"
+	@echo "  NS_APP=$(NS_APP)  NS_INFRA=$(NS_INFRA)  NS_PREVIEWS=$(NS_PREVIEWS)"
 	@echo "  CHART=$(CHART)"
 	@echo "  INSIGHT_VERSION=$(INSIGHT_VERSION)"
 	@echo "  VALUES=$(VALUES)"
@@ -543,6 +544,7 @@ deploy-insight: sync-clean vpn-up kube-ctx confirm values-present chart-present 
 	@mkdir -p $(RENDER_DIR)
 	@helm template $(RELEASE) $(CHART) --version $(INSIGHT_VERSION) $(HELM_EXTRA_FLAGS) \
 		-n $(NS_APP) -f $(VALUES) \
+		--set previews.experiments.namespace=$(NS_PREVIEWS) \
 		> $(RENDER_DIR)/last-render-$(ENV).yaml
 	@echo "$(C_GRN)rendered$(C_RST) $(CHART):$(INSIGHT_VERSION) → $(RENDER_DIR)/last-render-$(ENV).yaml"
 	@# A release whose only revision is a failed install cannot be upgraded, and
@@ -588,6 +590,7 @@ deploy-insight: sync-clean vpn-up kube-ctx confirm values-present chart-present 
 		--version $(INSIGHT_VERSION) $(HELM_EXTRA_FLAGS) $(HELM_UPGRADE_FLAGS) "$${SET_ARGS[@]}" \
 		--namespace $(NS_APP) $(HELM_NS_FLAG) \
 		-f $(VALUES) \
+		--set previews.experiments.namespace=$(NS_PREVIEWS) \
 		--wait $(HELM_ATOMIC_FLAG) --timeout $(TIMEOUT) \
 		--history-max 10 \
 		2>&1 | tee $$LOG || rc=$$?; \
@@ -1191,9 +1194,16 @@ bootstrap-envoy-gateway: vpn-up kube-ctx
 		--version $(ENVOY_GATEWAY_VERSION) $(HELM_EXTRA_FLAGS) \
 		$$VALUES_ARGS \
 		--wait --timeout 5m
+	@# Namespaces come from inventory.yaml (namespaces.*), never hardcoded:
+	@# ${NS_APP} / ${NS_INFRA} / ${NS_PREVIEWS} placeholders in gateway.yaml
+	@# are substituted here. A manifest without placeholders applies as-is.
 	@if [ -f $(BOOTSTRAP_DIR)/gateway.yaml ]; then \
 		echo "applying $(BOOTSTRAP_DIR)/gateway.yaml"; \
-		kubectl --context $(KUBE_CTX) apply -f $(BOOTSTRAP_DIR)/gateway.yaml; \
+		sed -e 's|$${NS_APP}|$(NS_APP)|g' \
+		    -e 's|$${NS_INFRA}|$(NS_INFRA)|g' \
+		    -e 's|$${NS_PREVIEWS}|$(NS_PREVIEWS)|g' \
+		    $(BOOTSTRAP_DIR)/gateway.yaml \
+		| kubectl --context $(KUBE_CTX) apply -f -; \
 	fi
 
 .PHONY: bootstrap-cert-manager

--- a/deploy/gitops/README.md
+++ b/deploy/gitops/README.md
@@ -404,8 +404,9 @@ spec:
             matchExpressions:
               - key: kubernetes.io/metadata.name
                 operator: In
-                # insight-previews: preview-experiment HTTPRoutes attach from there
-                values: [insight, insight-infra, insight-previews]
+                # Substituted from inventory.yaml `namespaces.*` at apply time;
+                # the previews namespace carries the per-experiment HTTPRoutes.
+                values: [${NS_APP}, ${NS_INFRA}, ${NS_PREVIEWS}]
 ```
 
 cert-manager (installed with `config.enableGatewayAPI=true`) watches

--- a/deploy/gitops/README.md
+++ b/deploy/gitops/README.md
@@ -404,7 +404,8 @@ spec:
             matchExpressions:
               - key: kubernetes.io/metadata.name
                 operator: In
-                values: [insight, insight-infra]
+                # insight-previews: preview-experiment HTTPRoutes attach from there
+                values: [insight, insight-infra, insight-previews]
 ```
 
 cert-manager (installed with `config.enableGatewayAPI=true`) watches

--- a/deploy/gitops/bootstrap/functional-ci/gateway.yaml
+++ b/deploy/gitops/bootstrap/functional-ci/gateway.yaml
@@ -29,4 +29,6 @@ spec:
             matchExpressions:
               - key: kubernetes.io/metadata.name
                 operator: In
-                values: [insight, insight-infra]
+                # insight-previews: the previews service's per-experiment
+                # HTTPRoutes attach from there (#1981).
+                values: [insight, insight-infra, insight-previews]

--- a/deploy/gitops/bootstrap/functional-ci/gateway.yaml
+++ b/deploy/gitops/bootstrap/functional-ci/gateway.yaml
@@ -29,6 +29,8 @@ spec:
             matchExpressions:
               - key: kubernetes.io/metadata.name
                 operator: In
-                # insight-previews: the previews service's per-experiment
-                # HTTPRoutes attach from there (#1981).
-                values: [insight, insight-infra, insight-previews]
+                # Substituted from inventory.yaml `namespaces.*` by `make
+                # bootstrap-envoy-gateway` — never hardcode namespaces here.
+                # The previews namespace carries the per-experiment
+                # HTTPRoutes (#1981).
+                values: [${NS_APP}, ${NS_INFRA}, ${NS_PREVIEWS}]

--- a/deploy/gitops/bootstrap/local/gateway.yaml
+++ b/deploy/gitops/bootstrap/local/gateway.yaml
@@ -28,6 +28,8 @@ spec:
             matchExpressions:
               - key: kubernetes.io/metadata.name
                 operator: In
-                # insight-previews: the previews service's per-experiment
-                # HTTPRoutes attach from there (#1981).
-                values: [insight, insight-infra, insight-previews]
+                # Substituted from inventory.yaml `namespaces.*` by `make
+                # bootstrap-envoy-gateway` — never hardcode namespaces here.
+                # The previews namespace carries the per-experiment
+                # HTTPRoutes (#1981).
+                values: [${NS_APP}, ${NS_INFRA}, ${NS_PREVIEWS}]

--- a/deploy/gitops/bootstrap/local/gateway.yaml
+++ b/deploy/gitops/bootstrap/local/gateway.yaml
@@ -28,4 +28,6 @@ spec:
             matchExpressions:
               - key: kubernetes.io/metadata.name
                 operator: In
-                values: [insight, insight-infra]
+                # insight-previews: the previews service's per-experiment
+                # HTTPRoutes attach from there (#1981).
+                values: [insight, insight-infra, insight-previews]

--- a/deploy/gitops/environments/functional-ci/inventory.yaml
+++ b/deploy/gitops/environments/functional-ci/inventory.yaml
@@ -11,6 +11,9 @@ protected: false
 namespaces:
   services: insight
   infra: insight-infra
+  # Preview experiments (#1981): substituted into gateway.yaml's
+  # allowedRoutes and set as previews.experiments.namespace on deploy.
+  previews: insight-previews
 
 release: insight
 

--- a/deploy/gitops/environments/local/inventory.yaml.template
+++ b/deploy/gitops/environments/local/inventory.yaml.template
@@ -17,6 +17,8 @@ protected: false              # true → `make deploy` requires
 namespaces:
   services: insight           # L3 app subcharts
   infra:    insight-infra     # L2 shared stateful
+  previews: insight-previews  # preview experiments (#1981); feeds the
+                              # Gateway allowedRoutes + the previews chart
   # Controller namespaces accept upstream-chart defaults; uncomment
   # only to override.
   # envoyGateway:  envoy-gateway-system

--- a/deploy/gitops/environments/test-stand/values.yaml
+++ b/deploy/gitops/environments/test-stand/values.yaml
@@ -430,6 +430,15 @@ gitCliProxy:
   # skips any connector whose descriptor sets `platform_config.git_proxy`.
   deploy: false
 
+previews:
+  # Off, against the chart default: the subchart emits a Namespace and
+  # Role/RoleBinding in the experiments namespace, and this stand deploys
+  # with the namespace-scoped `ci-deployer` ServiceAccount — the upgrade
+  # dies on `namespaces is forbidden` before anything renders. Turn on only
+  # together with a ci-deployer-rbac.yaml grant for that namespace, when the
+  # stand suite starts exercising previews (#1981).
+  deploy: false
+
 frontend: # the web UI (dashboard)
   replicaCount: 1
   route:


### PR DESCRIPTION
**Why.** The previews service (#2373, merged in #2950) creates per-experiment `HTTPRoute`s in the experiments namespace, but the shared Gateway's `allowedRoutes` selector doesn't admit it — routes never attach. Separately, every test-stand deploy since the previews chart published dies on `namespaces "insight-previews" is forbidden`: the subchart emits a Namespace + cross-namespace RBAC the namespace-scoped `ci-deployer` cannot touch.

**What changed.** `gateway.yaml` stops hardcoding namespaces: `${NS_APP}`/`${NS_INFRA}`/`${NS_PREVIEWS}` placeholders, substituted by `make bootstrap-envoy-gateway` from `inventory.yaml` `namespaces.*` (a manifest without placeholders still applies as-is). `deploy-insight` passes `previews.experiments.namespace=$(NS_PREVIEWS)` so the chart and the Gateway admission derive from the same inventory key. test-stand sets `previews.deploy=false`.

**Namespaces are inventory values, not constants.** `namespaces.previews` defaults to `insight-previews` when absent, so existing inventories need no edit.

**test-stand opts out rather than getting RBAC.** Nothing exercises previews there yet; re-enable together with a `ci-deployer-rbac.yaml` grant. One value to flip.

**Out of scope.** The private stands' half lands in insight-gitops (dev only; the cfabric template admits every namespace via `from: All`).

**Verified.** Substituted manifests parse and both listeners carry all three namespaces; `make -n bootstrap-envoy-gateway ENV=functional-ci` prints the substituted apply. Refs #1981.
