### PR TITLE
feat(analytics): preview reports

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -2221,6 +2221,169 @@
         ],
         "type": "object"
       },
+      "ReportColumnDataType": {
+        "enum": [
+          "text",
+          "date",
+          "number"
+        ],
+        "type": "string"
+      },
+      "ReportColumnMetadata": {
+        "properties": {
+          "data_type": {
+            "$ref": "#/components/schemas/ReportColumnDataType"
+          },
+          "format": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MetricFormat"
+              }
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "unit": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "label",
+          "data_type"
+        ],
+        "type": "object"
+      },
+      "ReportGranularity": {
+        "enum": [
+          "day",
+          "week",
+          "month",
+          "quarter",
+          "year"
+        ],
+        "type": "string"
+      },
+      "ReportPeriod": {
+        "additionalProperties": false,
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "from",
+          "to"
+        ],
+        "type": "object"
+      },
+      "ReportPreviewResponse": {
+        "properties": {
+          "columns": {
+            "items": {
+              "$ref": "#/components/schemas/ReportColumnMetadata"
+            },
+            "type": "array"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/Vec"
+            },
+            "type": "array"
+          },
+          "total_rows": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "columns",
+          "rows",
+          "total_rows"
+        ],
+        "type": "object"
+      },
+      "ReportRecipe": {
+        "additionalProperties": false,
+        "properties": {
+          "granularity": {
+            "$ref": "#/components/schemas/ReportGranularity"
+          },
+          "metric_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "period": {
+            "$ref": "#/components/schemas/ReportPeriod"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ReportSubject"
+          }
+        },
+        "required": [
+          "subject",
+          "period",
+          "granularity",
+          "metric_keys"
+        ],
+        "type": "object"
+      },
+      "ReportSubject": {
+        "oneOf": [
+          {
+            "properties": {
+              "ids": {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": {
+                "enum": [
+                  "people"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "ids",
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "tenant"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "RollupValueDto": {
         "properties": {
           "contributing_entity_count": {
@@ -2894,6 +3057,27 @@
           }
         },
         "type": "object"
+      },
+      "Vec": {
+        "items": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "format": "double",
+                  "type": "number"
+                }
+              ]
+            }
+          ]
+        },
+        "type": "array"
       }
     },
     "securitySchemes": {
@@ -5990,6 +6174,90 @@
           }
         ],
         "summary": "Run a saved query"
