### PR TITLE
feat(gitops-sample): namespace-portable cross-service hostnames in the system layer

### DIFF
--- a/deploy/gitops/Brewfile
+++ b/deploy/gitops/Brewfile
@@ -11,7 +11,7 @@ brew "kubeseal"       # Bitnami sealed-secrets client
 brew "skopeo"         # OCI registry tag listing (optional, for chart-version automation)
 brew "yq"             # YAML editing (image.tag bumps, values reads)
 brew "jq"             # JSON post-processing
-brew "gettext"        # envsubst — argo RBAC templating + system-values namespace rendering
+brew "gettext"        # envsubst — argo RBAC templating (make system-argo)
 brew "gnu-getopt"     # GNU getopt for portable option parsing in scripts (optional)
 
 # Password-manager CLI: integration-specific. `make seal-secret` shells out

--- a/deploy/gitops/Brewfile
+++ b/deploy/gitops/Brewfile
@@ -11,6 +11,7 @@ brew "kubeseal"       # Bitnami sealed-secrets client
 brew "skopeo"         # OCI registry tag listing (optional, for chart-version automation)
 brew "yq"             # YAML editing (image.tag bumps, values reads)
 brew "jq"             # JSON post-processing
+brew "gettext"        # envsubst — argo RBAC templating + system-values namespace rendering
 brew "gnu-getopt"     # GNU getopt for portable option parsing in scripts (optional)
 
 # Password-manager CLI: integration-specific. `make seal-secret` shells out

--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -52,6 +52,19 @@ NS_INFRA         ?= $(shell yq -r '.namespaces.infra    // "insight-infra"'  $(I
 NS_PREVIEWS      ?= $(shell yq -r '.namespaces.previews // "insight-previews"' $(INVENTORY) 2>/dev/null)
 RELEASE          ?= $(shell yq -r '.release             // "insight"'        $(INVENTORY) 2>/dev/null)
 
+# Producer namespaces for the cross-service hostnames in system/*/values.yaml
+# (`loki.${NS_LOKI}.svc.cluster.local` and friends). One variable per producer
+# that another release addresses; every system-* target here installs into
+# NS_INFRA, so they all default to it. Override per invocation (env var / CLI)
+# if an environment hosts a producer elsewhere. render-system-values.sh
+# substitutes them before helm reads the values — see _system_values_args.
+NS_LOKI               ?= $(NS_INFRA)
+NS_TEMPO              ?= $(NS_INFRA)
+NS_VICTORIAMETRICS    ?= $(NS_INFRA)
+NS_KUBE_STATE_METRICS ?= $(NS_INFRA)
+NS_CLICKHOUSE         ?= $(NS_INFRA)
+NS_REDPANDA           ?= $(NS_INFRA)
+
 # Back-compat alias for older targets still referencing NAMESPACE.
 NAMESPACE        ?= $(NS_APP)
 CHART            ?= oci://ghcr.io/constructorfabric/charts/insight
@@ -661,9 +674,17 @@ define _helm_repo_add
 	helm repo add $(1) $(2) >/dev/null 2>&1 || true; helm repo update $(1) >/dev/null
 endef
 
-# Helper: render `-f system/<svc>/values.yaml [-f environments/<env>/<svc>-values.yaml]`
+# Helper: render `-f <base> [-f <overlay>]` for system/<svc>/values.yaml and
+# environments/<env>/<svc>-values.yaml. Values are NOT passed to helm verbatim:
+# render-system-values.sh resolves the ${NS_*} producer-namespace placeholders
+# (envsubst with an explicit allowlist — Grafana `$VAR`/`$$VAR` provisioning
+# escapes and any other `$` syntax pass through untouched) into
+# $(RENDER_DIR)/system-values/ and helm reads the rendered copies.
 # Usage: $(call _system_values_args,<svc>)
-_system_values_args = -f system/$(1)/values.yaml $(shell test -s environments/$(ENV)/$(1)-values.yaml && echo -f environments/$(ENV)/$(1)-values.yaml)
+_system_ns_env = NS_INFRA=$(NS_INFRA) NS_LOKI=$(NS_LOKI) NS_TEMPO=$(NS_TEMPO) \
+	NS_VICTORIAMETRICS=$(NS_VICTORIAMETRICS) NS_KUBE_STATE_METRICS=$(NS_KUBE_STATE_METRICS) \
+	NS_CLICKHOUSE=$(NS_CLICKHOUSE) NS_REDPANDA=$(NS_REDPANDA)
+_system_values_args = $(or $(shell $(_system_ns_env) bash scripts/render-system-values.sh $(1) $(ENV) $(RENDER_DIR)/system-values),$(error render-system-values.sh failed for '$(1)' — see the message above))
 
 # Helper: require a sealed-secret named `<svc>-creds` to be present in
 # the repo for this env. Apply it to $(NS_INFRA). If missing, print

--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -52,18 +52,15 @@ NS_INFRA         ?= $(shell yq -r '.namespaces.infra    // "insight-infra"'  $(I
 NS_PREVIEWS      ?= $(shell yq -r '.namespaces.previews // "insight-previews"' $(INVENTORY) 2>/dev/null)
 RELEASE          ?= $(shell yq -r '.release             // "insight"'        $(INVENTORY) 2>/dev/null)
 
-# Producer namespaces for the cross-service hostnames in system/*/values.yaml
-# (`loki.${NS_LOKI}.svc.cluster.local` and friends). One variable per producer
-# that another release addresses; every system-* target here installs into
-# NS_INFRA, so they all default to it. Override per invocation (env var / CLI)
-# if an environment hosts a producer elsewhere. render-system-values.sh
-# substitutes them before helm reads the values — see _system_values_args.
-NS_LOKI               ?= $(NS_INFRA)
-NS_TEMPO              ?= $(NS_INFRA)
-NS_VICTORIAMETRICS    ?= $(NS_INFRA)
-NS_KUBE_STATE_METRICS ?= $(NS_INFRA)
-NS_CLICKHOUSE         ?= $(NS_INFRA)
-NS_REDPANDA           ?= $(NS_INFRA)
+# Namespaces for the cross-service hostnames in system/*/values.yaml
+# (`loki.${NS_MONITORING}.svc.cluster.local` and friends), substituted by
+# render-system-values.sh before helm reads the values — see
+# _system_values_args. Data stores are addressed via ${NS_INFRA}; the
+# observability stack (LGTM + kube-state-metrics) via ${NS_MONITORING}, one
+# unit that an environment may host apart from the data stores. Every
+# system-* target here installs into NS_INFRA, so it defaults to that —
+# override per invocation (env var / CLI) if the stack lives elsewhere.
+NS_MONITORING    ?= $(NS_INFRA)
 
 # Back-compat alias for older targets still referencing NAMESPACE.
 NAMESPACE        ?= $(NS_APP)
@@ -681,9 +678,7 @@ endef
 # any other `$` syntax pass through untouched) into
 # $(RENDER_DIR)/system-values/ and helm reads the rendered copies.
 # Usage: $(call _system_values_args,<svc>)
-_system_ns_env = NS_INFRA=$(NS_INFRA) NS_LOKI=$(NS_LOKI) NS_TEMPO=$(NS_TEMPO) \
-	NS_VICTORIAMETRICS=$(NS_VICTORIAMETRICS) NS_KUBE_STATE_METRICS=$(NS_KUBE_STATE_METRICS) \
-	NS_CLICKHOUSE=$(NS_CLICKHOUSE) NS_REDPANDA=$(NS_REDPANDA)
+_system_ns_env = NS_INFRA=$(NS_INFRA) NS_MONITORING=$(NS_MONITORING)
 _system_values_args = $(or $(shell $(_system_ns_env) bash scripts/render-system-values.sh $(1) $(ENV) $(RENDER_DIR)/system-values),$(error render-system-values.sh failed for '$(1)' — see the message above))
 
 # Helper: require a sealed-secret named `<svc>-creds` to be present in

--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -677,8 +677,8 @@ endef
 # Helper: render `-f <base> [-f <overlay>]` for system/<svc>/values.yaml and
 # environments/<env>/<svc>-values.yaml. Values are NOT passed to helm verbatim:
 # render-system-values.sh resolves the ${NS_*} producer-namespace placeholders
-# (envsubst with an explicit allowlist — Grafana `$VAR`/`$$VAR` provisioning
-# escapes and any other `$` syntax pass through untouched) into
+# (exact braced tokens only — Grafana `$VAR`/`$$VAR` provisioning escapes and
+# any other `$` syntax pass through untouched) into
 # $(RENDER_DIR)/system-values/ and helm reads the rendered copies.
 # Usage: $(call _system_values_args,<svc>)
 _system_ns_env = NS_INFRA=$(NS_INFRA) NS_LOKI=$(NS_LOKI) NS_TEMPO=$(NS_TEMPO) \

--- a/deploy/gitops/scripts/doctor.sh
+++ b/deploy/gitops/scripts/doctor.sh
@@ -50,6 +50,7 @@ check kubeseal kubeseal "0.27"  "brew install kubeseal"         'kubeseal --vers
 check skopeo   skopeo   "1.14"  "brew install skopeo"           'skopeo --version'
 check yq       yq       "4.x"   "brew install yq"               'yq --version'
 check jq       jq       "1.6"   "brew install jq"               'jq --version'
+check envsubst envsubst "any"   "brew install gettext"          'envsubst --version | head -n1'
 check git      git      "2.40"  "system / brew install git"     'git --version'
 check make     make     "3.81"  "system / brew install make"    'make --version | head -n1'
 

--- a/deploy/gitops/scripts/render-system-values.sh
+++ b/deploy/gitops/scripts/render-system-values.sh
@@ -22,7 +22,7 @@ SVC=${1:?usage: render-system-values.sh <svc> <env> <out-dir>}
 ENV_NAME=${2:?usage: render-system-values.sh <svc> <env> <out-dir>}
 OUT_DIR=${3:?usage: render-system-values.sh <svc> <env> <out-dir>}
 
-NS_VARS=(NS_INFRA NS_LOKI NS_TEMPO NS_VICTORIAMETRICS NS_KUBE_STATE_METRICS NS_CLICKHOUSE NS_REDPANDA)
+NS_VARS=(NS_INFRA NS_MONITORING)
 
 SED_ARGS=()
 for v in "${NS_VARS[@]}"; do

--- a/deploy/gitops/scripts/render-system-values.sh
+++ b/deploy/gitops/scripts/render-system-values.sh
@@ -11,10 +11,10 @@
 # environments/<env>/<svc>-values.yaml when present and non-empty) into
 # <out-dir> and prints the `-f <rendered>` arguments for helm.
 #
-# Substitution is envsubst with an EXPLICIT allowlist: only the NS_* variables
-# below are replaced. Every other `$` construct passes through byte-identical —
-# Grafana provisioning `$VAR` / `$$VAR` escapes, dashboard `$__auto` intervals,
-# and anything `${…}`-shaped inside Alloy configs.
+# Substitution replaces ONLY the exact braced tokens for the NS_* variables
+# below. Every other `$` construct passes through byte-identical — Grafana
+# provisioning `$VAR` / `$$VAR` escapes, dashboard `$__auto` intervals, bare
+# `$NS_*` text, and anything `${…}`-shaped inside Alloy configs.
 
 set -euo pipefail
 
@@ -24,17 +24,18 @@ OUT_DIR=${3:?usage: render-system-values.sh <svc> <env> <out-dir>}
 
 NS_VARS=(NS_INFRA NS_LOKI NS_TEMPO NS_VICTORIAMETRICS NS_KUBE_STATE_METRICS NS_CLICKHOUSE NS_REDPANDA)
 
-command -v envsubst >/dev/null 2>&1 \
-  || { echo "render-system-values: envsubst not found (install gettext)" >&2; exit 1; }
-
-ALLOWLIST=""
+SED_ARGS=()
 for v in "${NS_VARS[@]}"; do
+  val=${!v:-}
   # An empty namespace renders `svc..svc.cluster.local` — refuse rather
   # than hand helm a values file with a broken FQDN.
-  [ -n "${!v:-}" ] \
+  [ -n "$val" ] \
     || { echo "render-system-values: \$$v is empty — inventory not readable?" >&2; exit 1; }
-  export "${v?}"
-  ALLOWLIST+="\${$v} "
+  # A DNS-1123 label is also what keeps the value inert inside the sed
+  # expression below.
+  [[ $val =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]] \
+    || { echo "render-system-values: \$$v='$val' is not a DNS-1123 label" >&2; exit 1; }
+  SED_ARGS+=(-e "s/[\$]{$v}/$val/g")
 done
 
 BASE="system/$SVC/values.yaml"
@@ -44,7 +45,7 @@ mkdir -p "$OUT_DIR"
 
 render() {
   local src=$1 dst=$2
-  envsubst "$ALLOWLIST" < "$src" > "$dst"
+  sed "${SED_ARGS[@]}" < "$src" > "$dst"
   printf ' -f %s' "$dst"
 }
 

--- a/deploy/gitops/scripts/render-system-values.sh
+++ b/deploy/gitops/scripts/render-system-values.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# render-system-values.sh — resolve the ${NS_*} producer-namespace
+# placeholders in L2 system values so cross-service hostnames follow the
+# inventory instead of hardcoding `insight-infra`.
+#
+# Usage (the Makefile's _system_values_args is the only caller):
+#   NS_INFRA=… NS_LOKI=… … render-system-values.sh <svc> <env> <out-dir>
+#
+# Renders system/<svc>/values.yaml (and the per-env overlay
+# environments/<env>/<svc>-values.yaml when present and non-empty) into
+# <out-dir> and prints the `-f <rendered>` arguments for helm.
+#
+# Substitution is envsubst with an EXPLICIT allowlist: only the NS_* variables
+# below are replaced. Every other `$` construct passes through byte-identical —
+# Grafana provisioning `$VAR` / `$$VAR` escapes, dashboard `$__auto` intervals,
+# and anything `${…}`-shaped inside Alloy configs.
+
+set -euo pipefail
+
+SVC=${1:?usage: render-system-values.sh <svc> <env> <out-dir>}
+ENV_NAME=${2:?usage: render-system-values.sh <svc> <env> <out-dir>}
+OUT_DIR=${3:?usage: render-system-values.sh <svc> <env> <out-dir>}
+
+NS_VARS=(NS_INFRA NS_LOKI NS_TEMPO NS_VICTORIAMETRICS NS_KUBE_STATE_METRICS NS_CLICKHOUSE NS_REDPANDA)
+
+command -v envsubst >/dev/null 2>&1 \
+  || { echo "render-system-values: envsubst not found (install gettext)" >&2; exit 1; }
+
+ALLOWLIST=""
+for v in "${NS_VARS[@]}"; do
+  # An empty namespace renders `svc..svc.cluster.local` — refuse rather
+  # than hand helm a values file with a broken FQDN.
+  [ -n "${!v:-}" ] \
+    || { echo "render-system-values: \$$v is empty — inventory not readable?" >&2; exit 1; }
+  export "${v?}"
+  ALLOWLIST+="\${$v} "
+done
+
+BASE="system/$SVC/values.yaml"
+[ -f "$BASE" ] || { echo "render-system-values: $BASE not found" >&2; exit 1; }
+
+mkdir -p "$OUT_DIR"
+
+render() {
+  local src=$1 dst=$2
+  envsubst "$ALLOWLIST" < "$src" > "$dst"
+  printf ' -f %s' "$dst"
+}
+
+render "$BASE" "$OUT_DIR/$ENV_NAME-$SVC-values.yaml"
+
+OVERLAY="environments/$ENV_NAME/$SVC-values.yaml"
+if [ -s "$OVERLAY" ]; then
+  render "$OVERLAY" "$OUT_DIR/$ENV_NAME-$SVC-overlay.yaml"
+fi
+echo

--- a/deploy/gitops/system/README.md
+++ b/deploy/gitops/system/README.md
@@ -1,7 +1,8 @@
 # L2 — System Layer
 
-Shared infrastructure services that live in the `insight-infra`
-namespace, **one Helm release per service**. `make system ENV=<env>`
+Shared infrastructure services that live in the infra namespace
+(inventory `namespaces.infra`, `insight-infra` by default), **one Helm
+release per service**. `make system ENV=<env>`
 chains every service whose `inventory.system.<svc>` toggle is true;
 per-service `make system-<svc>` targets remain for one-offs and
 rotation. The toggles exist because each cluster picks which services
@@ -13,7 +14,7 @@ model and full workflow.
 
 ## Services
 
-| Directory | Chart | Helm release in `insight-infra` | Needs a Secret? |
+| Directory | Chart | Helm release (in the infra namespace) | Needs a Secret? |
 |-----------|-------|---------------------------------|-----------------|
 | `mariadb/` | `oci://registry-1.docker.io/bitnamicharts/mariadb` | `mariadb` | yes → [SECRETS.md](mariadb/SECRETS.md) |
 | `clickhouse/` | `oci://registry-1.docker.io/bitnamicharts/clickhouse` | `clickhouse` | yes → [SECRETS.md](clickhouse/SECRETS.md) |
@@ -120,6 +121,33 @@ environments/<env>/<svc>-values.yaml                # per-env overlay — create
 
 Both are passed to `helm upgrade --install` in that order. Missing
 overlay file = base values used as-is.
+
+### Cross-service hostnames — `${NS_*}` placeholders
+
+Neither file reaches helm verbatim: `scripts/render-system-values.sh`
+first resolves the `${NS_*}` placeholders that cross-service references
+use (`http://loki.${NS_LOKI}.svc.cluster.local:3100`, …), writing the
+rendered copies to `.deploy/system-values/` — inspect them there after a
+run. There is one variable per producer another release addresses, each
+defaulting to the inventory's `namespaces.infra`:
+
+| Variable | Producer it locates | Consumers |
+|----------|--------------------|-----------|
+| `NS_LOKI` | `loki` | alloy, grafana |
+| `NS_TEMPO` | `tempo` | alloy, grafana |
+| `NS_VICTORIAMETRICS` | `victoriametrics` | alloy, alloy-metrics, grafana |
+| `NS_KUBE_STATE_METRICS` | `kube-state-metrics` | alloy-metrics |
+| `NS_CLICKHOUSE` | `clickhouse` | alloy-metrics, grafana |
+| `NS_REDPANDA` | `redpanda` | redpanda-console |
+
+Service *names* stay literal on purpose — `fullnameOverride` in each
+producer's values pins them, so the name is the contract and only the
+namespace moves. Substitution is `envsubst` with exactly this allowlist
+(plus `NS_INFRA`): every other `$` construct — Grafana provisioning
+`$VAR` / `$$VAR` escapes, `$__auto` in dashboards, `${…}`-shaped strings
+in Alloy configs — passes through byte-identical, so overlays that carry
+full Alloy configs or restated datasource lists can keep using the
+placeholders too.
 
 ## Secret layout
 

--- a/deploy/gitops/system/README.md
+++ b/deploy/gitops/system/README.md
@@ -92,7 +92,8 @@ pods, shipped helm output). Deploy markers come from the
 helm log to Loki via `scripts/push-deploy-log.sh` (best-effort).
 
 **Access (follow-up: auth).** The baseline Grafana ships with no ingress and
-no SSO — reach it via port-forward:
+no SSO — reach it via port-forward (commands assume the default
+`namespaces.infra: insight-infra`; swap in your inventory's value):
 
 ```shell
 kubectl -n insight-infra port-forward svc/grafana 3000:80
@@ -122,9 +123,10 @@ environments/<env>/<svc>-values.yaml                # per-env overlay — create
 Both are passed to `helm upgrade --install` in that order. Missing
 overlay file = base values used as-is.
 
-### Cross-service hostnames — `${NS_*}` placeholders
+### Cross-service hostnames
 
-Neither file reaches helm verbatim: `scripts/render-system-values.sh`
+Cross-service references are written as `${NS_*}` placeholders, and
+neither file reaches helm verbatim: `scripts/render-system-values.sh`
 first resolves the `${NS_*}` placeholders that cross-service references
 use (`http://loki.${NS_LOKI}.svc.cluster.local:3100`, …), writing the
 rendered copies to `.deploy/system-values/` — inspect them there after a
@@ -142,18 +144,21 @@ defaulting to the inventory's `namespaces.infra`:
 
 Service *names* stay literal on purpose — `fullnameOverride` in each
 producer's values pins them, so the name is the contract and only the
-namespace moves. Substitution is `envsubst` with exactly this allowlist
-(plus `NS_INFRA`): every other `$` construct — Grafana provisioning
-`$VAR` / `$$VAR` escapes, `$__auto` in dashboards, `${…}`-shaped strings
-in Alloy configs — passes through byte-identical, so overlays that carry
-full Alloy configs or restated datasource lists can keep using the
-placeholders too.
+namespace moves. Substitution replaces only the exact braced tokens for
+this variable set (plus `NS_INFRA`): every other `$` construct — Grafana
+provisioning `$VAR` / `$$VAR` escapes, `$__auto` in dashboards,
+`${…}`-shaped strings in Alloy configs — passes through byte-identical,
+so overlays that carry full Alloy configs or restated datasource lists
+can keep using the placeholders too.
 
 ## Secret layout
 
 ```
-environments/<env>/sealed-secrets/insight-infra/<svc>-creds-sealedsecret.yaml
+environments/<env>/sealed-secrets/<infra-namespace>/<svc>-creds-sealedsecret.yaml
 ```
+
+(`<infra-namespace>` is the inventory's `namespaces.infra` —
+`insight-infra` by default; the Makefile resolves the directory from it.)
 
 Files are sealed against the cluster's sealed-secrets-controller public
 cert (`environments/<env>/pub-cert.pem`). Source of truth for the

--- a/deploy/gitops/system/README.md
+++ b/deploy/gitops/system/README.md
@@ -130,22 +130,21 @@ neither file reaches helm verbatim: `scripts/render-system-values.sh`
 first resolves the `${NS_*}` placeholders that cross-service references
 use (`http://loki.${NS_LOKI}.svc.cluster.local:3100`, …), writing the
 rendered copies to `.deploy/system-values/` — inspect them there after a
-run. There is one variable per producer another release addresses, each
-defaulting to the inventory's `namespaces.infra`:
+run. Two variables cover every cross-service reference:
 
-| Variable | Producer it locates | Consumers |
-|----------|--------------------|-----------|
-| `NS_LOKI` | `loki` | alloy, grafana |
-| `NS_TEMPO` | `tempo` | alloy, grafana |
-| `NS_VICTORIAMETRICS` | `victoriametrics` | alloy, alloy-metrics, grafana |
-| `NS_KUBE_STATE_METRICS` | `kube-state-metrics` | alloy-metrics |
-| `NS_CLICKHOUSE` | `clickhouse` | alloy-metrics, grafana |
-| `NS_REDPANDA` | `redpanda` | redpanda-console |
+| Variable | Locates | Consumers |
+|----------|---------|-----------|
+| `NS_INFRA` | the data stores (`clickhouse`, `redpanda`) | alloy-metrics, grafana, redpanda-console |
+| `NS_MONITORING` | the observability unit (`loki`, `tempo`, `victoriametrics`, `kube-state-metrics`) | alloy, alloy-metrics, grafana |
+
+`NS_MONITORING` defaults to `NS_INFRA` — the layout every environment
+here uses — and exists because the observability stack is the one unit
+an environment plausibly hosts apart from the data stores.
 
 Service *names* stay literal on purpose — `fullnameOverride` in each
 producer's values pins them, so the name is the contract and only the
-namespace moves. Substitution replaces only the exact braced tokens for
-this variable set (plus `NS_INFRA`): every other `$` construct — Grafana
+namespace moves. Substitution replaces only these two exact braced
+tokens: every other `$` construct — Grafana
 provisioning `$VAR` / `$$VAR` escapes, `$__auto` in dashboards,
 `${…}`-shaped strings in Alloy configs — passes through byte-identical,
 so overlays that carry full Alloy configs or restated datasource lists

--- a/deploy/gitops/system/alloy-metrics/values.yaml
+++ b/deploy/gitops/system/alloy-metrics/values.yaml
@@ -9,7 +9,12 @@
 ##
 ## Chart: grafana/alloy
 ## Pin in Makefile: ALLOY_VERSION (shared with the log collector)
-## Release: `alloy-metrics` in namespace `insight-infra`.
+## Release: `alloy-metrics` in the infra namespace (inventory
+## `namespaces.infra`, `insight-infra` by default).
+##
+## The `${NS_*}` placeholders below are the namespaces of the releases this
+## config scrapes / writes to, resolved by scripts/render-system-values.sh
+## before helm reads the file (see system/README.md § Values layout).
 ##
 ## Deployment rather than DaemonSet: every target is discovered
 ## cluster-wide, so one replica scrapes the whole cluster; a DaemonSet
@@ -79,11 +84,11 @@ alloy:
       }
 
       // ── kube-state-metrics — object state ──────────────────────────────
-      // Static target: the system-kube-state-metrics release in this
-      // namespace (fullnameOverride pins the Service name).
+      // Static target: the system-kube-state-metrics release
+      // (fullnameOverride pins the Service name).
       prometheus.scrape "kube_state_metrics" {
         targets = [
-          {"__address__" = "kube-state-metrics.insight-infra.svc.cluster.local:8080", "job" = "kube-state-metrics"},
+          {"__address__" = "kube-state-metrics.${NS_KUBE_STATE_METRICS}.svc.cluster.local:8080", "job" = "kube-state-metrics"},
         ]
         scrape_interval = "30s"
         forward_to      = [prometheus.relabel.drop_noise.receiver]
@@ -94,7 +99,7 @@ alloy:
       // system/clickhouse/values.yaml): /metrics on the Service's 8001 port.
       prometheus.scrape "clickhouse" {
         targets = [
-          {"__address__" = "clickhouse.insight-infra.svc.cluster.local:8001", "job" = "clickhouse"},
+          {"__address__" = "clickhouse.${NS_CLICKHOUSE}.svc.cluster.local:8001", "job" = "clickhouse"},
         ]
         scrape_interval = "30s"
         forward_to      = [prometheus.relabel.drop_noise.receiver]
@@ -134,6 +139,6 @@ alloy:
 
       prometheus.remote_write "victoriametrics" {
         endpoint {
-          url = "http://victoriametrics-server.insight-infra.svc.cluster.local:8428/api/v1/write"
+          url = "http://victoriametrics-server.${NS_VICTORIAMETRICS}.svc.cluster.local:8428/api/v1/write"
         }
       }

--- a/deploy/gitops/system/alloy-metrics/values.yaml
+++ b/deploy/gitops/system/alloy-metrics/values.yaml
@@ -88,7 +88,7 @@ alloy:
       // (fullnameOverride pins the Service name).
       prometheus.scrape "kube_state_metrics" {
         targets = [
-          {"__address__" = "kube-state-metrics.${NS_KUBE_STATE_METRICS}.svc.cluster.local:8080", "job" = "kube-state-metrics"},
+          {"__address__" = "kube-state-metrics.${NS_MONITORING}.svc.cluster.local:8080", "job" = "kube-state-metrics"},
         ]
         scrape_interval = "30s"
         forward_to      = [prometheus.relabel.drop_noise.receiver]
@@ -99,7 +99,7 @@ alloy:
       // system/clickhouse/values.yaml): /metrics on the Service's 8001 port.
       prometheus.scrape "clickhouse" {
         targets = [
-          {"__address__" = "clickhouse.${NS_CLICKHOUSE}.svc.cluster.local:8001", "job" = "clickhouse"},
+          {"__address__" = "clickhouse.${NS_INFRA}.svc.cluster.local:8001", "job" = "clickhouse"},
         ]
         scrape_interval = "30s"
         forward_to      = [prometheus.relabel.drop_noise.receiver]
@@ -139,6 +139,6 @@ alloy:
 
       prometheus.remote_write "victoriametrics" {
         endpoint {
-          url = "http://victoriametrics-server.${NS_VICTORIAMETRICS}.svc.cluster.local:8428/api/v1/write"
+          url = "http://victoriametrics-server.${NS_MONITORING}.svc.cluster.local:8428/api/v1/write"
         }
       }

--- a/deploy/gitops/system/alloy/values.yaml
+++ b/deploy/gitops/system/alloy/values.yaml
@@ -103,7 +103,7 @@ alloy:
 
       loki.write "default" {
         endpoint {
-          url = "http://loki.${NS_LOKI}.svc.cluster.local:3100/loki/api/v1/push"
+          url = "http://loki.${NS_MONITORING}.svc.cluster.local:3100/loki/api/v1/push"
         }
       }
 
@@ -131,13 +131,13 @@ alloy:
 
       prometheus.remote_write "victoriametrics" {
         endpoint {
-          url = "http://victoriametrics-server.${NS_VICTORIAMETRICS}.svc.cluster.local:8428/api/v1/write"
+          url = "http://victoriametrics-server.${NS_MONITORING}.svc.cluster.local:8428/api/v1/write"
         }
       }
 
       otelcol.exporter.otlp "to_tempo" {
         client {
-          endpoint = "tempo.${NS_TEMPO}.svc.cluster.local:4317"
+          endpoint = "tempo.${NS_MONITORING}.svc.cluster.local:4317"
           tls {
             // In-cluster hop; Tempo's ingest is plaintext.
             insecure = true

--- a/deploy/gitops/system/alloy/values.yaml
+++ b/deploy/gitops/system/alloy/values.yaml
@@ -9,7 +9,12 @@
 ##
 ## Chart: grafana/alloy   (https://grafana.github.io/helm-charts)
 ## Pin in Makefile: ALLOY_VERSION
-## Release: `alloy` in namespace `insight-infra`.
+## Release: `alloy` in the infra namespace (inventory `namespaces.infra`,
+## `insight-infra` by default).
+##
+## The `${NS_*}` placeholders below are the namespaces of the releases this
+## config pushes to, resolved by scripts/render-system-values.sh before helm
+## reads the file (see system/README.md § Values layout).
 ##
 ## Per-env overrides go in environments/<env>/alloy-values.yaml.
 ##
@@ -32,7 +37,7 @@ alloy:
   mounts:
     varlog: true
   # OTLP listeners, added to both the container and the chart's ClusterIP
-  # Service — `alloy.insight-infra.svc.cluster.local:4317/4318` is the
+  # Service — `alloy.<infra-ns>.svc.cluster.local:4317/4318` is the
   # stable endpoint services export to. The Service spans every DaemonSet
   # pod; any node's agent accepts and routes the payload.
   extraPorts:
@@ -98,7 +103,7 @@ alloy:
 
       loki.write "default" {
         endpoint {
-          url = "http://loki.insight-infra.svc.cluster.local:3100/loki/api/v1/push"
+          url = "http://loki.${NS_LOKI}.svc.cluster.local:3100/loki/api/v1/push"
         }
       }
 
@@ -126,15 +131,15 @@ alloy:
 
       prometheus.remote_write "victoriametrics" {
         endpoint {
-          url = "http://victoriametrics-server.insight-infra.svc.cluster.local:8428/api/v1/write"
+          url = "http://victoriametrics-server.${NS_VICTORIAMETRICS}.svc.cluster.local:8428/api/v1/write"
         }
       }
 
       otelcol.exporter.otlp "to_tempo" {
         client {
-          endpoint = "tempo.insight-infra.svc.cluster.local:4317"
+          endpoint = "tempo.${NS_TEMPO}.svc.cluster.local:4317"
           tls {
-            // In-cluster hop inside insight-infra; Tempo's ingest is plaintext.
+            // In-cluster hop; Tempo's ingest is plaintext.
             insecure = true
           }
         }

--- a/deploy/gitops/system/clickhouse/values.yaml
+++ b/deploy/gitops/system/clickhouse/values.yaml
@@ -3,12 +3,13 @@
 ##
 ## Chart: oci://registry-1.docker.io/bitnamicharts/clickhouse
 ## Pin in Makefile: CLICKHOUSE_VERSION
-## Release: `clickhouse` in namespace `insight-infra`.
+## Release: `clickhouse` in the infra namespace (inventory `namespaces.infra`,
+## `insight-infra` by default).
 ##
 ## Per-env overrides go in environments/<env>/clickhouse-values.yaml.
 ##
 ## App layer reaches this release as
-## `clickhouse.insight-infra.svc.cluster.local:8123` (HTTP) or `:9000` (native).
+## `clickhouse.<infra-ns>.svc.cluster.local:8123` (HTTP) or `:9000` (native).
 ##
 
 fullnameOverride: clickhouse

--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -4,7 +4,12 @@
 ##
 ## Chart: grafana/grafana   (https://grafana.github.io/helm-charts)
 ## Pin in Makefile: GRAFANA_VERSION
-## Release: `grafana` in namespace `insight-infra`.
+## Release: `grafana` in the infra namespace (inventory `namespaces.infra`,
+## `insight-infra` by default).
+##
+## The `${NS_*}` placeholders below are the namespaces of the datasource
+## releases, resolved by scripts/render-system-values.sh before helm reads
+## the file (see system/README.md § Values layout).
 ##
 ## Per-env overrides go in environments/<env>/grafana-values.yaml
 ## (ingress host, OIDC, admin secret).
@@ -67,7 +72,9 @@ envFromSecrets:
 # INVARIANT: helm REPLACES lists — a per-env overlay that touches
 # `datasources` must restate every entry below, and the uids (`loki`, `vm`,
 # `tempo`, `clickhouse`) must stay what they are or every provisioned
-# dashboard panel goes dark.
+# dashboard panel goes dark. Overlays go through the same ${NS_*}
+# substitution as this file, so restated entries keep the placeholders
+# instead of hardcoding a namespace.
 datasources:
   datasources.yaml:
     apiVersion: 1
@@ -76,7 +83,7 @@ datasources:
         uid: loki
         type: loki
         access: proxy
-        url: http://loki.insight-infra.svc.cluster.local:3100
+        url: http://loki.${NS_LOKI}.svc.cluster.local:3100
         isDefault: true
         jsonData:
           maxLines: 1000
@@ -93,14 +100,14 @@ datasources:
         uid: tempo
         type: tempo
         access: proxy
-        url: http://tempo.insight-infra.svc.cluster.local:3200
+        url: http://tempo.${NS_TEMPO}.svc.cluster.local:3200
         isDefault: false
 
       - name: VictoriaMetrics
         uid: vm
         type: prometheus
         access: proxy
-        url: http://victoriametrics-server.insight-infra.svc.cluster.local:8428
+        url: http://victoriametrics-server.${NS_VICTORIAMETRICS}.svc.cluster.local:8428
         isDefault: false
         jsonData:
           timeInterval: "30s"
@@ -115,7 +122,7 @@ datasources:
         access: proxy
         isDefault: false
         jsonData:
-          host: clickhouse.insight-infra.svc.cluster.local
+          host: clickhouse.${NS_CLICKHOUSE}.svc.cluster.local
           port: 9000
           protocol: native
           secure: false

--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -83,7 +83,7 @@ datasources:
         uid: loki
         type: loki
         access: proxy
-        url: http://loki.${NS_LOKI}.svc.cluster.local:3100
+        url: http://loki.${NS_MONITORING}.svc.cluster.local:3100
         isDefault: true
         jsonData:
           maxLines: 1000
@@ -100,14 +100,14 @@ datasources:
         uid: tempo
         type: tempo
         access: proxy
-        url: http://tempo.${NS_TEMPO}.svc.cluster.local:3200
+        url: http://tempo.${NS_MONITORING}.svc.cluster.local:3200
         isDefault: false
 
       - name: VictoriaMetrics
         uid: vm
         type: prometheus
         access: proxy
-        url: http://victoriametrics-server.${NS_VICTORIAMETRICS}.svc.cluster.local:8428
+        url: http://victoriametrics-server.${NS_MONITORING}.svc.cluster.local:8428
         isDefault: false
         jsonData:
           timeInterval: "30s"
@@ -122,7 +122,7 @@ datasources:
         access: proxy
         isDefault: false
         jsonData:
-          host: clickhouse.${NS_CLICKHOUSE}.svc.cluster.local
+          host: clickhouse.${NS_INFRA}.svc.cluster.local
           port: 9000
           protocol: native
           secure: false

--- a/deploy/gitops/system/kube-state-metrics/values.yaml
+++ b/deploy/gitops/system/kube-state-metrics/values.yaml
@@ -6,7 +6,8 @@
 ##
 ## Chart: prometheus-community/kube-state-metrics
 ## Pin in Makefile: KUBE_STATE_METRICS_VERSION
-## Release: `kube-state-metrics` in namespace `insight-infra`.
+## Release: `kube-state-metrics` in the infra namespace (inventory `namespaces.infra`,
+## `insight-infra` by default).
 ##
 ## Per-env overrides go in environments/<env>/kube-state-metrics-values.yaml
 ## — custom-resource metrics (e.g. Argo Workflow phase) belong there, since
@@ -42,8 +43,8 @@ collectors:
   - replicasets
   - statefulsets
 
-# Cluster-wide: the workloads live in `insight`, the data stores in
-# `insight-infra`.
+# Cluster-wide: the workloads live in the services namespace, the data
+# stores in the infra namespace.
 namespaces: ""
 
 selfMonitor:

--- a/deploy/gitops/system/loki/values.yaml
+++ b/deploy/gitops/system/loki/values.yaml
@@ -3,12 +3,13 @@
 ##
 ## Chart: grafana-community/loki   (https://grafana-community.github.io/helm-charts)
 ## Pin in Makefile: LOKI_VERSION
-## Release: `loki` in namespace `insight-infra`.
+## Release: `loki` in the infra namespace (inventory `namespaces.infra`,
+## `insight-infra` by default).
 ##
 ## Per-env overrides go in environments/<env>/loki-values.yaml.
 ##
 ## Push/query endpoint other components use:
-##   http://loki.insight-infra.svc.cluster.local:3100
+##   http://loki.<infra-ns>.svc.cluster.local:3100
 ##
 ## SCOPE: this is the dev / single-tenant baseline — SingleBinary mode,
 ## node-local filesystem storage, NO HA. For production move to

--- a/deploy/gitops/system/mariadb/values.yaml
+++ b/deploy/gitops/system/mariadb/values.yaml
@@ -3,12 +3,13 @@
 ##
 ## Chart: oci://registry-1.docker.io/bitnamicharts/mariadb
 ## Pin in Makefile: MARIADB_VERSION (default 20.0.x)
-## Release: `mariadb` in namespace `insight-infra`.
+## Release: `mariadb` in the infra namespace (inventory `namespaces.infra`,
+## `insight-infra` by default).
 ##
 ## Per-env overrides go in environments/<env>/mariadb-values.yaml.
 ##
 ## App layer (umbrella in the `insight` namespace) reaches this release
-## as `mariadb.insight-infra.svc.cluster.local:3306`. The umbrella's
+## as `mariadb.<infra-ns>.svc.cluster.local:3306`. The umbrella's
 ## `mariadb.host` value should be left empty so the chart helper
 ## resolves to that DNS name automatically.
 ##

--- a/deploy/gitops/system/redis/values.yaml
+++ b/deploy/gitops/system/redis/values.yaml
@@ -3,12 +3,13 @@
 ##
 ## Chart: oci://registry-1.docker.io/bitnamicharts/redis
 ## Pin in Makefile: REDIS_VERSION
-## Release: `redis` in namespace `insight-infra`.
+## Release: `redis` in the infra namespace (inventory `namespaces.infra`,
+## `insight-infra` by default).
 ##
 ## Per-env overrides go in environments/<env>/redis-values.yaml.
 ##
 ## App layer reaches this release as
-## `redis-master.insight-infra.svc.cluster.local:6379`.
+## `redis-master.<infra-ns>.svc.cluster.local:6379`.
 ## Used by analytics as query-response cache.
 ##
 

--- a/deploy/gitops/system/redpanda-console/values.yaml
+++ b/deploy/gitops/system/redpanda-console/values.yaml
@@ -9,7 +9,7 @@
 ## Per-env overrides go in environments/<env>/redpanda-console-values.yaml
 ## (usually to enable an ingress for the UI).
 ##
-## Reaches the broker as `redpanda.${NS_REDPANDA}.svc.cluster.local:9093`
+## Reaches the broker as `redpanda.${NS_INFRA}.svc.cluster.local:9093`
 ## (Kafka API) — the placeholder is resolved by
 ## scripts/render-system-values.sh before helm reads the file
 ## (see system/README.md § Values layout).
@@ -24,7 +24,7 @@ fullnameOverride: redpanda-console
 config:
   kafka:
     brokers:
-      - redpanda.${NS_REDPANDA}.svc.cluster.local:9093
+      - redpanda.${NS_INFRA}.svc.cluster.local:9093
 
 # UI is internal-only by default. Enable an ingress in the per-env
 # overlay if the team wants browser access to the console.

--- a/deploy/gitops/system/redpanda-console/values.yaml
+++ b/deploy/gitops/system/redpanda-console/values.yaml
@@ -3,13 +3,16 @@
 ##
 ## Chart: redpanda/console (repo: https://charts.redpanda.com)
 ## Pin in Makefile: REDPANDA_CONSOLE_VERSION (3.7.0 at time of writing)
-## Release: `redpanda-console` in namespace `insight-infra`.
+## Release: `redpanda-console` in the infra namespace (inventory
+## `namespaces.infra`, `insight-infra` by default).
 ##
 ## Per-env overrides go in environments/<env>/redpanda-console-values.yaml
 ## (usually to enable an ingress for the UI).
 ##
-## Reaches the broker as
-## `redpanda.insight-infra.svc.cluster.local:9093` (Kafka API).
+## Reaches the broker as `redpanda.${NS_REDPANDA}.svc.cluster.local:9093`
+## (Kafka API) — the placeholder is resolved by
+## scripts/render-system-values.sh before helm reads the file
+## (see system/README.md § Values layout).
 ##
 ## Chart 3.x removed the `console:` top-level wrapper; values that used
 ## to live under `console.config.*` now sit directly at the top level
@@ -21,7 +24,7 @@ fullnameOverride: redpanda-console
 config:
   kafka:
     brokers:
-      - redpanda.insight-infra.svc.cluster.local:9093
+      - redpanda.${NS_REDPANDA}.svc.cluster.local:9093
 
 # UI is internal-only by default. Enable an ingress in the per-env
 # overlay if the team wants browser access to the console.

--- a/deploy/gitops/system/redpanda/values.yaml
+++ b/deploy/gitops/system/redpanda/values.yaml
@@ -3,12 +3,13 @@
 ##
 ## Chart: redpanda/redpanda (repo: https://charts.redpanda.com)
 ## Pin in Makefile: REDPANDA_VERSION
-## Release: `redpanda` in namespace `insight-infra`.
+## Release: `redpanda` in the infra namespace (inventory `namespaces.infra`,
+## `insight-infra` by default).
 ##
 ## Per-env overrides go in environments/<env>/redpanda-values.yaml.
 ##
 ## App layer reaches this release as
-## `redpanda.insight-infra.svc.cluster.local:9093` (Kafka API).
+## `redpanda.<infra-ns>.svc.cluster.local:9093` (Kafka API).
 ## Redpanda Console runs as a separate release — see system/redpanda-console/.
 ##
 

--- a/deploy/gitops/system/tempo/values.yaml
+++ b/deploy/gitops/system/tempo/values.yaml
@@ -4,13 +4,14 @@
 ##
 ## Chart: grafana-community/tempo   (https://grafana-community.github.io/helm-charts)
 ## Pin in Makefile: TEMPO_VERSION
-## Release: `tempo` in namespace `insight-infra`.
+## Release: `tempo` in the infra namespace (inventory `namespaces.infra`,
+## `insight-infra` by default).
 ##
 ## Per-env overrides go in environments/<env>/tempo-values.yaml.
 ##
 ## Endpoints other components use:
-##   OTLP push:  tempo.insight-infra.svc.cluster.local:4317 (gRPC) / 4318 (HTTP)
-##   Query API:  http://tempo.insight-infra.svc.cluster.local:3200 (Grafana datasource)
+##   OTLP push:  tempo.<infra-ns>.svc.cluster.local:4317 (gRPC) / 4318 (HTTP)
+##   Query API:  http://tempo.<infra-ns>.svc.cluster.local:3200 (Grafana datasource)
 ##
 ## Receivers stay at the chart default (OTLP + Jaeger): the chart's port
 ## templates hard-require the jaeger block, and an emptied protocol map

--- a/deploy/gitops/system/victoriametrics/values.yaml
+++ b/deploy/gitops/system/victoriametrics/values.yaml
@@ -3,11 +3,12 @@
 ##
 ## Chart: vm/victoria-metrics-single
 ## Pin in Makefile: VICTORIAMETRICS_VERSION
-## Release: `victoriametrics` in namespace `insight-infra`.
+## Release: `victoriametrics` in the infra namespace (inventory `namespaces.infra`,
+## `insight-infra` by default).
 ##
 ## Write/query endpoint other components use (PromQL queries, and the
 ## remote-write receiver at /api/v1/write — always on, no flag needed):
-##   http://victoriametrics-server.insight-infra.svc.cluster.local:8428
+##   http://victoriametrics-server.<infra-ns>.svc.cluster.local:8428
 ##
 ## Per-env overrides go in environments/<env>/victoriametrics-values.yaml.
 ##


### PR DESCRIPTION
**Why.** Every cross-service hostname in the L2 system values hardcodes `insight-infra`, so an environment that hosts a producer in another namespace silently breaks every consumer, and the only remedy is restating whole values blocks (helm replaces lists).

**What changed.** System values now reach helm through `scripts/render-system-values.sh`, which resolves two placeholders — `${NS_INFRA}` for the data stores and `${NS_MONITORING}` for the observability unit (LGTM + kube-state-metrics) — by exact braced-token substitution, so Grafana's `$VAR`/`$$VAR` provisioning escapes, bare `$NS_*`, and `${…}`-shaped Alloy syntax pass through untouched. Rendered copies land in `.deploy/system-values/`; a failed render or a namespace that is not a DNS-1123 label aborts make instead of letting helm fall back to chart defaults.

**Two variables, not one per producer.** The observability stack is the one unit an environment plausibly hosts apart from the data stores; `NS_MONITORING` defaults to `NS_INFRA`, so existing environments behave exactly as before. Service names stay literal — `fullnameOverride` pins them as the contract.

**Out of scope.** Actually moving a release to another namespace, and the app-layer (`charts/insight`) endpoints.

**Verified.** `helm template` at the Makefile-pinned chart versions diffs empty against the previous values for alloy, alloy-metrics, grafana and redpanda-console (chart-generated random secrets aside); with overrides every rendered FQDN follows its variable. `alloy validate` (docker, app v1.19.2) passes for both collector configs, default and override. functional-ci runs on this PR as the live gate.