+      }
+    },
+    "/v1/reports/preview": {
+      "post": {
+        "operationId": "analytics_api.reports.preview",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportRecipe"
+              }
+            }
+          },
+          "description": "Report recipe",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReportPreviewResponse"
+                }
+              }
+            },
+            "description": "Report preview"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "415": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unsupported Media Type"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Preview a metric report"
       }
     },
     "/v1/usage/config": {

--- a/src/backend/services/analytics/src/api/metric_results.rs
+++ b/src/backend/services/analytics/src/api/metric_results.rs
@@ -1,12 +1,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use axum::Json;
 use axum::extract::Extension;
 use axum::http::HeaderMap;
 use futures::stream::{self, StreamExt};
-use serde::de::DeserializeOwned;
 use toolkit_canonical_errors::CanonicalError;
 use toolkit_security::SecurityContext;
 
@@ -26,13 +24,9 @@ use crate::domain::metric_results::{
     plan_queries, plan_rankings, validate_request,
 };
 use crate::domain::person_visibility::authorize_person_ids;
+use crate::infra::query::{QueryFetchError, fetch_json_rows};
 
 const QUERY_CONCURRENCY: usize = 4;
-// Client-side bound on one view query, network stalls included. The
-// insight-clickhouse client already caps server-side execution at 30s
-// (`max_execution_time`); this covers the transport path that setting
-// cannot reach (dead peer, half-open connection).
-const QUERY_FETCH_TIMEOUT: Duration = Duration::from_mins(1);
 
 pub async fn query_metric_results(
     Extension(state): Extension<Arc<AppState>>,
@@ -384,44 +378,16 @@ async fn fetch_rows<T>(
     log_comment: &str,
 ) -> Result<Vec<T>, ViewFailure>
 where
-    T: DeserializeOwned,
+    T: serde::de::DeserializeOwned,
 {
-    let mut ch_query = state
-        .ch
-        .query(&query.sql)
-        .with_setting("log_comment", log_comment);
-    for param in &query.params {
-        ch_query = ch_query.bind(param.as_str());
-    }
-
-    let mut cursor = ch_query.fetch_bytes("JSONEachRow").map_err(|e| {
-        tracing::error!(error = %e, comment = log_comment, sql = %query.sql, "ClickHouse metric-results query failed");
-        ViewFailure::from_query_error(&e.to_string())
-    })?;
-
-    let raw_bytes = tokio::time::timeout(QUERY_FETCH_TIMEOUT, cursor.collect())
+    fetch_json_rows(&state.ch, &query.sql, &query.params, log_comment)
         .await
-        .map_err(|_| {
-            tracing::error!(comment = log_comment, sql = %query.sql, "ClickHouse metric-results fetch timed out");
-            ViewFailure::timeout()
-        })?
-        .map_err(|e| {
-            tracing::error!(error = %e, comment = log_comment, sql = %query.sql, "ClickHouse metric-results fetch failed");
-            ViewFailure::from_query_error(&e.to_string())
-        })?;
-
-    if raw_bytes.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    raw_bytes
-        .split(|&b| b == b'\n')
-        .filter(|line| !line.is_empty())
-        .map(serde_json::from_slice)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| {
-            tracing::error!(error = %e, comment = log_comment, sql = %query.sql, "failed to parse metric-results rows");
-            ViewFailure::from_parse_error(&e.to_string())
+        .map_err(|error| match error {
+            QueryFetchError::Submit(message) | QueryFetchError::Fetch(message) => {
+                ViewFailure::from_query_error(&message)
+            }
+            QueryFetchError::Timeout => ViewFailure::timeout(),
+            QueryFetchError::Parse(message) => ViewFailure::from_parse_error(&message),
         })
 }
 

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -9,6 +9,7 @@ mod metric_drilldown;
 mod metric_results;
 mod metrics;
 mod person_names;
+mod reports;
 mod saved_queries;
 pub(crate) mod usage;
 
@@ -464,6 +465,25 @@ pub(crate) fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) ->
         .error_415(openapi)
         .error_500(openapi)
         .handler(metric_results::query_metric_results)
+        .register(router, openapi);
+
+    router = OperationBuilder::post("/v1/reports/preview")
+        .operation_id("analytics_api.reports.preview")
+        .summary("Preview a metric report")
+        .authenticated()
+        .no_license_required()
+        .json_request::<crate::domain::reports::dto::ReportPreviewRequest>(openapi, "Report recipe")
+        .json_response_with_schema::<crate::domain::reports::dto::ReportPreviewResponse>(
+            openapi,
+            StatusCode::OK,
+            "Report preview",
+        )
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_415(openapi)
+        .error_500(openapi)
+        .handler(reports::preview_report)
         .register(router, openapi);
 
     // Saved-query CRUD + run (#1965) — the presentation-layer "Data Analytics"

--- a/src/backend/services/analytics/src/api/openapi_tests.rs
+++ b/src/backend/services/analytics/src/api/openapi_tests.rs
@@ -40,6 +40,7 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
         "/v1/metric-drilldown",
         "/v1/metric-drilldown/export",
         "/v1/metric-results",
+        "/v1/reports/preview",
         "/v1/metrics",
         "/v1/metrics/export",
         "/v1/metrics/import",
@@ -55,7 +56,7 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
     }
     assert_eq!(
         paths.len(),
-        23,
+        24,
         "the contract must carry exactly the surviving paths, got {:?}",
         paths.keys().collect::<Vec<_>>()
     );

--- a/src/backend/services/analytics/src/api/reports.rs
+++ b/src/backend/services/analytics/src/api/reports.rs
@@ -1,0 +1,277 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::Json;
+use axum::extract::Extension;
+use axum::http::HeaderMap;
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::SecurityContext;
+
+use super::AppState;
+use crate::domain::metric_access::authorize_tenant_metrics;
+use crate::domain::person_visibility::authorize_and_hydrate_person_profiles;
+use crate::domain::reports::dto::{ReportPreviewRequest, ReportPreviewResponse};
+use crate::domain::reports::executor::{
+    ReportExecutionContext, ReportRowSink, ReportSinkError, execute_report,
+};
+use crate::domain::reports::planner::{ReportPlan, ReportPlannerLimits, plan_report};
+use crate::domain::reports::query::ClickHouseReportQueryRunner;
+use crate::domain::reports::row::ReportRow;
+use crate::domain::reports::validation::{
+    ReportSubjectSelection, ValidatedReportRecipe, validate_preview,
+};
+use crate::infra::identity::IdentityProfile;
+
+const MAX_PREVIEW_ROWS: usize = 20;
+
+pub async fn preview_report(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    headers: HeaderMap,
+    Json(request): Json<ReportPreviewRequest>,
+) -> Result<Json<ReportPreviewResponse>, CanonicalError> {
+    let response = build_preview(&state, &ctx, &headers, request).await?;
+
+    Ok(Json(response))
+}
+
+async fn build_preview(
+    state: &Arc<AppState>,
+    ctx: &SecurityContext,
+    headers: &HeaderMap,
+    request: ReportPreviewRequest,
+) -> Result<ReportPreviewResponse, CanonicalError> {
+    authorize_tenant_subject(state, &request)?;
+
+    let recipe = validate_preview(&state.db, ctx.subject_tenant_id(), request).await?;
+    let profiles = hydrate_profiles(state, ctx, headers, &recipe).await?;
+    let full_plan = plan_report(&recipe, &profiles, planner_limits()).map_err(report_internal)?;
+    let (preview_recipe, preview_profiles) = preview_inputs(&recipe, &full_plan, profiles)
+        .ok_or_else(|| CanonicalError::internal("report preview could not be planned").create())?;
+    let mut preview_plan = plan_report(&preview_recipe, &preview_profiles, planner_limits())
+        .map_err(report_internal)?;
+    preview_plan.columns = full_plan.columns.clone();
+
+    let runner = ClickHouseReportQueryRunner::new(&state.ch);
+    let rows = execute_report(
+        &preview_recipe,
+        &preview_plan,
+        &preview_profiles,
+        ReportExecutionContext {
+            tenant_id: ctx.subject_tenant_id(),
+            enforce_tenant_scope: state.config.metric_catalog.enforce_tenant_scope,
+        },
+        &runner,
+        PreviewSink::default(),
+    )
+    .await
+    .map_err(report_internal)?;
+
+    Ok(ReportPreviewResponse {
+        columns: full_plan
+            .columns
+            .iter()
+            .map(|column| column.metadata.clone())
+            .collect(),
+        rows,
+        total_rows: full_plan.size.total_rows,
+    })
+}
+
+fn authorize_tenant_subject(
+    state: &AppState,
+    request: &ReportPreviewRequest,
+) -> Result<(), CanonicalError> {
+    if matches!(
+        &request.subject,
+        crate::domain::reports::dto::ReportSubject::Tenant {}
+    ) {
+        authorize_tenant_metrics(state.config.metric_catalog.tenant_metrics_enabled)?;
+    }
+
+    Ok(())
+}
+
+async fn hydrate_profiles(
+    state: &AppState,
+    ctx: &SecurityContext,
+    headers: &HeaderMap,
+    recipe: &ValidatedReportRecipe,
+) -> Result<Vec<IdentityProfile>, CanonicalError> {
+    let ReportSubjectSelection::People { ids } = &recipe.subject else {
+        return Ok(Vec::new());
+    };
+
+    authorize_and_hydrate_person_profiles(
+        &state.identity,
+        ctx,
+        super::forwarded_authorization(headers),
+        ids,
+    )
+    .await
+}
+
+fn planner_limits() -> ReportPlannerLimits {
+    ReportPlannerLimits {
+        max_batch_cells: usize::MAX,
+    }
+}
+
+fn preview_inputs(
+    recipe: &ValidatedReportRecipe,
+    full_plan: &ReportPlan,
+    profiles: Vec<IdentityProfile>,
+) -> Option<(ValidatedReportRecipe, Vec<IdentityProfile>)> {
+    let period_count = full_plan.periods.len().min(MAX_PREVIEW_ROWS);
+    let preview_to = full_plan.periods.get(period_count.checked_sub(1)?)?.to;
+    let (subject, preview_profiles) = match &recipe.subject {
+        ReportSubjectSelection::People { ids } => {
+            let people = MAX_PREVIEW_ROWS.div_ceil(period_count).min(ids.len());
+            (
+                ReportSubjectSelection::People {
+                    ids: ids[..people].to_vec(),
+                },
+                profiles.into_iter().take(people).collect(),
+            )
+        }
+        ReportSubjectSelection::Tenant { id } => {
+            (ReportSubjectSelection::Tenant { id: *id }, vec![])
+        }
+    };
+
+    Some((
+        ValidatedReportRecipe {
+            subject,
+            from: recipe.from,
+            to: preview_to,
+            granularity: recipe.granularity,
+            metrics: recipe.metrics.clone(),
+        },
+        preview_profiles,
+    ))
+}
+
+fn report_internal(error: impl std::fmt::Debug) -> CanonicalError {
+    tracing::error!(?error, "report preview failed");
+    CanonicalError::internal("report preview failed").create()
+}
+
+#[derive(Debug, Default)]
+struct PreviewSink {
+    rows: Vec<ReportRow>,
+}
+
+#[async_trait]
+impl ReportRowSink for PreviewSink {
+    type Output = Vec<ReportRow>;
+
+    async fn write_rows(&mut self, rows: &[ReportRow]) -> Result<(), ReportSinkError> {
+        let remaining = MAX_PREVIEW_ROWS.saturating_sub(self.rows.len());
+
+        self.rows.extend(rows.iter().take(remaining).cloned());
+        Ok(())
+    }
+
+    async fn finish(self) -> Result<Self::Output, ReportSinkError> {
+        Ok(self.rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use chrono::NaiveDate;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::domain::reports::dto::ReportGranularity;
+
+    #[tokio::test]
+    async fn preview_keeps_full_columns_and_caps_rows_at_twenty() {
+        let profiles = vec![
+            profile(1, []),
+            profile(2, []),
+            profile(3, [("department", "Engineering")]),
+        ];
+        let recipe = ValidatedReportRecipe {
+            subject: ReportSubjectSelection::People {
+                ids: profiles.iter().map(|profile| profile.person_id).collect(),
+            },
+            from: date("2026-01-01"),
+            to: date("2026-12-31"),
+            granularity: ReportGranularity::Month,
+            metrics: vec![],
+        };
+        let full_plan = plan_report(&recipe, &profiles, planner_limits())
+            .unwrap_or_else(|error| panic!("full report should plan: {error}"));
+        let (preview_recipe, preview_profiles) = preview_inputs(&recipe, &full_plan, profiles)
+            .unwrap_or_else(|| panic!("preview inputs should exist"));
+        let mut preview_plan = plan_report(&preview_recipe, &preview_profiles, planner_limits())
+            .unwrap_or_else(|error| panic!("preview report should plan: {error}"));
+        preview_plan.columns = full_plan.columns.clone();
+
+        assert_eq!(preview_plan.size.total_rows, 24);
+        assert_eq!(preview_profiles.len(), 2);
+        assert!(
+            preview_plan
+                .columns
+                .iter()
+                .any(|column| column.metadata.key == "department")
+        );
+
+        let mut sink = PreviewSink::default();
+        sink.write_rows(&vec![Vec::new(); 12])
+            .await
+            .unwrap_or_else(|error| panic!("first preview batch should write: {error}"));
+        sink.write_rows(&vec![Vec::new(); 12])
+            .await
+            .unwrap_or_else(|error| panic!("second preview batch should write: {error}"));
+        let rows = sink
+            .finish()
+            .await
+            .unwrap_or_else(|error| panic!("preview should finish: {error}"));
+
+        assert_eq!(rows.len(), MAX_PREVIEW_ROWS);
+    }
+
+    #[test]
+    fn tenant_preview_stops_after_twenty_periods() {
+        let tenant_id = Uuid::from_u128(9);
+        let recipe = ValidatedReportRecipe {
+            subject: ReportSubjectSelection::Tenant { id: tenant_id },
+            from: date("2026-01-01"),
+            to: date("2026-02-28"),
+            granularity: ReportGranularity::Day,
+            metrics: vec![],
+        };
+        let full_plan = plan_report(&recipe, &[], planner_limits())
+            .unwrap_or_else(|error| panic!("full report should plan: {error}"));
+        let (preview_recipe, preview_profiles) = preview_inputs(&recipe, &full_plan, vec![])
+            .unwrap_or_else(|| panic!("preview inputs should exist"));
+        let preview_plan = plan_report(&preview_recipe, &preview_profiles, planner_limits())
+            .unwrap_or_else(|error| panic!("preview report should plan: {error}"));
+
+        assert_eq!(preview_plan.size.total_rows, MAX_PREVIEW_ROWS as u64);
+        assert_eq!(
+            preview_plan.periods.last().map(|period| period.to),
+            Some(date("2026-01-20"))
+        );
+    }
+
+    fn date(value: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(value, "%Y-%m-%d")
+            .unwrap_or_else(|error| panic!("fixture date must parse: {error}"))
+    }
+
+    fn profile<const N: usize>(id: u128, attributes: [(&str, &str); N]) -> IdentityProfile {
+        IdentityProfile {
+            person_id: Uuid::from_u128(id),
+            attributes: attributes
+                .into_iter()
+                .map(|(key, value)| (key.to_owned(), value.to_owned()))
+                .collect::<BTreeMap<_, _>>(),
+            supervisor: None,
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_results/batch.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/batch.rs
@@ -372,7 +372,7 @@ fn plan_timeseries(
         query: compile_timeseries_query(
             &metric.def,
             req,
-            *bucket,
+            (*bucket).into(),
             dimensions,
             &metric.filters,
             resolved.as_ref(),

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -357,6 +357,7 @@ pub(crate) fn compile_report_timeseries_query(
         to,
         metrics: Vec::new(),
         enforce_tenant_scope,
+        compare_to: None,
     };
 
     compile_timeseries_query(def, &request, bucket, &[], &[], None)
@@ -2518,7 +2519,7 @@ mod tests {
                 )
             }),
             ("timeseries", |req| {
-                compile_timeseries_query(&sum_metric(), req, Bucket::Week, &[], &[], None)
+                compile_timeseries_query(&sum_metric(), req, Bucket::Week.into(), &[], &[], None)
             }),
             ("rollup", |req| {
                 compile_rollup_query(

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -341,6 +341,27 @@ pub(crate) fn compile_timeseries_query(
     CompiledQuery { sql, params }
 }
 
+pub(crate) fn compile_report_timeseries_query(
+    def: &MetricDefinition,
+    tenant_id: uuid::Uuid,
+    entity: ValidatedEntitySelection,
+    from: chrono::NaiveDate,
+    to: chrono::NaiveDate,
+    enforce_tenant_scope: bool,
+    bucket: QueryBucket,
+) -> CompiledQuery {
+    let request = ValidatedMetricResultsRequest {
+        tenant_id,
+        entity,
+        from,
+        to,
+        metrics: Vec::new(),
+        enforce_tenant_scope,
+    };
+
+    compile_timeseries_query(def, &request, bucket, &[], &[], None)
+}
+
 pub(crate) fn compile_group_ranking_query(
     def: &MetricDefinition,
     req: &ValidatedMetricResultsRequest,

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -19,6 +19,25 @@ use crate::domain::metric_definitions::{
 pub(crate) const UNKNOWN_DIMENSION_VALUE: &str = "__unknown__";
 pub(crate) const UNKNOWN_DIMENSION_LABEL: &str = "Unknown";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QueryBucket {
+    Day,
+    Week,
+    Month,
+    Quarter,
+    Year,
+}
+
+impl From<Bucket> for QueryBucket {
+    fn from(bucket: Bucket) -> Self {
+        match bucket {
+            Bucket::Day => Self::Day,
+            Bucket::Week => Self::Week,
+            Bucket::Month => Self::Month,
+        }
+    }
+}
+
 /// The live email → person map every person-entity read resolves through.
 pub(crate) const PERSON_MAP_RELATION: &str = "identity.person_map";
 
@@ -271,7 +290,7 @@ fn window_term(window: Option<DateWindow>, params: &mut Vec<String>) -> String {
 pub(crate) fn compile_timeseries_query(
     def: &MetricDefinition,
     req: &ValidatedMetricResultsRequest,
-    bucket: Bucket,
+    bucket: QueryBucket,
     dimensions: &[String],
     filters: &[ValidatedDimensionFilter],
     group_limit: Option<&ResolvedGroupLimit>,
@@ -365,7 +384,7 @@ pub(crate) fn compile_group_ranking_query(
 fn compile_capped_timeseries_query(
     def: &MetricDefinition,
     req: &ValidatedMetricResultsRequest,
-    bucket: Bucket,
+    bucket: QueryBucket,
     dimensions: &[String],
     filters: &[ValidatedDimensionFilter],
     group_limit: &ResolvedGroupLimit,
@@ -1734,11 +1753,13 @@ fn placeholders(count: usize) -> String {
 // totals row's absent key with NULL instead of the default date, which the
 // row parser rejects. The date-range predicate has already dropped NULL
 // dates, so `assumeNotNull` never sees one.
-fn bucket_expr(bucket: Bucket) -> &'static str {
+fn bucket_expr(bucket: QueryBucket) -> &'static str {
     match bucket {
-        Bucket::Day => "assumeNotNull(metric_date)",
-        Bucket::Week => "toStartOfWeek(assumeNotNull(metric_date), 1)",
-        Bucket::Month => "toStartOfMonth(assumeNotNull(metric_date))",
+        QueryBucket::Day => "assumeNotNull(metric_date)",
+        QueryBucket::Week => "toStartOfWeek(assumeNotNull(metric_date), 1)",
+        QueryBucket::Month => "toStartOfMonth(assumeNotNull(metric_date))",
+        QueryBucket::Quarter => "toStartOfQuarter(assumeNotNull(metric_date))",
+        QueryBucket::Year => "toStartOfYear(assumeNotNull(metric_date))",
     }
 }
 
@@ -2278,7 +2299,8 @@ mod tests {
         };
         *denominator_aggregation = RatioDenominatorAggregation::DistinctCount;
 
-        let query = compile_timeseries_query(&metric, &request(), Bucket::Week, &[], &[], None);
+        let query =
+            compile_timeseries_query(&metric, &request(), QueryBucket::Week, &[], &[], None);
 
         assert!(
             query
@@ -2706,7 +2728,7 @@ mod tests {
         // term) is applied by the wrap OUTSIDE it, exactly as for a managed
         // relation, so a custom metric inherits identical tenant scoping.
         let def = custom_sum_metric();
-        let ts = compile_timeseries_query(&def, &request(), Bucket::Day, &[], &[], None);
+        let ts = compile_timeseries_query(&def, &request(), QueryBucket::Day, &[], &[], None);
         assert!(ts.sql.contains(&format!("FROM ({CUSTOM_SQL})")));
         assert!(!ts.sql.contains("insight.ai_metric_observations"));
         assert!(ts.sql.contains("WHERE tenant_id = ?"));
@@ -2763,7 +2785,7 @@ mod tests {
     fn tenant_is_bound_from_context_once_per_contract_read() {
         let sum = sum_metric();
 
-        let ts = compile_timeseries_query(&sum, &request(), Bucket::Day, &[], &[], None);
+        let ts = compile_timeseries_query(&sum, &request(), QueryBucket::Day, &[], &[], None);
         assert!(ts.sql.contains("WHERE tenant_id = ?"), "timeseries read");
         assert_eq!(tenant_binds(&ts), 1);
         assert_eq!(ts.sql.matches('?').count(), ts.params.len());
@@ -2795,7 +2817,7 @@ mod tests {
         // With enforcement off, every contract read swaps the exact-match term
         // for the tautology, so nothing filters by tenant — yet the placeholder
         // (and its bound value) stays in place, so param arity is unchanged.
-        let ts = compile_timeseries_query(&sum, &req, Bucket::Day, &[], &[], None);
+        let ts = compile_timeseries_query(&sum, &req, QueryBucket::Day, &[], &[], None);
         assert!(
             ts.sql.contains("(tenant_id = ? OR 1 = 1)"),
             "timeseries uses the bypass term"
@@ -2822,9 +2844,23 @@ mod tests {
     #[test]
     fn timeseries_query_buckets_on_a_non_nullable_date() {
         for (bucket, expr) in [
-            (Bucket::Day, "assumeNotNull(metric_date)"),
-            (Bucket::Week, "toStartOfWeek(assumeNotNull(metric_date), 1)"),
-            (Bucket::Month, "toStartOfMonth(assumeNotNull(metric_date))"),
+            (QueryBucket::Day, "assumeNotNull(metric_date)"),
+            (
+                QueryBucket::Week,
+                "toStartOfWeek(assumeNotNull(metric_date), 1)",
+            ),
+            (
+                QueryBucket::Month,
+                "toStartOfMonth(assumeNotNull(metric_date))",
+            ),
+            (
+                QueryBucket::Quarter,
+                "toStartOfQuarter(assumeNotNull(metric_date))",
+            ),
+            (
+                QueryBucket::Year,
+                "toStartOfYear(assumeNotNull(metric_date))",
+            ),
         ] {
             let query = compile_timeseries_query(&sum_metric(), &request(), bucket, &[], &[], None);
             assert!(
@@ -2886,7 +2922,7 @@ mod tests {
             let query = compile_timeseries_query(
                 &def,
                 &request(),
-                Bucket::Week,
+                QueryBucket::Week,
                 &dimensions,
                 &[],
                 Some(&resolved_limit(true)),
@@ -2915,7 +2951,7 @@ mod tests {
         let query = compile_timeseries_query(
             &ratio_metric(),
             &request(),
-            Bucket::Day,
+            QueryBucket::Day,
             &["tool".to_owned()],
             &[],
             Some(&resolved_limit(false)),
@@ -2971,7 +3007,7 @@ mod tests {
         let query = compile_timeseries_query(
             &sum_metric(),
             &request(),
-            Bucket::Day,
+            QueryBucket::Day,
             &["tool".to_owned()],
             &[],
             Some(&ResolvedGroupLimit {
@@ -3281,8 +3317,14 @@ mod tests {
 
     #[test]
     fn median_single_views_use_exact_median() {
-        let ts =
-            compile_timeseries_query(&median_metric(), &request(), Bucket::Week, &[], &[], None);
+        let ts = compile_timeseries_query(
+            &median_metric(),
+            &request(),
+            QueryBucket::Week,
+            &[],
+            &[],
+            None,
+        );
         assert!(
             ts.sql
                 .contains("quantileExactIf(0.5)(value, value IS NOT NULL)")
@@ -3324,7 +3366,7 @@ mod tests {
         let ts = compile_timeseries_query(
             &percentile_metric(),
             &request(),
-            Bucket::Week,
+            QueryBucket::Week,
             &[],
             &[],
             None,
@@ -3382,8 +3424,14 @@ mod tests {
         // not 0%: the numerator aggregates OrNull in every query shape, while
         // the denominator relies on nullIf alone.
         let batched = compile_period_batch_query(&[&ratio_metric()], &request(), &[]);
-        let ts =
-            compile_timeseries_query(&ratio_metric(), &request(), Bucket::Week, &[], &[], None);
+        let ts = compile_timeseries_query(
+            &ratio_metric(),
+            &request(),
+            QueryBucket::Week,
+            &[],
+            &[],
+            None,
+        );
         let bd = compile_breakdown_query(&ratio_metric(), &request(), &["tool".to_owned()], &[]);
         assert!(
             batched
@@ -3405,7 +3453,7 @@ mod tests {
         let ts = compile_timeseries_query(
             &distinct_count_metric(),
             &request(),
-            Bucket::Week,
+            QueryBucket::Week,
             &[],
             &[],
             None,
@@ -3496,7 +3544,7 @@ mod tests {
             clamp_max: Some(100.0),
             ..ValueTransform::default()
         });
-        let ts = compile_timeseries_query(&def, &request(), Bucket::Day, &[], &[], None);
+        let ts = compile_timeseries_query(&def, &request(), QueryBucket::Day, &[], &[], None);
         let bd = compile_breakdown_query(&def, &request(), &[], &[]);
         for query in [&ts, &bd] {
             assert!(

--- a/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
@@ -404,7 +404,7 @@ async fn timeseries_over_nullable_metric_date_builds_every_bucket() -> anyhow::R
     let req = request();
 
     for bucket in [Bucket::Day, Bucket::Week, Bucket::Month] {
-        let query = compile_timeseries_query(&def, &req, bucket, &[], &[], None);
+        let query = compile_timeseries_query(&def, &req, bucket.into(), &[], &[], None);
         let rows: Vec<TimeseriesQueryRow> = fetch_rows(&ch, &query)
             .await
             .map_err(|e| anyhow::anyhow!("bucket {bucket:?}: {e}"))?;
@@ -457,7 +457,7 @@ async fn capped_timeseries_over_nullable_metric_date_builds() -> anyhow::Result<
     let query = compile_timeseries_query(
         &def,
         &req,
-        Bucket::Day,
+        Bucket::Day.into(),
         &dimensions,
         &[],
         Some(&group_limit),

--- a/src/backend/services/analytics/src/domain/metric_results/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/mod.rs
@@ -26,5 +26,5 @@ pub use dto::{
     MetricResultsEntityDto, MetricResultsPeriodDto, MetricResultsRequest, MetricResultsResponse,
 };
 pub use failure::ViewFailure;
+pub(crate) use validation::{ValidatedEntitySelection, normalize_key, normalize_metric_key};
 pub use validation::{ValidatedMetricResultsRequest, validate_request};
-pub(crate) use validation::{normalize_key, normalize_metric_key};

--- a/src/backend/services/analytics/src/domain/metric_results/view.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/view.rs
@@ -40,3 +40,18 @@ pub enum MetricResultViewKind {
     Rollup,
     Histogram,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Bucket;
+
+    #[test]
+    fn public_bucket_rejects_internal_report_granularities() {
+        for value in [r#""quarter""#, r#""year""#] {
+            assert!(
+                serde_json::from_str::<Bucket>(value).is_err(),
+                "should reject: {value}"
+            );
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/mod.rs
+++ b/src/backend/services/analytics/src/domain/mod.rs
@@ -11,4 +11,5 @@ pub mod metric_key;
 pub mod metric_results;
 pub(crate) mod person_visibility;
 pub mod query_gate;
+pub mod reports;
 pub mod saved_query;

--- a/src/backend/services/analytics/src/domain/person_visibility.rs
+++ b/src/backend/services/analytics/src/domain/person_visibility.rs
@@ -3,7 +3,7 @@ use toolkit_security::SecurityContext;
 use uuid::Uuid;
 
 use crate::api::error::MetricError;
-use crate::infra::identity::IdentityClient;
+use crate::infra::identity::{IdentityClient, IdentityProfile};
 
 const SERVICE_SUBJECT_TYPE: &str = "service";
 
@@ -18,6 +18,66 @@ pub(crate) async fn authorize_person_ids(
     }
 
     authorize_visible_person_ids(identity, ctx.subject_id(), authorization, person_ids).await
+}
+
+pub(crate) async fn authorize_and_hydrate_person_profiles(
+    identity: &IdentityClient,
+    ctx: &SecurityContext,
+    authorization: Option<&str>,
+    person_ids: &[Uuid],
+) -> Result<Vec<IdentityProfile>, CanonicalError> {
+    if !identity.is_configured() {
+        tracing::error!("identity service is not configured; reports cannot hydrate profiles");
+        return Err(unavailable());
+    }
+
+    let caller = ctx.subject_id();
+    if caller.is_nil() {
+        tracing::error!("report access attempted with no resolved caller");
+        return Err(unavailable());
+    }
+
+    let Some(authorization) = authorization else {
+        tracing::error!(caller = %caller, "no Authorization header to forward to identity");
+        return Err(unavailable());
+    };
+
+    let profiles = identity
+        .profiles_batch(person_ids, Some(authorization))
+        .await
+        .map_err(|error| {
+            tracing::error!(error = %error, caller = %caller, "profile batch failed");
+            unavailable()
+        })?;
+
+    if !profile_batch_contract_holds(person_ids, &profiles) {
+        tracing::error!(caller = %caller, "identity profile batch violated its ordered-subset contract");
+        return Err(unavailable());
+    }
+
+    let unmatched = person_ids.len().saturating_sub(profiles.len());
+    if unmatched > 0 {
+        return Err(denied(caller, unmatched));
+    }
+
+    Ok(profiles)
+}
+
+fn profile_batch_contract_holds(requested: &[Uuid], profiles: &[IdentityProfile]) -> bool {
+    let mut requested = requested.iter();
+    profiles.iter().all(|profile| {
+        if profile
+            .supervisor
+            .as_ref()
+            .is_some_and(|supervisor| supervisor.person_id.is_nil())
+        {
+            return false;
+        }
+
+        requested
+            .by_ref()
+            .any(|person_id| *person_id == profile.person_id)
+    })
 }
 
 async fn authorize_visible_person_ids(
@@ -137,6 +197,17 @@ mod tests {
         let app = Router::new().route(
             "/v1/visible-persons",
             post(move || async move { status.into_response() }),
+        );
+        IdentityClient::new(&serve(app).await).unwrap()
+    }
+
+    async fn spawn_profiles_identity(body: serde_json::Value) -> IdentityClient {
+        let app = Router::new().route(
+            "/v1/profiles/batch",
+            post(move || {
+                let body = body.clone();
+                async move { axum::Json(body) }
+            }),
         );
         IdentityClient::new(&serve(app).await).unwrap()
     }
@@ -287,6 +358,131 @@ mod tests {
             status,
             StatusCode::INTERNAL_SERVER_ERROR,
             "a broken authn path is not a visibility denial"
+        );
+    }
+
+    #[tokio::test]
+    async fn profile_hydration_requires_every_requested_person_in_order() {
+        let identity = spawn_profiles_identity(serde_json::json!({
+            "profiles": [
+                {"person_id": SELF_PERSON, "attributes": {}},
+                {"person_id": REPORT_PERSON, "attributes": {"display_name": "Example User"}}
+            ]
+        }))
+        .await;
+        let ctx = ctx_for("user", CALLER);
+
+        let profiles = authorize_and_hydrate_person_profiles(
+            &identity,
+            &ctx,
+            Some("Bearer tok"),
+            &[SELF_PERSON, REPORT_PERSON],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            profiles
+                .iter()
+                .map(|profile| profile.person_id)
+                .collect::<Vec<_>>(),
+            vec![SELF_PERSON, REPORT_PERSON]
+        );
+    }
+
+    #[tokio::test]
+    async fn omitted_profile_rejects_the_whole_report_as_not_visible() {
+        let identity = spawn_profiles_identity(serde_json::json!({
+            "profiles": [{"person_id": SELF_PERSON, "attributes": {}}]
+        }))
+        .await;
+        let ctx = ctx_for("user", CALLER);
+
+        let error = authorize_and_hydrate_person_profiles(
+            &identity,
+            &ctx,
+            Some("Bearer tok"),
+            &[SELF_PERSON, STRANGER_PERSON],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.into_response().status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn reordered_profile_success_is_a_dependency_error() {
+        let identity = spawn_profiles_identity(serde_json::json!({
+            "profiles": [
+                {"person_id": REPORT_PERSON, "attributes": {}},
+                {"person_id": SELF_PERSON, "attributes": {}}
+            ]
+        }))
+        .await;
+        let ctx = ctx_for("user", CALLER);
+
+        let error = authorize_and_hydrate_person_profiles(
+            &identity,
+            &ctx,
+            Some("Bearer tok"),
+            &[SELF_PERSON, REPORT_PERSON],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[tokio::test]
+    async fn unrequested_profile_success_is_a_dependency_error() {
+        let identity = spawn_profiles_identity(serde_json::json!({
+            "profiles": [{"person_id": STRANGER_PERSON, "attributes": {}}]
+        }))
+        .await;
+        let ctx = ctx_for("user", CALLER);
+
+        let error = authorize_and_hydrate_person_profiles(
+            &identity,
+            &ctx,
+            Some("Bearer tok"),
+            &[SELF_PERSON],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[tokio::test]
+    async fn nil_supervisor_success_is_a_dependency_error() {
+        let identity = spawn_profiles_identity(serde_json::json!({
+            "profiles": [{
+                "person_id": SELF_PERSON,
+                "attributes": {},
+                "supervisor": {"person_id": Uuid::nil(), "attributes": {}}
+            }]
+        }))
+        .await;
+        let ctx = ctx_for("user", CALLER);
+
+        let error = authorize_and_hydrate_person_profiles(
+            &identity,
+            &ctx,
+            Some("Bearer tok"),
+            &[SELF_PERSON],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
         );
     }
 }

--- a/src/backend/services/analytics/src/domain/reports/columns.rs
+++ b/src/backend/services/analytics/src/domain/reports/columns.rs
@@ -1,0 +1,332 @@
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::domain::metric_definitions::{MetricDefinition, MetricFormat};
+use crate::infra::identity::IdentityProfile;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReportColumnDataType {
+    Text,
+    Date,
+    Number,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+pub(crate) struct ReportColumnMetadata {
+    pub(crate) key: String,
+    pub(crate) label: String,
+    pub(crate) data_type: ReportColumnDataType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) format: Option<MetricFormat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) unit: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlannedColumnSource {
+    PersonDisplay,
+    PersonAttribute(&'static str),
+    SupervisorDisplay,
+    SupervisorAttribute(&'static str),
+    PeriodLabel,
+    PeriodFrom,
+    PeriodTo,
+    Metric(usize),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PlannedColumn {
+    pub(crate) metadata: ReportColumnMetadata,
+    pub(crate) source: PlannedColumnSource,
+}
+
+pub(crate) fn plan_columns(
+    profiles: &[IdentityProfile],
+    metrics: &[MetricDefinition],
+) -> Vec<PlannedColumn> {
+    let mut columns = Vec::new();
+    if !profiles.is_empty() {
+        columns.push(text_column(
+            "person",
+            "Person",
+            PlannedColumnSource::PersonDisplay,
+        ));
+
+        let optional_columns = [
+            (
+                "email",
+                "Email",
+                PlannedColumnSource::PersonAttribute("email"),
+            ),
+            (
+                "division",
+                "Division",
+                PlannedColumnSource::PersonAttribute("division"),
+            ),
+            (
+                "department",
+                "Department",
+                PlannedColumnSource::PersonAttribute("department"),
+            ),
+            (
+                "job_title",
+                "Job title",
+                PlannedColumnSource::PersonAttribute("job_title"),
+            ),
+            ("manager", "Manager", PlannedColumnSource::SupervisorDisplay),
+            (
+                "manager_email",
+                "Manager email",
+                PlannedColumnSource::SupervisorAttribute("email"),
+            ),
+            (
+                "status",
+                "Status",
+                PlannedColumnSource::PersonAttribute("status"),
+            ),
+        ];
+        for (key, label, source) in optional_columns {
+            if profiles.iter().any(|profile| {
+                profile_text(source, profile).is_some_and(|value| !value.trim().is_empty())
+            }) {
+                columns.push(text_column(key, label, source));
+            }
+        }
+    }
+
+    columns.extend([
+        text_column("period", "Period", PlannedColumnSource::PeriodLabel),
+        date_column("from", "From", PlannedColumnSource::PeriodFrom),
+        date_column("to", "To", PlannedColumnSource::PeriodTo),
+    ]);
+    columns.extend(
+        metrics
+            .iter()
+            .enumerate()
+            .map(|(index, metric)| PlannedColumn {
+                metadata: ReportColumnMetadata {
+                    key: metric.base.key.clone(),
+                    label: metric.base.label.clone(),
+                    data_type: ReportColumnDataType::Number,
+                    format: Some(metric.base.format),
+                    unit: metric.base.unit.clone(),
+                },
+                source: PlannedColumnSource::Metric(index),
+            }),
+    );
+
+    columns
+}
+
+pub(crate) fn profile_text(source: PlannedColumnSource, profile: &IdentityProfile) -> Option<&str> {
+    match source {
+        PlannedColumnSource::PersonDisplay => {
+            first_attribute(&profile.attributes, &["display_name", "username", "email"])
+        }
+        PlannedColumnSource::PersonAttribute(attribute) => {
+            profile.attributes.get(attribute).map(String::as_str)
+        }
+        PlannedColumnSource::SupervisorDisplay => profile
+            .supervisor
+            .as_ref()
+            .and_then(|person| first_attribute(&person.attributes, &["display_name", "username"])),
+        PlannedColumnSource::SupervisorAttribute(attribute) => profile
+            .supervisor
+            .as_ref()
+            .and_then(|person| person.attributes.get(attribute))
+            .map(String::as_str),
+        PlannedColumnSource::PeriodLabel
+        | PlannedColumnSource::PeriodFrom
+        | PlannedColumnSource::PeriodTo
+        | PlannedColumnSource::Metric(_) => None,
+    }
+}
+
+fn text_column(key: &str, label: &str, source: PlannedColumnSource) -> PlannedColumn {
+    PlannedColumn {
+        metadata: ReportColumnMetadata {
+            key: key.to_owned(),
+            label: label.to_owned(),
+            data_type: ReportColumnDataType::Text,
+            format: None,
+            unit: None,
+        },
+        source,
+    }
+}
+
+fn date_column(key: &str, label: &str, source: PlannedColumnSource) -> PlannedColumn {
+    PlannedColumn {
+        metadata: ReportColumnMetadata {
+            key: key.to_owned(),
+            label: label.to_owned(),
+            data_type: ReportColumnDataType::Date,
+            format: None,
+            unit: None,
+        },
+        source,
+    }
+}
+
+fn first_attribute<'a>(
+    attributes: &'a std::collections::BTreeMap<String, String>,
+    keys: &[&str],
+) -> Option<&'a str> {
+    keys.iter()
+        .filter_map(|key| attributes.get(*key))
+        .find(|value| !value.trim().is_empty())
+        .map(String::as_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::domain::metric_definitions::definition::{
+        AliasCollapse, ComputationSpec, MetricBase, MetricDirection, MetricInput, MetricInputRole,
+        ObservationRelation, ObservationSource,
+    };
+    use crate::infra::identity::IdentityProfileRelationship;
+
+    fn attributes(values: &[(&str, &str)]) -> BTreeMap<String, String> {
+        values
+            .iter()
+            .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+            .collect()
+    }
+
+    fn profile(
+        id: u128,
+        values: &[(&str, &str)],
+        supervisor: Option<&[(&str, &str)]>,
+    ) -> IdentityProfile {
+        IdentityProfile {
+            person_id: Uuid::from_u128(id),
+            attributes: attributes(values),
+            supervisor: supervisor.map(|values| IdentityProfileRelationship {
+                person_id: Uuid::from_u128(id + 100),
+                attributes: attributes(values),
+            }),
+        }
+    }
+
+    fn metric(key: &str, label: &str, format: MetricFormat) -> MetricDefinition {
+        MetricDefinition {
+            base: MetricBase {
+                key: key.to_owned(),
+                label: label.to_owned(),
+                short_label: None,
+                description: None,
+                explanation: None,
+                entity_type: "person".to_owned(),
+                format,
+                unit: Some("items".to_owned()),
+                direction: MetricDirection::Neutral,
+                peer_cohort_key: None,
+                allowed_dimensions: vec![],
+            },
+            spec: ComputationSpec::Sum {
+                value: MetricInput {
+                    role: MetricInputRole::Value,
+                    observation: ObservationSource::Managed(
+                        ObservationRelation::parse("test_metric_observations")
+                            .unwrap_or_else(|| panic!("fixture relation must parse")),
+                    ),
+                    source_key: "test".to_owned(),
+                    measure_key: "value".to_owned(),
+                    alias_collapse: AliasCollapse::Sum,
+                },
+            },
+            transform: None,
+        }
+    }
+
+    #[test]
+    fn includes_populated_profile_columns_and_metrics_in_recipe_order() {
+        let profiles = vec![
+            profile(
+                1,
+                &[("username", "example-user"), ("department", "Engineering")],
+                None,
+            ),
+            profile(
+                2,
+                &[
+                    ("display_name", "Example Two"),
+                    ("email", "two@example.com"),
+                ],
+                Some(&[
+                    ("display_name", "Example Manager"),
+                    ("email", "manager@example.com"),
+                ]),
+            ),
+        ];
+        let metrics = vec![
+            metric("git.commits", "Commits", MetricFormat::Integer),
+            metric("git.review_rate", "Review rate", MetricFormat::Percent),
+        ];
+
+        let columns = plan_columns(&profiles, &metrics);
+        let keys = columns
+            .iter()
+            .map(|column| column.metadata.key.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            keys,
+            [
+                "person",
+                "email",
+                "department",
+                "manager",
+                "manager_email",
+                "period",
+                "from",
+                "to",
+                "git.commits",
+                "git.review_rate",
+            ]
+        );
+        assert_eq!(
+            profile_text(columns[0].source, &profiles[0]),
+            Some("example-user")
+        );
+        assert_eq!(
+            profile_text(columns[3].source, &profiles[1]),
+            Some("Example Manager")
+        );
+        assert_eq!(columns[8].metadata.format, Some(MetricFormat::Integer));
+        assert_eq!(columns[9].metadata.format, Some(MetricFormat::Percent));
+    }
+
+    #[test]
+    fn omits_every_optional_profile_column_when_profiles_have_no_attributes() {
+        let profiles = vec![profile(1, &[], None)];
+
+        let columns = plan_columns(&profiles, &[]);
+        let keys = columns
+            .iter()
+            .map(|column| column.metadata.key.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(keys, ["person", "period", "from", "to"]);
+        assert_eq!(profile_text(columns[0].source, &profiles[0]), None);
+    }
+
+    #[test]
+    fn tenant_columns_contain_only_periods_and_metrics() {
+        let metrics = vec![metric("ci.builds", "Builds", MetricFormat::Integer)];
+
+        let columns = plan_columns(&[], &metrics);
+        let keys = columns
+            .iter()
+            .map(|column| column.metadata.key.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(keys, ["period", "from", "to", "ci.builds"]);
+    }
+}

--- a/src/backend/services/analytics/src/domain/reports/columns.rs
+++ b/src/backend/services/analytics/src/domain/reports/columns.rs
@@ -6,21 +6,21 @@ use crate::infra::identity::IdentityProfile;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum ReportColumnDataType {
+pub enum ReportColumnDataType {
     Text,
     Date,
     Number,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
-pub(crate) struct ReportColumnMetadata {
-    pub(crate) key: String,
-    pub(crate) label: String,
-    pub(crate) data_type: ReportColumnDataType,
+pub struct ReportColumnMetadata {
+    pub key: String,
+    pub label: String,
+    pub data_type: ReportColumnDataType,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) format: Option<MetricFormat>,
+    pub format: Option<MetricFormat>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) unit: Option<String>,
+    pub unit: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/backend/services/analytics/src/domain/reports/dto.rs
+++ b/src/backend/services/analytics/src/domain/reports/dto.rs
@@ -1,5 +1,9 @@
 use serde::Deserialize;
+use serde::Serialize;
 use uuid::Uuid;
+
+use super::columns::ReportColumnMetadata;
+use super::row::ReportRow;
 
 #[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
@@ -11,6 +15,16 @@ pub struct ReportRecipe {
 }
 
 pub type ReportPreviewRequest = ReportRecipe;
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ReportPreviewResponse {
+    pub columns: Vec<ReportColumnMetadata>,
+    pub rows: Vec<ReportRow>,
+    pub total_rows: u64,
+}
+
+impl toolkit::api::api_dto::RequestApiDto for ReportRecipe {}
+impl toolkit::api::api_dto::ResponseApiDto for ReportPreviewResponse {}
 
 #[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]

--- a/src/backend/services/analytics/src/domain/reports/dto.rs
+++ b/src/backend/services/analytics/src/domain/reports/dto.rs
@@ -27,14 +27,6 @@ impl toolkit::api::api_dto::RequestApiDto for ReportRecipe {}
 impl toolkit::api::api_dto::ResponseApiDto for ReportPreviewResponse {}
 
 #[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
-#[serde(deny_unknown_fields)]
-pub struct ReportExportRequest {
-    #[serde(flatten)]
-    pub recipe: ReportRecipe,
-    pub format: ReportExportFormat,
-}
-
-#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ReportSubject {
     People { ids: Vec<Uuid> },
@@ -58,13 +50,6 @@ pub enum ReportGranularity {
     Year,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, utoipa::ToSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum ReportExportFormat {
-    Csv,
-    Xlsx,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -85,20 +70,5 @@ mod tests {
             r#"{{"subject":{{"type":"tenant","ids":["{PERSON_ID}"]}},"period":{{"from":"2026-01-01","to":"2026-01-31"}},"granularity":"day","metric_keys":["ci.builds"]}}"#
         );
         assert!(serde_json::from_str::<ReportPreviewRequest>(&tenant_with_ids).is_err());
-    }
-
-    #[test]
-    fn export_accepts_only_declared_formats() {
-        let csv = r#"{"subject":{"type":"tenant"},"period":{"from":"2026-01-01","to":"2026-01-31"},"granularity":"month","metric_keys":["ci.builds"],"format":"csv"}"#.to_owned();
-        assert!(serde_json::from_str::<ReportExportRequest>(&csv).is_ok());
-
-        let invalid = csv.replace("\"csv\"", "\"pdf\"");
-        assert!(serde_json::from_str::<ReportExportRequest>(&invalid).is_err());
-
-        let unknown_field = csv.replace(
-            "\"format\":\"csv\"",
-            "\"format\":\"csv\",\"filename\":\"report.csv\"",
-        );
-        assert!(serde_json::from_str::<ReportExportRequest>(&unknown_field).is_err());
     }
 }

--- a/src/backend/services/analytics/src/domain/reports/dto.rs
+++ b/src/backend/services/analytics/src/domain/reports/dto.rs
@@ -1,0 +1,90 @@
+use serde::Deserialize;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReportRecipe {
+    pub subject: ReportSubject,
+    pub period: ReportPeriod,
+    pub granularity: ReportGranularity,
+    pub metric_keys: Vec<String>,
+}
+
+pub type ReportPreviewRequest = ReportRecipe;
+
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReportExportRequest {
+    #[serde(flatten)]
+    pub recipe: ReportRecipe,
+    pub format: ReportExportFormat,
+}
+
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ReportSubject {
+    People { ids: Vec<Uuid> },
+    Tenant {},
+}
+
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReportPeriod {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportGranularity {
+    Day,
+    Week,
+    Month,
+    Quarter,
+    Year,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReportExportFormat {
+    Csv,
+    Xlsx,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PERSON_ID: &str = "019e27bc-dec0-7626-81a9-c5524662a6a9";
+
+    #[test]
+    fn preview_rejects_unknown_fields_and_invalid_subject_ids() {
+        let unknown_field = format!(
+            r#"{{"subject":{{"type":"people","ids":["{PERSON_ID}"]}},"period":{{"from":"2026-01-01","to":"2026-01-31"}},"granularity":"day","metric_keys":["git.commits"],"tab":"overview"}}"#
+        );
+        assert!(serde_json::from_str::<ReportPreviewRequest>(&unknown_field).is_err());
+
+        let invalid_id = r#"{"subject":{"type":"people","ids":["not-a-uuid"]},"period":{"from":"2026-01-01","to":"2026-01-31"},"granularity":"day","metric_keys":["git.commits"]}"#;
+        assert!(serde_json::from_str::<ReportPreviewRequest>(invalid_id).is_err());
+
+        let tenant_with_ids = format!(
+            r#"{{"subject":{{"type":"tenant","ids":["{PERSON_ID}"]}},"period":{{"from":"2026-01-01","to":"2026-01-31"}},"granularity":"day","metric_keys":["ci.builds"]}}"#
+        );
+        assert!(serde_json::from_str::<ReportPreviewRequest>(&tenant_with_ids).is_err());
+    }
+
+    #[test]
+    fn export_accepts_only_declared_formats() {
+        let csv = r#"{"subject":{"type":"tenant"},"period":{"from":"2026-01-01","to":"2026-01-31"},"granularity":"month","metric_keys":["ci.builds"],"format":"csv"}"#.to_owned();
+        assert!(serde_json::from_str::<ReportExportRequest>(&csv).is_ok());
+
+        let invalid = csv.replace("\"csv\"", "\"pdf\"");
+        assert!(serde_json::from_str::<ReportExportRequest>(&invalid).is_err());
+
+        let unknown_field = csv.replace(
+            "\"format\":\"csv\"",
+            "\"format\":\"csv\",\"filename\":\"report.csv\"",
+        );
+        assert!(serde_json::from_str::<ReportExportRequest>(&unknown_field).is_err());
+    }
+}

--- a/src/backend/services/analytics/src/domain/reports/executor.rs
+++ b/src/backend/services/analytics/src/domain/reports/executor.rs
@@ -1,0 +1,164 @@
+use async_trait::async_trait;
+use futures::StreamExt;
+use futures::stream;
+use uuid::Uuid;
+
+use crate::infra::identity::IdentityProfile;
+
+use super::planner::{PlannedReportSubject, ReportPlan};
+use super::query::{
+    ReportMetricQuery, ReportQueryError, ReportQueryRunner, ReportQuerySubject,
+    compile_report_metric_query,
+};
+use super::row::{
+    ReportMetricValues, ReportRow, ReportRowError, assemble_people_rows, assemble_tenant_rows,
+};
+use super::validation::ValidatedReportRecipe;
+
+const REPORT_QUERY_CONCURRENCY: usize = 4;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ReportExecutionContext {
+    pub(crate) tenant_id: Uuid,
+    pub(crate) enforce_tenant_scope: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("report sink failed: {0}")]
+pub(crate) struct ReportSinkError(pub(crate) String);
+
+#[async_trait]
+pub(crate) trait ReportRowSink {
+    type Output;
+
+    async fn write_rows(&mut self, rows: &[ReportRow]) -> Result<(), ReportSinkError>;
+    async fn finish(self) -> Result<Self::Output, ReportSinkError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ReportExecutionError {
+    #[error("report metric query failed")]
+    Query(#[source] ReportQueryError),
+    #[error("report metric result shape is invalid")]
+    Row(#[source] ReportRowError),
+    #[error("report plan does not match its inputs")]
+    PlanMismatch,
+    #[error("report output failed")]
+    Sink(#[source] ReportSinkError),
+}
+
+pub(crate) async fn execute_report<R, S>(
+    recipe: &ValidatedReportRecipe,
+    plan: &ReportPlan,
+    profiles: &[IdentityProfile],
+    context: ReportExecutionContext,
+    runner: &R,
+    mut sink: S,
+) -> Result<S::Output, ReportExecutionError>
+where
+    R: ReportQueryRunner,
+    S: ReportRowSink,
+{
+    match &plan.subject {
+        PlannedReportSubject::People { ids, batches } => {
+            if ids.len() != profiles.len()
+                || !ids
+                    .iter()
+                    .zip(profiles)
+                    .all(|(id, profile)| id == &profile.person_id)
+            {
+                return Err(ReportExecutionError::PlanMismatch);
+            }
+            for batch in batches {
+                let batch_ids = ids
+                    .get(batch.person_start..batch.person_end)
+                    .ok_or(ReportExecutionError::PlanMismatch)?;
+                let batch_profiles = profiles
+                    .get(batch.person_start..batch.person_end)
+                    .ok_or(ReportExecutionError::PlanMismatch)?;
+                let values = execute_metric_queries(
+                    recipe,
+                    plan,
+                    context,
+                    ReportQuerySubject::People(batch_ids.to_vec()),
+                    runner,
+                )
+                .await?;
+                let rows =
+                    assemble_people_rows(&plan.columns, &plan.periods, batch_profiles, &values)
+                        .map_err(ReportExecutionError::Row)?;
+
+                sink.write_rows(&rows)
+                    .await
+                    .map_err(ReportExecutionError::Sink)?;
+            }
+        }
+        PlannedReportSubject::Tenant { id } => {
+            if !profiles.is_empty() || *id != context.tenant_id {
+                return Err(ReportExecutionError::PlanMismatch);
+            }
+            let values = execute_metric_queries(
+                recipe,
+                plan,
+                context,
+                ReportQuerySubject::Tenant(*id),
+                runner,
+            )
+            .await?;
+            let rows = assemble_tenant_rows(&plan.columns, &plan.periods, *id, &values)
+                .map_err(ReportExecutionError::Row)?;
+
+            sink.write_rows(&rows)
+                .await
+                .map_err(ReportExecutionError::Sink)?;
+        }
+    }
+
+    sink.finish().await.map_err(ReportExecutionError::Sink)
+}
+
+async fn execute_metric_queries<R: ReportQueryRunner>(
+    recipe: &ValidatedReportRecipe,
+    plan: &ReportPlan,
+    context: ReportExecutionContext,
+    subject: ReportQuerySubject,
+    runner: &R,
+) -> Result<Vec<ReportMetricValues>, ReportExecutionError> {
+    let queries = recipe
+        .metrics
+        .iter()
+        .enumerate()
+        .map(|(metric_index, metric)| {
+            compile_report_metric_query(
+                metric_index,
+                metric,
+                context.tenant_id,
+                subject.clone(),
+                recipe.from,
+                recipe.to,
+                plan.bucket,
+                context.enforce_tenant_scope,
+            )
+        });
+    let mut results = stream::iter(queries)
+        .map(|query: ReportMetricQuery| runner.run(query))
+        .buffer_unordered(REPORT_QUERY_CONCURRENCY);
+    let mut ordered = (0..recipe.metrics.len())
+        .map(|_| None)
+        .collect::<Vec<Option<ReportMetricValues>>>();
+    while let Some(result) = results.next().await {
+        let values = result.map_err(ReportExecutionError::Query)?;
+        let Some(slot) = ordered.get_mut(values.metric_index) else {
+            return Err(ReportExecutionError::PlanMismatch);
+        };
+        if slot.is_some() {
+            return Err(ReportExecutionError::PlanMismatch);
+        }
+        *slot = Some(values);
+    }
+
+    ordered
+        .into_iter()
+        .collect::<Option<Vec<_>>>()
+        .ok_or(ReportExecutionError::PlanMismatch)
+}

--- a/src/backend/services/analytics/src/domain/reports/executor.rs
+++ b/src/backend/services/analytics/src/domain/reports/executor.rs
@@ -133,7 +133,7 @@ async fn execute_metric_queries<R: ReportQueryRunner>(
                 metric_index,
                 metric,
                 context.tenant_id,
-                subject.clone(),
+                &subject,
                 recipe.from,
                 recipe.to,
                 plan.bucket,

--- a/src/backend/services/analytics/src/domain/reports/executor.rs
+++ b/src/backend/services/analytics/src/domain/reports/executor.rs
@@ -139,7 +139,8 @@ async fn execute_metric_queries<R: ReportQueryRunner>(
                 plan.bucket,
                 context.enforce_tenant_scope,
             )
-        });
+        })
+        .collect::<Vec<ReportMetricQuery>>();
     let mut results = stream::iter(queries)
         .map(|query: ReportMetricQuery| runner.run(query))
         .buffer_unordered(REPORT_QUERY_CONCURRENCY);

--- a/src/backend/services/analytics/src/domain/reports/executor_test_fixtures.rs
+++ b/src/backend/services/analytics/src/domain/reports/executor_test_fixtures.rs
@@ -1,0 +1,125 @@
+use std::collections::BTreeMap;
+
+use chrono::NaiveDate;
+use uuid::Uuid;
+
+use super::dto::ReportGranularity;
+use super::executor::ReportExecutionContext;
+use super::row::{ReportCell, ReportMetricValue};
+use super::validation::{ReportSubjectSelection, ValidatedReportRecipe};
+use crate::domain::metric_definitions::MetricDefinition;
+use crate::domain::metric_definitions::definition::{
+    AliasCollapse, ComputationSpec, MetricBase, MetricDirection, MetricFormat, MetricInput,
+    MetricInputRole, ObservationRelation, ObservationSource,
+};
+use crate::infra::identity::IdentityProfile;
+
+pub(super) fn context() -> ReportExecutionContext {
+    ReportExecutionContext {
+        tenant_id: Uuid::from_u128(9),
+        enforce_tenant_scope: true,
+    }
+}
+
+pub(super) fn people_recipe(
+    profiles: &[IdentityProfile],
+    metric_count: usize,
+) -> ValidatedReportRecipe {
+    ValidatedReportRecipe {
+        subject: ReportSubjectSelection::People {
+            ids: profiles.iter().map(|profile| profile.person_id).collect(),
+        },
+        from: date("2026-01-01"),
+        to: date("2026-02-28"),
+        granularity: ReportGranularity::Month,
+        metrics: (0..metric_count)
+            .map(|index| metric(index, "person"))
+            .collect(),
+    }
+}
+
+pub(super) fn tenant_recipe(tenant_id: Uuid, metric_count: usize) -> ValidatedReportRecipe {
+    ValidatedReportRecipe {
+        subject: ReportSubjectSelection::Tenant { id: tenant_id },
+        from: date("2026-01-01"),
+        to: date("2026-02-28"),
+        granularity: ReportGranularity::Month,
+        metrics: (0..metric_count)
+            .map(|index| metric(index, "tenant"))
+            .collect(),
+    }
+}
+
+pub(super) fn profile(id: u128, display_name: &str) -> IdentityProfile {
+    IdentityProfile {
+        person_id: Uuid::from_u128(id),
+        attributes: BTreeMap::from([("display_name".to_owned(), display_name.to_owned())]),
+        supervisor: None,
+    }
+}
+
+fn metric(index: usize, entity_type: &str) -> MetricDefinition {
+    MetricDefinition {
+        base: MetricBase {
+            key: format!("test.metric_{index}"),
+            label: format!("Metric {index}"),
+            short_label: None,
+            description: None,
+            explanation: None,
+            entity_type: entity_type.to_owned(),
+            format: MetricFormat::Integer,
+            unit: None,
+            direction: MetricDirection::Neutral,
+            peer_cohort_key: None,
+            allowed_dimensions: vec![],
+        },
+        spec: ComputationSpec::Sum {
+            value: MetricInput {
+                role: MetricInputRole::Value,
+                observation: ObservationSource::Managed(
+                    ObservationRelation::parse("test_metric_observations")
+                        .unwrap_or_else(|| panic!("fixture relation must parse")),
+                ),
+                source_key: "test".to_owned(),
+                measure_key: "value".to_owned(),
+                alias_collapse: AliasCollapse::Sum,
+            },
+        },
+        transform: None,
+    }
+}
+
+pub(super) fn date(value: &str) -> NaiveDate {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .unwrap_or_else(|error| panic!("fixture date must parse: {error}"))
+}
+
+pub(super) fn value(entity_id: u128, bucket_start: &str, value: Option<f64>) -> ReportMetricValue {
+    ReportMetricValue {
+        entity_id: Uuid::from_u128(entity_id),
+        bucket_start: date(bucket_start),
+        value,
+    }
+}
+
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "matches the positional row cell shape"
+)]
+pub(super) fn text(value: &str) -> Option<ReportCell> {
+    Some(ReportCell::Text(value.to_owned()))
+}
+
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "matches the positional row cell shape"
+)]
+pub(super) fn number(value: f64) -> Option<ReportCell> {
+    Some(ReportCell::Number(value))
+}
+
+pub(super) fn metric_number(index: usize) -> f64 {
+    f64::from(
+        u32::try_from(index).unwrap_or_else(|error| panic!("fixture index must fit u32: {error}")),
+    )
+}

--- a/src/backend/services/analytics/src/domain/reports/executor_tests.rs
+++ b/src/backend/services/analytics/src/domain/reports/executor_tests.rs
@@ -252,7 +252,7 @@ impl ReportQueryRunner for FakeRunner {
             return Err(ReportQueryError::InvalidResultShape);
         }
         let selected_ids = match &query.subject {
-            ReportQuerySubject::People(ids) => ids.to_vec(),
+            ReportQuerySubject::People(ids) => ids.clone(),
             ReportQuerySubject::Tenant(id) => vec![*id],
         };
         let values = self

--- a/src/backend/services/analytics/src/domain/reports/executor_tests.rs
+++ b/src/backend/services/analytics/src/domain/reports/executor_tests.rs
@@ -1,0 +1,299 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use super::executor::{ReportRowSink, ReportSinkError, execute_report};
+use super::executor_test_fixtures::*;
+use super::planner::{ReportPlannerLimits, plan_report};
+use super::query::{ReportMetricQuery, ReportQueryError, ReportQueryRunner, ReportQuerySubject};
+use super::row::{ReportMetricValue, ReportMetricValues, ReportRow};
+
+#[tokio::test]
+async fn executes_people_batches_sequentially_and_emits_person_major_rows() {
+    let profiles = [
+        profile(2, "Second"),
+        profile(1, "First"),
+        profile(3, "Third"),
+    ];
+    let recipe = people_recipe(&profiles, 2);
+    let plan = plan_report(
+        &recipe,
+        &profiles,
+        ReportPlannerLimits { max_batch_cells: 4 },
+    )
+    .unwrap_or_else(|error| panic!("report should plan: {error}"));
+    let runner = FakeRunner::new(HashMap::from([
+        (
+            0,
+            vec![
+                value(2, "2026-01-01", Some(20.0)),
+                value(1, "2026-02-01", Some(10.0)),
+            ],
+        ),
+        (1, vec![value(3, "2026-01-01", Some(30.0))]),
+    ]));
+
+    let rows = execute_report(
+        &recipe,
+        &plan,
+        &profiles,
+        context(),
+        &runner,
+        RecordingSink::default(),
+    )
+    .await
+    .unwrap_or_else(|error| panic!("report should execute: {error}"));
+
+    assert_eq!(rows.len(), 6);
+    assert_eq!(rows[0][0], text("Second"));
+    assert_eq!(rows[0][1], text("2026-01"));
+    assert_eq!(rows[0][4], number(20.0));
+    assert_eq!(rows[1][4], None);
+    assert_eq!(rows[2][0], text("First"));
+    assert_eq!(rows[3][4], number(10.0));
+    assert_eq!(rows[4][0], text("Third"));
+    assert_eq!(rows[4][5], number(30.0));
+    assert_eq!(
+        runner.person_batches(),
+        vec![2, 2, 1, 1, 3, 3],
+        "each two-query batch must finish before the next person starts"
+    );
+}
+
+#[tokio::test]
+async fn tenant_execution_has_no_profile_columns_and_orders_periods_chronologically() {
+    let tenant_id = Uuid::from_u128(9);
+    let recipe = tenant_recipe(tenant_id, 1);
+    let plan = plan_report(
+        &recipe,
+        &[],
+        ReportPlannerLimits {
+            max_batch_cells: 100,
+        },
+    )
+    .unwrap_or_else(|error| panic!("report should plan: {error}"));
+    let runner = FakeRunner::new(HashMap::from([(
+        0,
+        vec![ReportMetricValue {
+            entity_id: tenant_id,
+            bucket_start: date("2026-02-01"),
+            value: Some(4.0),
+        }],
+    )]));
+
+    let rows = execute_report(
+        &recipe,
+        &plan,
+        &[],
+        context(),
+        &runner,
+        RecordingSink::default(),
+    )
+    .await
+    .unwrap_or_else(|error| panic!("report should execute: {error}"));
+
+    assert_eq!(plan.columns.len(), 4);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(
+        rows[0],
+        vec![
+            text("2026-01"),
+            text("2026-01-01"),
+            text("2026-01-31"),
+            None
+        ]
+    );
+    assert_eq!(
+        rows[1],
+        vec![
+            text("2026-02"),
+            text("2026-02-01"),
+            text("2026-02-28"),
+            number(4.0)
+        ]
+    );
+    assert_eq!(runner.tenant_queries(), 1);
+}
+
+#[tokio::test]
+async fn keeps_more_than_fifty_metrics_in_recipe_order_with_four_queries_in_flight() {
+    let tenant_id = Uuid::from_u128(9);
+    let recipe = tenant_recipe(tenant_id, 64);
+    let plan = plan_report(
+        &recipe,
+        &[],
+        ReportPlannerLimits {
+            max_batch_cells: 100_000,
+        },
+    )
+    .unwrap_or_else(|error| panic!("report should plan: {error}"));
+    let responses = (0..64)
+        .map(|metric_index| {
+            (
+                metric_index,
+                vec![ReportMetricValue {
+                    entity_id: tenant_id,
+                    bucket_start: date("2026-01-01"),
+                    value: Some(metric_number(metric_index)),
+                }],
+            )
+        })
+        .collect();
+    let runner = FakeRunner::new(responses);
+
+    let rows = execute_report(
+        &recipe,
+        &plan,
+        &[],
+        context(),
+        &runner,
+        RecordingSink::default(),
+    )
+    .await
+    .unwrap_or_else(|error| panic!("report should execute: {error}"));
+
+    assert_eq!(runner.max_active.load(Ordering::SeqCst), 4);
+    assert_eq!(rows.len(), 2);
+    for metric_index in 0..64 {
+        assert_eq!(
+            rows[0][metric_index + 3],
+            number(metric_number(metric_index))
+        );
+    }
+}
+
+#[tokio::test]
+async fn query_failure_writes_no_batch_and_never_finishes_sink() {
+    let tenant_id = Uuid::from_u128(9);
+    let recipe = tenant_recipe(tenant_id, 5);
+    let plan = plan_report(
+        &recipe,
+        &[],
+        ReportPlannerLimits {
+            max_batch_cells: 100,
+        },
+    )
+    .unwrap_or_else(|error| panic!("report should plan: {error}"));
+    let runner = FakeRunner::new(HashMap::new()).failing(2);
+    let sink = RecordingSink::default();
+    let writes = Arc::clone(&sink.writes);
+    let finishes = Arc::clone(&sink.finishes);
+
+    let result = execute_report(&recipe, &plan, &[], context(), &runner, sink).await;
+    assert!(result.is_err());
+    assert!(
+        writes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_empty()
+    );
+    assert_eq!(finishes.load(Ordering::SeqCst), 0);
+}
+
+struct FakeRunner {
+    responses: HashMap<usize, Vec<ReportMetricValue>>,
+    fail_metric: Option<usize>,
+    active: AtomicUsize,
+    max_active: AtomicUsize,
+    subjects: Mutex<Vec<ReportQuerySubject>>,
+}
+
+impl FakeRunner {
+    fn new(responses: HashMap<usize, Vec<ReportMetricValue>>) -> Self {
+        Self {
+            responses,
+            fail_metric: None,
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+            subjects: Mutex::new(Vec::new()),
+        }
+    }
+    fn failing(mut self, metric_index: usize) -> Self {
+        self.fail_metric = Some(metric_index);
+        self
+    }
+    fn person_batches(&self) -> Vec<u128> {
+        self.subjects
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .filter_map(|subject| match subject {
+                ReportQuerySubject::People(ids) => ids.first().map(Uuid::as_u128),
+                ReportQuerySubject::Tenant(_) => None,
+            })
+            .collect()
+    }
+    fn tenant_queries(&self) -> usize {
+        self.subjects
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .filter(|subject| matches!(subject, ReportQuerySubject::Tenant(_)))
+            .count()
+    }
+}
+
+#[async_trait]
+impl ReportQueryRunner for FakeRunner {
+    async fn run(&self, query: ReportMetricQuery) -> Result<ReportMetricValues, ReportQueryError> {
+        self.subjects
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(query.subject.clone());
+        let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_active.fetch_max(active, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        self.active.fetch_sub(1, Ordering::SeqCst);
+        if self.fail_metric == Some(query.metric_index) {
+            return Err(ReportQueryError::InvalidResultShape);
+        }
+        let selected_ids = match &query.subject {
+            ReportQuerySubject::People(ids) => ids.to_vec(),
+            ReportQuerySubject::Tenant(id) => vec![*id],
+        };
+        let values = self
+            .responses
+            .get(&query.metric_index)
+            .into_iter()
+            .flatten()
+            .filter(|value| selected_ids.contains(&value.entity_id))
+            .cloned()
+            .collect();
+        Ok(ReportMetricValues {
+            metric_index: query.metric_index,
+            values,
+        })
+    }
+}
+
+#[derive(Default)]
+struct RecordingSink {
+    writes: Arc<Mutex<Vec<ReportRow>>>,
+    finishes: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl ReportRowSink for RecordingSink {
+    type Output = Vec<ReportRow>;
+    async fn write_rows(&mut self, rows: &[ReportRow]) -> Result<(), ReportSinkError> {
+        self.writes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .extend_from_slice(rows);
+        Ok(())
+    }
+
+    async fn finish(self) -> Result<Self::Output, ReportSinkError> {
+        self.finishes.fetch_add(1, Ordering::SeqCst);
+        let rows = self
+            .writes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        Ok(rows)
+    }
+}

--- a/src/backend/services/analytics/src/domain/reports/mod.rs
+++ b/src/backend/services/analytics/src/domain/reports/mod.rs
@@ -1,0 +1,2 @@
+pub mod dto;
+pub mod validation;

--- a/src/backend/services/analytics/src/domain/reports/mod.rs
+++ b/src/backend/services/analytics/src/domain/reports/mod.rs
@@ -1,7 +1,14 @@
 pub(crate) mod columns;
 pub mod dto;
+pub(crate) mod executor;
+#[cfg(test)]
+mod executor_test_fixtures;
+#[cfg(test)]
+mod executor_tests;
 pub(crate) mod period;
 pub(crate) mod planner;
 #[cfg(test)]
 mod planner_tests;
+pub(crate) mod query;
+pub(crate) mod row;
 pub mod validation;

--- a/src/backend/services/analytics/src/domain/reports/mod.rs
+++ b/src/backend/services/analytics/src/domain/reports/mod.rs
@@ -1,2 +1,7 @@
+pub(crate) mod columns;
 pub mod dto;
+pub(crate) mod period;
+pub(crate) mod planner;
+#[cfg(test)]
+mod planner_tests;
 pub mod validation;

--- a/src/backend/services/analytics/src/domain/reports/period.rs
+++ b/src/backend/services/analytics/src/domain/reports/period.rs
@@ -1,0 +1,202 @@
+use chrono::{Datelike, Days, NaiveDate};
+
+use super::dto::ReportGranularity;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReportBucket {
+    Day,
+    Week,
+    Month,
+    Quarter,
+    Year,
+}
+
+impl From<ReportGranularity> for ReportBucket {
+    fn from(value: ReportGranularity) -> Self {
+        match value {
+            ReportGranularity::Day => Self::Day,
+            ReportGranularity::Week => Self::Week,
+            ReportGranularity::Month => Self::Month,
+            ReportGranularity::Quarter => Self::Quarter,
+            ReportGranularity::Year => Self::Year,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PlannedPeriod {
+    pub(crate) label: String,
+    pub(crate) bucket_start: NaiveDate,
+    pub(crate) from: NaiveDate,
+    pub(crate) to: NaiveDate,
+}
+
+pub(crate) fn enumerate_periods(
+    from: NaiveDate,
+    to: NaiveDate,
+    bucket: ReportBucket,
+) -> Vec<PlannedPeriod> {
+    if from > to {
+        return Vec::new();
+    }
+
+    let mut periods = Vec::new();
+    let mut bucket_start = containing_bucket_start(from, bucket);
+    loop {
+        let next_start = following_bucket_start(bucket_start, bucket);
+        let bucket_end = next_start
+            .and_then(|start| start.checked_sub_days(Days::new(1)))
+            .unwrap_or(NaiveDate::MAX);
+        let period_from = from.max(bucket_start);
+        let period_to = to.min(bucket_end);
+
+        periods.push(PlannedPeriod {
+            label: bucket_label(bucket_start, bucket),
+            bucket_start,
+            from: period_from,
+            to: period_to,
+        });
+
+        if period_to == to {
+            break;
+        }
+        bucket_start = next_start.unwrap_or(NaiveDate::MAX);
+    }
+
+    periods
+}
+
+fn containing_bucket_start(date: NaiveDate, bucket: ReportBucket) -> NaiveDate {
+    match bucket {
+        ReportBucket::Day => date,
+        ReportBucket::Week => date
+            .checked_sub_days(Days::new(u64::from(date.weekday().num_days_from_monday())))
+            .unwrap_or(NaiveDate::MIN),
+        ReportBucket::Month => calendar_date(date.year(), date.month(), 1),
+        ReportBucket::Quarter => {
+            let first_month = ((date.month() - 1) / 3) * 3 + 1;
+            calendar_date(date.year(), first_month, 1)
+        }
+        ReportBucket::Year => calendar_date(date.year(), 1, 1),
+    }
+}
+
+fn following_bucket_start(date: NaiveDate, bucket: ReportBucket) -> Option<NaiveDate> {
+    match bucket {
+        ReportBucket::Day => date.checked_add_days(Days::new(1)),
+        ReportBucket::Week => date.checked_add_days(Days::new(7)),
+        ReportBucket::Month => add_calendar_months(date, 1),
+        ReportBucket::Quarter => add_calendar_months(date, 3),
+        ReportBucket::Year => date
+            .year()
+            .checked_add(1)
+            .and_then(|year| NaiveDate::from_ymd_opt(year, 1, 1)),
+    }
+}
+
+fn add_calendar_months(date: NaiveDate, months: u32) -> Option<NaiveDate> {
+    let zero_based_month = date.month0().checked_add(months)?;
+    let year_offset = i32::try_from(zero_based_month / 12).ok()?;
+    let year = date.year().checked_add(year_offset)?;
+    let month = zero_based_month % 12 + 1;
+
+    NaiveDate::from_ymd_opt(year, month, 1)
+}
+
+fn calendar_date(year: i32, month: u32, day: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(year, month, day).unwrap_or(NaiveDate::MIN)
+}
+
+fn bucket_label(start: NaiveDate, bucket: ReportBucket) -> String {
+    match bucket {
+        ReportBucket::Day | ReportBucket::Week => start.format("%Y-%m-%d").to_string(),
+        ReportBucket::Month => start.format("%Y-%m").to_string(),
+        ReportBucket::Quarter => format!("{}-Q{}", start.year(), (start.month0() / 3) + 1),
+        ReportBucket::Year => start.format("%Y").to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn date(value: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(value, "%Y-%m-%d")
+            .unwrap_or_else(|error| panic!("fixture date must parse: {error}"))
+    }
+
+    #[test]
+    fn clips_calendar_period_boundaries() {
+        let cases = [
+            (
+                ReportBucket::Day,
+                "2024-02-28",
+                "2024-03-01",
+                vec![
+                    ("2024-02-28", "2024-02-28", "2024-02-28"),
+                    ("2024-02-29", "2024-02-29", "2024-02-29"),
+                    ("2024-03-01", "2024-03-01", "2024-03-01"),
+                ],
+            ),
+            (
+                ReportBucket::Week,
+                "2026-05-13",
+                "2026-05-26",
+                vec![
+                    ("2026-05-11", "2026-05-13", "2026-05-17"),
+                    ("2026-05-18", "2026-05-18", "2026-05-24"),
+                    ("2026-05-25", "2026-05-25", "2026-05-26"),
+                ],
+            ),
+            (
+                ReportBucket::Month,
+                "2024-02-10",
+                "2024-04-03",
+                vec![
+                    ("2024-02", "2024-02-10", "2024-02-29"),
+                    ("2024-03", "2024-03-01", "2024-03-31"),
+                    ("2024-04", "2024-04-01", "2024-04-03"),
+                ],
+            ),
+            (
+                ReportBucket::Quarter,
+                "2025-12-20",
+                "2026-04-05",
+                vec![
+                    ("2025-Q4", "2025-12-20", "2025-12-31"),
+                    ("2026-Q1", "2026-01-01", "2026-03-31"),
+                    ("2026-Q2", "2026-04-01", "2026-04-05"),
+                ],
+            ),
+            (
+                ReportBucket::Year,
+                "2023-07-01",
+                "2025-02-01",
+                vec![
+                    ("2023", "2023-07-01", "2023-12-31"),
+                    ("2024", "2024-01-01", "2024-12-31"),
+                    ("2025", "2025-01-01", "2025-02-01"),
+                ],
+            ),
+        ];
+
+        for (bucket, from, to, expected) in cases {
+            let actual = enumerate_periods(date(from), date(to), bucket)
+                .into_iter()
+                .map(|period| {
+                    (
+                        period.label,
+                        period.from.format("%Y-%m-%d").to_string(),
+                        period.to.format("%Y-%m-%d").to_string(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let expected = expected
+                .into_iter()
+                .map(|(label, from, to)| (label.to_owned(), from.to_owned(), to.to_owned()))
+                .collect::<Vec<_>>();
+
+            assert_eq!(actual, expected, "wrong periods for {bucket:?}");
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/reports/planner.rs
+++ b/src/backend/services/analytics/src/domain/reports/planner.rs
@@ -153,11 +153,10 @@ fn plan_person_batches(
         .checked_mul(metrics)
         .ok_or(ReportPlanningError::SizeOverflow)?;
     let query_people = METRIC_QUERY_VALUE_LIMIT / query_values_per_person;
-    let cell_people = if cells_per_person == 0 {
-        usize::MAX
-    } else {
-        limits.max_batch_cells / cells_per_person
-    };
+    let cell_people = limits
+        .max_batch_cells
+        .checked_div(cells_per_person)
+        .unwrap_or(usize::MAX);
     let people_per_batch = query_people.min(cell_people);
     if people_per_batch == 0 {
         return Err(ReportPlanningError::BatchLimitTooSmall);

--- a/src/backend/services/analytics/src/domain/reports/planner.rs
+++ b/src/backend/services/analytics/src/domain/reports/planner.rs
@@ -7,8 +7,6 @@ use super::period::{PlannedPeriod, ReportBucket, enumerate_periods};
 use super::validation::{ReportSubjectSelection, ValidatedReportRecipe};
 
 pub(crate) const METRIC_QUERY_VALUE_LIMIT: usize = 5000;
-const XLSX_MAX_ROWS: u64 = 1_048_576;
-const XLSX_MAX_COLUMNS: u64 = 16_384;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ReportPlannerLimits {
@@ -21,12 +19,6 @@ pub(crate) struct ReportSize {
     pub(crate) total_cells: u64,
     pub(crate) worksheet_rows: u64,
     pub(crate) worksheet_columns: u64,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct XlsxDimensions {
-    pub(crate) rows: u32,
-    pub(crate) columns: u16,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,23 +55,6 @@ pub(crate) enum ReportPlanningError {
     SizeOverflow,
     #[error("report batch limits cannot fit one person")]
     BatchLimitTooSmall,
-    #[error("report exceeds XLSX worksheet dimensions")]
-    XlsxDimensionsExceeded,
-}
-
-impl ReportSize {
-    pub(crate) fn xlsx_dimensions(self) -> Result<XlsxDimensions, ReportPlanningError> {
-        if self.worksheet_rows > XLSX_MAX_ROWS || self.worksheet_columns > XLSX_MAX_COLUMNS {
-            return Err(ReportPlanningError::XlsxDimensionsExceeded);
-        }
-
-        let rows = u32::try_from(self.worksheet_rows)
-            .map_err(|_| ReportPlanningError::XlsxDimensionsExceeded)?;
-        let columns = u16::try_from(self.worksheet_columns)
-            .map_err(|_| ReportPlanningError::XlsxDimensionsExceeded)?;
-
-        Ok(XlsxDimensions { rows, columns })
-    }
 }
 
 pub(crate) fn plan_report(

--- a/src/backend/services/analytics/src/domain/reports/planner.rs
+++ b/src/backend/services/analytics/src/domain/reports/planner.rs
@@ -1,0 +1,198 @@
+use uuid::Uuid;
+
+use crate::infra::identity::IdentityProfile;
+
+use super::columns::{PlannedColumn, plan_columns};
+use super::period::{PlannedPeriod, ReportBucket, enumerate_periods};
+use super::validation::{ReportSubjectSelection, ValidatedReportRecipe};
+
+pub(crate) const METRIC_QUERY_VALUE_LIMIT: usize = 5000;
+const XLSX_MAX_ROWS: u64 = 1_048_576;
+const XLSX_MAX_COLUMNS: u64 = 16_384;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReportPlannerLimits {
+    pub(crate) max_batch_cells: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReportSize {
+    pub(crate) total_rows: u64,
+    pub(crate) total_cells: u64,
+    pub(crate) worksheet_rows: u64,
+    pub(crate) worksheet_columns: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct XlsxDimensions {
+    pub(crate) rows: u32,
+    pub(crate) columns: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PersonQueryBatch {
+    pub(crate) person_start: usize,
+    pub(crate) person_end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PlannedReportSubject {
+    People {
+        ids: Vec<Uuid>,
+        batches: Vec<PersonQueryBatch>,
+    },
+    Tenant {
+        id: Uuid,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) struct ReportPlan {
+    pub(crate) bucket: ReportBucket,
+    pub(crate) periods: Vec<PlannedPeriod>,
+    pub(crate) columns: Vec<PlannedColumn>,
+    pub(crate) subject: PlannedReportSubject,
+    pub(crate) size: ReportSize,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub(crate) enum ReportPlanningError {
+    #[error("hydrated profiles do not match report subject")]
+    ProfileSetMismatch,
+    #[error("report size exceeds supported arithmetic")]
+    SizeOverflow,
+    #[error("report batch limits cannot fit one person")]
+    BatchLimitTooSmall,
+    #[error("report exceeds XLSX worksheet dimensions")]
+    XlsxDimensionsExceeded,
+}
+
+impl ReportSize {
+    pub(crate) fn xlsx_dimensions(self) -> Result<XlsxDimensions, ReportPlanningError> {
+        if self.worksheet_rows > XLSX_MAX_ROWS || self.worksheet_columns > XLSX_MAX_COLUMNS {
+            return Err(ReportPlanningError::XlsxDimensionsExceeded);
+        }
+
+        let rows = u32::try_from(self.worksheet_rows)
+            .map_err(|_| ReportPlanningError::XlsxDimensionsExceeded)?;
+        let columns = u16::try_from(self.worksheet_columns)
+            .map_err(|_| ReportPlanningError::XlsxDimensionsExceeded)?;
+
+        Ok(XlsxDimensions { rows, columns })
+    }
+}
+
+pub(crate) fn plan_report(
+    recipe: &ValidatedReportRecipe,
+    profiles: &[IdentityProfile],
+    limits: ReportPlannerLimits,
+) -> Result<ReportPlan, ReportPlanningError> {
+    validate_profiles(&recipe.subject, profiles)?;
+
+    let bucket = ReportBucket::from(recipe.granularity);
+    let periods = enumerate_periods(recipe.from, recipe.to, bucket);
+    let columns = plan_columns(profiles, &recipe.metrics);
+    let subject_count = match &recipe.subject {
+        ReportSubjectSelection::People { ids } => ids.len(),
+        ReportSubjectSelection::Tenant { .. } => 1,
+    };
+    let size = calculate_size(subject_count, periods.len(), columns.len())?;
+    let subject = match &recipe.subject {
+        ReportSubjectSelection::People { ids } => PlannedReportSubject::People {
+            ids: ids.clone(),
+            batches: plan_person_batches(ids.len(), periods.len(), recipe.metrics.len(), limits)?,
+        },
+        ReportSubjectSelection::Tenant { id } => PlannedReportSubject::Tenant { id: *id },
+    };
+
+    Ok(ReportPlan {
+        bucket,
+        periods,
+        columns,
+        subject,
+        size,
+    })
+}
+
+fn validate_profiles(
+    subject: &ReportSubjectSelection,
+    profiles: &[IdentityProfile],
+) -> Result<(), ReportPlanningError> {
+    let matches = match subject {
+        ReportSubjectSelection::People { ids } => {
+            ids.len() == profiles.len()
+                && ids
+                    .iter()
+                    .zip(profiles)
+                    .all(|(requested, profile)| requested == &profile.person_id)
+        }
+        ReportSubjectSelection::Tenant { .. } => profiles.is_empty(),
+    };
+
+    if matches {
+        Ok(())
+    } else {
+        Err(ReportPlanningError::ProfileSetMismatch)
+    }
+}
+
+fn calculate_size(
+    subject_count: usize,
+    period_count: usize,
+    column_count: usize,
+) -> Result<ReportSize, ReportPlanningError> {
+    let subject_count =
+        u64::try_from(subject_count).map_err(|_| ReportPlanningError::SizeOverflow)?;
+    let period_count =
+        u64::try_from(period_count).map_err(|_| ReportPlanningError::SizeOverflow)?;
+    let column_count =
+        u64::try_from(column_count).map_err(|_| ReportPlanningError::SizeOverflow)?;
+    let total_rows = subject_count
+        .checked_mul(period_count)
+        .ok_or(ReportPlanningError::SizeOverflow)?;
+    let total_cells = total_rows
+        .checked_mul(column_count)
+        .ok_or(ReportPlanningError::SizeOverflow)?;
+    let worksheet_rows = total_rows
+        .checked_add(1)
+        .ok_or(ReportPlanningError::SizeOverflow)?;
+
+    Ok(ReportSize {
+        total_rows,
+        total_cells,
+        worksheet_rows,
+        worksheet_columns: column_count,
+    })
+}
+
+fn plan_person_batches(
+    people: usize,
+    periods: usize,
+    metrics: usize,
+    limits: ReportPlannerLimits,
+) -> Result<Vec<PersonQueryBatch>, ReportPlanningError> {
+    let query_values_per_person = periods
+        .checked_add(1)
+        .ok_or(ReportPlanningError::SizeOverflow)?;
+    let cells_per_person = periods
+        .checked_mul(metrics)
+        .ok_or(ReportPlanningError::SizeOverflow)?;
+    let query_people = METRIC_QUERY_VALUE_LIMIT / query_values_per_person;
+    let cell_people = if cells_per_person == 0 {
+        usize::MAX
+    } else {
+        limits.max_batch_cells / cells_per_person
+    };
+    let people_per_batch = query_people.min(cell_people);
+    if people_per_batch == 0 {
+        return Err(ReportPlanningError::BatchLimitTooSmall);
+    }
+
+    Ok((0..people)
+        .step_by(people_per_batch)
+        .map(|person_start| PersonQueryBatch {
+            person_start,
+            person_end: people.min(person_start + people_per_batch),
+        })
+        .collect())
+}

--- a/src/backend/services/analytics/src/domain/reports/planner_tests.rs
+++ b/src/backend/services/analytics/src/domain/reports/planner_tests.rs
@@ -1,0 +1,249 @@
+use std::collections::BTreeMap;
+
+use chrono::NaiveDate;
+use uuid::Uuid;
+
+use super::dto::ReportGranularity;
+use super::period::ReportBucket;
+use super::planner::*;
+use super::validation::{ReportSubjectSelection, ValidatedReportRecipe};
+use crate::domain::metric_definitions::definition::{
+    AliasCollapse, ComputationSpec, MetricBase, MetricDirection, MetricFormat, MetricInput,
+    MetricInputRole, ObservationRelation, ObservationSource,
+};
+use crate::infra::identity::IdentityProfile;
+
+const XLSX_MAX_ROWS: u64 = 1_048_576;
+const XLSX_MAX_COLUMNS: u64 = 16_384;
+
+fn date(value: &str) -> NaiveDate {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .unwrap_or_else(|error| panic!("fixture date must parse: {error}"))
+}
+
+fn metric(index: usize, entity_type: &str) -> crate::domain::metric_definitions::MetricDefinition {
+    crate::domain::metric_definitions::MetricDefinition {
+        base: MetricBase {
+            key: format!("test.metric_{index}"),
+            label: format!("Metric {index}"),
+            short_label: None,
+            description: None,
+            explanation: None,
+            entity_type: entity_type.to_owned(),
+            format: MetricFormat::Integer,
+            unit: None,
+            direction: MetricDirection::Neutral,
+            peer_cohort_key: None,
+            allowed_dimensions: vec![],
+        },
+        spec: ComputationSpec::Sum {
+            value: MetricInput {
+                role: MetricInputRole::Value,
+                observation: ObservationSource::Managed(
+                    ObservationRelation::parse("test_metric_observations")
+                        .unwrap_or_else(|| panic!("fixture relation must parse")),
+                ),
+                source_key: "test".to_owned(),
+                measure_key: "value".to_owned(),
+                alias_collapse: AliasCollapse::Sum,
+            },
+        },
+        transform: None,
+    }
+}
+
+fn profile(id: u128) -> IdentityProfile {
+    IdentityProfile {
+        person_id: Uuid::from_u128(id),
+        attributes: BTreeMap::new(),
+        supervisor: None,
+    }
+}
+
+fn people_recipe(
+    ids: Vec<Uuid>,
+    from: &str,
+    to: &str,
+    granularity: ReportGranularity,
+    metric_count: usize,
+) -> ValidatedReportRecipe {
+    ValidatedReportRecipe {
+        subject: ReportSubjectSelection::People { ids },
+        from: date(from),
+        to: date(to),
+        granularity,
+        metrics: (0..metric_count)
+            .map(|index| metric(index, "person"))
+            .collect(),
+    }
+}
+
+#[test]
+fn preserves_people_order_and_builds_sequential_cell_bounded_batches() {
+    let profiles = vec![profile(3), profile(1), profile(2)];
+    let recipe = people_recipe(
+        profiles.iter().map(|profile| profile.person_id).collect(),
+        "2026-01-15",
+        "2026-03-20",
+        ReportGranularity::Month,
+        1,
+    );
+
+    let plan = plan_report(
+        &recipe,
+        &profiles,
+        ReportPlannerLimits { max_batch_cells: 6 },
+    )
+    .unwrap_or_else(|error| panic!("report should plan: {error}"));
+
+    let PlannedReportSubject::People { ids, batches } = &plan.subject else {
+        panic!("expected people plan");
+    };
+    assert_eq!(
+        ids,
+        &[Uuid::from_u128(3), Uuid::from_u128(1), Uuid::from_u128(2)]
+    );
+    assert_eq!(
+        batches,
+        &[
+            PersonQueryBatch {
+                person_start: 0,
+                person_end: 2,
+            },
+            PersonQueryBatch {
+                person_start: 2,
+                person_end: 3,
+            },
+        ]
+    );
+    assert_eq!(
+        plan.periods
+            .iter()
+            .map(|period| period.label.as_str())
+            .collect::<Vec<_>>(),
+        ["2026-01", "2026-02", "2026-03"]
+    );
+    assert_eq!(plan.size.total_rows, 9);
+    assert_eq!(plan.size.total_cells, 45);
+    assert_eq!(plan.size.worksheet_rows, 10);
+    assert_eq!(plan.size.worksheet_columns, 5);
+    for batch in batches {
+        let people = batch.person_end - batch.person_start;
+        assert!(people * plan.periods.len() * recipe.metrics.len() <= 6);
+    }
+}
+
+#[test]
+fn every_person_batch_satisfies_metric_query_value_limit() {
+    let profiles = vec![profile(1), profile(2), profile(3)];
+    let recipe = people_recipe(
+        profiles.iter().map(|profile| profile.person_id).collect(),
+        "2020-01-01",
+        "2025-06-22",
+        ReportGranularity::Day,
+        1,
+    );
+
+    let plan = plan_report(
+        &recipe,
+        &profiles,
+        ReportPlannerLimits {
+            max_batch_cells: usize::MAX,
+        },
+    )
+    .unwrap_or_else(|error| panic!("report should plan: {error}"));
+    let PlannedReportSubject::People { batches, .. } = &plan.subject else {
+        panic!("expected people plan");
+    };
+
+    for batch in batches {
+        let people = batch.person_end - batch.person_start;
+        assert!(people * (plan.periods.len() + 1) <= METRIC_QUERY_VALUE_LIMIT);
+    }
+}
+
+#[test]
+fn tenant_plan_supports_more_than_fifty_metrics_without_profile_columns() {
+    let tenant_id = Uuid::from_u128(9);
+    let recipe = ValidatedReportRecipe {
+        subject: ReportSubjectSelection::Tenant { id: tenant_id },
+        from: date("2026-01-01"),
+        to: date("2026-06-30"),
+        granularity: ReportGranularity::Quarter,
+        metrics: (0..64).map(|index| metric(index, "tenant")).collect(),
+    };
+
+    let plan = plan_report(
+        &recipe,
+        &[],
+        ReportPlannerLimits {
+            max_batch_cells: 100_000,
+        },
+    )
+    .unwrap_or_else(|error| panic!("report should plan: {error}"));
+
+    assert_eq!(plan.bucket, ReportBucket::Quarter);
+    assert_eq!(plan.periods.len(), 2);
+    assert_eq!(plan.columns.len(), 67);
+    assert_eq!(plan.size.total_rows, 2);
+    assert_eq!(plan.size.total_cells, 134);
+    assert_eq!(plan.subject, PlannedReportSubject::Tenant { id: tenant_id });
+}
+
+#[test]
+fn rejects_profiles_that_do_not_match_people_order() {
+    let recipe = people_recipe(
+        vec![Uuid::from_u128(1), Uuid::from_u128(2)],
+        "2026-01-01",
+        "2026-01-31",
+        ReportGranularity::Month,
+        1,
+    );
+    let profiles = vec![profile(2), profile(1)];
+
+    let result = plan_report(
+        &recipe,
+        &profiles,
+        ReportPlannerLimits {
+            max_batch_cells: 100,
+        },
+    );
+    let Err(error) = result else {
+        panic!("reordered profiles must fail closed");
+    };
+
+    assert_eq!(error, ReportPlanningError::ProfileSetMismatch);
+}
+
+#[test]
+fn checks_xlsx_dimensions_against_format_limits() {
+    let supported = ReportSize {
+        total_rows: XLSX_MAX_ROWS - 1,
+        total_cells: 1,
+        worksheet_rows: XLSX_MAX_ROWS,
+        worksheet_columns: XLSX_MAX_COLUMNS,
+    };
+    assert_eq!(
+        supported.xlsx_dimensions(),
+        Ok(XlsxDimensions {
+            rows: 1_048_576,
+            columns: 16_384,
+        })
+    );
+
+    for exceeded in [
+        ReportSize {
+            worksheet_rows: XLSX_MAX_ROWS + 1,
+            ..supported
+        },
+        ReportSize {
+            worksheet_columns: XLSX_MAX_COLUMNS + 1,
+            ..supported
+        },
+    ] {
+        assert_eq!(
+            exceeded.xlsx_dimensions(),
+            Err(ReportPlanningError::XlsxDimensionsExceeded)
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/reports/planner_tests.rs
+++ b/src/backend/services/analytics/src/domain/reports/planner_tests.rs
@@ -13,9 +13,6 @@ use crate::domain::metric_definitions::definition::{
 };
 use crate::infra::identity::IdentityProfile;
 
-const XLSX_MAX_ROWS: u64 = 1_048_576;
-const XLSX_MAX_COLUMNS: u64 = 16_384;
-
 fn date(value: &str) -> NaiveDate {
     NaiveDate::parse_from_str(value, "%Y-%m-%d")
         .unwrap_or_else(|error| panic!("fixture date must parse: {error}"))
@@ -213,37 +210,4 @@ fn rejects_profiles_that_do_not_match_people_order() {
     };
 
     assert_eq!(error, ReportPlanningError::ProfileSetMismatch);
-}
-
-#[test]
-fn checks_xlsx_dimensions_against_format_limits() {
-    let supported = ReportSize {
-        total_rows: XLSX_MAX_ROWS - 1,
-        total_cells: 1,
-        worksheet_rows: XLSX_MAX_ROWS,
-        worksheet_columns: XLSX_MAX_COLUMNS,
-    };
-    assert_eq!(
-        supported.xlsx_dimensions(),
-        Ok(XlsxDimensions {
-            rows: 1_048_576,
-            columns: 16_384,
-        })
-    );
-
-    for exceeded in [
-        ReportSize {
-            worksheet_rows: XLSX_MAX_ROWS + 1,
-            ..supported
-        },
-        ReportSize {
-            worksheet_columns: XLSX_MAX_COLUMNS + 1,
-            ..supported
-        },
-    ] {
-        assert_eq!(
-            exceeded.xlsx_dimensions(),
-            Err(ReportPlanningError::XlsxDimensionsExceeded)
-        );
-    }
 }

--- a/src/backend/services/analytics/src/domain/reports/query.rs
+++ b/src/backend/services/analytics/src/domain/reports/query.rs
@@ -1,0 +1,223 @@
+use async_trait::async_trait;
+use chrono::NaiveDate;
+use uuid::Uuid;
+
+use crate::domain::metric_definitions::MetricDefinition;
+use crate::domain::metric_results::ValidatedEntitySelection;
+use crate::domain::metric_results::compiler::{
+    CompiledQuery, QueryBucket, TimeseriesQueryRow, compile_report_timeseries_query,
+};
+use crate::infra::query::{QueryFetchError, fetch_json_rows};
+
+use super::period::ReportBucket;
+use super::row::{ReportMetricValue, ReportMetricValues};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReportQuerySubject {
+    People(Vec<Uuid>),
+    Tenant(Uuid),
+}
+
+#[derive(Debug)]
+pub(crate) struct ReportMetricQuery {
+    pub(crate) metric_index: usize,
+    pub(crate) metric_key: String,
+    pub(crate) subject: ReportQuerySubject,
+    pub(crate) compiled: CompiledQuery,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ReportQueryError {
+    #[error("metric query failed")]
+    Fetch(#[source] QueryFetchError),
+    #[error("metric query returned an invalid result shape")]
+    InvalidResultShape,
+}
+
+#[async_trait]
+pub(crate) trait ReportQueryRunner: Sync {
+    async fn run(&self, query: ReportMetricQuery) -> Result<ReportMetricValues, ReportQueryError>;
+}
+
+pub(crate) struct ClickHouseReportQueryRunner<'a> {
+    client: &'a insight_clickhouse::Client,
+}
+
+impl<'a> ClickHouseReportQueryRunner<'a> {
+    pub(crate) fn new(client: &'a insight_clickhouse::Client) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl ReportQueryRunner for ClickHouseReportQueryRunner<'_> {
+    async fn run(&self, query: ReportMetricQuery) -> Result<ReportMetricValues, ReportQueryError> {
+        let log_comment = format!("report:timeseries:{}", query.metric_key);
+        let rows = fetch_json_rows::<TimeseriesQueryRow>(
+            self.client,
+            &query.compiled.sql,
+            &query.compiled.params,
+            &log_comment,
+        )
+        .await
+        .map_err(ReportQueryError::Fetch)?;
+        let mut values = Vec::new();
+        for row in rows {
+            if row.is_total == 1 {
+                continue;
+            }
+            if row.is_total != 0
+                || row.rank.is_some()
+                || row.remainder != 0
+                || row.group_label.is_some()
+                || !row.extra.is_empty()
+            {
+                return Err(ReportQueryError::InvalidResultShape);
+            }
+            let entity_id = row
+                .entity_id
+                .parse()
+                .map_err(|_| ReportQueryError::InvalidResultShape)?;
+            let bucket_start = NaiveDate::parse_from_str(&row.bucket_start, "%Y-%m-%d")
+                .map_err(|_| ReportQueryError::InvalidResultShape)?;
+
+            values.push(ReportMetricValue {
+                entity_id,
+                bucket_start,
+                value: row.value,
+            });
+        }
+
+        Ok(ReportMetricValues {
+            metric_index: query.metric_index,
+            values,
+        })
+    }
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "query scope is explicit at the compiler boundary"
+)]
+pub(crate) fn compile_report_metric_query(
+    metric_index: usize,
+    metric: &MetricDefinition,
+    tenant_id: Uuid,
+    subject: ReportQuerySubject,
+    from: NaiveDate,
+    to: NaiveDate,
+    bucket: ReportBucket,
+    enforce_tenant_scope: bool,
+) -> ReportMetricQuery {
+    let entity = match &subject {
+        ReportQuerySubject::People(ids) => ValidatedEntitySelection::Person { ids: ids.clone() },
+        ReportQuerySubject::Tenant(id) => ValidatedEntitySelection::Tenant { id: *id },
+    };
+    let bucket = match bucket {
+        ReportBucket::Day => QueryBucket::Day,
+        ReportBucket::Week => QueryBucket::Week,
+        ReportBucket::Month => QueryBucket::Month,
+        ReportBucket::Quarter => QueryBucket::Quarter,
+        ReportBucket::Year => QueryBucket::Year,
+    };
+    let compiled = compile_report_timeseries_query(
+        metric,
+        tenant_id,
+        entity,
+        from,
+        to,
+        enforce_tenant_scope,
+        bucket,
+    );
+
+    ReportMetricQuery {
+        metric_index,
+        metric_key: metric.key().to_owned(),
+        subject,
+        compiled,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::metric_definitions::definition::{
+        AliasCollapse, ComputationSpec, MetricBase, MetricDirection, MetricFormat, MetricInput,
+        MetricInputRole, ObservationRelation, ObservationSource,
+    };
+
+    #[test]
+    fn report_query_uses_direct_quarter_aggregation_and_preserves_parameter_order() {
+        let tenant_id = Uuid::from_u128(9);
+        let person_id = Uuid::from_u128(2);
+        let query = compile_report_metric_query(
+            3,
+            &metric(),
+            tenant_id,
+            ReportQuerySubject::People(vec![person_id]),
+            date("2026-01-10"),
+            date("2026-06-20"),
+            ReportBucket::Quarter,
+            true,
+        );
+
+        assert!(
+            query
+                .compiled
+                .sql
+                .contains("toString(toStartOfQuarter(assumeNotNull(metric_date))) AS bucket_start")
+        );
+        assert!(query.compiled.sql.contains("GROUP BY GROUPING SETS"));
+        assert_eq!(
+            query.compiled.params,
+            [
+                person_id.to_string(),
+                "2026-01-10".to_owned(),
+                "2026-06-20".to_owned(),
+                person_id.to_string(),
+                tenant_id.to_string(),
+                "test".to_owned(),
+                "person".to_owned(),
+                "2026-01-10".to_owned(),
+                "2026-06-20".to_owned(),
+                "value".to_owned(),
+            ]
+        );
+    }
+
+    fn date(value: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(value, "%Y-%m-%d")
+            .unwrap_or_else(|error| panic!("fixture date must parse: {error}"))
+    }
+
+    fn metric() -> MetricDefinition {
+        MetricDefinition {
+            base: MetricBase {
+                key: "test.metric".to_owned(),
+                label: "Test metric".to_owned(),
+                short_label: None,
+                description: None,
+                explanation: None,
+                entity_type: "person".to_owned(),
+                format: MetricFormat::Integer,
+                unit: None,
+                direction: MetricDirection::Neutral,
+                peer_cohort_key: None,
+                allowed_dimensions: vec![],
+            },
+            spec: ComputationSpec::Sum {
+                value: MetricInput {
+                    role: MetricInputRole::Value,
+                    observation: ObservationSource::Managed(
+                        ObservationRelation::parse("test_metric_observations")
+                            .unwrap_or_else(|| panic!("fixture relation must parse")),
+                    ),
+                    source_key: "test".to_owned(),
+                    measure_key: "value".to_owned(),
+                    alias_collapse: AliasCollapse::Sum,
+                },
+            },
+            transform: None,
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/reports/query.rs
+++ b/src/backend/services/analytics/src/domain/reports/query.rs
@@ -22,6 +22,7 @@ pub(crate) enum ReportQuerySubject {
 pub(crate) struct ReportMetricQuery {
     pub(crate) metric_index: usize,
     pub(crate) metric_key: String,
+    #[cfg(test)]
     pub(crate) subject: ReportQuerySubject,
     pub(crate) compiled: CompiledQuery,
 }
@@ -103,7 +104,7 @@ pub(crate) fn compile_report_metric_query(
     metric_index: usize,
     metric: &MetricDefinition,
     tenant_id: Uuid,
-    subject: ReportQuerySubject,
+    subject: &ReportQuerySubject,
     from: NaiveDate,
     to: NaiveDate,
     bucket: ReportBucket,
@@ -133,7 +134,8 @@ pub(crate) fn compile_report_metric_query(
     ReportMetricQuery {
         metric_index,
         metric_key: metric.key().to_owned(),
-        subject,
+        #[cfg(test)]
+        subject: subject.clone(),
         compiled,
     }
 }
@@ -154,7 +156,7 @@ mod tests {
             3,
             &metric(),
             tenant_id,
-            ReportQuerySubject::People(vec![person_id]),
+            &ReportQuerySubject::People(vec![person_id]),
             date("2026-01-10"),
             date("2026-06-20"),
             ReportBucket::Quarter,

--- a/src/backend/services/analytics/src/domain/reports/row.rs
+++ b/src/backend/services/analytics/src/domain/reports/row.rs
@@ -12,12 +12,12 @@ use super::period::PlannedPeriod;
 
 #[derive(Debug, Clone, PartialEq, Serialize, ToSchema)]
 #[serde(untagged)]
-pub(crate) enum ReportCell {
+pub enum ReportCell {
     Text(String),
     Number(f64),
 }
 
-pub(crate) type ReportRow = Vec<Option<ReportCell>>;
+pub type ReportRow = Vec<Option<ReportCell>>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ReportMetricValue {

--- a/src/backend/services/analytics/src/domain/reports/row.rs
+++ b/src/backend/services/analytics/src/domain/reports/row.rs
@@ -1,0 +1,304 @@
+use std::collections::{HashMap, HashSet};
+
+use chrono::NaiveDate;
+use serde::Serialize;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::infra::identity::IdentityProfile;
+
+use super::columns::{PlannedColumn, PlannedColumnSource, profile_text};
+use super::period::PlannedPeriod;
+
+#[derive(Debug, Clone, PartialEq, Serialize, ToSchema)]
+#[serde(untagged)]
+pub(crate) enum ReportCell {
+    Text(String),
+    Number(f64),
+}
+
+pub(crate) type ReportRow = Vec<Option<ReportCell>>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ReportMetricValue {
+    pub(crate) entity_id: Uuid,
+    pub(crate) bucket_start: NaiveDate,
+    pub(crate) value: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ReportMetricValues {
+    pub(crate) metric_index: usize,
+    pub(crate) values: Vec<ReportMetricValue>,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub(crate) enum ReportRowError {
+    #[error("metric result shape does not match report plan")]
+    MetricShapeMismatch,
+}
+
+pub(crate) fn assemble_people_rows(
+    columns: &[PlannedColumn],
+    periods: &[PlannedPeriod],
+    profiles: &[IdentityProfile],
+    metrics: &[ReportMetricValues],
+) -> Result<Vec<ReportRow>, ReportRowError> {
+    let entity_ids = profiles
+        .iter()
+        .map(|profile| profile.person_id)
+        .collect::<HashSet<_>>();
+    let metric_values = index_metric_values(columns, periods, &entity_ids, metrics)?;
+    let mut rows = Vec::with_capacity(profiles.len().saturating_mul(periods.len()));
+
+    for profile in profiles {
+        for period in periods {
+            rows.push(assemble_row(
+                columns,
+                period,
+                Some(profile),
+                profile.person_id,
+                &metric_values,
+            ));
+        }
+    }
+
+    Ok(rows)
+}
+
+pub(crate) fn assemble_tenant_rows(
+    columns: &[PlannedColumn],
+    periods: &[PlannedPeriod],
+    tenant_id: Uuid,
+    metrics: &[ReportMetricValues],
+) -> Result<Vec<ReportRow>, ReportRowError> {
+    let entity_ids = HashSet::from([tenant_id]);
+    let metric_values = index_metric_values(columns, periods, &entity_ids, metrics)?;
+
+    Ok(periods
+        .iter()
+        .map(|period| assemble_row(columns, period, None, tenant_id, &metric_values))
+        .collect())
+}
+
+type MetricValueIndex = Vec<HashMap<(Uuid, NaiveDate), Option<f64>>>;
+
+fn index_metric_values(
+    columns: &[PlannedColumn],
+    periods: &[PlannedPeriod],
+    entity_ids: &HashSet<Uuid>,
+    metrics: &[ReportMetricValues],
+) -> Result<MetricValueIndex, ReportRowError> {
+    let metric_count = columns
+        .iter()
+        .filter_map(|column| match column.source {
+            PlannedColumnSource::Metric(index) => Some(index + 1),
+            PlannedColumnSource::PersonDisplay
+            | PlannedColumnSource::PersonAttribute(_)
+            | PlannedColumnSource::SupervisorDisplay
+            | PlannedColumnSource::SupervisorAttribute(_)
+            | PlannedColumnSource::PeriodLabel
+            | PlannedColumnSource::PeriodFrom
+            | PlannedColumnSource::PeriodTo => None,
+        })
+        .max()
+        .unwrap_or_default();
+    if metrics.len() != metric_count {
+        return Err(ReportRowError::MetricShapeMismatch);
+    }
+
+    let bucket_starts = periods
+        .iter()
+        .map(|period| period.bucket_start)
+        .collect::<HashSet<_>>();
+    let mut indexed = (0..metric_count)
+        .map(|_| None)
+        .collect::<Vec<Option<HashMap<_, _>>>>();
+    for metric in metrics {
+        let Some(slot) = indexed.get_mut(metric.metric_index) else {
+            return Err(ReportRowError::MetricShapeMismatch);
+        };
+        if slot.is_some() {
+            return Err(ReportRowError::MetricShapeMismatch);
+        }
+
+        let mut values = HashMap::with_capacity(metric.values.len());
+        for value in &metric.values {
+            if !entity_ids.contains(&value.entity_id)
+                || !bucket_starts.contains(&value.bucket_start)
+                || value.value.is_some_and(|number| !number.is_finite())
+                || values
+                    .insert((value.entity_id, value.bucket_start), value.value)
+                    .is_some()
+            {
+                return Err(ReportRowError::MetricShapeMismatch);
+            }
+        }
+        *slot = Some(values);
+    }
+
+    indexed
+        .into_iter()
+        .collect::<Option<Vec<_>>>()
+        .ok_or(ReportRowError::MetricShapeMismatch)
+}
+
+fn assemble_row(
+    columns: &[PlannedColumn],
+    period: &PlannedPeriod,
+    profile: Option<&IdentityProfile>,
+    entity_id: Uuid,
+    metrics: &MetricValueIndex,
+) -> ReportRow {
+    columns
+        .iter()
+        .map(|column| match column.source {
+            PlannedColumnSource::PersonDisplay
+            | PlannedColumnSource::PersonAttribute(_)
+            | PlannedColumnSource::SupervisorDisplay
+            | PlannedColumnSource::SupervisorAttribute(_) => profile
+                .and_then(|profile| profile_text(column.source, profile))
+                .map(text),
+            PlannedColumnSource::PeriodLabel => Some(text(&period.label)),
+            PlannedColumnSource::PeriodFrom => Some(text(&period.from.to_string())),
+            PlannedColumnSource::PeriodTo => Some(text(&period.to.to_string())),
+            PlannedColumnSource::Metric(index) => metrics[index]
+                .get(&(entity_id, period.bucket_start))
+                .copied()
+                .flatten()
+                .map(ReportCell::Number),
+        })
+        .collect()
+}
+
+fn text(value: &str) -> ReportCell {
+    ReportCell::Text(value.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use chrono::NaiveDate;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::domain::reports::columns::{
+        PlannedColumn, PlannedColumnSource, ReportColumnDataType, ReportColumnMetadata,
+    };
+    use crate::domain::reports::period::PlannedPeriod;
+    use crate::infra::identity::IdentityProfile;
+
+    #[test]
+    fn people_rows_follow_person_then_period_order_and_leave_missing_metrics_empty() {
+        let profiles = [profile(2, "Second"), profile(1, "First")];
+        let periods = [
+            period("2026-01", "2026-01-01"),
+            period("2026-02", "2026-02-01"),
+        ];
+        let columns = [
+            column("person", PlannedColumnSource::PersonDisplay),
+            column("period", PlannedColumnSource::PeriodLabel),
+            column("metric.one", PlannedColumnSource::Metric(0)),
+        ];
+        let values = [metric_values(
+            0,
+            &[(2, "2026-01-01", Some(2.0)), (1, "2026-02-01", Some(1.0))],
+        )];
+
+        let rows = assemble_people_rows(&columns, &periods, &profiles, &values)
+            .unwrap_or_else(|error| panic!("rows should assemble: {error}"));
+
+        assert_eq!(
+            rows,
+            vec![
+                vec![text("Second"), text("2026-01"), number(2.0)],
+                vec![text("Second"), text("2026-02"), None],
+                vec![text("First"), text("2026-01"), None],
+                vec![text("First"), text("2026-02"), number(1.0)],
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_non_finite_metric_values() {
+        let profiles = [profile(1, "First")];
+        let periods = [period("2026-01", "2026-01-01")];
+        let columns = [column("metric.one", PlannedColumnSource::Metric(0))];
+        let values = [metric_values(0, &[(1, "2026-01-01", Some(f64::NAN))])];
+
+        assert_eq!(
+            assemble_people_rows(&columns, &periods, &profiles, &values),
+            Err(ReportRowError::MetricShapeMismatch)
+        );
+    }
+
+    fn date(value: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(value, "%Y-%m-%d")
+            .unwrap_or_else(|error| panic!("fixture date must parse: {error}"))
+    }
+
+    fn profile(id: u128, display_name: &str) -> IdentityProfile {
+        IdentityProfile {
+            person_id: Uuid::from_u128(id),
+            attributes: BTreeMap::from([("display_name".to_owned(), display_name.to_owned())]),
+            supervisor: None,
+        }
+    }
+
+    fn period(label: &str, bucket_start: &str) -> PlannedPeriod {
+        let date = date(bucket_start);
+        PlannedPeriod {
+            label: label.to_owned(),
+            bucket_start: date,
+            from: date,
+            to: date,
+        }
+    }
+
+    fn column(key: &str, source: PlannedColumnSource) -> PlannedColumn {
+        PlannedColumn {
+            metadata: ReportColumnMetadata {
+                key: key.to_owned(),
+                label: key.to_owned(),
+                data_type: ReportColumnDataType::Text,
+                format: None,
+                unit: None,
+            },
+            source,
+        }
+    }
+
+    fn metric_values(
+        metric_index: usize,
+        values: &[(u128, &str, Option<f64>)],
+    ) -> ReportMetricValues {
+        ReportMetricValues {
+            metric_index,
+            values: values
+                .iter()
+                .map(|(entity_id, bucket_start, value)| ReportMetricValue {
+                    entity_id: Uuid::from_u128(*entity_id),
+                    bucket_start: date(bucket_start),
+                    value: *value,
+                })
+                .collect(),
+        }
+    }
+
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "matches the positional row cell shape"
+    )]
+    fn text(value: &str) -> Option<ReportCell> {
+        Some(ReportCell::Text(value.to_owned()))
+    }
+
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "matches the positional row cell shape"
+    )]
+    fn number(value: f64) -> Option<ReportCell> {
+        Some(ReportCell::Number(value))
+    }
+}

--- a/src/backend/services/analytics/src/domain/reports/validation.rs
+++ b/src/backend/services/analytics/src/domain/reports/validation.rs
@@ -9,9 +9,7 @@ use crate::api::error::MetricError;
 use crate::domain::metric_definitions::{MetricDefinition, load_definitions};
 use crate::domain::metric_results::normalize_metric_key;
 
-use super::dto::{
-    ReportExportRequest, ReportGranularity, ReportPreviewRequest, ReportRecipe, ReportSubject,
-};
+use super::dto::{ReportGranularity, ReportPreviewRequest, ReportRecipe, ReportSubject};
 
 const MAX_REPORT_PEOPLE: usize = 1000;
 
@@ -53,14 +51,6 @@ pub async fn validate_preview(
     request: ReportPreviewRequest,
 ) -> Result<ValidatedReportRecipe, CanonicalError> {
     validate_recipe(db, tenant_id, request).await
-}
-
-pub async fn validate_export(
-    db: &DatabaseConnection,
-    tenant_id: Uuid,
-    request: ReportExportRequest,
-) -> Result<ValidatedReportRecipe, CanonicalError> {
-    validate_recipe(db, tenant_id, request.recipe).await
 }
 
 async fn validate_recipe(

--- a/src/backend/services/analytics/src/domain/reports/validation.rs
+++ b/src/backend/services/analytics/src/domain/reports/validation.rs
@@ -1,0 +1,351 @@
+use std::collections::{BTreeSet, HashMap};
+
+use chrono::NaiveDate;
+use sea_orm::DatabaseConnection;
+use toolkit_canonical_errors::CanonicalError;
+use uuid::Uuid;
+
+use crate::api::error::MetricError;
+use crate::domain::metric_definitions::{MetricDefinition, load_definitions};
+use crate::domain::metric_results::normalize_metric_key;
+
+use super::dto::{
+    ReportExportRequest, ReportGranularity, ReportPreviewRequest, ReportRecipe, ReportSubject,
+};
+
+const MAX_REPORT_PEOPLE: usize = 1000;
+
+#[derive(Debug)]
+pub struct ValidatedReportRecipe {
+    pub subject: ReportSubjectSelection,
+    pub from: NaiveDate,
+    pub to: NaiveDate,
+    pub granularity: ReportGranularity,
+    pub metrics: Vec<MetricDefinition>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReportSubjectSelection {
+    People { ids: Vec<Uuid> },
+    Tenant { id: Uuid },
+}
+
+impl ReportSubjectSelection {
+    fn entity_type(&self) -> &'static str {
+        match self {
+            Self::People { .. } => "person",
+            Self::Tenant { .. } => "tenant",
+        }
+    }
+}
+
+struct RecipeShape {
+    subject: ReportSubjectSelection,
+    from: NaiveDate,
+    to: NaiveDate,
+    granularity: ReportGranularity,
+    metric_keys: Vec<String>,
+}
+
+pub async fn validate_preview(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    request: ReportPreviewRequest,
+) -> Result<ValidatedReportRecipe, CanonicalError> {
+    validate_recipe(db, tenant_id, request).await
+}
+
+pub async fn validate_export(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    request: ReportExportRequest,
+) -> Result<ValidatedReportRecipe, CanonicalError> {
+    validate_recipe(db, tenant_id, request.recipe).await
+}
+
+async fn validate_recipe(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    request: ReportRecipe,
+) -> Result<ValidatedReportRecipe, CanonicalError> {
+    let shape = validate_recipe_shape(request, tenant_id)?;
+    let definitions = load_definitions(db, tenant_id, &shape.metric_keys).await?;
+    let metrics = validate_loaded_definitions(&shape, &definitions)?;
+
+    Ok(ValidatedReportRecipe {
+        subject: shape.subject,
+        from: shape.from,
+        to: shape.to,
+        granularity: shape.granularity,
+        metrics,
+    })
+}
+
+fn validate_recipe_shape(
+    request: ReportRecipe,
+    tenant_id: Uuid,
+) -> Result<RecipeShape, CanonicalError> {
+    let subject = match request.subject {
+        ReportSubject::People { ids } => ReportSubjectSelection::People {
+            ids: validate_people(ids)?,
+        },
+        ReportSubject::Tenant {} => ReportSubjectSelection::Tenant { id: tenant_id },
+    };
+    let from = parse_date("period.from", &request.period.from)?;
+    let to = parse_date("period.to", &request.period.to)?;
+    if from > to {
+        return invalid("period", "period.from must be before or equal to period.to");
+    }
+
+    Ok(RecipeShape {
+        subject,
+        from,
+        to,
+        granularity: request.granularity,
+        metric_keys: validate_metric_keys(request.metric_keys)?,
+    })
+}
+
+fn validate_people(ids: Vec<Uuid>) -> Result<Vec<Uuid>, CanonicalError> {
+    if ids.is_empty() {
+        return invalid("subject.ids", "subject.ids must not be empty");
+    }
+    if ids.len() > MAX_REPORT_PEOPLE {
+        return invalid(
+            "subject.ids",
+            format!("subject.ids must contain at most {MAX_REPORT_PEOPLE} people"),
+        );
+    }
+
+    let mut seen = BTreeSet::new();
+    for id in &ids {
+        if id.is_nil() {
+            return invalid("subject.ids", "subject.ids must be person UUIDs");
+        }
+        if !seen.insert(*id) {
+            return invalid("subject.ids", "subject.ids must not contain duplicates");
+        }
+    }
+    Ok(ids)
+}
+
+fn validate_metric_keys(metric_keys: Vec<String>) -> Result<Vec<String>, CanonicalError> {
+    if metric_keys.is_empty() {
+        return invalid("metric_keys", "metric_keys must not be empty");
+    }
+
+    let mut seen = BTreeSet::new();
+    let mut normalized = Vec::with_capacity(metric_keys.len());
+    for metric_key in metric_keys {
+        let metric_key = normalize_metric_key("metric_keys", &metric_key)?;
+        if !seen.insert(metric_key.clone()) {
+            return invalid("metric_keys", format!("duplicate metric key: {metric_key}"));
+        }
+        normalized.push(metric_key);
+    }
+    Ok(normalized)
+}
+
+fn validate_loaded_definitions(
+    shape: &RecipeShape,
+    definitions: &HashMap<String, MetricDefinition>,
+) -> Result<Vec<MetricDefinition>, CanonicalError> {
+    let mut metrics = Vec::with_capacity(shape.metric_keys.len());
+    for metric_key in &shape.metric_keys {
+        let definition = definitions.get(metric_key).cloned().ok_or_else(|| {
+            MetricError::invalid_argument()
+                .with_field_violation(
+                    "metric_keys",
+                    format!("unknown or unavailable metric key: {metric_key}"),
+                    "UNAVAILABLE",
+                )
+                .create()
+        })?;
+        if definition.base.entity_type != shape.subject.entity_type() {
+            return invalid(
+                "subject.type",
+                format!(
+                    "metric {metric_key} is defined for entity type {}",
+                    definition.base.entity_type
+                ),
+            );
+        }
+        metrics.push(definition);
+    }
+    Ok(metrics)
+}
+
+fn parse_date(field: &'static str, value: &str) -> Result<NaiveDate, CanonicalError> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").map_err(|_| {
+        MetricError::invalid_argument()
+            .with_field_violation(field, "expected YYYY-MM-DD", "INVALID")
+            .create()
+    })
+}
+
+fn invalid<T>(field: &'static str, message: impl Into<String>) -> Result<T, CanonicalError> {
+    Err(MetricError::invalid_argument()
+        .with_field_violation(field, message.into(), "INVALID")
+        .create())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::metric_definitions::definition::{
+        MetricBase, MetricInputRole, ObservationRelation,
+    };
+    use crate::domain::metric_definitions::{
+        AliasCollapse, ComputationSpec, MetricDirection, MetricFormat, MetricInput,
+        ObservationSource,
+    };
+    use crate::domain::reports::dto::{ReportPeriod, ReportSubject};
+
+    const FIRST_PERSON: Uuid = Uuid::from_u128(0x019e_27bc_dec0_7626_81a9_c552_4662_a6a9);
+    const SECOND_PERSON: Uuid = Uuid::from_u128(0x019e_27bc_dec0_7626_81a9_c552_4662_a6aa);
+
+    fn recipe(subject: ReportSubject, metric_keys: &[&str]) -> ReportRecipe {
+        ReportRecipe {
+            subject,
+            period: ReportPeriod {
+                from: "2026-01-01".to_owned(),
+                to: "2026-03-31".to_owned(),
+            },
+            granularity: ReportGranularity::Month,
+            metric_keys: metric_keys.iter().map(|key| (*key).to_owned()).collect(),
+        }
+    }
+
+    fn definition(metric_key: &str, entity_type: &str) -> MetricDefinition {
+        MetricDefinition {
+            base: MetricBase {
+                key: metric_key.to_owned(),
+                label: "Metric".to_owned(),
+                short_label: None,
+                description: None,
+                explanation: None,
+                entity_type: entity_type.to_owned(),
+                format: MetricFormat::Integer,
+                unit: None,
+                direction: MetricDirection::Neutral,
+                peer_cohort_key: None,
+                allowed_dimensions: vec![],
+            },
+            spec: ComputationSpec::Sum {
+                value: MetricInput {
+                    role: MetricInputRole::Value,
+                    observation: ObservationSource::Managed(
+                        ObservationRelation::parse("test_metric_observations")
+                            .unwrap_or_else(|| panic!("fixture relation must parse")),
+                    ),
+                    source_key: "test".to_owned(),
+                    measure_key: "value".to_owned(),
+                    alias_collapse: AliasCollapse::Sum,
+                },
+            },
+            transform: None,
+        }
+    }
+
+    #[test]
+    fn preserves_people_and_metric_order_after_validation() {
+        let shape = validate_recipe_shape(
+            recipe(
+                ReportSubject::People {
+                    ids: vec![FIRST_PERSON, SECOND_PERSON],
+                },
+                &["git.commits", "tasks.closed"],
+            ),
+            Uuid::nil(),
+        )
+        .unwrap_or_else(|error| panic!("expected valid recipe: {error}"));
+
+        let ReportSubjectSelection::People { ids } = shape.subject else {
+            panic!("expected people subject");
+        };
+        assert_eq!(ids, [FIRST_PERSON, SECOND_PERSON]);
+        assert_eq!(shape.metric_keys, ["git.commits", "tasks.closed"]);
+    }
+
+    #[test]
+    fn rejects_empty_or_duplicate_people() {
+        for ids in [vec![], vec![FIRST_PERSON, FIRST_PERSON]] {
+            assert!(
+                validate_recipe_shape(
+                    recipe(ReportSubject::People { ids }, &["git.commits"]),
+                    Uuid::nil(),
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_more_people_than_identity_can_hydrate() {
+        let ids = (0..=MAX_REPORT_PEOPLE)
+            .map(|offset| Uuid::from_u128(offset as u128 + 1))
+            .collect();
+
+        assert!(
+            validate_recipe_shape(
+                recipe(ReportSubject::People { ids }, &["git.commits"]),
+                Uuid::nil(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_empty_or_duplicate_metric_keys() {
+        for metric_keys in [
+            vec![],
+            vec![""],
+            vec!["git.commits", "git.commits"],
+            vec!["Git.Commits", "git.commits"],
+        ] {
+            let keys = metric_keys.clone();
+            assert!(
+                validate_recipe_shape(recipe(ReportSubject::Tenant {}, &keys), Uuid::nil(),)
+                    .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_or_reversed_dates() {
+        let mut malformed = recipe(ReportSubject::Tenant {}, &["git.commits"]);
+        malformed.period.from = "not-a-date".to_owned();
+        assert!(validate_recipe_shape(malformed, Uuid::nil()).is_err());
+
+        let mut reversed = recipe(ReportSubject::Tenant {}, &["git.commits"]);
+        reversed.period.from = "2026-04-01".to_owned();
+        assert!(validate_recipe_shape(reversed, Uuid::nil()).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_subject_type_during_deserialization() {
+        let request = r#"{"subject":{"type":"group"},"period":{"from":"2026-01-01","to":"2026-01-31"},"granularity":"day","metric_keys":["git.commits"]}"#;
+        assert!(serde_json::from_str::<ReportRecipe>(request).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_or_subject_incompatible_metrics() {
+        let shape = validate_recipe_shape(
+            recipe(
+                ReportSubject::People {
+                    ids: vec![FIRST_PERSON],
+                },
+                &["git.commits"],
+            ),
+            Uuid::nil(),
+        )
+        .unwrap_or_else(|error| panic!("expected valid recipe: {error}"));
+        assert!(validate_loaded_definitions(&shape, &HashMap::new()).is_err());
+
+        let definitions = HashMap::from([(
+            "git.commits".to_owned(),
+            definition("git.commits", "tenant"),
+        )]);
+        assert!(validate_loaded_definitions(&shape, &definitions).is_err());
+    }
+}

--- a/src/backend/services/analytics/src/infra/identity/mod.rs
+++ b/src/backend/services/analytics/src/infra/identity/mod.rs
@@ -3,7 +3,7 @@
 //! Calls the Identity service to resolve which persons the caller may see.
 //! Used by the person-visibility gate on the metric-result surfaces.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -24,6 +24,32 @@ struct VisiblePersonsResponse {
     // INVARIANT: no serde default — a 200 omitting this field is a contract
     // mismatch, and an empty set here would deny every caller.
     visible: Vec<Uuid>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProfilesBatchRequest<'a> {
+    person_ids: &'a [Uuid],
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProfilesBatchResponse {
+    profiles: Vec<IdentityProfile>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct IdentityProfile {
+    pub(crate) person_id: Uuid,
+    pub(crate) attributes: BTreeMap<String, String>,
+    pub(crate) supervisor: Option<IdentityProfileRelationship>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct IdentityProfileRelationship {
+    pub(crate) person_id: Uuid,
+    pub(crate) attributes: BTreeMap<String, String>,
 }
 
 /// The seeded `admin` role id — a stable migration constant of the identity
@@ -78,6 +104,23 @@ impl IdentityClient {
 
         let checked: VisiblePersonsResponse = resp.json().await?;
         Ok(checked.visible.into_iter().collect())
+    }
+
+    pub(crate) async fn profiles_batch(
+        &self,
+        person_ids: &[Uuid],
+        authorization: Option<&str>,
+    ) -> anyhow::Result<Vec<IdentityProfile>> {
+        let url = format!("{}/v1/profiles/batch", self.base_url);
+
+        let req = self
+            .http
+            .post(&url)
+            .json(&ProfilesBatchRequest { person_ids });
+        let resp = Self::send(req, authorization, "profile batch").await?;
+
+        let batch: ProfilesBatchResponse = resp.json().await?;
+        Ok(batch.profiles)
     }
 
     /// Whether the caller holds the active `admin` identity role.
@@ -161,6 +204,32 @@ mod tests {
         (format!("http://{addr}"), seen)
     }
 
+    async fn spawn_profiles_batch(status: StatusCode, body: serde_json::Value) -> (String, Seen) {
+        let seen: Seen = Arc::default();
+        let record = Arc::clone(&seen);
+        let app = Router::new().route(
+            "/v1/profiles/batch",
+            post(
+                move |headers: HeaderMap, axum::Json(req): axum::Json<serde_json::Value>| {
+                    let record = Arc::clone(&record);
+                    let body = body.clone();
+                    async move {
+                        let auth = headers
+                            .get(AUTHORIZATION)
+                            .and_then(|v| v.to_str().ok())
+                            .map(str::to_owned);
+                        *record.lock().unwrap() = Some((auth, req));
+                        (status, axum::Json(body))
+                    }
+                },
+            ),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (format!("http://{addr}"), seen)
+    }
+
     #[tokio::test]
     async fn visible_person_ids_forwards_the_callers_bearer_and_sends_every_id() {
         let (url, seen) = spawn_visible_persons(
@@ -207,6 +276,68 @@ mod tests {
             !err.to_string().is_empty(),
             "a contract mismatch must surface as a dependency error, not as `nothing visible`"
         );
+    }
+
+    #[tokio::test]
+    async fn profiles_batch_forwards_auth_and_decodes_generic_attributes() {
+        let person_id = Uuid::from_u128(0xa);
+        let supervisor_id = Uuid::from_u128(0xb);
+        let (url, seen) = spawn_profiles_batch(
+            StatusCode::OK,
+            serde_json::json!({
+                "profiles": [{
+                    "person_id": person_id,
+                    "attributes": {
+                        "display_name": "Example User",
+                        "department": "Engineering"
+                    },
+                    "supervisor": {
+                        "person_id": supervisor_id,
+                        "attributes": {"display_name": "Example Manager"}
+                    }
+                }]
+            }),
+        )
+        .await;
+
+        let profiles = IdentityClient::new(&url)
+            .unwrap()
+            .profiles_batch(&[person_id], Some("Bearer caller-tok"))
+            .await
+            .unwrap();
+
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].person_id, person_id);
+        assert_eq!(
+            profiles[0]
+                .attributes
+                .get("display_name")
+                .map(String::as_str),
+            Some("Example User")
+        );
+        assert_eq!(
+            profiles[0].supervisor.as_ref().map(|value| value.person_id),
+            Some(supervisor_id)
+        );
+
+        let (auth, req) = seen.lock().unwrap().take().unwrap();
+        assert_eq!(auth.as_deref(), Some("Bearer caller-tok"));
+        assert_eq!(req, serde_json::json!({"person_ids": [person_id]}));
+    }
+
+    #[tokio::test]
+    async fn malformed_profiles_batch_success_is_an_error() {
+        let person_id = Uuid::from_u128(0xa);
+        let (url, _) =
+            spawn_profiles_batch(StatusCode::OK, serde_json::json!({"profiles": [{}]})).await;
+
+        let error = IdentityClient::new(&url)
+            .unwrap()
+            .profiles_batch(&[person_id], Some("Bearer tok"))
+            .await
+            .unwrap_err();
+
+        assert!(!error.to_string().is_empty());
     }
 
     #[test]

--- a/src/backend/services/analytics/src/infra/mod.rs
+++ b/src/backend/services/analytics/src/infra/mod.rs
@@ -1,3 +1,4 @@
 pub mod anthropic;
 pub mod db;
 pub mod identity;
+pub(crate) mod query;

--- a/src/backend/services/analytics/src/infra/query.rs
+++ b/src/backend/services/analytics/src/infra/query.rs
@@ -1,0 +1,60 @@
+use std::time::Duration;
+
+use serde::de::DeserializeOwned;
+
+const QUERY_FETCH_TIMEOUT: Duration = Duration::from_mins(1);
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum QueryFetchError {
+    #[error("query submission failed: {0}")]
+    Submit(String),
+    #[error("query fetch timed out")]
+    Timeout,
+    #[error("query fetch failed: {0}")]
+    Fetch(String),
+    #[error("query result parsing failed: {0}")]
+    Parse(String),
+}
+
+pub(crate) async fn fetch_json_rows<T>(
+    client: &insight_clickhouse::Client,
+    sql: &str,
+    params: &[String],
+    log_comment: &str,
+) -> Result<Vec<T>, QueryFetchError>
+where
+    T: DeserializeOwned,
+{
+    let mut query = client.query(sql).with_setting("log_comment", log_comment);
+    for param in params {
+        query = query.bind(param.as_str());
+    }
+
+    let mut cursor = query.fetch_bytes("JSONEachRow").map_err(|error| {
+        tracing::error!(error = %error, comment = log_comment, sql, "ClickHouse query failed");
+        QueryFetchError::Submit(error.to_string())
+    })?;
+    let raw_bytes = tokio::time::timeout(QUERY_FETCH_TIMEOUT, cursor.collect())
+        .await
+        .map_err(|_| {
+            tracing::error!(comment = log_comment, sql, "ClickHouse query fetch timed out");
+            QueryFetchError::Timeout
+        })?
+        .map_err(|error| {
+            tracing::error!(error = %error, comment = log_comment, sql, "ClickHouse query fetch failed");
+            QueryFetchError::Fetch(error.to_string())
+        })?;
+    if raw_bytes.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    raw_bytes
+        .split(|&byte| byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(serde_json::from_slice)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| {
+            tracing::error!(error = %error, comment = log_comment, sql, "failed to parse ClickHouse query rows");
+            QueryFetchError::Parse(error.to_string())
+        })
+}

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -728,6 +728,66 @@ class PutSettingsRequest(BaseModel):
     system_prompt: str
 
 
+class ReportColumnDataType(StrEnum):
+    text = 'text'
+    date = 'date'
+    number = 'number'
+
+
+class ReportColumnMetadata(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    data_type: ReportColumnDataType
+    format: MetricFormat | None = None
+    key: str
+    label: str
+    unit: str | None = None
+
+
+class ReportGranularity(StrEnum):
+    day = 'day'
+    week = 'week'
+    month = 'month'
+    quarter = 'quarter'
+    year = 'year'
+
+
+class ReportPeriod(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    from_: str = Field(..., alias='from')
+    to: str
+
+
+class Type7(StrEnum):
+    people = 'people'
+
+
+class ReportSubject1(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    ids: list[UUID]
+    type: Type7
+
+
+class Type8(StrEnum):
+    tenant = 'tenant'
+
+
+class ReportSubject2(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Type8
+
+
+class ReportSubject(RootModel[ReportSubject1 | ReportSubject2]):
+    root: ReportSubject1 | ReportSubject2
+
+
 class RollupValueDto(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
@@ -974,6 +1034,10 @@ class ValueTransform(BaseModel):
     clamp_min: float | None = None
     multiplier: float | None = None
     offset: float | None = None
+
+
+class Vec(RootModel[list[str | float | None]]):
+    root: list[str | float | None]
 
 
 class BreakdownValueDto(BaseModel):
@@ -1239,6 +1303,25 @@ class MetricSnapshot(BaseModel):
     trend: list[float | None] | None = Field(None, description="The sparkline's readings, oldest first.")
     until: str = Field(..., description='Inclusive end of the window, `YYYY-MM-DD`.')
     value: str = Field(..., description='The formatted value the tile shows.')
+
+
+class ReportPreviewResponse(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    columns: list[ReportColumnMetadata]
+    rows: list[Vec]
+    total_rows: int = Field(..., ge=0)
+
+
+class ReportRecipe(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    granularity: ReportGranularity
+    metric_keys: list[str]
+    period: ReportPeriod
+    subject: ReportSubject
 
 
 class SavedQueryListResponse(BaseModel):


### PR DESCRIPTION
**Why.** Report preview needs one backend contract that supports both person-scoped metrics and tenant-scoped metrics without reproducing analytics logic in the browser.

**What changed.** Adds `POST /v1/reports/preview` with recipe validation, visible-profile hydration, dynamic columns, period planning, bounded query batches, and positional response rows.

**Subject determines metric compatibility.** People and tenant metrics cannot be mixed; frontend tabs are not part of the API recipe.

**Profile attributes remain optional.** Analytics includes populated provider-backed attributes and never adds internal person IDs as report columns.

**Stack.** 2 of 4; depends on #2970 and is followed by #2968.

23 focused report tests passed.

**Out of scope.** File export and frontend adoption remain in downstream PRs in this stack.

**Verified.** Focused report tests and Clippy; analytics OpenAPI and generated-schema drift checks.
