### PR TITLE
feat(semantic): transcribe the wiki, tasks, ai, collab, and ci metric families

### DIFF
--- a/deploy/compose/analytics-fullauth.yaml
+++ b/deploy/compose/analytics-fullauth.yaml
@@ -95,4 +95,7 @@ gears:
       clickhouse_database: "insight"
       identity_url: ""
       redis_url: ""
-      metric_catalog: {}
+      metric_catalog:
+        # The stand serves the tenant-grain families, so the deployed-stand
+        # suite exercises the surfaces that answer them.
+        tenant_metrics_enabled: true

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -253,8 +253,8 @@
             "$ref": "#/components/schemas/Direction"
           },
           "entity_type": {
-            "description": "What the metric's values are keyed by, such as `person`.",
-            "type": "string"
+            "$ref": "#/components/schemas/EntityType",
+            "description": "What the metric's values are keyed by."
           },
           "format": {
             "$ref": "#/components/schemas/Format"
@@ -1820,7 +1820,8 @@
             "$ref": "#/components/schemas/Direction"
           },
           "entity_type": {
-            "type": "string"
+            "$ref": "#/components/schemas/EntityType",
+            "description": "What the metric's values are keyed by. INVARIANT: equal to the grain of\nevery dataset its measures read — see `validate`."
           },
           "format": {
             "$ref": "#/components/schemas/Format"
@@ -3967,12 +3968,13 @@
             ]
           },
           "subject": {
-            "type": "string"
+            "description": "Absent when the metric measures the tenant: the answer is about the\ncaller's own tenant, which the question already named.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
-        "required": [
-          "subject"
-        ],
         "type": "object"
       },
       "Subjects": {
@@ -4584,7 +4586,9 @@
           "metric_expression",
           "unknown_derived_input",
           "unused_derived_input",
-          "dimension_bindings_disagree"
+          "dimension_bindings_disagree",
+          "entity_grain_mismatch",
+          "cohort_without_peers"
         ],
         "type": "string"
       },

--- a/src/backend/services/analytics/src/api/catalog/metrics.rs
+++ b/src/backend/services/analytics/src/api/catalog/metrics.rs
@@ -1,22 +1,29 @@
+use std::sync::Arc;
+
 use axum::Json;
+use axum::extract::Extension;
 use toolkit_canonical_errors::CanonicalError;
 
+use crate::api::AppState;
 use crate::domain::metric_query::capability::{MetricCatalogResponse, describe};
 use crate::domain::metric_query::product_metric_catalog;
 
-// SAFETY: the answer is a projection of definitions compiled into the binary,
-// so this handler takes neither a security context nor a backend — there is no
-// tenant value it could disclose.
-pub async fn list_metric_catalog() -> Result<Json<MetricCatalogResponse>, CanonicalError> {
+// SAFETY: the answer is a projection of definitions compiled into the binary
+// plus this installation's own gate, so it takes no security context — there is
+// no tenant value it could disclose.
+pub async fn list_metric_catalog(
+    Extension(state): Extension<Arc<AppState>>,
+) -> Result<Json<MetricCatalogResponse>, CanonicalError> {
     let catalog = product_metric_catalog().map_err(|error| {
         tracing::error!(%error, "the shipped definitions did not load");
         CanonicalError::internal("metric definitions unavailable").create()
     })?;
 
-    let response = describe(catalog).map_err(|error| {
-        tracing::error!(%error, "a shipped metric did not resolve its inputs");
-        CanonicalError::internal("metric definitions unavailable").create()
-    })?;
+    let response =
+        describe(catalog, state.config.metric_catalog.tenant_metrics_enabled).map_err(|error| {
+            tracing::error!(%error, "a shipped metric did not resolve its inputs");
+            CanonicalError::internal("metric definitions unavailable").create()
+        })?;
 
     Ok(Json(response))
 }

--- a/src/backend/services/analytics/src/api/query/comparisons.rs
+++ b/src/backend/services/analytics/src/api/query/comparisons.rs
@@ -24,6 +24,9 @@ pub async fn query_comparisons(
         CanonicalError::internal("metric definitions unavailable").create()
     })?;
 
+    // INVARIANT: no tenant-metric gate is needed here — validation refuses a
+    // tenant-grain metric outright, so nothing keyed by the tenant is compared,
+    // and the population itself is disclosed only as aggregates.
     let batch = validate_request(catalog, req)?;
 
     // SAFETY: every target is checked individually before a single read is

--- a/src/backend/services/analytics/src/api/query/distributions.rs
+++ b/src/backend/services/analytics/src/api/query/distributions.rs
@@ -7,6 +7,7 @@ use toolkit_canonical_errors::CanonicalError;
 use toolkit_security::SecurityContext;
 
 use crate::api::AppState;
+use crate::domain::metric_access::authorize_tenant_metrics;
 use crate::domain::metric_query::distributions::{
     DistributionsRequest, DistributionsResponse, answer, validate_request,
 };
@@ -25,6 +26,9 @@ pub async fn query_distributions(
     })?;
 
     let batch = validate_request(catalog, req)?;
+    if batch.asks_about_the_tenant() {
+        authorize_tenant_metrics(state.config.metric_catalog.tenant_metrics_enabled)?;
+    }
 
     // SAFETY: every subject is checked individually; a batch is never a way
     // around the gate deciding which people a caller may read.

--- a/src/backend/services/analytics/src/api/query/rows.rs
+++ b/src/backend/services/analytics/src/api/query/rows.rs
@@ -7,6 +7,7 @@ use toolkit_canonical_errors::CanonicalError;
 use toolkit_security::SecurityContext;
 
 use crate::api::AppState;
+use crate::domain::metric_access::authorize_tenant_metrics;
 use crate::domain::metric_query::product_metric_catalog;
 use crate::domain::metric_query::rows::{RowsRequest, RowsResponse, answer, validate_request};
 use crate::domain::person_visibility::authorize_person_ids;
@@ -23,6 +24,9 @@ pub async fn query_rows(
     })?;
 
     let request = validate_request(catalog, req)?;
+    if request.asks_about_the_tenant() {
+        authorize_tenant_metrics(state.config.metric_catalog.tenant_metrics_enabled)?;
+    }
 
     // SAFETY: every subject is checked individually; a page is never a way
     // around the gate deciding which people a caller may read.
@@ -30,7 +34,7 @@ pub async fn query_rows(
         &state.identity,
         &ctx,
         crate::api::forwarded_authorization(&headers),
-        &request.subjects,
+        request.subjects.person_ids(),
     )
     .await?;
 

--- a/src/backend/services/analytics/src/api/query/values.rs
+++ b/src/backend/services/analytics/src/api/query/values.rs
@@ -53,16 +53,11 @@ async fn authorize_subjects(
 
     // SAFETY: every person is checked individually; a batch is never a way
     // around the gate deciding which people a caller may read.
-    let person_ids = batch.subject_ids();
-    if person_ids.is_empty() {
-        return Ok(());
-    }
-
     authorize_person_ids(
         &state.identity,
         ctx,
         crate::api::forwarded_authorization(headers),
-        &person_ids,
+        &batch.subject_ids(),
     )
     .await
 }

--- a/src/backend/services/analytics/src/domain/compiler/combined_split.rs
+++ b/src/backend/services/analytics/src/domain/compiler/combined_split.rs
@@ -466,7 +466,7 @@ mod tests {
         );
 
         assert!(compiled.sql.contains(
-            "        toFloat64(countIfOrNull(state = ?) / nullIf(countIf(1), 0)) AS value,"
+            "        toFloat64(countIfOrNull(coalesce(state = ?, 0)) / nullIf(countIf(1), 0)) AS value,"
         ));
         assert_eq!(compiled.params[0], text("acme-tenant"));
         assert_eq!(compiled.params[3], text("example/app"));

--- a/src/backend/services/analytics/src/domain/compiler/comparison.rs
+++ b/src/backend/services/analytics/src/domain/compiler/comparison.rs
@@ -6,7 +6,7 @@
 use std::fmt::Write;
 
 use crate::domain::definitions::definition::MetricDefinition;
-use crate::domain::field_catalog::model::CatalogDataset;
+use crate::domain::field_catalog::model::{CatalogDataset, EntityType};
 
 use super::error::CompileError;
 use super::fold::{Fold, transform_in_place};
@@ -40,13 +40,13 @@ pub fn compile_cohort_members_query(
     push_cohort_scope_values(
         &mut params,
         &query.tenant_id,
-        &query.entity_type,
+        query.entity_type,
         &query.cohort_key,
     );
     push_cohort_scope_values(
         &mut params,
         &query.tenant_id,
-        &query.entity_type,
+        query.entity_type,
         &query.cohort_key,
     );
     params.extend(query.targets.iter().cloned().map(QueryParam::Text));
@@ -172,7 +172,7 @@ fn push_cohort_scope(
     metric: &MetricDefinition,
     cohort_key: &str,
 ) {
-    push_cohort_scope_values(params, &query.tenant_id, &metric.entity_type, cohort_key);
+    push_cohort_scope_values(params, &query.tenant_id, metric.entity_type, cohort_key);
 }
 
 // INVARIANT: tenancy leads a cohort read exactly as it leads a dataset read,
@@ -180,11 +180,11 @@ fn push_cohort_scope(
 fn push_cohort_scope_values(
     params: &mut Vec<QueryParam>,
     tenant_id: &str,
-    entity_type: &str,
+    entity_type: EntityType,
     cohort_key: &str,
 ) {
     params.push(QueryParam::Text(tenant_id.to_owned()));
-    params.push(QueryParam::Text(entity_type.to_owned()));
+    params.push(QueryParam::Text(entity_type.as_db().to_owned()));
     params.push(QueryParam::Text(cohort_key.to_owned()));
 }
 
@@ -339,6 +339,7 @@ mod tests {
     };
     use crate::domain::compiler::sql::QueryParam;
     use crate::domain::definitions::definition::MetricDefinition;
+    use crate::domain::field_catalog::model::EntityType;
 
     fn cohort_metric() -> MetricDefinition {
         MetricDefinition {
@@ -380,7 +381,7 @@ mod tests {
     fn members_query(targets: &[&str]) -> CohortMembersQuery {
         CohortMembersQuery {
             tenant_id: "acme-tenant".to_owned(),
-            entity_type: "person".to_owned(),
+            entity_type: EntityType::Person,
             cohort_key: "org_unit".to_owned(),
             targets: targets.iter().map(|target| (*target).to_owned()).collect(),
             row_limit: 10_001,

--- a/src/backend/services/analytics/src/domain/compiler/fixtures.rs
+++ b/src/backend/services/analytics/src/domain/compiler/fixtures.rs
@@ -14,6 +14,8 @@ use crate::domain::definitions::definition::{
     MetricDefinition, Transform,
 };
 
+use crate::domain::field_catalog::model::EntityType;
+
 use super::error::CompileError;
 use super::metric::compile_metric_query;
 use super::request::{
@@ -77,7 +79,7 @@ pub fn metric(computation: Computation) -> MetricDefinition {
         transform: None,
         format: Format::Percent,
         direction: Direction::HigherIsBetter,
-        entity_type: "person".to_owned(),
+        entity_type: EntityType::Person,
         cohort_key: None,
         label: None,
         description: None,

--- a/src/backend/services/analytics/src/domain/compiler/fold.rs
+++ b/src/backend/services/analytics/src/domain/compiler/fold.rs
@@ -277,8 +277,9 @@ impl<'a> Fold<'a> {
                 numerator,
                 denominator,
             } => {
-                // INVARIANT: an empty numerator is an unknown split and a zero
-                // denominator an undefined ratio; both read NULL, never zero.
+                // INVARIANT: a zero denominator is an undefined ratio and reads
+                // NULL; `-OrNull` leaves an unmatched numerator NULL only for a
+                // value fold, since a count reports 0 over any group scanned.
                 let numerator = conditional_aggregate_expr(
                     numerator,
                     &fold_condition(numerator, params)?,
@@ -304,8 +305,8 @@ impl<'a> Fold<'a> {
                 format!("stddevSampIfOrNull({value}, {value} IS NOT NULL)")
             }
             FoldKind::Derived { inputs, expr } => {
-                // INVARIANT: an input that matched no row folds to NULL and
-                // arithmetic propagates it, so the value stays unknown.
+                // INVARIANT: a count-shaped input reports zero for a group it
+                // matched nothing in; the other folds read NULL and propagate.
                 let mut folded = Vec::with_capacity(expr.references.len());
                 for alias in &expr.references {
                     let (_, measure) =
@@ -374,12 +375,18 @@ fn row_value<'a>(
 }
 
 /// The rows one input folds over, as an aggregate-function condition.
+///
+/// SAFETY: an aggregate combinator admits no row on a NULL condition, so the
+/// collapse makes a row the filter is unknown of a definite non-match.
 fn fold_condition(
     measure: &MeasureDefinition,
     params: &mut Vec<QueryParam>,
 ) -> Result<String, CompileError> {
     match &measure.filter {
-        Some(filter) => render_filter(measure, filter, params),
+        Some(filter) => Ok(format!(
+            "coalesce({}, 0)",
+            render_filter(measure, filter, params)?
+        )),
         None => Ok("1".to_owned()),
     }
 }

--- a/src/backend/services/analytics/src/domain/compiler/measure.rs
+++ b/src/backend/services/analytics/src/domain/compiler/measure.rs
@@ -92,7 +92,9 @@ mod tests {
     use crate::domain::definitions::filter::{
         FilterError, FilterLeaf, FilterOp, FilterTree, FilterValue, Scalar,
     };
-    use crate::domain::field_catalog::model::{CatalogField, FieldRole, FieldType, ReadDiscipline};
+    use crate::domain::field_catalog::model::{
+        CatalogField, EntityType, FieldRole, FieldType, ReadDiscipline,
+    };
 
     fn measure() -> MeasureDefinition {
         MeasureDefinition {
@@ -577,6 +579,7 @@ any:
             key: "git_pull_requests".to_owned(),
             database: "silver".to_owned(),
             relation: "class_git_pull_requests".to_owned(),
+            entity_type: EntityType::Person,
             read_discipline: ReadDiscipline::Direct,
             sorting_key: vec!["unique_key".to_owned()],
             row_identity: vec!["unique_key".to_owned()],

--- a/src/backend/services/analytics/src/domain/compiler/metric.rs
+++ b/src/backend/services/analytics/src/domain/compiler/metric.rs
@@ -174,7 +174,7 @@ mod tests {
                 "SELECT",
                 "    author_email AS entity_id,",
                 "    toString(toStartOfWeek(toDate(assumeNotNull(closed_on)), 1)) AS bucket_start,",
-                "    toFloat64(countIfOrNull(state = ?) / nullIf(countIf(state IN (?, ?)), 0)) AS value,",
+                "    toFloat64(countIfOrNull(coalesce(state = ?, 0)) / nullIf(countIf(coalesce(state IN (?, ?), 0)), 0)) AS value,",
                 "    toUInt8(grouping(toStartOfWeek(toDate(assumeNotNull(closed_on)), 1))) AS is_total,",
                 "    CAST(NULL AS Nullable(UInt32)) AS rank,",
                 "    toUInt8(0) AS remainder,",
@@ -185,7 +185,7 @@ mod tests {
                 "  AND toDate(closed_on) <= toDate(?)",
                 "  AND isNotNull(closed_on)",
                 "GROUP BY GROUPING SETS ((entity_id, toStartOfWeek(toDate(assumeNotNull(closed_on)), 1)), (entity_id))",
-                "HAVING countIf(state = ? OR state IN (?, ?)) > 0",
+                "HAVING countIf(coalesce(state = ?, 0) OR coalesce(state IN (?, ?), 0)) > 0",
                 "ORDER BY entity_id, is_total, bucket_start",
                 "LIMIT ?",
                 ")",
@@ -223,9 +223,9 @@ mod tests {
         );
 
         assert!(
-            compiled
-                .sql
-                .contains("toFloat64(countIfOrNull(state = ?) / nullIf(countIf(1), 0)) AS value"),
+            compiled.sql.contains(
+                "toFloat64(countIfOrNull(coalesce(state = ?, 0)) / nullIf(countIf(1), 0)) AS value"
+            ),
             "{}",
             compiled.sql
         );
@@ -258,13 +258,46 @@ mod tests {
 
         assert!(
             compiled.sql.contains(
-                "toFloat64(sumIfOrNull(lines_added, state = ?) / nullIf(uniqExactIf(pull_request_id, is_draft = ?), 0)) AS value"
+                "toFloat64(sumIfOrNull(lines_added, coalesce(state = ?, 0)) / nullIf(uniqExactIf(pull_request_id, coalesce(is_draft = ?, 0)), 0)) AS value"
             ),
             "{}",
             compiled.sql
         );
         assert_eq!(compiled.params[0], text("merged"));
         assert_eq!(compiled.params[1], QueryParam::Bool(0));
+    }
+
+    #[test]
+    fn a_fold_condition_over_a_nullable_column_is_false_where_the_column_is_null() {
+        let sized = measure(
+            "prs_sized",
+            Some("{ field: lines_added, op: gt, value: 0 }"),
+        );
+        let merged = measure(
+            "prs_merged",
+            Some("{ field: state, op: eq, value: merged }"),
+        );
+
+        let compiled = compile(
+            &metric(ratio("prs_sized", "prs_merged")),
+            &[sized, merged],
+            &query(ViewKind::SubjectTotal),
+        );
+
+        assert!(
+            compiled.sql.contains(
+                "toFloat64(countIfOrNull(coalesce(lines_added > ?, 0)) / nullIf(countIf(coalesce(state = ?, 0)), 0)) AS value"
+            ),
+            "a row the filter is unknown of folds as a non-match, so the fold reports zero without a definite-false row beside it: {}",
+            compiled.sql
+        );
+        assert!(
+            compiled.sql.contains(
+                "HAVING countIf(coalesce(lines_added > ?, 0) OR coalesce(state = ?, 0)) > 0"
+            ),
+            "{}",
+            compiled.sql
+        );
     }
 
     #[test]
@@ -361,7 +394,7 @@ mod tests {
             lines(&[
                 "SELECT",
                 "    author_email AS entity_id,",
-                "    toFloat64(((countIfOrNull(1)) - (countIfOrNull(state = ?))) / (countIfOrNull(1))) AS value",
+                "    toFloat64(((countIfOrNull(1)) - (countIfOrNull(coalesce(state = ?, 0)))) / (countIfOrNull(1))) AS value",
                 "FROM silver.class_git_pull_requests FINAL",
                 "WHERE tenant_id = ?",
                 "  AND toDate(closed_on) >= toDate(?)",
@@ -402,7 +435,7 @@ mod tests {
             assert!(
                 compiled
                     .sql
-                    .contains("(countIfOrNull(state = ?)) - (countIfOrNull(1))"),
+                    .contains("(countIfOrNull(coalesce(state = ?, 0))) - (countIfOrNull(1))"),
                 "{name}: {}",
                 compiled.sql
             );
@@ -597,9 +630,9 @@ mod tests {
         );
 
         assert!(
-            compiled
-                .sql
-                .contains("HAVING countIf(state = ? OR state IN (?, ?)) > 0"),
+            compiled.sql.contains(
+                "HAVING countIf(coalesce(state = ?, 0) OR coalesce(state IN (?, ?), 0)) > 0"
+            ),
             "{}",
             compiled.sql
         );
@@ -623,7 +656,9 @@ mod tests {
         );
 
         assert!(
-            compiled.sql.contains("nullIf(countIf(state IN (?, ?)), 0)"),
+            compiled
+                .sql
+                .contains("nullIf(countIf(coalesce(state IN (?, ?), 0)), 0)"),
             "{}",
             compiled.sql
         );

--- a/src/backend/services/analytics/src/domain/compiler/request.rs
+++ b/src/backend/services/analytics/src/domain/compiler/request.rs
@@ -8,6 +8,8 @@ use std::num::NonZeroU32;
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 
+use crate::domain::field_catalog::model::EntityType;
+
 /// The time grain a measure is folded to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -296,7 +298,7 @@ pub enum SortValue {
 pub struct CohortMembersQuery {
     pub tenant_id: String,
     /// The entity type the metric declares, which cohort membership is under.
-    pub entity_type: String,
+    pub entity_type: EntityType,
     pub cohort_key: String,
     /// Person references whose own cohorts the membership is read from.
     pub targets: Vec<String>,

--- a/src/backend/services/analytics/src/domain/definitions/definition.rs
+++ b/src/backend/services/analytics/src/domain/definitions/definition.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use super::filter::FilterTree;
+use crate::domain::field_catalog::model::EntityType;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
@@ -149,7 +150,9 @@ pub struct MetricDefinition {
     pub transform: Option<Transform>,
     pub format: Format,
     pub direction: Direction,
-    pub entity_type: String,
+    /// What the metric's values are keyed by. INVARIANT: equal to the grain of
+    /// every dataset its measures read — see `validate`.
+    pub entity_type: EntityType,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cohort_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -305,7 +308,7 @@ dimensions:
             transform: None,
             format: Format::Percent,
             direction: Direction::HigherIsBetter,
-            entity_type: "person".to_owned(),
+            entity_type: EntityType::Person,
             cohort_key: None,
             label: None,
             description: None,
@@ -345,7 +348,7 @@ dimensions:
             transform: None,
             format: Format::Percent,
             direction: Direction::HigherIsBetter,
-            entity_type: "person".to_owned(),
+            entity_type: EntityType::Person,
             cohort_key: None,
             label: None,
             description: None,

--- a/src/backend/services/analytics/src/domain/definitions/dry_run.rs
+++ b/src/backend/services/analytics/src/domain/definitions/dry_run.rs
@@ -54,6 +54,8 @@ pub enum ValidationErrorKind {
     UnknownDerivedInput,
     UnusedDerivedInput,
     DimensionBindingsDisagree,
+    EntityGrainMismatch,
+    CohortWithoutPeers,
 }
 
 /// INVARIANT: the submitted definitions are judged as part of one set with the
@@ -113,6 +115,8 @@ const fn kind_of(error: &ValidationError) -> ValidationErrorKind {
         ValidationError::DimensionBindingsDisagree { .. } => {
             ValidationErrorKind::DimensionBindingsDisagree
         }
+        ValidationError::EntityGrainMismatch { .. } => ValidationErrorKind::EntityGrainMismatch,
+        ValidationError::CohortWithoutPeers { .. } => ValidationErrorKind::CohortWithoutPeers,
     }
 }
 

--- a/src/backend/services/analytics/src/domain/definitions/dry_run/tests.rs
+++ b/src/backend/services/analytics/src/domain/definitions/dry_run/tests.rs
@@ -116,7 +116,22 @@ fn assert_each_kind_is_reported(cases: &[(ValidationErrorKind, Value)]) {
 
 #[test]
 fn every_rule_a_measure_can_break_is_reported_under_its_own_discriminant() {
-    let cases: [(ValidationErrorKind, Value); 9] = [
+    let cases: [(ValidationErrorKind, Value); 11] = [
+        (
+            // A person-grain metric authored over a tenant-grain dataset.
+            ValidationErrorKind::EntityGrainMismatch,
+            json!({ "metrics": [with(probe_metric("ci_runs_decided"), "key", json!("probe.runs"))] }),
+        ),
+        (
+            ValidationErrorKind::CohortWithoutPeers,
+            json!({
+                "metrics": [with(
+                    with(probe_metric("ci_runs_decided"), "entity_type", json!("tenant")),
+                    "cohort_key",
+                    json!("org_unit"),
+                )],
+            }),
+        ),
         (
             ValidationErrorKind::KeyShape,
             json!({ "measures": [with(probe_measure(), "key", json!("Not A Key"))] }),

--- a/src/backend/services/analytics/src/domain/definitions/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/definitions/live_tests.rs
@@ -4,6 +4,8 @@
 
 use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, Statement, Value};
 
+use crate::domain::field_catalog::model::EntityType;
+
 use super::definition::{
     Aggregation, Computation, DatasetDefinition, Direction, Format, MeasureDefinition,
     MetricDefinition, Origin, ReadDiscipline, Transform,
@@ -56,7 +58,7 @@ fn metric(key: &str, measure_key: &str) -> MetricDefinition {
         transform: None,
         format: Format::Integer,
         direction: Direction::HigherIsBetter,
-        entity_type: "person".to_owned(),
+        entity_type: EntityType::Person,
         cohort_key: None,
         label: None,
         description: None,

--- a/src/backend/services/analytics/src/domain/definitions/seeds.rs
+++ b/src/backend/services/analytics/src/domain/definitions/seeds.rs
@@ -23,6 +23,7 @@ const FAMILIES: &[(&str, &str)] = &[
     ("tasks", include_str!("seeds/tasks.yaml")),
     ("wiki", include_str!("seeds/wiki.yaml")),
     ("collab", include_str!("seeds/collab.yaml")),
+    ("ci", include_str!("seeds/ci.yaml")),
 ];
 
 #[derive(Debug, Deserialize)]
@@ -126,7 +127,7 @@ pub async fn reconcile_product_definitions(db: &DatabaseConnection) -> Result<()
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use crate::domain::field_catalog::model::CatalogDataset;
+    use crate::domain::field_catalog::model::{CatalogDataset, EntityType};
 
     #[test]
     fn every_shipped_definition_is_valid() {
@@ -160,6 +161,7 @@ mod tests {
             key: key.to_owned(),
             database: database.to_owned(),
             relation: key.to_owned(),
+            entity_type: EntityType::Person,
             read_discipline,
             sorting_key: Vec::new(),
             row_identity: Vec::new(),

--- a/src/backend/services/analytics/src/domain/definitions/seeds.rs
+++ b/src/backend/services/analytics/src/domain/definitions/seeds.rs
@@ -22,6 +22,7 @@ const FAMILIES: &[(&str, &str)] = &[
     ("git", include_str!("seeds/git.yaml")),
     ("tasks", include_str!("seeds/tasks.yaml")),
     ("wiki", include_str!("seeds/wiki.yaml")),
+    ("collab", include_str!("seeds/collab.yaml")),
 ];
 
 #[derive(Debug, Deserialize)]

--- a/src/backend/services/analytics/src/domain/definitions/seeds.rs
+++ b/src/backend/services/analytics/src/domain/definitions/seeds.rs
@@ -19,6 +19,7 @@ const ACTOR: &str = "product-seed";
 
 const FAMILIES: &[(&str, &str)] = &[
     ("git", include_str!("seeds/git.yaml")),
+    ("tasks", include_str!("seeds/tasks.yaml")),
     ("wiki", include_str!("seeds/wiki.yaml")),
 ];
 

--- a/src/backend/services/analytics/src/domain/definitions/seeds.rs
+++ b/src/backend/services/analytics/src/domain/definitions/seeds.rs
@@ -18,6 +18,7 @@ use crate::domain::field_catalog::{
 const ACTOR: &str = "product-seed";
 
 const FAMILIES: &[(&str, &str)] = &[
+    ("ai", include_str!("seeds/ai.yaml")),
     ("git", include_str!("seeds/git.yaml")),
     ("tasks", include_str!("seeds/tasks.yaml")),
     ("wiki", include_str!("seeds/wiki.yaml")),

--- a/src/backend/services/analytics/src/domain/definitions/seeds.rs
+++ b/src/backend/services/analytics/src/domain/definitions/seeds.rs
@@ -17,7 +17,10 @@ use crate::domain::field_catalog::{
 
 const ACTOR: &str = "product-seed";
 
-const FAMILIES: &[(&str, &str)] = &[("git", include_str!("seeds/git.yaml"))];
+const FAMILIES: &[(&str, &str)] = &[
+    ("git", include_str!("seeds/git.yaml")),
+    ("wiki", include_str!("seeds/wiki.yaml")),
+];
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/src/backend/services/analytics/src/domain/definitions/seeds/ai.yaml
+++ b/src/backend/services/analytics/src/domain/definitions/seeds/ai.yaml
@@ -1,0 +1,393 @@
+# AI measures and metrics. Datasets are not authored here — they are a
+# projection of the field catalog.
+measures:
+  - key: accepted_lines
+    dataset: ai_usage
+    description: Lines a person accepted from a coding AI tool.
+    filter: { field: surface, op: eq, value: dev }
+    aggregation: sum
+    value_expr: lines_added
+    event_time: usage_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: removed_lines
+    dataset: ai_usage
+    description: Lines a person accepted a coding AI tool's deletion of.
+    filter: { field: surface, op: eq, value: dev }
+    aggregation: sum
+    value_expr: lines_removed
+    event_time: usage_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: ai_active_days
+    dataset: ai_usage
+    description: >-
+      Calendar days on which a person used any AI tool, coding and assistant
+      alike.
+    aggregation: count_distinct
+    subject_expr: usage_date
+    event_time: usage_date
+    entity: email
+
+  - key: cost_usd
+    dataset: ai_usage
+    description: >-
+      What a person's AI usage would cost at the vendor's token rates, across
+      coding and assistant tools.
+    aggregation: sum
+    value_expr: cost_usd
+    event_time: usage_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: accepted_edit_actions
+    dataset: ai_usage
+    description: Edit or tool suggestions a person accepted from a coding AI tool.
+    filter: { field: surface, op: eq, value: dev }
+    aggregation: sum
+    value_expr: tool_use_accepted
+    event_time: usage_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: tool_use_offered
+    dataset: ai_usage
+    description: Edit or tool suggestions a coding AI tool offered a person.
+    filter: { field: surface, op: eq, value: dev }
+    aggregation: sum
+    value_expr: tool_use_offered
+    event_time: usage_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: dev_conversations
+    dataset: ai_usage
+    description: >-
+      Conversations a person held with a coding AI tool, counted as that tool
+      counts them.
+    filter: { field: surface, op: eq, value: dev }
+    aggregation: sum
+    value_expr: dev_conversations
+    event_time: usage_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: assistant_messages
+    dataset: ai_usage
+    description: Messages a person exchanged with an AI assistant.
+    filter: { field: surface, op: neq, value: dev }
+    aggregation: sum
+    value_expr: assistant_messages
+    event_time: usage_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+      - { key: surface, value_field: surface, label_field: surface_label }
+
+  - key: assistant_actions
+    dataset: ai_usage
+    description: Actions an AI assistant took for a person.
+    filter: { field: surface, op: neq, value: dev }
+    aggregation: sum
+    value_expr: assistant_actions
+    event_time: usage_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+      - { key: surface, value_field: surface, label_field: surface_label }
+
+  - key: chat_assistant_conversations
+    dataset: ai_usage
+    description: Conversations a person held with an AI assistant on its chat surface.
+    filter: { field: surface, op: eq, value: chat }
+    aggregation: sum
+    value_expr: chat_conversations
+    event_time: usage_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+      - { key: surface, value_field: surface, label_field: surface_label }
+
+  - key: prs_with_assistant
+    dataset: ai_usage
+    description: >-
+      Pull requests a coding AI tool reported itself active in, as that tool
+      attributes them.
+    filter: { field: surface, op: eq, value: dev }
+    aggregation: sum
+    value_expr: prs_with_assistant
+    event_time: usage_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+      - { key: seat_status, value_field: seat_status }
+
+  - key: prs_total
+    dataset: ai_usage
+    description: Pull requests a coding AI tool observed for a person over its own window.
+    filter: { field: surface, op: eq, value: dev }
+    aggregation: sum
+    value_expr: prs_total
+    event_time: usage_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+      - { key: seat_status, value_field: seat_status }
+
+  - key: seat_cost_usd
+    dataset: ai_seat_months
+    description: >-
+      The invoiced price of a person's AI seat for a billing month. A seat whose
+      tier the invoice does not price carries no value.
+    aggregation: sum
+    value_expr: seat_cost_usd
+    event_time: period_month
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+      - { key: seat_tier, value_field: seat_tier }
+
+  - key: extra_usage_usd
+    dataset: ai_seat_months
+    description: >-
+      What the vendor billed a person's seat for a billing month once the usage
+      included in its fee ran out.
+    aggregation: sum
+    value_expr: extra_usage_usd
+    event_time: period_month
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+      - { key: seat_tier, value_field: seat_tier }
+
+  - key: extra_usage_limit_usd
+    dataset: ai_seat_months
+    description: >-
+      The ceiling the vendor stops a seat's extra usage at. A seat with no
+      ceiling carries no value.
+    aggregation: sum
+    value_expr: extra_usage_limit_usd
+    event_time: period_month
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+      - { key: seat_tier, value_field: seat_tier }
+
+  - key: daily_extra_usage_usd
+    dataset: ai_seat_days
+    description: >-
+      A day's share of the billed extra usage, the step between two of the
+      vendor's month-to-date readings.
+    aggregation: sum
+    value_expr: daily_extra_usage_usd
+    event_time: snapshot_date
+    entity: email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+      - { key: seat_tier, value_field: seat_tier }
+
+metrics:
+  - key: ai.accepted_lines
+    computation: { type: direct, measure: accepted_lines }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI-added lines
+    description: >-
+      Added lines the person accepted from coding AI tools during the period.
+
+  - key: ai.removed_lines
+    computation: { type: direct, measure: removed_lines }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI-removed lines
+    description: >-
+      Deleted lines the person accepted from coding AI tools during the period.
+
+  - key: ai.active_days
+    computation: { type: direct, measure: ai_active_days }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI active days
+    description: >-
+      Distinct days in the period with AI activity attributed to the person,
+      across coding and assistant tools alike.
+
+  - key: ai.cost
+    computation: { type: direct, measure: cost_usd }
+    format: currency
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI potential usage cost
+    description: >-
+      The person's AI usage priced at the vendor's token rates — what the
+      consumption would cost if billed purely by usage. It includes usage a seat
+      already covered and excludes seat fees, so it is not the invoiced amount,
+      and only tools that price usage per person contribute. Never add it to
+      actual usage cost, which is the billed part of this same consumption.
+
+  - key: ai.accepted_edit_actions
+    computation: { type: direct, measure: accepted_edit_actions }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Accepted AI edits
+    description: >-
+      Edit or tool suggestions the person accepted from coding AI tools during
+      the period.
+
+  - key: ai.tool_acceptance_rate
+    computation: { type: ratio, numerator: accepted_edit_actions, denominator: tool_use_offered }
+    transform: { multiplier: 100.0 }
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI tool acceptance
+    description: >-
+      Accepted AI edit or tool suggestions divided by the suggestions offered.
+
+  - key: ai.assistant_messages
+    computation: { type: direct, measure: assistant_messages }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI assistant messages
+    description: >-
+      Assistant messages attributed to the person during the period.
+
+  - key: ai.assistant_actions
+    computation: { type: direct, measure: assistant_actions }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI assistant actions
+    description: >-
+      Assistant actions attributed to the person during the period.
+
+  - key: ai.dev_conversations
+    computation: { type: direct, measure: dev_conversations }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI dev conversations
+    description: >-
+      Conversations the person held with coding AI tools, counted as the vendor
+      counts them. For the agent tools that is the session or thread count — a
+      session is the unit of conversation there, and no vendor publishes a
+      separate conversation counter — so the number reads as "times the person
+      started working with the assistant", not as messages exchanged. Tools that
+      report no such unit, inline-completion tools among them, return no value
+      rather than a zero.
+
+  - key: ai.chat_assistant_conversations
+    computation: { type: direct, measure: chat_assistant_conversations }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI chat conversations
+    description: >-
+      Chat assistant conversations attributed to the person during the period.
+
+  - key: ai.prs_with_assistant
+    computation: { type: direct, measure: prs_with_assistant }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: PRs with AI assistance
+    description: >-
+      Pull requests where the coding assistant was active at least once, as the
+      vendor attributes them. Reported only by sources that connect to the code
+      host themselves, so a person working without that connection returns no
+      value rather than a zero. Counts pull requests, not commits or lines, and
+      says nothing about how much of the change the assistant wrote.
+
+  - key: ai.prs_total
+    computation: { type: direct, measure: prs_total }
+    format: integer
+    direction: neutral
+    entity_type: person
+    cohort_key: org_unit
+    label: PRs seen by the AI vendor
+    description: >-
+      Pull requests the AI vendor observed for the person, served as the context
+      for PRs with AI assistance rather than as a goal of its own. It is the
+      vendor's count over the vendor's own window, which need not be the day it
+      is reported against and need not agree with the git sources — read it next
+      to that metric, not next to git pull-request metrics.
+
+  - key: ai.seat_cost
+    computation: { type: direct, measure: seat_cost_usd }
+    format: currency
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI seat cost
+    description: >-
+      The invoiced price of one seat for a billing month, from the invoice's
+      per-seat amount. Dated at that month's first day, so a window must hold it
+      to return the fee. The month comes from the read, not from the vendor. A
+      seat whose tier the invoice does not price returns no value.
+
+  - key: ai.extra_usage_cost
+    computation: { type: direct, measure: extra_usage_usd }
+    format: currency
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI actual usage cost
+    description: >-
+      What the vendor billed on top of the seat fee, once included usage ran
+      out. Exact as of that month's last reading, dated at its first day, so a
+      window missing that day returns nothing — read the per-day distribution.
+      The month comes from the read, not the vendor. Never added to potential
+      usage cost.
+
+  - key: ai.daily_approximate_extra_usage_cost
+    computation: { type: direct, measure: daily_extra_usage_usd }
+    format: currency
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: AI actual usage cost — approximate distribution
+    description: >-
+      The billed extra-usage cost placed on the days spent. Only a month-to-date
+      total is reported, so a day is the step between readings — exact in sum
+      against it, approximate in placement. The month comes from the read, so
+      the 1st can cover several days. No reading means no point, and none is
+      negative.
+
+  - key: ai.extra_usage_utilisation
+    computation: { type: ratio, numerator: extra_usage_usd, denominator: extra_usage_limit_usd }
+    transform: { multiplier: 100.0 }
+    format: percent
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Extra-usage ceiling used
+    description: >-
+      Extra usage measured against the seat's ceiling. At 100% the vendor stops
+      the seat, so this reads as proximity to being blocked, not waste. A seat
+      with no ceiling returns no value, not zero. Above 100%, the ceiling was
+      lowered below what the seat had spent. Its month comes from the read, not
+      the vendor.

--- a/src/backend/services/analytics/src/domain/definitions/seeds/ci.yaml
+++ b/src/backend/services/analytics/src/domain/definitions/seeds/ci.yaml
@@ -1,0 +1,270 @@
+# CI measures and metrics. Datasets are not authored here — they are a
+# projection of the field catalog.
+#
+# This family is TENANT grain: a pipeline run, a deployment and a collected
+# commit belong to the organization, so every dataset keys its rows by the
+# tenant and no identity is ever resolved. A question about these metrics names
+# the tenant as its subject and never a person.
+measures:
+  - key: ci_runs_decided
+    dataset: ci_runs
+    description: Pipeline runs that reached a decided outcome, dated by the day the run started.
+    aggregation: count
+    event_time: started_at
+    entity: entity_id
+    dimensions:
+      - { key: repository, value_field: repository_value, label_field: repository_label }
+      - { key: pipeline, value_field: pipeline_value, label_field: pipeline_label }
+      - { key: trigger, value_field: trigger_value, label_field: trigger_label }
+      - { key: outcome, value_field: outcome_value, label_field: outcome_label }
+      - { key: hour_block, value_field: hour_block_value, label_field: hour_block_label }
+
+  - key: ci_gate_runs
+    dataset: ci_runs
+    description: >-
+      Gate runs: triggered by a push, a pull request or the merge queue, and
+      decided. Cancelled and skipped runs decide nothing, and a run stopped at
+      an approval wall never executed, so neither is a gate run.
+    filter: { field: is_gate, op: eq, value: 1 }
+    aggregation: count
+    event_time: started_at
+    entity: entity_id
+    dimensions:
+      - { key: repository, value_field: repository_value, label_field: repository_label }
+      - { key: pipeline, value_field: pipeline_value, label_field: pipeline_label }
+      - { key: hour_block, value_field: hour_block_value, label_field: hour_block_label }
+
+  - key: ci_gate_passed
+    dataset: ci_runs
+    description: Gate runs that succeeded.
+    filter:
+      all:
+        - { field: is_gate, op: eq, value: 1 }
+        - { field: outcome_value, op: eq, value: success }
+    aggregation: count
+    event_time: started_at
+    entity: entity_id
+    dimensions:
+      - { key: repository, value_field: repository_value, label_field: repository_label }
+      - { key: pipeline, value_field: pipeline_value, label_field: pipeline_label }
+      - { key: hour_block, value_field: hour_block_value, label_field: hour_block_label }
+
+  - key: ci_gate_first_try_passed
+    dataset: ci_runs
+    description: Gate runs that succeeded on their first attempt, without a re-run.
+    filter:
+      all:
+        - { field: is_gate, op: eq, value: 1 }
+        - { field: outcome_value, op: eq, value: success }
+        - { field: attempt, op: eq, value: 1 }
+    aggregation: count
+    event_time: started_at
+    entity: entity_id
+    dimensions:
+      - { key: repository, value_field: repository_value, label_field: repository_label }
+      - { key: pipeline, value_field: pipeline_value, label_field: pipeline_label }
+
+  - key: ci_gate_retried
+    dataset: ci_runs
+    description: Gate runs whose final state came from a re-run, counted once at their last attempt.
+    filter:
+      all:
+        - { field: is_gate, op: eq, value: 1 }
+        - { field: is_retry, op: eq, value: 1 }
+    aggregation: count
+    event_time: started_at
+    entity: entity_id
+    dimensions:
+      - { key: repository, value_field: repository_value, label_field: repository_label }
+      - { key: pipeline, value_field: pipeline_value, label_field: pipeline_label }
+
+  - key: ci_run_duration_min
+    dataset: ci_runs
+    description: >-
+      Wall-clock minutes a gate run took, per run. Instant failures that never
+      really ran carry no duration and are excluded, so they count toward rates
+      without dragging the timings down.
+    filter:
+      all:
+        - { field: is_gate, op: eq, value: 1 }
+        - { field: duration_min, op: gt, value: 0 }
+    aggregation: avg
+    value_expr: duration_min
+    event_time: started_at
+    entity: entity_id
+    dimensions:
+      - { key: repository, value_field: repository_value, label_field: repository_label }
+      - { key: pipeline, value_field: pipeline_value, label_field: pipeline_label }
+      - { key: outcome, value_field: outcome_value, label_field: outcome_label }
+
+  - key: ci_run_hours
+    dataset: ci_runs
+    description: >-
+      Wall-clock hours a decided run spent executing, whatever its trigger.
+      Elapsed time of the run, not the sum of the jobs inside it.
+    filter: { field: duration_h, op: gt, value: 0 }
+    aggregation: sum
+    value_expr: duration_h
+    event_time: started_at
+    entity: entity_id
+    dimensions:
+      - { key: repository, value_field: repository_value, label_field: repository_label }
+      - { key: pipeline, value_field: pipeline_value, label_field: pipeline_label }
+      - { key: outcome, value_field: outcome_value, label_field: outcome_label }
+
+  - key: ci_runs_matched_commit
+    dataset: ci_runs
+    description: >-
+      Decided runs whose head commit exists among the collected commits. Pull
+      request runs build synthetic merge refs, and fork commits are never
+      collected, so this is the ceiling for any reading that joins CI to git
+      history.
+    filter: { field: commit_known, op: eq, value: 1 }
+    aggregation: count
+    event_time: started_at
+    entity: entity_id
+
+  - key: ci_deployments_created
+    dataset: ci_deployments
+    description: >-
+      Deployments recorded, dated by their creation. The outcome is the latest
+      status the deployment reached; one with no status yet reads as pending.
+    aggregation: count
+    event_time: created_at
+    entity: entity_id
+    dimensions:
+      - { key: repository, value_field: repository_value, label_field: repository_label }
+      - { key: environment, value_field: environment_value, label_field: environment_label }
+      - { key: outcome, value_field: outcome_value, label_field: outcome_label }
+      - { key: env_kind, value_field: env_kind_value, label_field: env_kind_label }
+
+  - key: ci_commits_collected
+    dataset: ci_commits
+    description: Commits the git connector collected, dated at their commit time.
+    aggregation: count
+    event_time: committed_at
+    entity: entity_id
+
+metrics:
+  - key: ci.runs
+    computation: { type: direct, measure: ci_runs_decided }
+    format: integer
+    direction: higher_is_better
+    entity_type: tenant
+    label: CI runs
+    description: >-
+      Every pipeline run that reached a decided outcome, dated by the day the
+      run started, whatever its trigger. Runs still in progress are not counted
+      until they decide.
+
+  - key: ci.gate_pass_rate
+    computation: { type: ratio, numerator: ci_gate_passed, denominator: ci_gate_runs }
+    transform: { multiplier: 100.0 }
+    format: percent
+    direction: higher_is_better
+    entity_type: tenant
+    label: Gate pass rate
+    description: >-
+      Success share of gate runs — runs triggered by a push, a pull request or
+      the merge queue that reached a decided outcome. Cancelled and skipped
+      runs decide nothing and stay out of both sides.
+
+  - key: ci.gate_first_try_pass_rate
+    computation: { type: ratio, numerator: ci_gate_first_try_passed, denominator: ci_gate_runs }
+    transform: { multiplier: 100.0 }
+    format: percent
+    direction: higher_is_better
+    entity_type: tenant
+    label: First-try pass rate
+    description: >-
+      Gate runs that passed on their first attempt, as a share of all gate
+      runs. The gap to the plain pass rate is green that had to be bought with
+      a re-run.
+
+  - key: ci.gate_retry_share
+    computation: { type: ratio, numerator: ci_gate_retried, denominator: ci_gate_runs }
+    transform: { multiplier: 100.0 }
+    format: percent
+    direction: lower_is_better
+    entity_type: tenant
+    label: Retried gate runs
+    description: >-
+      Gate runs whose final state came from a re-run, as a share of all gate
+      runs. A retried run counts once, at its last attempt.
+
+  - key: ci.run_duration_min
+    computation: { type: percentile, measure: ci_run_duration_min, quantile: 0.5 }
+    format: decimal
+    direction: lower_is_better
+    entity_type: tenant
+    label: Gate run duration
+    description: >-
+      Median wall-clock minutes from a gate run's start to its decision. Wall
+      clock, not billable compute.
+
+  - key: ci.run_duration_min_p90
+    computation: { type: percentile, measure: ci_run_duration_min, quantile: 0.9 }
+    format: decimal
+    direction: lower_is_better
+    entity_type: tenant
+    label: Gate run duration p90
+    description: >-
+      The 90th percentile of gate run duration — nine in ten runs finish
+      faster. The gap to the median is the bad-day penalty a developer waits
+      for.
+
+  - key: ci.run_duration_min_stddev
+    computation: { type: stddev, measure: ci_run_duration_min }
+    format: decimal
+    direction: lower_is_better
+    entity_type: tenant
+    label: Gate run duration spread
+    description: >-
+      Standard deviation of gate run durations, in minutes. A pipeline whose
+      duration swings wildly is harder to plan around than a slow but steady
+      one.
+
+  - key: ci.run_hours
+    computation: { type: direct, measure: ci_run_hours }
+    format: decimal
+    direction: lower_is_better
+    entity_type: tenant
+    label: CI hours
+    description: >-
+      Wall-clock hours all decided runs spent executing, whatever the trigger.
+      Not billable compute minutes — parallel jobs inside one run count as the
+      run's elapsed time, not their sum.
+
+  - key: ci.runs_matched_commit
+    computation: { type: direct, measure: ci_runs_matched_commit }
+    format: integer
+    direction: higher_is_better
+    entity_type: tenant
+    label: Runs matching a collected commit
+    description: >-
+      Decided runs whose head commit exists among the collected commits. Set
+      beside total runs and collected commits it shows how far a CI-to-git
+      join can be trusted.
+
+  - key: ci.commits_observed
+    computation: { type: direct, measure: ci_commits_collected }
+    format: integer
+    direction: neutral
+    entity_type: tenant
+    label: Commits collected
+    description: >-
+      Commits the git connector collected, dated at their commit time — the
+      other side of the run-to-commit join. Where runs far outnumber matched
+      runs while commits stay high, CI is running on refs the commit stream
+      does not see rather than on missing history.
+
+  - key: ci.deployments
+    computation: { type: direct, measure: ci_deployments_created }
+    format: integer
+    direction: higher_is_better
+    entity_type: tenant
+    label: Deployments
+    description: >-
+      Deployments recorded in the period. The outcome is the latest status the
+      deployment reached; one with no status yet shows as pending rather than
+      being rounded away.

--- a/src/backend/services/analytics/src/domain/definitions/seeds/collab.yaml
+++ b/src/backend/services/analytics/src/domain/definitions/seeds/collab.yaml
@@ -1,0 +1,454 @@
+# Collaboration measures and metrics. Datasets are not authored here — they are
+# a projection of the field catalog.
+measures:
+  - key: total_chat_messages
+    dataset: collab_activity
+    description: Chat messages a person sent, across every conversation type a tool reports.
+    aggregation: sum
+    value_expr: total_chat_messages
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: channel_posts
+    dataset: collab_activity
+    description: >-
+      Messages a person posted to shared channels, thread replies included, so
+      tools that report posts and replies separately stay comparable.
+    aggregation: sum
+    value_expr: channel_posts_total
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: direct_and_group_messages
+    dataset: collab_activity
+    description: >-
+      Chat messages a person sent in direct and group conversations. A tool that
+      does not distinguish conversation types reports none.
+    aggregation: sum
+    value_expr: direct_and_group_messages
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: chat_active_tool_days
+    dataset: collab_activity
+    description: >-
+      Tool-days on which a person sent at least one chat message — one per tool
+      per day, so a day spent messaging on two tools counts twice.
+    filter: { field: total_chat_messages, op: gt, value: 0 }
+    aggregation: count
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: collab_active_days
+    dataset: collab_activity
+    description: >-
+      Calendar days on which a person took a deliberate collaboration action —
+      sending a message, sending email, engaging or sharing a file, attending a
+      meeting. Receiving and reading email are passive and do not count.
+    filter: { field: is_deliberately_active, op: eq, value: 1 }
+    aggregation: count_distinct
+    subject_expr: activity_date
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: days_with_meetings
+    dataset: collab_activity
+    description: >-
+      Deliberately active days on which a person spent time in at least one
+      meeting.
+    filter:
+      all:
+        - { field: is_deliberately_active, op: eq, value: 1 }
+        - { field: meeting_seconds, op: gt, value: 0 }
+    aggregation: count_distinct
+    subject_expr: activity_date
+    event_time: activity_date
+    entity: person_email
+
+  - key: emails_sent
+    dataset: collab_activity
+    description: Emails a person sent.
+    aggregation: sum
+    value_expr: emails_sent
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: emails_received
+    dataset: collab_activity
+    description: Emails a person received.
+    aggregation: sum
+    value_expr: emails_received
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: emails_read
+    dataset: collab_activity
+    description: Emails a person read.
+    aggregation: sum
+    value_expr: emails_read
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: files_engaged
+    dataset: collab_activity
+    description: Files a person viewed or edited.
+    aggregation: sum
+    value_expr: files_engaged
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: files_shared_internal
+    dataset: collab_activity
+    description: Files a person shared with people inside the organization.
+    aggregation: sum
+    value_expr: files_shared_internal
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: files_shared_external
+    dataset: collab_activity
+    description: Files a person shared with people outside the organization.
+    aggregation: sum
+    value_expr: files_shared_external
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: files_shared
+    dataset: collab_file_shares
+    description: >-
+      Files a person shared with any recipient, splittable by whether the
+      recipients were inside or outside the organization.
+    aggregation: sum
+    value_expr: files_shared
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: scope, value_field: scope, label_field: scope_label }
+
+  - key: meeting_hours
+    dataset: collab_activity
+    description: >-
+      Hours a person spent in meetings, taking the longest active modality —
+      audio, video or screen share — of each meeting.
+    aggregation: sum
+    value_expr: meeting_hours
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: meetings_attended
+    dataset: collab_activity
+    description: Meetings a person attended.
+    aggregation: sum
+    value_expr: meetings_attended
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: meetings_organized
+    dataset: collab_activity
+    description: >-
+      Meetings a person organized. A tool that does not report an organizer
+      reports none.
+    aggregation: sum
+    value_expr: meetings_organized
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: adhoc_meetings_attended
+    dataset: collab_activity
+    description: >-
+      Unscheduled meetings a person attended. A tool that does not classify
+      meetings reports none.
+    aggregation: sum
+    value_expr: adhoc_meetings_attended
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: scheduled_meetings_attended
+    dataset: collab_activity
+    description: >-
+      Scheduled meetings a person attended. A tool that does not classify
+      meetings reports none.
+    aggregation: sum
+    value_expr: scheduled_meetings_attended
+    event_time: activity_date
+    entity: person_email
+    dimensions:
+      - { key: tool, value_field: tool, label_field: tool_label }
+
+  - key: focus_hours
+    dataset: collab_activity
+    description: >-
+      Working hours a person spent outside meetings. A property of the day, so
+      one row per person and day carries it.
+    aggregation: sum
+    value_expr: focus_hours
+    event_time: activity_date
+    entity: person_email
+
+  - key: working_hours
+    dataset: collab_activity
+    description: >-
+      Scheduled working hours in a person's day, defaulting to a nominal
+      eight-hour day where no HR source provides them.
+    aggregation: sum
+    value_expr: working_hours
+    event_time: activity_date
+    entity: person_email
+
+  - key: active_modalities
+    dataset: collab_active_modalities
+    description: >-
+      Collaboration modalities — chat, meetings, email, documents — a person was
+      deliberately active in.
+    aggregation: count_distinct
+    subject_expr: modality
+    event_time: activity_date
+    entity: person_email
+
+metrics:
+  - key: collab.messages_sent
+    computation: { type: direct, measure: total_chat_messages }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Messages sent
+    description: >-
+      Chat messages the person sent across messaging tools. Counts are not
+      directly comparable between tools: some fold thread replies into the
+      total, and a suite may combine private-chat and channel messages.
+
+  - key: collab.channel_posts
+    computation: { type: direct, measure: channel_posts }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Channel posts
+    description: >-
+      Channel posts plus thread replies across messaging tools. Tools that
+      report posts and replies separately are folded so counts stay comparable.
+
+  - key: collab.dm_ratio
+    computation: { type: ratio, numerator: direct_and_group_messages, denominator: total_chat_messages }
+    transform: { multiplier: 100.0 }
+    format: percent
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: DM ratio
+    description: >-
+      Direct and group-chat messages divided by all chat messages. A lower ratio
+      means more communication happens in open channels. Tools that do not
+      distinguish message types report no value.
+
+  - key: collab.msgs_per_active_day
+    computation: { type: ratio, numerator: total_chat_messages, denominator: chat_active_tool_days }
+    format: decimal
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Messages per active day
+    description: >-
+      Chat messages sent divided by the tool-days the person sent any. Broken
+      down by tool, each tool's own active days divide its own messages; across
+      tools, a day counts once per tool the person messaged on.
+
+  - key: collab.active_days
+    computation: { type: direct, measure: collab_active_days }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Active days
+    description: >-
+      Distinct days on which the person took a deliberate collaboration action —
+      sending a message, sending email, engaging or sharing a file, or attending
+      a meeting. Passive activity such as receiving or reading email is excluded.
+
+  - key: collab.emails_sent
+    computation: { type: direct, measure: emails_sent }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Emails sent
+    description: Emails the person sent during the period.
+
+  - key: collab.emails_received
+    computation: { type: direct, measure: emails_received }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Emails received
+    description: Emails the person received during the period.
+
+  - key: collab.emails_read
+    computation: { type: direct, measure: emails_read }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Emails read
+    description: Emails the person read during the period.
+
+  - key: collab.files_engaged
+    computation: { type: direct, measure: files_engaged }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Files engaged
+    description: Files the person viewed or edited during the period.
+
+  - key: collab.files_shared_internal
+    computation: { type: direct, measure: files_shared_internal }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Files shared (internal)
+    description: Files the person shared with people inside the organization.
+
+  - key: collab.files_shared_external
+    computation: { type: direct, measure: files_shared_external }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Files shared (external)
+    description: Files the person shared with people outside the organization.
+
+  - key: collab.files_shared
+    computation: { type: direct, measure: files_shared }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Files shared
+    description: >-
+      Files the person shared with recipients inside or outside the
+      organization, splittable by which of the two.
+
+  - key: collab.meeting_hours
+    computation: { type: direct, measure: meeting_hours }
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Meeting hours
+    description: >-
+      Hours spent in meetings, taking the longest active modality — audio, video
+      or screen share — per meeting. A tool that reports modality durations as
+      full-session estimates runs higher than one that reports actual time.
+
+  - key: collab.meetings_count
+    computation: { type: direct, measure: meetings_attended }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Meetings attended
+    description: Distinct meetings the person attended across meeting tools.
+
+  - key: collab.meeting_free_days
+    computation:
+      type: derived
+      inputs: { active: collab_active_days, with_meetings: days_with_meetings }
+      expr: active - with_meetings
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Meeting-free days
+    description: >-
+      Days on which the person was actively collaborating but spent no time in
+      meetings — a proxy for uninterrupted working days.
+
+  - key: collab.focus_time_pct
+    computation: { type: ratio, numerator: focus_hours, denominator: working_hours }
+    transform: { multiplier: 100.0 }
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Focus time
+    description: >-
+      Share of the workday not spent in meetings: meeting-free hours divided by
+      scheduled working hours. Scheduled hours default to a nominal eight-hour
+      day where an HR source does not provide them.
+
+  - key: collab.breadth
+    computation: { type: direct, measure: active_modalities }
+    format: integer
+    direction: neutral
+    entity_type: person
+    cohort_key: org_unit
+    label: Collaboration breadth
+    description: >-
+      Distinct collaboration modalities — chat, meetings, email, documents — the
+      person was deliberately active in during the period.
+
+  - key: collab.meetings_organized
+    computation: { type: direct, measure: meetings_organized }
+    format: integer
+    direction: neutral
+    entity_type: person
+    cohort_key: org_unit
+    label: Meetings organized
+    description: >-
+      Meetings the person organized. Reported only by tools that expose
+      organizer counts.
+
+  - key: collab.adhoc_meetings
+    computation: { type: direct, measure: adhoc_meetings_attended }
+    format: integer
+    direction: neutral
+    entity_type: person
+    cohort_key: org_unit
+    label: Ad-hoc meetings
+    description: >-
+      Unscheduled meetings the person attended. Reported only by tools that
+      distinguish ad-hoc from scheduled meetings.
+
+  - key: collab.scheduled_meetings
+    computation: { type: direct, measure: scheduled_meetings_attended }
+    format: integer
+    direction: neutral
+    entity_type: person
+    cohort_key: org_unit
+    label: Scheduled meetings
+    description: >-
+      Scheduled meetings the person attended. Reported only by tools that
+      distinguish ad-hoc from scheduled meetings.

--- a/src/backend/services/analytics/src/domain/definitions/seeds/git.yaml
+++ b/src/backend/services/analytics/src/domain/definitions/seeds/git.yaml
@@ -452,6 +452,27 @@ measures:
       - { key: project, value_field: project, label_field: project_label }
       - { key: source, value_field: source, label_field: source_label }
 
+  - key: pr_commit_count
+    dataset: git_pull_requests
+    description: >-
+      Commits linked to one merged pull request, dated by the merge, for
+      requests whose source linked any.
+    filter:
+      all:
+        - { field: merged, op: eq, value: 1 }
+        - { field: closed_at, op: not_null }
+        - { field: linked_commit_count, op: not_null }
+    aggregation: avg
+    value_expr: linked_commit_count
+    event_time: closed_at
+    entity: author_email
+    dimensions:
+      - { key: branch_scope, value_field: branch_scope, label_field: branch_scope_label }
+      - { key: destination_branch, value_field: destination_branch, label_field: destination_branch_label }
+      - { key: repository, value_field: repository, label_field: repository_label }
+      - { key: project, value_field: project, label_field: project_label }
+      - { key: source, value_field: source, label_field: source_label }
+
   - key: pr_cycle_hours
     dataset: git_pull_requests
     description: Hours from opening one pull request to merging it, dated by the merge.
@@ -530,6 +551,35 @@ measures:
       - { key: repository, value_field: repository, label_field: repository_label }
       - { key: project, value_field: project, label_field: project_label }
       - { key: source, value_field: source, label_field: source_label }
+
+  - key: reviews_submitted
+    dataset: git_review_events
+    description: >-
+      Review verdicts a person submitted, counted once per review and dated by
+      its submission.
+    filter: { field: event_kind, op: eq, value: review }
+    aggregation: count
+    event_time: observed_at
+    entity: entity_id
+    dimensions:
+      - { key: repository, value_field: repository_value, label_field: repository_label }
+      - { key: project, value_field: project_value, label_field: project_label }
+      - { key: source, value_field: source_value, label_field: source_label }
+
+  - key: pr_comments
+    dataset: git_review_events
+    description: >-
+      Comments a person wrote on pull requests — conversation and inline review
+      comments alike — counted once per comment and dated by its posting.
+    filter: { field: event_kind, op: eq, value: comment }
+    aggregation: count
+    event_time: observed_at
+    entity: entity_id
+    dimensions:
+      - { key: comment_target, value_field: comment_target_value, label_field: comment_target_label }
+      - { key: repository, value_field: repository_value, label_field: repository_label }
+      - { key: project, value_field: project_value, label_field: project_label }
+      - { key: source, value_field: source_value, label_field: source_label }
 
 metrics:
   - key: git.commits
@@ -873,6 +923,18 @@ metrics:
       Smaller requests are easier to review. Sources that do not report line
       counts contribute no values.
 
+  - key: git.pr_commits
+    computation: { type: percentile, measure: pr_commit_count, quantile: 0.5 }
+    format: decimal
+    direction: neutral
+    entity_type: person
+    cohort_key: org_unit
+    label: Commits per PR
+    description: >-
+      Median count of commits linked to authored pull requests, over requests
+      merged in the period. A merged request whose commits the source does not
+      link contributes no value.
+
   - key: git.pr_cycle_time_h
     computation: { type: percentile, measure: pr_cycle_hours, quantile: 0.5 }
     format: decimal
@@ -883,6 +945,17 @@ metrics:
     description: >-
       Median hours from opening a pull request to merging it, over requests
       merged in the period.
+
+  - key: git.pr_cycle_time_p75_h
+    computation: { type: percentile, measure: pr_cycle_hours, quantile: 0.75 }
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: PR cycle time (p75)
+    description: >-
+      75th percentile of hours from opening a pull request to merging it, over
+      requests merged in the period.
 
   - key: git.first_review_time_h
     computation: { type: percentile, measure: pr_first_review_hours, quantile: 0.5 }
@@ -895,6 +968,19 @@ metrics:
       Median hours from opening a pull request to its first submitted review,
       over first reviews recorded in the period. Requests without a review, and
       sources without review timestamps, contribute no duration.
+
+  - key: git.first_review_time_p75_h
+    computation: { type: percentile, measure: pr_first_review_hours, quantile: 0.75 }
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Time to first review (p75)
+    description: >-
+      75th percentile of hours from opening a pull request to its first
+      submitted review, over first reviews recorded in the period. Requests
+      without a review, and sources without review timestamps, contribute no
+      duration.
 
   - key: git.review_wait_share
     computation: { type: percentile, measure: pr_review_wait_share, quantile: 0.5 }
@@ -931,3 +1017,29 @@ metrics:
       Median hours from the latest reported approval with a timestamp to merge,
       over pull requests merged in the period. Sources that expose approvals
       without per-approval timestamps contribute no value.
+
+  - key: git.reviews_performed
+    computation: { type: direct, measure: reviews_submitted }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Reviews performed
+    description: >-
+      Review verdicts the person submitted on any pull request, dated by
+      submission. This is the reviewer's side of review coverage — the reviews
+      a person performed, not the reviews their own requests received.
+
+  - key: git.pr_comments
+    computation: { type: direct, measure: pr_comments }
+    format: integer
+    direction: neutral
+    entity_type: person
+    cohort_key: org_unit
+    label: PR comments
+    description: >-
+      Comments the person wrote on pull requests — conversation and inline
+      review comments alike — dated by posting. The comment target dimension
+      splits comments on the person's own requests from comments on other
+      people's; a comment whose request author cannot be determined counts
+      under others, so the two halves add up to the total.

--- a/src/backend/services/analytics/src/domain/definitions/seeds/tasks.yaml
+++ b/src/backend/services/analytics/src/domain/definitions/seeds/tasks.yaml
@@ -1,0 +1,390 @@
+# Task measures and metrics. Datasets are not authored here — they are a
+# projection of the field catalog.
+measures:
+  - key: tasks_closed
+    dataset: task_closed_issues
+    description: >-
+      Issues a person closed, counted once per issue on the day it entered a
+      done status. An issue that has since been reopened is not one of them.
+    filter: { field: is_closed, op: eq, value: 1 }
+    aggregation: count
+    event_time: closed_at
+    entity: assignee_email
+    dimensions:
+      - { key: type, value_field: issue_type, label_field: issue_type_label }
+      - { key: source, value_field: source, label_field: source_label }
+
+  - key: bugs_fixed
+    dataset: task_closed_issues
+    description: Closed issues of a bug type.
+    filter: { field: is_bug, op: eq, value: 1 }
+    aggregation: count
+    event_time: closed_at
+    entity: assignee_email
+
+  - key: closed_non_bug
+    dataset: task_closed_issues
+    description: >-
+      Closed issues of a known non-bug type. An issue whose type the tracker
+      does not let us classify is neither a bug nor one of these.
+    filter: { field: is_non_bug, op: eq, value: 1 }
+    aggregation: count
+    event_time: closed_at
+    entity: assignee_email
+
+  - key: due_date_on_time
+    dataset: task_closed_issues
+    description: Closed issues that carried a due date and closed on or before it.
+    filter: { field: on_time, op: eq, value: 1 }
+    aggregation: count
+    event_time: closed_at
+    entity: assignee_email
+
+  - key: due_date_with_due
+    dataset: task_closed_issues
+    description: Closed issues that carried a due date at all.
+    filter: { field: has_due_date, op: eq, value: 1 }
+    aggregation: count
+    event_time: closed_at
+    entity: assignee_email
+
+  - key: late_count
+    dataset: task_closed_issues
+    description: Closed issues that carried a due date and closed after it.
+    filter: { field: is_late, op: eq, value: 1 }
+    aggregation: count
+    event_time: closed_at
+    entity: assignee_email
+
+  - key: slip_days_total
+    dataset: task_closed_issues
+    description: Days past the due date, summed over the issues that closed late.
+    filter: { field: is_late, op: eq, value: 1 }
+    aggregation: sum
+    value_expr: slip_days
+    event_time: closed_at
+    entity: assignee_email
+
+  - key: dev_hours
+    dataset: task_closed_issues
+    description: >-
+      Hours one closed issue spent in in-progress statuses entered before its
+      close. Issues that never entered one fold no value.
+    filter: { field: dev_seconds, op: gt, value: 0 }
+    aggregation: sum
+    value_expr: dev_hours
+    event_time: closed_at
+    entity: assignee_email
+    dimensions:
+      - { key: type, value_field: issue_type, label_field: issue_type_label }
+      - { key: source, value_field: source, label_field: source_label }
+
+  - key: resolution_days
+    dataset: task_closed_issues
+    description: >-
+      Days from creating one issue to closing it. An issue created and closed
+      inside the same second folds no value.
+    filter: { field: lead_seconds, op: gt, value: 0 }
+    aggregation: sum
+    value_expr: resolution_days
+    event_time: closed_at
+    entity: assignee_email
+    dimensions:
+      - { key: type, value_field: issue_type, label_field: issue_type_label }
+      - { key: source, value_field: source, label_field: source_label }
+
+  - key: pickup_days
+    dataset: task_closed_issues
+    description: >-
+      Days from creating one issue to the first in-progress status it entered
+      before its close. An issue that never entered one folds no value.
+    filter: { field: pickup_days, op: not_null }
+    aggregation: sum
+    value_expr: pickup_days
+    event_time: closed_at
+    entity: assignee_email
+    dimensions:
+      - { key: type, value_field: issue_type, label_field: issue_type_label }
+      - { key: source, value_field: source, label_field: source_label }
+
+  - key: flow_dev_seconds
+    dataset: task_closed_issues
+    description: >-
+      Seconds of active development, over the closed issues that have both a
+      development time and a lifetime to compare it against.
+    filter:
+      all:
+        - { field: dev_seconds, op: gt, value: 0 }
+        - { field: lead_seconds, op: gt, value: 0 }
+    aggregation: sum
+    value_expr: dev_seconds
+    event_time: closed_at
+    entity: assignee_email
+
+  - key: flow_lead_seconds
+    dataset: task_closed_issues
+    description: >-
+      Seconds of issue lifetime, over the same closed issues the development
+      seconds are taken from, so the two are a share of one another.
+    filter:
+      all:
+        - { field: dev_seconds, op: gt, value: 0 }
+        - { field: lead_seconds, op: gt, value: 0 }
+    aggregation: sum
+    value_expr: lead_seconds
+    event_time: closed_at
+    entity: assignee_email
+
+  - key: close_events
+    dataset: task_close_events
+    description: >-
+      Times an issue entered a done status. An issue closed, reopened and
+      closed again is counted once per close.
+    aggregation: count
+    event_time: close_at
+    entity: assignee_email
+
+  - key: reopened_within_14d
+    dataset: task_close_events
+    description: Closes the issue came back out of within 14 days.
+    filter: { field: reopened_within_14d, op: eq, value: 1 }
+    aggregation: count
+    event_time: close_at
+    entity: assignee_email
+
+  - key: estimation_error_pct
+    dataset: task_estimation_days
+    description: >-
+      How far one person-day's estimates landed from the time that day's work
+      actually took, in percentage points, over- and under-estimation alike.
+      Days whose estimates missed by more than the estimate itself are not
+      read as estimation error and fold no value.
+    filter:
+      all:
+        - { field: estimation_pct, op: gt, value: 0 }
+        - { field: estimation_pct, op: lte, value: 200 }
+    aggregation: sum
+    value_expr: estimation_error_pct
+    event_time: closed_date
+    entity: assignee_email
+
+  - key: estimation_samples
+    dataset: task_estimation_days
+    description: Person-days whose estimates are close enough to time spent to read as error.
+    filter:
+      all:
+        - { field: estimation_pct, op: gt, value: 0 }
+        - { field: estimation_pct, op: lte, value: 200 }
+    aggregation: count
+    event_time: closed_date
+    entity: assignee_email
+
+  - key: worklog_seconds
+    dataset: task_person_days
+    description: >-
+      Seconds a person logged against issues on a day their issues were also
+      being worked, so logged time always has tracked time to compare against.
+    filter: { field: in_progress_seconds, op: gt, value: 0 }
+    aggregation: sum
+    value_expr: worklog_seconds
+    event_time: metric_date
+    entity: entity_id
+
+  - key: in_progress_seconds
+    dataset: task_person_days
+    description: Seconds a person's issues spent in in-progress statuses on a day.
+    filter: { field: in_progress_seconds, op: gt, value: 0 }
+    aggregation: sum
+    value_expr: in_progress_seconds
+    event_time: metric_date
+    entity: entity_id
+
+  - key: stale_open_issues
+    dataset: task_open_issues
+    description: >-
+      Open issues whose status has not moved in more than 14 days, counted
+      against the day their status last moved.
+    filter: { field: idle_days, op: gt, value: 14 }
+    aggregation: count
+    event_time: last_status_event_at
+    entity: assignee_email
+
+metrics:
+  - key: tasks.closed
+    computation: { type: direct, measure: tasks_closed }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Issues closed
+    description: >-
+      Issues the person moved into a closed status during the period. Bugs are
+      part of this number and are listed separately by type.
+
+  - key: tasks.bugs_fixed
+    computation: { type: direct, measure: bugs_fixed }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Bugs closed
+    description: >-
+      Issues of a bug type the person closed during the period. Part of issues
+      closed, not a separate total.
+
+  - key: tasks.closed_non_bug
+    computation: { type: direct, measure: closed_non_bug }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Non-bug issues closed
+    description: >-
+      Issues of a known non-bug type the person closed during the period.
+      Issues whose type cannot be determined are excluded rather than counted
+      here.
+
+  - key: tasks.dev_time
+    computation: { type: percentile, measure: dev_hours, quantile: 0.5 }
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Development time
+    description: >-
+      Median hours closed issues spent in in-progress statuses, from first
+      pickup to close. An issue that never entered one contributes no value.
+
+  - key: tasks.resolution_time
+    computation: { type: percentile, measure: resolution_days, quantile: 0.5 }
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Time to resolution
+    description: >-
+      Median days from creating an issue to closing it, over the issues closed
+      in the period.
+
+  - key: tasks.pickup_time
+    computation: { type: percentile, measure: pickup_days, quantile: 0.5 }
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Pickup time
+    description: >-
+      Median days from creating an issue to first entering an in-progress
+      status, over the issues closed in the period. An issue that never entered
+      one contributes no value.
+
+  - key: tasks.flow_efficiency
+    computation: { type: ratio, numerator: flow_dev_seconds, denominator: flow_lead_seconds }
+    transform: { multiplier: 100.0, clamp_max: 100.0 }
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Flow efficiency
+    description: >-
+      Time in active development as a share of total issue lifetime, across the
+      issues closed in the period. Only issues carrying both a development time
+      and a lifetime take part.
+
+  - key: tasks.reopen_rate
+    computation: { type: ratio, numerator: reopened_within_14d, denominator: close_events }
+    transform: { multiplier: 100.0 }
+    format: percent
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Reopen rate
+    description: >-
+      Of the issue closes in the period, the share followed by a reopen within
+      14 days. A close near the period end may still be reopened afterwards.
+
+  - key: tasks.due_date_compliance
+    computation: { type: ratio, numerator: due_date_on_time, denominator: due_date_with_due }
+    transform: { multiplier: 100.0 }
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Due date compliance
+    description: >-
+      Of the issues closed in the period that carried a due date, the share
+      closed on or before it. Issues with no due date do not affect it.
+
+  - key: tasks.on_time_delivery
+    computation: { type: ratio, numerator: due_date_on_time, denominator: tasks_closed }
+    transform: { multiplier: 100.0 }
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: On-time delivery
+    description: >-
+      Of all issues closed in the period, the share closed on or before a due
+      date. Issues closed without a due date lower it, which is what separates
+      it from due date compliance.
+
+  - key: tasks.avg_slip
+    computation: { type: ratio, numerator: slip_days_total, denominator: late_count }
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Average slip
+    description: >-
+      Average days past the due date, over the issues closed late in the
+      period. Issues closed on time do not affect it.
+
+  - key: tasks.estimation_accuracy
+    computation: { type: ratio, numerator: estimation_error_pct, denominator: estimation_samples }
+    transform: { multiplier: -1.0, offset: 100.0, clamp_min: 0.0, clamp_max: 100.0 }
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Estimation accuracy
+    description: >-
+      100 minus the average deviation between original estimates and time
+      spent, over days whose estimated work stayed within twice the estimate.
+      100 means estimates matched reality; over- and under-estimation count
+      equally.
+
+  - key: tasks.worklog_accuracy
+    computation: { type: ratio, numerator: worklog_seconds, denominator: in_progress_seconds }
+    transform: { multiplier: 100.0, clamp_max: 100.0 }
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Worklog accuracy
+    description: >-
+      Logged work time as a share of the time issues spent in in-progress
+      statuses. Days on which nothing was in progress take no part.
+
+  - key: tasks.bugs_ratio
+    computation: { type: ratio, numerator: bugs_fixed, denominator: tasks_closed }
+    transform: { multiplier: 100.0 }
+    format: percent
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Bugs share of closed issues
+    description: >-
+      Bug-type issues as a share of all issues closed in the period, issues of
+      an undetermined type included in the denominator. A share, so it cannot
+      exceed 100%.
+
+  - key: tasks.stale_in_progress
+    computation: { type: direct, measure: stale_open_issues }
+    format: integer
+    direction: lower_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Stale in progress
+    description: >-
+      Open issues whose status has not moved in more than 14 days, counted
+      against the day their status last moved.

--- a/src/backend/services/analytics/src/domain/definitions/seeds/wiki.yaml
+++ b/src/backend/services/analytics/src/domain/definitions/seeds/wiki.yaml
@@ -1,0 +1,83 @@
+# Wiki measures and metrics. Datasets are not authored here — they are a
+# projection of the field catalog.
+measures:
+  - key: pages_created
+    dataset: wiki_pages
+    description: Wiki pages a person authored, counted once per page on its creation date.
+    aggregation: count
+    event_time: created_at
+    entity: author_email
+
+  - key: wiki_edits
+    dataset: wiki_person_days
+    description: >-
+      Edit sessions a person recorded. Consecutive saves of one page inside a
+      short window arrive as a single edit, so autosaves do not inflate it.
+    aggregation: sum
+    value_expr: edits
+    event_time: activity_date
+    entity: author_email
+
+  - key: wiki_pages_edited
+    dataset: wiki_person_days
+    description: Distinct wiki pages a person edited, counted per day the page was touched.
+    aggregation: sum
+    value_expr: pages_edited
+    event_time: activity_date
+    entity: author_email
+
+  - key: wiki_comments_received
+    dataset: wiki_person_days
+    description: >-
+      Comments and replies other people left on wiki pages a person authored,
+      attributed through authorship of the commented page.
+    aggregation: sum
+    value_expr: comments_received
+    event_time: activity_date
+    entity: author_email
+
+metrics:
+  - key: wiki.pages_created
+    computation: { type: direct, measure: pages_created }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Pages created
+    description: >-
+      Wiki pages the person created during the period, counted on the page's
+      creation date.
+
+  - key: wiki.edits
+    computation: { type: direct, measure: wiki_edits }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Page edits
+    description: >-
+      Logical wiki edits the person made during the period. Consecutive saves
+      of the same page within a short window count as one edit, so autosaves do
+      not inflate the number.
+
+  - key: wiki.pages_edited
+    computation: { type: direct, measure: wiki_pages_edited }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Pages edited
+    description: >-
+      Distinct wiki pages the person edited during the period, counted per day
+      the page was touched.
+
+  - key: wiki.comments
+    computation: { type: direct, measure: wiki_comments_received }
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    cohort_key: org_unit
+    label: Comments received
+    description: >-
+      Comments and replies other people left on wiki pages the person authored
+      — a signal of how much their documentation is read and discussed.

--- a/src/backend/services/analytics/src/domain/definitions/store.rs
+++ b/src/backend/services/analytics/src/domain/definitions/store.rs
@@ -449,7 +449,7 @@ async fn insert_metric<C: ConnectionTrait>(
             json_value(metric.transform.as_ref()),
             Value::from(metric.format.as_db()),
             Value::from(metric.direction.as_db()),
-            Value::from(metric.entity_type.as_str()),
+            Value::from(metric.entity_type.as_db()),
             optional_str(metric.cohort_key.as_deref()),
             Value::from(origin.as_db()),
         ],
@@ -475,7 +475,7 @@ async fn update_metric<C: ConnectionTrait>(
                 json_value(metric.transform.as_ref()),
                 Value::from(metric.format.as_db()),
                 Value::from(metric.direction.as_db()),
-                Value::from(metric.entity_type.as_str()),
+                Value::from(metric.entity_type.as_db()),
                 optional_str(metric.cohort_key.as_deref()),
                 Value::from(metric.key.as_str()),
                 Value::from(from_version),
@@ -557,6 +557,7 @@ mod tests {
     use crate::domain::definitions::definition::{
         Aggregation, Computation, DimensionBinding, Direction, Format, ReadDiscipline, Transform,
     };
+    use crate::domain::field_catalog::model::EntityType;
 
     fn dataset() -> DatasetDefinition {
         DatasetDefinition {
@@ -592,7 +593,7 @@ dimensions:
             transform: None,
             format: Format::Integer,
             direction: Direction::HigherIsBetter,
-            entity_type: "person".to_owned(),
+            entity_type: EntityType::Person,
             cohort_key: None,
             label: None,
             description: None,

--- a/src/backend/services/analytics/src/domain/definitions/validate.rs
+++ b/src/backend/services/analytics/src/domain/definitions/validate.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use super::definition::{Computation, MeasureDefinition, MetricDefinition, Operand};
 use super::expr::{ScalarExprError, validate_scalar_expr};
 use super::filter::FilterError;
-use crate::domain::field_catalog::model::{CatalogDataset, FieldCatalog, FieldRole};
+use crate::domain::field_catalog::model::{CatalogDataset, EntityType, FieldCatalog, FieldRole};
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum ValidationError {
@@ -76,6 +76,19 @@ pub enum ValidationError {
     UnknownDerivedInput { metric: String, alias: String },
     #[error("metric `{metric}` declares input `{alias}`, which its expression never reads")]
     UnusedDerivedInput { metric: String, alias: String },
+    #[error(
+        "metric `{metric}` is authored at {metric_grain} grain but reads measure `{measure}` \
+         over dataset `{dataset}`, whose rows are {dataset_grain} grain"
+    )]
+    EntityGrainMismatch {
+        metric: String,
+        measure: String,
+        dataset: String,
+        metric_grain: EntityType,
+        dataset_grain: EntityType,
+    },
+    #[error("metric `{metric}` is {grain} grain and may not declare a cohort to compare against")]
+    CohortWithoutPeers { metric: String, grain: EntityType },
     #[error("metric `{metric}` inputs `{a}` and `{b}` bind dimension `{key}` to different fields")]
     DimensionBindingsDisagree {
         metric: String,
@@ -107,7 +120,7 @@ pub fn validate_definitions(
         if !seen.insert(metric.key.as_str()) {
             errors.push(ValidationError::DuplicateKey(metric.key.clone()));
         }
-        validate_metric(metric, measures, &mut errors);
+        validate_metric(catalog, metric, measures, &mut errors);
     }
 
     if errors.is_empty() {
@@ -259,6 +272,7 @@ fn validate_operand(measure: &MeasureDefinition, errors: &mut Vec<ValidationErro
 }
 
 fn validate_metric(
+    catalog: &FieldCatalog,
     metric: &MetricDefinition,
     measures: &[MeasureDefinition],
     errors: &mut Vec<ValidationError>,
@@ -293,6 +307,8 @@ fn validate_metric(
 
     validate_computation(metric, measures, errors);
     validate_shared_dimensions(metric, measures, errors);
+    validate_entity_grain(catalog, metric, measures, errors);
+    validate_cohort_grain(metric, errors);
 
     // Joining aggregates across datasets is capability the compiler does not
     // have, so a definition may not ask for it.
@@ -305,6 +321,46 @@ fn validate_metric(
             metric: metric.key.clone(),
             a: (*first_key).to_owned(),
             b: (*other_key).to_owned(),
+        });
+    }
+}
+
+/// What a metric's values are keyed by is not a label on the metric — it is a
+/// property of the rows it folds. A metric may therefore only claim the grain
+/// every dataset it reads is authored at, because nothing downstream can turn
+/// a per-person row into a tenant value or the other way round.
+fn validate_entity_grain(
+    catalog: &FieldCatalog,
+    metric: &MetricDefinition,
+    measures: &[MeasureDefinition],
+    errors: &mut Vec<ValidationError>,
+) {
+    for input in metric.input_measures() {
+        let Some(measure) = measures.iter().find(|measure| measure.key == input) else {
+            continue;
+        };
+        let Some(dataset) = catalog.dataset(&measure.dataset) else {
+            continue;
+        };
+        if dataset.entity_type != metric.entity_type {
+            errors.push(ValidationError::EntityGrainMismatch {
+                metric: metric.key.clone(),
+                measure: measure.key.clone(),
+                dataset: dataset.key.clone(),
+                metric_grain: metric.entity_type,
+                dataset_grain: dataset.entity_type,
+            });
+        }
+    }
+}
+
+/// A cohort is a grouping of people, and a tenant has no peers to be grouped
+/// with: a cohort comparison over one would name a population of itself.
+fn validate_cohort_grain(metric: &MetricDefinition, errors: &mut Vec<ValidationError>) {
+    if metric.entity_type == EntityType::Tenant && metric.cohort_key.is_some() {
+        errors.push(ValidationError::CohortWithoutPeers {
+            metric: metric.key.clone(),
+            grain: metric.entity_type,
         });
     }
 }
@@ -513,7 +569,7 @@ datasets:
             transform: None,
             format: Format::Integer,
             direction: Direction::HigherIsBetter,
-            entity_type: "person".to_owned(),
+            entity_type: EntityType::Person,
             cohort_key: None,
             label: None,
             description: None,

--- a/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
+++ b/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
@@ -66,7 +66,15 @@
         "type": "String"
       },
       {
-        "name": "source_entity_id",
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
         "type": "String"
       },
       {
@@ -138,6 +146,18 @@
         "type": "String"
       },
       {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
         "name": "metric_date",
         "type": "Date"
       },
@@ -186,7 +206,15 @@
         "type": "String"
       },
       {
-        "name": "source_entity_id",
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
         "type": "String"
       },
       {
@@ -258,6 +286,18 @@
         "type": "String"
       },
       {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
         "name": "metric_date",
         "type": "Date"
       },
@@ -307,6 +347,158 @@
       },
       {
         "name": "source_entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "record_id",
+        "type": "String"
+      },
+      {
+        "name": "record_kind",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "record_label",
+        "type": "String"
+      },
+      {
+        "name": "contribution",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      },
+      {
+        "name": "details",
+        "type": "Map(String, Nullable(String))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ci_metric_evidence",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date, record_id"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "value",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ci_metric_observations",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
         "type": "String"
       },
       {
@@ -378,6 +570,18 @@
         "type": "String"
       },
       {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
         "name": "metric_date",
         "type": "Date"
       },
@@ -406,6 +610,166 @@
     "engine": "MergeTree",
     "relation": "collab_metric_observations",
     "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "branch_scope_value",
+        "type": "String"
+      },
+      {
+        "name": "branch_scope_label",
+        "type": "String"
+      },
+      {
+        "name": "project_value",
+        "type": "String"
+      },
+      {
+        "name": "project_label",
+        "type": "String"
+      },
+      {
+        "name": "repository_value",
+        "type": "String"
+      },
+      {
+        "name": "repository_label",
+        "type": "String"
+      },
+      {
+        "name": "source_value",
+        "type": "String"
+      },
+      {
+        "name": "source_label",
+        "type": "String"
+      },
+      {
+        "name": "source_dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_authored_commits",
+    "sorting_key": "tenant_id, data_source, commit_hash"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "file_path",
+        "type": "String"
+      },
+      {
+        "name": "file_extension",
+        "type": "String"
+      },
+      {
+        "name": "change_type",
+        "type": "String"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "pre_image_oid",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "post_image_oid",
+        "type": "Nullable(String)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_commit_file_changes",
+    "sorting_key": "tenant_id, data_source, commit_hash"
   },
   {
     "columns": [
@@ -522,6 +886,30 @@
     "engine": "MergeTree",
     "relation": "git_default_branch_commits",
     "sorting_key": "tenant_id, source_id, project_key, repo_slug, commit_hash"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_derived_commits",
+    "sorting_key": "tenant_id, data_source, commit_hash"
   },
   {
     "columns": [
@@ -654,7 +1042,15 @@
         "type": "String"
       },
       {
-        "name": "source_entity_id",
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
         "type": "String"
       },
       {
@@ -723,6 +1119,18 @@
       },
       {
         "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
         "type": "String"
       },
       {
@@ -914,6 +1322,114 @@
   {
     "columns": [
       {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "event_kind",
+        "type": "String"
+      },
+      {
+        "name": "event_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "pr_id",
+        "type": "Int64"
+      },
+      {
+        "name": "pr_number",
+        "type": "Int64"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "title",
+        "type": "String"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "author_email",
+        "type": "String"
+      },
+      {
+        "name": "actor_person_id",
+        "type": "String"
+      },
+      {
+        "name": "author_person_id",
+        "type": "String"
+      },
+      {
+        "name": "comment_target_value",
+        "type": "String"
+      },
+      {
+        "name": "comment_target_label",
+        "type": "String"
+      },
+      {
+        "name": "project_value",
+        "type": "String"
+      },
+      {
+        "name": "project_label",
+        "type": "String"
+      },
+      {
+        "name": "repository_value",
+        "type": "String"
+      },
+      {
+        "name": "repository_label",
+        "type": "String"
+      },
+      {
+        "name": "destination_branch_value",
+        "type": "String"
+      },
+      {
+        "name": "destination_branch_label",
+        "type": "String"
+      },
+      {
+        "name": "source_value",
+        "type": "String"
+      },
+      {
+        "name": "source_label",
+        "type": "String"
+      },
+      {
+        "name": "source_dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_review_events",
+    "sorting_key": "tenant_id, entity_id, metric_date"
+  },
+  {
+    "columns": [
+      {
         "name": "source_key",
         "type": "String"
       },
@@ -935,9 +1451,9 @@
       }
     ],
     "database": "insight",
-    "engine": "MergeTree",
+    "engine": "View",
     "relation": "identity_resolution_coverage",
-    "sorting_key": "source_key"
+    "sorting_key": ""
   },
   {
     "columns": [
@@ -963,9 +1479,9 @@
       }
     ],
     "database": "insight",
-    "engine": "MergeTree",
+    "engine": "View",
     "relation": "metric_entity_cohorts_current",
-    "sorting_key": "tenant_id, entity_type, cohort_key, entity_id"
+    "sorting_key": ""
   },
   {
     "columns": [
@@ -1066,7 +1582,15 @@
         "type": "String"
       },
       {
-        "name": "source_entity_id",
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
         "type": "String"
       },
       {
@@ -1135,6 +1659,18 @@
       },
       {
         "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
         "type": "String"
       },
       {
@@ -1246,7 +1782,15 @@
         "type": "String"
       },
       {
-        "name": "source_entity_id",
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
         "type": "String"
       },
       {
@@ -1318,6 +1862,18 @@
         "type": "String"
       },
       {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
         "name": "metric_date",
         "type": "Date"
       },
@@ -1346,6 +1902,82 @@
     "engine": "MergeTree",
     "relation": "wiki_metric_observations",
     "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "page_id",
+        "type": "String"
+      },
+      {
+        "name": "title",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "space_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "author_email",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "created_date",
+        "type": "Nullable(Date)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "wiki_pages",
+    "sorting_key": "tenant_id, author_email, created_at"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "author_email",
+        "type": "String"
+      },
+      {
+        "name": "activity_date",
+        "type": "Date"
+      },
+      {
+        "name": "edits",
+        "type": "UInt64"
+      },
+      {
+        "name": "pages_edited",
+        "type": "UInt64"
+      },
+      {
+        "name": "comments_received",
+        "type": "UInt64"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "wiki_person_days",
+    "sorting_key": "tenant_id, author_email, activity_date"
   },
   {
     "columns": [
@@ -1619,6 +2251,10 @@
       },
       {
         "name": "tier_label",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "tier_ref",
         "type": "Nullable(String)"
       },
       {
@@ -2626,6 +3262,110 @@
         "type": "Nullable(String)"
       },
       {
+        "name": "repo_full_name",
+        "type": "String"
+      },
+      {
+        "name": "pipeline_key",
+        "type": "String"
+      },
+      {
+        "name": "pipeline_name",
+        "type": "String"
+      },
+      {
+        "name": "run_id",
+        "type": "Int64"
+      },
+      {
+        "name": "run_number",
+        "type": "Int64"
+      },
+      {
+        "name": "attempt",
+        "type": "Int64"
+      },
+      {
+        "name": "is_retry",
+        "type": "UInt8"
+      },
+      {
+        "name": "trigger_category",
+        "type": "String"
+      },
+      {
+        "name": "trigger_raw",
+        "type": "String"
+      },
+      {
+        "name": "outcome",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "is_gate",
+        "type": "UInt8"
+      },
+      {
+        "name": "branch",
+        "type": "String"
+      },
+      {
+        "name": "commit_sha",
+        "type": "String"
+      },
+      {
+        "name": "actor_login",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "started_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "finished_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "duration_s",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_ci_runs",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
         "name": "project_key",
         "type": "String"
       },
@@ -2696,11 +3436,147 @@
       {
         "name": "_airbyte_extracted_at",
         "type": "DateTime64(3)"
+      },
+      {
+        "name": "patch_id",
+        "type": "Nullable(String)"
       }
     ],
     "database": "silver",
     "engine": "ReplacingMergeTree",
     "relation": "class_git_commits",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "repo_full_name",
+        "type": "String"
+      },
+      {
+        "name": "deployment_id",
+        "type": "String"
+      },
+      {
+        "name": "event_id",
+        "type": "Int64"
+      },
+      {
+        "name": "state",
+        "type": "String"
+      },
+      {
+        "name": "environment",
+        "type": "String"
+      },
+      {
+        "name": "creator_login",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_deployment_events",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "repo_full_name",
+        "type": "String"
+      },
+      {
+        "name": "deployment_id",
+        "type": "String"
+      },
+      {
+        "name": "environment",
+        "type": "String"
+      },
+      {
+        "name": "is_production",
+        "type": "UInt8"
+      },
+      {
+        "name": "is_transient",
+        "type": "UInt8"
+      },
+      {
+        "name": "ref",
+        "type": "String"
+      },
+      {
+        "name": "commit_sha",
+        "type": "String"
+      },
+      {
+        "name": "task",
+        "type": "String"
+      },
+      {
+        "name": "creator_login",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_deployments",
     "sorting_key": "unique_key"
   },
   {
@@ -2861,6 +3737,82 @@
     "database": "silver",
     "engine": "ReplacingMergeTree",
     "relation": "class_git_item_events",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "pr_id",
+        "type": "Int64"
+      },
+      {
+        "name": "pr_number",
+        "type": "Int64"
+      },
+      {
+        "name": "event_kind",
+        "type": "String"
+      },
+      {
+        "name": "review_state",
+        "type": "String"
+      },
+      {
+        "name": "actor_login",
+        "type": "String"
+      },
+      {
+        "name": "actor_name",
+        "type": "String"
+      },
+      {
+        "name": "actor_account_id",
+        "type": "String"
+      },
+      {
+        "name": "actor_email",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_pr_review_events",
     "sorting_key": "unique_key"
   },
   {
@@ -3248,6 +4200,10 @@
       {
         "name": "_airbyte_extracted_at",
         "type": "DateTime64(3)"
+      },
+      {
+        "name": "default_branch",
+        "type": "Nullable(String)"
       }
     ],
     "database": "silver",
@@ -4422,6 +5378,18 @@
     "engine": "ReplacingMergeTree",
     "relation": "class_wiki_pages",
     "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "version",
+        "type": "UInt32"
+      }
+    ],
+    "database": "silver",
+    "engine": "View",
+    "relation": "contract_version",
+    "sorting_key": ""
   },
   {
     "columns": [

--- a/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
+++ b/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
@@ -658,6 +658,186 @@
         "type": "String"
       },
       {
+        "name": "person_email",
+        "type": "String"
+      },
+      {
+        "name": "activity_date",
+        "type": "Date"
+      },
+      {
+        "name": "tool",
+        "type": "String"
+      },
+      {
+        "name": "modality",
+        "type": "String"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "collab_active_modalities",
+    "sorting_key": "tenant_id, person_email, activity_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "person_email",
+        "type": "String"
+      },
+      {
+        "name": "activity_date",
+        "type": "Date"
+      },
+      {
+        "name": "tool",
+        "type": "String"
+      },
+      {
+        "name": "tool_label",
+        "type": "String"
+      },
+      {
+        "name": "total_chat_messages",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "channel_posts_total",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "direct_and_group_messages",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "emails_sent",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "emails_received",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "emails_read",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "files_engaged",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "files_shared_internal",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "files_shared_external",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "meeting_seconds",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "meeting_hours",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "meetings_attended",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "meetings_organized",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "adhoc_meetings_attended",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "scheduled_meetings_attended",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "focus_hours",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "working_hours",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "is_chat_active",
+        "type": "UInt8"
+      },
+      {
+        "name": "is_email_active",
+        "type": "UInt8"
+      },
+      {
+        "name": "is_documents_active",
+        "type": "UInt8"
+      },
+      {
+        "name": "is_meetings_active",
+        "type": "UInt8"
+      },
+      {
+        "name": "is_deliberately_active",
+        "type": "UInt8"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "collab_activity",
+    "sorting_key": "tenant_id, person_email, activity_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "person_email",
+        "type": "String"
+      },
+      {
+        "name": "activity_date",
+        "type": "Date"
+      },
+      {
+        "name": "tool",
+        "type": "String"
+      },
+      {
+        "name": "scope",
+        "type": "String"
+      },
+      {
+        "name": "scope_label",
+        "type": "String"
+      },
+      {
+        "name": "files_shared",
+        "type": "Nullable(Float64)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "collab_file_shares",
+    "sorting_key": "tenant_id, person_email, activity_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
         "name": "source_key",
         "type": "String"
       },

--- a/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
+++ b/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
@@ -1491,6 +1491,190 @@
     "columns": [
       {
         "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "String"
+      },
+      {
+        "name": "issue_id",
+        "type": "String"
+      },
+      {
+        "name": "id_readable",
+        "type": "String"
+      },
+      {
+        "name": "title",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "assignee_email",
+        "type": "String"
+      },
+      {
+        "name": "close_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "close_date",
+        "type": "Date"
+      },
+      {
+        "name": "reopened_within_14d",
+        "type": "UInt8"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "task_close_events",
+    "sorting_key": "tenant_id, assignee_email, close_at"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "String"
+      },
+      {
+        "name": "issue_id",
+        "type": "String"
+      },
+      {
+        "name": "id_readable",
+        "type": "String"
+      },
+      {
+        "name": "title",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "assignee_email",
+        "type": "String"
+      },
+      {
+        "name": "closed_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "closed_date",
+        "type": "Date"
+      },
+      {
+        "name": "issue_type",
+        "type": "String"
+      },
+      {
+        "name": "issue_type_label",
+        "type": "String"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "source_label",
+        "type": "String"
+      },
+      {
+        "name": "is_closed",
+        "type": "UInt8"
+      },
+      {
+        "name": "is_bug",
+        "type": "UInt8"
+      },
+      {
+        "name": "is_non_bug",
+        "type": "UInt8"
+      },
+      {
+        "name": "has_due_date",
+        "type": "UInt8"
+      },
+      {
+        "name": "on_time",
+        "type": "UInt8"
+      },
+      {
+        "name": "is_late",
+        "type": "UInt8"
+      },
+      {
+        "name": "slip_days",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "dev_seconds",
+        "type": "Float64"
+      },
+      {
+        "name": "dev_hours",
+        "type": "Float64"
+      },
+      {
+        "name": "lead_seconds",
+        "type": "Float64"
+      },
+      {
+        "name": "resolution_days",
+        "type": "Float64"
+      },
+      {
+        "name": "pickup_days",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "estimate_seconds",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "spent_seconds",
+        "type": "Nullable(Float64)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "task_closed_issues",
+    "sorting_key": "tenant_id, assignee_email, closed_at"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "assignee_email",
+        "type": "String"
+      },
+      {
+        "name": "closed_date",
+        "type": "Date"
+      },
+      {
+        "name": "estimation_pct",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "estimation_error_pct",
+        "type": "Nullable(Float64)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "task_estimation_days",
+    "sorting_key": "tenant_id, assignee_email, closed_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
         "type": "Nullable(String)"
       },
       {
@@ -1706,6 +1890,50 @@
     "engine": "MergeTree",
     "relation": "task_metric_observations",
     "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "String"
+      },
+      {
+        "name": "issue_id",
+        "type": "String"
+      },
+      {
+        "name": "id_readable",
+        "type": "String"
+      },
+      {
+        "name": "title",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "assignee_email",
+        "type": "String"
+      },
+      {
+        "name": "last_status_event_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "last_status_event_date",
+        "type": "Date"
+      },
+      {
+        "name": "idle_days",
+        "type": "Int64"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "task_open_issues",
+    "sorting_key": "tenant_id, assignee_email, last_status_event_at"
   },
   {
     "columns": [

--- a/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
+++ b/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
@@ -514,6 +514,126 @@
         "type": "String"
       },
       {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "source_id",
+        "type": "String"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "committed_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "commit_reference",
+        "type": "String"
+      },
+      {
+        "name": "repository_value",
+        "type": "String"
+      },
+      {
+        "name": "repository_label",
+        "type": "String"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ci_commits",
+    "sorting_key": "tenant_id, entity_id, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "source_id",
+        "type": "String"
+      },
+      {
+        "name": "deployment_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "created_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "deployment_label",
+        "type": "String"
+      },
+      {
+        "name": "repository_value",
+        "type": "String"
+      },
+      {
+        "name": "repository_label",
+        "type": "String"
+      },
+      {
+        "name": "environment_value",
+        "type": "String"
+      },
+      {
+        "name": "environment_label",
+        "type": "String"
+      },
+      {
+        "name": "outcome_value",
+        "type": "String"
+      },
+      {
+        "name": "outcome_label",
+        "type": "String"
+      },
+      {
+        "name": "env_kind_value",
+        "type": "String"
+      },
+      {
+        "name": "env_kind_label",
+        "type": "String"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ci_deployments",
+    "sorting_key": "tenant_id, entity_id, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
         "name": "source_key",
         "type": "String"
       },
@@ -650,6 +770,114 @@
     "engine": "MergeTree",
     "relation": "ci_metric_observations",
     "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "source_id",
+        "type": "String"
+      },
+      {
+        "name": "run_id",
+        "type": "String"
+      },
+      {
+        "name": "run_number",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "started_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "is_gate",
+        "type": "UInt8"
+      },
+      {
+        "name": "is_retry",
+        "type": "UInt8"
+      },
+      {
+        "name": "attempt",
+        "type": "UInt32"
+      },
+      {
+        "name": "commit_known",
+        "type": "UInt8"
+      },
+      {
+        "name": "branch",
+        "type": "String"
+      },
+      {
+        "name": "duration_min",
+        "type": "Float64"
+      },
+      {
+        "name": "duration_h",
+        "type": "Float64"
+      },
+      {
+        "name": "run_label",
+        "type": "String"
+      },
+      {
+        "name": "repository_value",
+        "type": "String"
+      },
+      {
+        "name": "repository_label",
+        "type": "String"
+      },
+      {
+        "name": "pipeline_value",
+        "type": "String"
+      },
+      {
+        "name": "pipeline_label",
+        "type": "String"
+      },
+      {
+        "name": "trigger_value",
+        "type": "String"
+      },
+      {
+        "name": "trigger_label",
+        "type": "String"
+      },
+      {
+        "name": "outcome_value",
+        "type": "String"
+      },
+      {
+        "name": "outcome_label",
+        "type": "String"
+      },
+      {
+        "name": "hour_block_value",
+        "type": "String"
+      },
+      {
+        "name": "hour_block_label",
+        "type": "String"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ci_runs",
+    "sorting_key": "tenant_id, entity_id, metric_date"
   },
   {
     "columns": [

--- a/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
+++ b/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
@@ -334,6 +334,186 @@
         "type": "String"
       },
       {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "account_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "String"
+      },
+      {
+        "name": "snapshot_date",
+        "type": "Date"
+      },
+      {
+        "name": "tool",
+        "type": "String"
+      },
+      {
+        "name": "tool_label",
+        "type": "String"
+      },
+      {
+        "name": "seat_tier",
+        "type": "String"
+      },
+      {
+        "name": "daily_extra_usage_usd",
+        "type": "Float64"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ai_seat_days",
+    "sorting_key": "tenant_id, email, snapshot_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "account_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "String"
+      },
+      {
+        "name": "period_month",
+        "type": "Date"
+      },
+      {
+        "name": "tool",
+        "type": "String"
+      },
+      {
+        "name": "tool_label",
+        "type": "String"
+      },
+      {
+        "name": "seat_tier",
+        "type": "String"
+      },
+      {
+        "name": "extra_usage_usd",
+        "type": "Float64"
+      },
+      {
+        "name": "extra_usage_limit_usd",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "seat_cost_usd",
+        "type": "Nullable(Float64)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ai_seat_months",
+    "sorting_key": "tenant_id, email, period_month"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "email",
+        "type": "String"
+      },
+      {
+        "name": "usage_date",
+        "type": "Date"
+      },
+      {
+        "name": "tool",
+        "type": "String"
+      },
+      {
+        "name": "tool_label",
+        "type": "String"
+      },
+      {
+        "name": "surface",
+        "type": "String"
+      },
+      {
+        "name": "surface_label",
+        "type": "String"
+      },
+      {
+        "name": "seat_status",
+        "type": "String"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(UInt64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(UInt64)"
+      },
+      {
+        "name": "tool_use_offered",
+        "type": "Nullable(UInt64)"
+      },
+      {
+        "name": "tool_use_accepted",
+        "type": "Nullable(UInt64)"
+      },
+      {
+        "name": "dev_conversations",
+        "type": "Nullable(UInt64)"
+      },
+      {
+        "name": "assistant_messages",
+        "type": "Nullable(UInt64)"
+      },
+      {
+        "name": "assistant_actions",
+        "type": "Nullable(UInt64)"
+      },
+      {
+        "name": "chat_conversations",
+        "type": "Nullable(UInt64)"
+      },
+      {
+        "name": "prs_with_assistant",
+        "type": "Nullable(UInt64)"
+      },
+      {
+        "name": "prs_total",
+        "type": "Nullable(UInt64)"
+      },
+      {
+        "name": "cost_usd",
+        "type": "Nullable(Float64)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ai_usage",
+    "sorting_key": "tenant_id, email, usage_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
         "name": "source_key",
         "type": "String"
       },

--- a/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
+++ b/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
@@ -1294,6 +1294,10 @@
         "type": "Nullable(Int64)"
       },
       {
+        "name": "linked_commit_count",
+        "type": "Nullable(UInt64)"
+      },
+      {
         "name": "cycle_hours",
         "type": "Nullable(Float64)"
       },

--- a/src/backend/services/analytics/src/domain/field_catalog/loader.rs
+++ b/src/backend/services/analytics/src/domain/field_catalog/loader.rs
@@ -7,7 +7,8 @@ use std::collections::{BTreeMap, HashSet};
 use serde::Deserialize;
 
 use super::model::{
-    CatalogDataset, CatalogField, DisplayRole, FieldCatalog, FieldRole, FieldType, ReadDiscipline,
+    CatalogDataset, CatalogField, DisplayRole, EntityType, FieldCatalog, FieldRole, FieldType,
+    ReadDiscipline,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -75,6 +76,10 @@ struct DatasetRoles {
     key: String,
     database: String,
     relation: String,
+    /// What one row is about. Omitted means a person, the grain every dataset
+    /// had before a tenant-grain one existed.
+    #[serde(default)]
+    entity_type: EntityType,
     #[serde(default)]
     row_identity: Vec<String>,
     #[serde(default)]
@@ -207,6 +212,7 @@ fn join(
         key: declared.key,
         database: declared.database,
         relation: declared.relation,
+        entity_type: declared.entity_type,
         read_discipline: ReadDiscipline::for_engine(&found.engine),
         sorting_key: parse_sorting_key(&found.sorting_key),
         row_identity: declared.row_identity,

--- a/src/backend/services/analytics/src/domain/field_catalog/model.rs
+++ b/src/backend/services/analytics/src/domain/field_catalog/model.rs
@@ -1,7 +1,47 @@
 //! Field-catalog vocabulary: what a dataset field is and what it may be used
 //! for. Types come from the schema artifact; roles are authored.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+
+/// What a row — and so every value read from it — is keyed by.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    Serialize,
+    Deserialize,
+    utoipa::ToSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum EntityType {
+    /// One row per observed person: a read resolves identities and reports a
+    /// value per person.
+    #[default]
+    Person,
+    /// One row per tenant: there is no person to resolve, and the tenant is
+    /// the single subject every value belongs to.
+    Tenant,
+}
+
+impl EntityType {
+    pub fn as_db(self) -> &'static str {
+        match self {
+            Self::Person => "person",
+            Self::Tenant => "tenant",
+        }
+    }
+}
+
+impl std::fmt::Display for EntityType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_db())
+    }
+}
 
 /// A field's type, normalized from the warehouse's spelling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -81,6 +121,9 @@ pub struct CatalogDataset {
     pub key: String,
     pub database: String,
     pub relation: String,
+    /// What one row is about. INVARIANT: this is the dataset's grain, and a
+    /// metric may only be authored at the grain of every dataset it reads.
+    pub entity_type: EntityType,
     pub read_discipline: ReadDiscipline,
     pub sorting_key: Vec<String>,
     /// INVARIANT: a row-by-row read orders by the sorting key AND these, since

--- a/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
+++ b/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
@@ -115,3 +115,30 @@ datasets:
         display: [actor]
       repository_label:
         display: [location]
+
+  - key: wiki_pages
+    database: insight
+    relation: wiki_pages
+    row_identity: [source_id, page_id]
+    fields:
+      tenant_id: tenant
+      author_email: entity
+      created_at: event_time
+      title:
+        display: [title]
+      page_id:
+        display: [reference]
+      space_name:
+        display: [location]
+
+  - key: wiki_person_days
+    database: insight
+    relation: wiki_person_days
+    row_identity: [source_id, author_email, activity_date]
+    fields:
+      tenant_id: tenant
+      author_email: entity
+      activity_date: event_time
+      edits: measurable
+      pages_edited: measurable
+      comments_received: measurable

--- a/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
+++ b/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
@@ -86,6 +86,7 @@ datasets:
       lines_added: measurable
       lines_removed: measurable
       files_changed: measurable
+      linked_commit_count: measurable
       reviewer_count: measurable
       cycle_hours: measurable
       first_review_hours: measurable
@@ -113,6 +114,33 @@ datasets:
         display: [title]
       author_name:
         display: [actor]
+      repository_label:
+        display: [location]
+
+  - key: git_review_events
+    database: insight
+    relation: git_review_events
+    row_identity: [source_id, event_key]
+    fields:
+      tenant_id: tenant
+      entity_id: entity
+      observed_at: event_time
+      comment_target_value:
+        role: dimension
+        label_field: comment_target_label
+      repository_value:
+        role: dimension
+        label_field: repository_label
+      project_value:
+        role: dimension
+        label_field: project_label
+      source_value:
+        role: dimension
+        label_field: source_label
+      pr_number:
+        display: [reference]
+      title:
+        display: [title]
       repository_label:
         display: [location]
 

--- a/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
+++ b/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
@@ -350,3 +350,79 @@ datasets:
       scope:
         role: dimension
         label_field: scope_label
+
+  # CI datasets are TENANT-grain: a run, a deployment and a collected commit
+  # belong to the organization, so entity_id holds the tenant id and no
+  # identity is ever resolved for them.
+  - key: ci_runs
+    database: insight
+    relation: ci_runs
+    entity_type: tenant
+    row_identity: [source_id, repository_value, run_id]
+    fields:
+      tenant_id: tenant
+      entity_id: entity
+      started_at: event_time
+      duration_min: measurable
+      duration_h: measurable
+      run_label:
+        display: [title]
+      run_number:
+        display: [reference]
+      branch:
+        display: [location]
+      repository_value:
+        role: dimension
+        label_field: repository_label
+      pipeline_value:
+        role: dimension
+        label_field: pipeline_label
+      trigger_value:
+        role: dimension
+        label_field: trigger_label
+      outcome_value:
+        role: dimension
+        label_field: outcome_label
+      hour_block_value:
+        role: dimension
+        label_field: hour_block_label
+
+  - key: ci_deployments
+    database: insight
+    relation: ci_deployments
+    entity_type: tenant
+    row_identity: [source_id, deployment_id]
+    fields:
+      tenant_id: tenant
+      entity_id: entity
+      created_at: event_time
+      deployment_label:
+        display: [title]
+      deployment_id:
+        display: [reference]
+      repository_value:
+        role: dimension
+        label_field: repository_label
+      environment_value:
+        role: dimension
+        label_field: environment_label
+      outcome_value:
+        role: dimension
+        label_field: outcome_label
+      env_kind_value:
+        role: dimension
+        label_field: env_kind_label
+
+  - key: ci_commits
+    database: insight
+    relation: ci_commits
+    entity_type: tenant
+    row_identity: [source_id, project_key, repo_slug, commit_hash]
+    fields:
+      tenant_id: tenant
+      entity_id: entity
+      committed_at: event_time
+      commit_reference:
+        display: [reference]
+      repository_label:
+        display: [location]

--- a/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
+++ b/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
@@ -170,3 +170,77 @@ datasets:
       edits: measurable
       pages_edited: measurable
       comments_received: measurable
+
+  - key: task_closed_issues
+    database: insight
+    relation: task_closed_issues
+    row_identity: [insight_source_id, issue_id]
+    fields:
+      tenant_id: tenant
+      assignee_email: entity
+      closed_at: event_time
+      dev_seconds: measurable
+      dev_hours: measurable
+      lead_seconds: measurable
+      resolution_days: measurable
+      pickup_days: measurable
+      slip_days: measurable
+      issue_type:
+        role: dimension
+        label_field: issue_type_label
+      source:
+        role: dimension
+        label_field: source_label
+      id_readable:
+        display: [reference]
+      title:
+        display: [title]
+
+  - key: task_close_events
+    database: insight
+    relation: task_close_events
+    row_identity: [insight_source_id, issue_id, close_at]
+    fields:
+      tenant_id: tenant
+      assignee_email: entity
+      close_at: event_time
+      id_readable:
+        display: [reference]
+      title:
+        display: [title]
+
+  - key: task_estimation_days
+    database: insight
+    relation: task_estimation_days
+    row_identity: [tenant_id, assignee_email, closed_date]
+    fields:
+      tenant_id: tenant
+      assignee_email: entity
+      closed_date: event_time
+      estimation_pct: measurable
+      estimation_error_pct: measurable
+
+  - key: task_person_days
+    database: insight
+    relation: task_worklog_flow
+    row_identity: [tenant_id, entity_id, metric_date]
+    fields:
+      tenant_id: tenant
+      entity_id: entity
+      metric_date: event_time
+      in_progress_seconds: measurable
+      worklog_seconds: measurable
+
+  - key: task_open_issues
+    database: insight
+    relation: task_open_issues
+    row_identity: [insight_source_id, issue_id]
+    fields:
+      tenant_id: tenant
+      assignee_email: entity
+      last_status_event_at: event_time
+      idle_days: measurable
+      id_readable:
+        display: [reference]
+      title:
+        display: [title]

--- a/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
+++ b/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
@@ -300,3 +300,53 @@ datasets:
         role: dimension
         label_field: tool_label
       seat_tier: dimension
+  - key: collab_activity
+    database: insight
+    relation: collab_activity
+    row_identity: [person_email, activity_date, tool]
+    fields:
+      tenant_id: tenant
+      person_email: entity
+      activity_date: event_time
+      total_chat_messages: measurable
+      channel_posts_total: measurable
+      direct_and_group_messages: measurable
+      emails_sent: measurable
+      emails_received: measurable
+      emails_read: measurable
+      files_engaged: measurable
+      files_shared_internal: measurable
+      files_shared_external: measurable
+      meeting_seconds: measurable
+      meeting_hours: measurable
+      meetings_attended: measurable
+      meetings_organized: measurable
+      adhoc_meetings_attended: measurable
+      scheduled_meetings_attended: measurable
+      focus_hours: measurable
+      working_hours: measurable
+      tool:
+        role: dimension
+        label_field: tool_label
+
+  - key: collab_active_modalities
+    database: insight
+    relation: collab_active_modalities
+    row_identity: [person_email, activity_date, tool, modality]
+    fields:
+      tenant_id: tenant
+      person_email: entity
+      activity_date: event_time
+
+  - key: collab_file_shares
+    database: insight
+    relation: collab_file_shares
+    row_identity: [person_email, activity_date, tool, scope]
+    fields:
+      tenant_id: tenant
+      person_email: entity
+      activity_date: event_time
+      files_shared: measurable
+      scope:
+        role: dimension
+        label_field: scope_label

--- a/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
+++ b/src/backend/services/analytics/src/domain/field_catalog/roles.yaml
@@ -244,3 +244,59 @@ datasets:
         display: [reference]
       title:
         display: [title]
+  - key: ai_usage
+    database: insight
+    relation: ai_usage
+    row_identity: [email, usage_date, tool, surface, seat_status]
+    fields:
+      tenant_id: tenant
+      email: entity
+      usage_date: event_time
+      lines_added: measurable
+      lines_removed: measurable
+      tool_use_offered: measurable
+      tool_use_accepted: measurable
+      dev_conversations: measurable
+      assistant_messages: measurable
+      assistant_actions: measurable
+      chat_conversations: measurable
+      prs_with_assistant: measurable
+      prs_total: measurable
+      cost_usd: measurable
+      tool:
+        role: dimension
+        label_field: tool_label
+      surface:
+        role: dimension
+        label_field: surface_label
+      seat_status: dimension
+
+  - key: ai_seat_months
+    database: insight
+    relation: ai_seat_months
+    row_identity: [source_id, account_id, period_month]
+    fields:
+      tenant_id: tenant
+      email: entity
+      period_month: event_time
+      extra_usage_usd: measurable
+      extra_usage_limit_usd: measurable
+      seat_cost_usd: measurable
+      tool:
+        role: dimension
+        label_field: tool_label
+      seat_tier: dimension
+
+  - key: ai_seat_days
+    database: insight
+    relation: ai_seat_days
+    row_identity: [source_id, account_id, snapshot_date]
+    fields:
+      tenant_id: tenant
+      email: entity
+      snapshot_date: event_time
+      daily_extra_usage_usd: measurable
+      tool:
+        role: dimension
+        label_field: tool_label
+      seat_tier: dimension

--- a/src/backend/services/analytics/src/domain/metric_query/capability/describe.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/capability/describe.rs
@@ -4,6 +4,7 @@
 
 use crate::domain::compiler::error::CompileError;
 use crate::domain::definitions::definition::{Computation, MetricDefinition};
+use crate::domain::field_catalog::model::EntityType;
 
 use super::super::catalog::MetricCatalog;
 use super::super::comparisons::{Population, population};
@@ -20,13 +21,28 @@ use super::dto::{
 const POPULATIONS: [Population; 2] = [Population::Tenant {}, Population::Cohort {}];
 
 /// What a client needs to form a valid question about any shipped metric.
-pub fn describe(catalog: &MetricCatalog) -> Result<MetricCatalogResponse, CompileError> {
+///
+/// INVARIANT: `tenant_metrics_enabled` is the same installation gate the query
+/// surfaces enforce, so the catalogue never advertises a metric a question
+/// about it would be refused for.
+pub fn describe(
+    catalog: &MetricCatalog,
+    tenant_metrics_enabled: bool,
+) -> Result<MetricCatalogResponse, CompileError> {
     let metrics = catalog
         .metrics()
+        .filter(|metric| served(metric, tenant_metrics_enabled))
         .map(|metric| describe_metric(catalog, metric))
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(MetricCatalogResponse { metrics })
+}
+
+fn served(metric: &MetricDefinition, tenant_metrics_enabled: bool) -> bool {
+    match metric.entity_type {
+        EntityType::Person => true,
+        EntityType::Tenant => tenant_metrics_enabled,
+    }
 }
 
 fn describe_metric(
@@ -50,14 +66,14 @@ fn describe_metric(
         description: metric.description.clone(),
         format: metric.format,
         direction: metric.direction,
-        entity_type: metric.entity_type.clone(),
+        entity_type: metric.entity_type,
         computation: computation_of(&metric.computation),
         cohort_key: metric.cohort_key.clone(),
         dimensions,
         questions: MetricQuestions {
             values: ValuesQuestions {
-                grains: offered_grains(splittable),
-                folds: offered_folds(splittable),
+                grains: offered_grains(metric.entity_type, splittable),
+                folds: offered_folds(metric.entity_type, splittable),
                 compare: offered_compare_offsets(),
                 split: splittable,
             },

--- a/src/backend/services/analytics/src/domain/metric_query/capability/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/capability/dto.rs
@@ -7,6 +7,7 @@
 use serde::Serialize;
 
 use crate::domain::definitions::definition::{Direction, Format};
+use crate::domain::field_catalog::model::EntityType;
 
 use super::super::comparisons::Population;
 use super::super::values::{CompareOffset, Fold, Grain};
@@ -27,8 +28,8 @@ pub struct CatalogMetric {
     pub description: Option<String>,
     pub format: Format,
     pub direction: Direction,
-    /// What the metric's values are keyed by, such as `person`.
-    pub entity_type: String,
+    /// What the metric's values are keyed by.
+    pub entity_type: EntityType,
     pub computation: CatalogComputation,
     /// The grouping a cohort comparison reads; absent when the metric declares
     /// none, and then no cohort comparison is offered.

--- a/src/backend/services/analytics/src/domain/metric_query/capability/tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/capability/tests.rs
@@ -3,18 +3,19 @@ use serde_json::{Value, json};
 use super::super::catalog::product_metric_catalog;
 use super::super::comparisons::{Population, population};
 use super::super::distributions::distributable;
-use super::super::fixtures::{SHIPPED_DISTRIBUTION_METRIC, SHIPPED_METRIC};
+use super::super::fixtures::{SHIPPED_DISTRIBUTION_METRIC, SHIPPED_METRIC, SHIPPED_TENANT_METRIC};
 use super::describe;
 
 use crate::domain::definitions::definition::{
     Computation, Direction, Format, MetricDefinition, Transform,
 };
+use crate::domain::field_catalog::model::EntityType;
 
 const SHIPPED_RATIO_METRIC: &str = "git.merge_rate";
 
 fn catalogued() -> Value {
     let catalog = product_metric_catalog().expect("the shipped definitions load");
-    serde_json::to_value(describe(catalog).expect("every shipped metric resolves its inputs"))
+    serde_json::to_value(describe(catalog, true).expect("every shipped metric resolves its inputs"))
         .expect("the catalogue serializes")
 }
 
@@ -37,7 +38,7 @@ fn without_cohort() -> MetricDefinition {
         transform: Option::<Transform>::None,
         format: Format::Integer,
         direction: Direction::Neutral,
-        entity_type: "person".to_owned(),
+        entity_type: EntityType::Person,
         cohort_key: None,
         label: None,
         description: None,
@@ -219,4 +220,99 @@ fn a_metric_declaring_a_cohort_advertises_both_populations() {
         json!([{ "type": "tenant" }, { "type": "cohort" }])
     );
     assert!(population(metric, Population::Cohort {}).is_ok());
+}
+
+#[test]
+fn a_tenant_metric_is_catalogued_as_asked_about_the_tenant_and_compared_against_nobody() {
+    let entry = entry(SHIPPED_TENANT_METRIC);
+
+    assert_eq!(entry["entity_type"], json!("tenant"));
+    assert_eq!(entry["cohort_key"], Value::Null);
+    assert_eq!(entry["questions"]["comparisons"]["populations"], json!([]));
+    assert_eq!(
+        entry["questions"]["values"]["grains"],
+        json!(["total", "day", "week", "month"])
+    );
+    assert_eq!(
+        entry["questions"]["values"]["folds"],
+        json!(["per_subject", "combined"])
+    );
+}
+
+#[test]
+fn the_catalogue_advertises_a_tenant_metric_only_where_the_installation_serves_one() {
+    let catalog = product_metric_catalog().expect("the shipped definitions load");
+    let keys = |tenant_metrics_enabled| -> Vec<String> {
+        describe(catalog, tenant_metrics_enabled)
+            .expect("every shipped metric resolves its inputs")
+            .metrics
+            .into_iter()
+            .filter(|metric| metric.entity_type == EntityType::Tenant)
+            .map(|metric| metric.key)
+            .collect()
+    };
+
+    assert!(
+        keys(true).contains(&SHIPPED_TENANT_METRIC.to_owned()),
+        "an installation serving tenant metrics advertises them: {:?}",
+        keys(true)
+    );
+    assert_eq!(
+        keys(false),
+        Vec::<String>::new(),
+        "an installation that refuses a tenant question must not advertise one"
+    );
+}
+
+/// The CI family is the first authored at tenant grain, and its metrics carry
+/// exactly the dimension sets the family means to offer. A metric's capability
+/// is the intersection of its inputs' declared keys, so this reads back what
+/// the authored measures actually agree on rather than what they meant to.
+#[test]
+fn the_ci_family_is_catalogued_with_the_dimensions_its_measures_share() {
+    let expected: [(&str, &[&str]); 11] = [
+        (
+            "ci.runs",
+            &["hour_block", "outcome", "pipeline", "repository", "trigger"],
+        ),
+        (
+            "ci.gate_pass_rate",
+            &["hour_block", "pipeline", "repository"],
+        ),
+        ("ci.gate_first_try_pass_rate", &["pipeline", "repository"]),
+        ("ci.gate_retry_share", &["pipeline", "repository"]),
+        (
+            "ci.run_duration_min",
+            &["outcome", "pipeline", "repository"],
+        ),
+        (
+            "ci.run_duration_min_p90",
+            &["outcome", "pipeline", "repository"],
+        ),
+        (
+            "ci.run_duration_min_stddev",
+            &["outcome", "pipeline", "repository"],
+        ),
+        ("ci.run_hours", &["outcome", "pipeline", "repository"]),
+        ("ci.runs_matched_commit", &[]),
+        ("ci.commits_observed", &[]),
+        (
+            "ci.deployments",
+            &["env_kind", "environment", "outcome", "repository"],
+        ),
+    ];
+
+    for (key, dimensions) in expected {
+        let entry = entry(key);
+        let mut catalogued: Vec<String> = entry["dimensions"]
+            .as_array()
+            .expect("dimensions are a list")
+            .iter()
+            .map(|dimension| dimension["key"].as_str().expect("a key").to_owned())
+            .collect();
+        catalogued.sort();
+
+        assert_eq!(catalogued, dimensions, "`{key}` offers {catalogued:?}");
+        assert_eq!(entry["entity_type"], json!("tenant"), "`{key}`");
+    }
 }

--- a/src/backend/services/analytics/src/domain/metric_query/comparisons/plan.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/comparisons/plan.rs
@@ -12,6 +12,7 @@ use crate::domain::compiler::request::{
     ViewKind, any_identity_resolved,
 };
 use crate::domain::compiler::sql::CompiledMeasureQuery;
+use crate::domain::field_catalog::model::EntityType;
 
 use super::super::catalog::MetricCatalog;
 use super::super::error::QueryError;
@@ -35,7 +36,7 @@ struct Populations {
 /// Everything a population read's answer depends on.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct PopulationKey {
-    entity_type: String,
+    entity_type: EntityType,
     cohort_key: String,
     targets: Vec<Uuid>,
 }
@@ -79,7 +80,7 @@ async fn resolve(
             cohort_key,
         } => {
             let key = PopulationKey {
-                entity_type: entity_type.clone(),
+                entity_type: *entity_type,
                 cohort_key: cohort_key.clone(),
                 targets: query.targets.clone(),
             };
@@ -113,7 +114,7 @@ async fn declared_cohort(
     let pool = cohort_pool(
         clickhouse,
         tenant_id,
-        &key.entity_type,
+        key.entity_type,
         &key.cohort_key,
         &key.targets,
     )
@@ -203,7 +204,7 @@ mod tests {
 
     fn declared() -> ValidatedPopulation {
         ValidatedPopulation::DeclaredCohort {
-            entity_type: "person".to_owned(),
+            entity_type: EntityType::Person,
             cohort_key: "org_unit".to_owned(),
         }
     }

--- a/src/backend/services/analytics/src/domain/metric_query/comparisons/pool.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/comparisons/pool.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use crate::domain::compiler::comparison::compile_cohort_members_query;
 use crate::domain::compiler::request::{CohortMembersQuery, ResolvedPerson};
+use crate::domain::field_catalog::model::EntityType;
 use crate::domain::identity_binding::{IdentitySet, resolve_all_identities, resolve_identities};
 
 use super::super::error::QueryError;
@@ -28,7 +29,7 @@ struct CohortMemberRow {
 pub(super) async fn cohort_pool(
     clickhouse: &insight_clickhouse::Client,
     tenant_id: Uuid,
-    entity_type: &str,
+    entity_type: EntityType,
     cohort_key: &str,
     targets: &[Uuid],
 ) -> Result<Vec<ResolvedPerson>, QueryError> {
@@ -40,7 +41,7 @@ pub(super) async fn cohort_pool(
 
     let query = CohortMembersQuery {
         tenant_id: tenant_id.to_string(),
-        entity_type: entity_type.to_owned(),
+        entity_type,
         cohort_key: cohort_key.to_owned(),
         targets: targets.iter().map(Uuid::to_string).collect(),
         row_limit: query_row_limit(),
@@ -270,7 +271,14 @@ mod tests {
     #[tokio::test]
     async fn a_comparison_with_no_target_asks_the_server_nothing() {
         for outcome in [
-            cohort_pool(&offline_clickhouse(), tenant(), "person", "org_unit", &[]).await,
+            cohort_pool(
+                &offline_clickhouse(),
+                tenant(),
+                EntityType::Person,
+                "org_unit",
+                &[],
+            )
+            .await,
             tenant_pool(&offline_clickhouse(), tenant(), &[]).await,
         ] {
             assert!(matches!(
@@ -288,7 +296,7 @@ mod tests {
             cohort_pool(
                 &offline_clickhouse(),
                 tenant(),
-                "person",
+                EntityType::Person,
                 "org_unit",
                 &[target],
             )

--- a/src/backend/services/analytics/src/domain/metric_query/comparisons/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/comparisons/validation.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use crate::domain::compiler::request::DimensionFilter;
 use crate::domain::definitions::definition::MetricDefinition;
+use crate::domain::field_catalog::model::EntityType;
 
 use super::super::catalog::MetricCatalog;
 use super::super::error::QueryError;
@@ -26,7 +27,7 @@ pub enum ValidatedPopulation {
     /// Everyone sharing the metric's declared cohort with the target, under
     /// the entity type the metric declares membership by.
     DeclaredCohort {
-        entity_type: String,
+        entity_type: EntityType,
         cohort_key: String,
     },
     /// Every person the tenant's identity mapping knows.
@@ -107,6 +108,15 @@ pub(in crate::domain::metric_query) fn population(
     metric: &MetricDefinition,
     population: Population,
 ) -> Result<ValidatedPopulation, QueryError> {
+    // A comparison sets one person against the people around them. A tenant is
+    // the only one of its kind in the answer, so there is no population to
+    // place it in.
+    if metric.entity_type == EntityType::Tenant {
+        return Err(QueryError::Unanswerable {
+            reason: "this metric measures the tenant, which has no peers to be compared with",
+        });
+    }
+
     match population {
         Population::Tenant {} => Ok(ValidatedPopulation::Tenant),
         Population::Cohort {} => {
@@ -117,7 +127,7 @@ pub(in crate::domain::metric_query) fn population(
             };
 
             Ok(ValidatedPopulation::DeclaredCohort {
-                entity_type: metric.entity_type.clone(),
+                entity_type: metric.entity_type,
                 cohort_key,
             })
         }
@@ -169,7 +179,7 @@ mod tests {
         assert_eq!(
             validated.queries[0].population,
             ValidatedPopulation::DeclaredCohort {
-                entity_type: "person".to_owned(),
+                entity_type: EntityType::Person,
                 cohort_key: "org_unit".to_owned(),
             }
         );

--- a/src/backend/services/analytics/src/domain/metric_query/comparisons/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/comparisons/validation.rs
@@ -138,7 +138,7 @@ pub(in crate::domain::metric_query) fn population(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::super::super::catalog::product_metric_catalog;
-    use super::super::super::fixtures::SHIPPED_METRIC;
+    use super::super::super::fixtures::{SHIPPED_METRIC, SHIPPED_TENANT_METRIC};
     use super::super::super::question::{MAX_QUERIES, MAX_SUBJECTS};
     use super::*;
 
@@ -215,6 +215,44 @@ mod tests {
             population(&undeclared, Population::Tenant {}).ok(),
             Some(ValidatedPopulation::Tenant),
             "a tenant population needs no declaration"
+        );
+    }
+
+    /// INVARIANT: `/v1/metric-comparisons` carries no tenant-metric gate of its
+    /// own, and is safe without one only because no tenant-grain metric can be
+    /// compared at all. Both populations are pinned so the refusal cannot be
+    /// narrowed to one of them without this failing.
+    #[test]
+    fn a_tenant_grain_metric_has_no_peers_and_is_refused_under_either_population() {
+        let tenant_metric = catalog()
+            .metric(SHIPPED_TENANT_METRIC)
+            .expect("the metric is shipped")
+            .clone();
+
+        for asked in [Population::Cohort {}, Population::Tenant {}] {
+            let named = format!("{asked:?}");
+
+            let refusal = population(&tenant_metric, asked)
+                .expect_err("a tenant measures no population it sits in");
+
+            assert!(
+                matches!(refusal, QueryError::Unanswerable { .. }),
+                "should refuse: {named} — got {refusal}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_question_naming_a_tenant_grain_metric_never_reaches_a_read() {
+        let refusal = validate(&query(&serde_json::json!({
+            "metric": SHIPPED_TENANT_METRIC,
+            "population": { "type": "tenant" },
+        })))
+        .expect_err("a tenant-grain metric names no comparison");
+
+        assert!(
+            matches!(refusal, QueryError::Unanswerable { .. }),
+            "{refusal}"
         );
     }
 

--- a/src/backend/services/analytics/src/domain/metric_query/distributions/assemble.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/distributions/assemble.rs
@@ -7,8 +7,8 @@ use std::collections::BTreeMap;
 use std::num::NonZeroU32;
 
 use serde::Deserialize;
-use uuid::Uuid;
 
+use super::super::question::ValidatedSubjects;
 use super::dto::{Histogram, HistogramBin, Quantile, SubjectDistribution};
 
 /// One observed (subject, bin) pair plus that subject's exact bounds.
@@ -39,7 +39,7 @@ struct Observed {
 }
 
 pub(super) fn subject_distributions(
-    subjects: &[Uuid],
+    subjects: &ValidatedSubjects,
     bins: Option<NonZeroU32>,
     quantiles: Option<&[f64]>,
     histogram_rows: Vec<HistogramRow>,
@@ -55,19 +55,29 @@ pub(super) fn subject_distributions(
         observed.entry(row.entity_id).or_default().quantile_values = row.quantile_values;
     }
 
-    subjects
-        .iter()
-        .map(|subject| {
-            let subject = subject.to_string();
-            let answered = observed.remove(&subject).unwrap_or_default();
+    let shape = |answered: &Observed, subject: Option<String>| SubjectDistribution {
+        histogram: bins.map(|bins| histogram(answered, bins)),
+        quantiles: quantiles.map(|quantiles| positions(answered, quantiles)),
+        subject,
+    };
 
-            SubjectDistribution {
-                histogram: bins.map(|bins| histogram(&answered, bins)),
-                quantiles: quantiles.map(|quantiles| positions(&answered, quantiles)),
-                subject,
-            }
-        })
-        .collect()
+    match subjects {
+        // A tenant read groups by the one entity its rows carry, so the answer
+        // is that one distribution — reported whether or not anything was
+        // observed, exactly as a person with no rows still gets an entry.
+        ValidatedSubjects::Tenant => {
+            let answered = observed.into_values().next().unwrap_or_default();
+            vec![shape(&answered, None)]
+        }
+        ValidatedSubjects::Persons(ids) => ids
+            .iter()
+            .map(|id| {
+                let subject = id.to_string();
+                let answered = observed.remove(&subject).unwrap_or_default();
+                shape(&answered, Some(subject))
+            })
+            .collect(),
+    }
 }
 
 /// The subject's own range cut into equal-width bins. A range collapsing to a
@@ -147,7 +157,13 @@ where
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use uuid::Uuid;
+
     use super::*;
+
+    fn people(ids: &[Uuid]) -> ValidatedSubjects {
+        ValidatedSubjects::Persons(ids.to_vec())
+    }
 
     fn person() -> Uuid {
         Uuid::from_u128(1)
@@ -187,7 +203,7 @@ mod tests {
     #[test]
     fn every_bin_of_the_range_is_reported_and_the_last_one_closes_on_the_maximum() {
         let distributions = subject_distributions(
-            &[person()],
+            &people(&[person()]),
             bins(4),
             None,
             vec![
@@ -216,7 +232,7 @@ mod tests {
     #[test]
     fn a_range_collapsing_to_a_point_is_one_bin_rather_than_a_cut_of_no_width() {
         let distributions = subject_distributions(
-            &[person()],
+            &people(&[person()]),
             bins(10),
             None,
             vec![histogram_row(&person().to_string(), 0, 5.0, 5.0, 4)],
@@ -243,7 +259,7 @@ mod tests {
         let unobserved = Uuid::from_u128(2);
 
         let distributions = subject_distributions(
-            &[observed, unobserved],
+            &people(&[observed, unobserved]),
             bins(2),
             Some(&[0.5]),
             vec![histogram_row(&observed.to_string(), 0, 0.0, 4.0, 1)],
@@ -254,7 +270,7 @@ mod tests {
         );
 
         assert_eq!(distributions.len(), 2);
-        assert_eq!(distributions[1].subject, unobserved.to_string());
+        assert_eq!(distributions[1].subject, Some(unobserved.to_string()));
         let histogram = distributions[1]
             .histogram
             .as_ref()
@@ -273,7 +289,7 @@ mod tests {
     #[test]
     fn each_position_keeps_the_value_the_read_projected_for_it() {
         let distributions = subject_distributions(
-            &[person()],
+            &people(&[person()]),
             None,
             Some(&[0.25, 0.5, 0.9]),
             Vec::new(),
@@ -309,7 +325,7 @@ mod tests {
         let second = Uuid::from_u128(2);
 
         let distributions = subject_distributions(
-            &[first, second],
+            &people(&[first, second]),
             bins(1),
             None,
             vec![
@@ -322,9 +338,35 @@ mod tests {
         assert_eq!(
             distributions
                 .iter()
-                .map(|distribution| distribution.subject.as_str())
+                .map(|distribution| distribution.subject.clone())
                 .collect::<Vec<_>>(),
-            vec![first.to_string(), second.to_string()]
+            vec![Some(first.to_string()), Some(second.to_string())]
         );
+    }
+
+    #[test]
+    fn a_tenant_distribution_is_one_entry_naming_nobody_whatever_the_read_observed() {
+        let observed = subject_distributions(
+            &ValidatedSubjects::Tenant,
+            NonZeroU32::new(2),
+            None,
+            vec![
+                histogram_row("acme-tenant", 0, 1.0, 3.0, 2),
+                histogram_row("acme-tenant", 1, 1.0, 3.0, 1),
+            ],
+            Vec::new(),
+        );
+        let unobserved = subject_distributions(
+            &ValidatedSubjects::Tenant,
+            NonZeroU32::new(2),
+            None,
+            Vec::new(),
+            Vec::new(),
+        );
+
+        for (named, answer) in [("observed", observed), ("unobserved", unobserved)] {
+            assert_eq!(answer.len(), 1, "{named}: the tenant is one subject");
+            assert_eq!(answer[0].subject, None, "{named}");
+        }
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_query/distributions/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/distributions/dto.rs
@@ -61,7 +61,10 @@ pub struct DistributionResult {
 
 #[derive(Debug, PartialEq, Serialize, utoipa::ToSchema)]
 pub struct SubjectDistribution {
-    pub subject: String,
+    /// Absent when the metric measures the tenant: the answer is about the
+    /// caller's own tenant, which the question already named.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
     /// Absent when the question asked for no histogram.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub histogram: Option<Histogram>,
@@ -182,7 +185,7 @@ mod tests {
                     served_from: ServedFrom::Computed,
                 },
                 subjects: vec![SubjectDistribution {
-                    subject: "00000000-0000-0000-0000-000000000001".to_owned(),
+                    subject: Some("00000000-0000-0000-0000-000000000001".to_owned()),
                     histogram: Some(Histogram {
                         lo: Some(0.0),
                         hi: Some(10.0),
@@ -241,7 +244,7 @@ mod tests {
                     served_from: ServedFrom::Computed,
                 },
                 subjects: vec![SubjectDistribution {
-                    subject: "00000000-0000-0000-0000-000000000001".to_owned(),
+                    subject: Some("00000000-0000-0000-0000-000000000001".to_owned()),
                     histogram: Some(Histogram {
                         lo: None,
                         hi: None,

--- a/src/backend/services/analytics/src/domain/metric_query/distributions/plan.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/distributions/plan.rs
@@ -14,7 +14,7 @@ use crate::domain::identity_binding::{IdentitySet, resolve_identities};
 
 use super::super::catalog::MetricCatalog;
 use super::super::error::QueryError;
-use super::super::question::query_row_limit;
+use super::super::question::{ValidatedSubjects, query_row_limit};
 use super::validation::{ValidatedDistribution, ValidatedDistributions};
 
 // INVARIANT: a distribution reports the whole window at once, so neither read
@@ -132,19 +132,24 @@ async fn identities(
 
 /// INVARIANT: a person is carried with their own identities rather than merged
 /// into one list, because the answer is keyed per person.
-fn entity_scope(subjects: &[Uuid], identities: &BTreeMap<Uuid, IdentitySet>) -> EntityScope {
-    EntityScope::People(
-        subjects
-            .iter()
-            .map(|id| ResolvedPerson {
-                person_ref: id.to_string(),
-                identities: identities
-                    .get(id)
-                    .map(IdentitySet::values)
-                    .unwrap_or_default(),
-            })
-            .collect(),
-    )
+fn entity_scope(
+    subjects: &ValidatedSubjects,
+    identities: &BTreeMap<Uuid, IdentitySet>,
+) -> EntityScope {
+    match subjects {
+        ValidatedSubjects::Tenant => EntityScope::Tenant,
+        ValidatedSubjects::Persons(ids) => EntityScope::People(
+            ids.iter()
+                .map(|id| ResolvedPerson {
+                    person_ref: id.to_string(),
+                    identities: identities
+                        .get(id)
+                        .map(IdentitySet::values)
+                        .unwrap_or_default(),
+                })
+                .collect(),
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -157,7 +162,9 @@ mod tests {
     use crate::domain::compiler::sql::QueryParam;
 
     use super::super::super::catalog::product_metric_catalog;
-    use super::super::super::fixtures::{SHIPPED_DISTRIBUTION_METRIC, offline_clickhouse, tenant};
+    use super::super::super::fixtures::{
+        SHIPPED_DISTRIBUTION_METRIC, offline_clickhouse, shipped_subjects, tenant,
+    };
     use super::*;
 
     fn person() -> Uuid {
@@ -167,7 +174,7 @@ mod tests {
     fn validated(bins: Option<u32>, quantiles: Option<Vec<f64>>) -> ValidatedDistribution {
         ValidatedDistribution {
             metric_key: SHIPPED_DISTRIBUTION_METRIC.to_owned(),
-            subjects: vec![person()],
+            subjects: ValidatedSubjects::Persons(vec![person()]),
             from: NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
             to: NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
             filters: Vec::new(),
@@ -285,7 +292,7 @@ mod tests {
     fn a_question_one_of_whose_people_resolves_is_read_for_that_person() {
         let unresolved = Uuid::from_u128(9);
         let query = ValidatedDistribution {
-            subjects: vec![person(), unresolved],
+            subjects: ValidatedSubjects::Persons(vec![person(), unresolved]),
             ..validated(Some(10), None)
         };
         let known = BTreeMap::from([(
@@ -315,7 +322,10 @@ mod tests {
 
     #[test]
     fn a_person_the_mapping_answers_nothing_for_is_scoped_to_no_identity_at_all() {
-        let scope = entity_scope(&[person()], &BTreeMap::new());
+        let scope = entity_scope(
+            &ValidatedSubjects::Persons(vec![person()]),
+            &BTreeMap::new(),
+        );
 
         assert_eq!(
             scope,
@@ -365,7 +375,7 @@ mod tests {
             let request: DistributionsRequest = serde_json::from_value(serde_json::json!({
                 "queries": [{
                     "metric": metric.key,
-                    "subjects": { "type": "persons", "ids": [person().to_string()] },
+                    "subjects": shipped_subjects(&metric.key),
                     "time": { "from": "2026-01-01", "to": "2026-01-31" },
                     "bins": 10,
                     "quantiles": [0.5],

--- a/src/backend/services/analytics/src/domain/metric_query/distributions/service.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/distributions/service.rs
@@ -133,13 +133,15 @@ mod tests {
 
     use chrono::NaiveDate;
 
+    use crate::domain::metric_query::question::ValidatedSubjects;
+
     use super::super::super::fixtures::{SHIPPED_DISTRIBUTION_METRIC, offline_clickhouse};
     use super::*;
 
     fn validated() -> ValidatedDistribution {
         ValidatedDistribution {
             metric_key: SHIPPED_DISTRIBUTION_METRIC.to_owned(),
-            subjects: vec![Uuid::from_u128(1)],
+            subjects: ValidatedSubjects::Persons(vec![Uuid::from_u128(1)]),
             from: NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
             to: NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
             filters: Vec::new(),

--- a/src/backend/services/analytics/src/domain/metric_query/distributions/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/distributions/validation.rs
@@ -9,11 +9,15 @@ use chrono::NaiveDate;
 use uuid::Uuid;
 
 use crate::domain::compiler::request::DimensionFilter;
+use crate::domain::field_catalog::model::EntityType;
 
 use super::super::catalog::MetricCatalog;
 use super::super::dto::Subjects;
 use super::super::error::QueryError;
-use super::super::question::{batch_size, defined_metric, filters, person_ids, window};
+use super::super::question::{
+    PERSON_SUBJECTS_OVER_A_TENANT_METRIC, ValidatedSubjects, batch_size, defined_metric, filters,
+    metric_entity_type, person_ids, window,
+};
 use super::dto::{DistributionQuery, DistributionsRequest};
 
 /// The field a distribution question names its people in.
@@ -30,7 +34,7 @@ const MAX_QUANTILES: usize = 10;
 #[derive(Debug, PartialEq)]
 pub struct ValidatedDistribution {
     pub metric_key: String,
-    pub subjects: Vec<Uuid>,
+    pub subjects: ValidatedSubjects,
     pub from: NaiveDate,
     pub to: NaiveDate,
     pub filters: Vec<DimensionFilter>,
@@ -51,10 +55,17 @@ impl ValidatedDistributions {
     pub fn subject_ids(&self) -> Vec<Uuid> {
         self.queries
             .iter()
-            .flat_map(|query| query.subjects.iter().copied())
+            .flat_map(|query| query.subjects.person_ids().iter().copied())
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
             .collect()
+    }
+
+    #[must_use]
+    pub fn asks_about_the_tenant(&self) -> bool {
+        self.queries
+            .iter()
+            .any(|query| matches!(query.subjects, ValidatedSubjects::Tenant))
     }
 }
 
@@ -79,7 +90,7 @@ fn validate_query(
 ) -> Result<ValidatedDistribution, QueryError> {
     let metric_key = defined_metric(catalog, &query.metric)?;
     distributable(catalog, &metric_key)?;
-    let subjects = subjects(query.subjects)?;
+    let subjects = subjects(metric_entity_type(catalog, &metric_key)?, query.subjects)?;
     let (from, to) = window(&query.time.from, &query.time.to)?;
     let filters = filters(catalog, &metric_key, query.filters)?;
     let quantiles = query.quantiles.map(quantiles).transpose()?;
@@ -114,14 +125,21 @@ pub(in crate::domain::metric_query) fn distributable(
         .map_err(QueryError::NoDistribution)
 }
 
-/// A distribution reports the values a subject's own events carried, and a
-/// dataset records no event keyed by the tenant.
-fn subjects(subjects: Subjects) -> Result<Vec<Uuid>, QueryError> {
-    match subjects {
-        Subjects::Persons { ids } => person_ids(SUBJECTS_FIELD, ids),
-        Subjects::Tenant {} => Err(QueryError::Unanswerable {
-            reason: "a distribution reports the values of a subject's own events, and no event \
-                     is recorded against the tenant itself",
+/// A distribution reports the values one subject's own events carried, so it
+/// answers only where the subjects the question names are the grain the metric
+/// records.
+fn subjects(entity_type: EntityType, subjects: Subjects) -> Result<ValidatedSubjects, QueryError> {
+    match (entity_type, subjects) {
+        (EntityType::Person, Subjects::Persons { ids }) => {
+            Ok(ValidatedSubjects::Persons(person_ids(SUBJECTS_FIELD, ids)?))
+        }
+        (EntityType::Tenant, Subjects::Tenant {}) => Ok(ValidatedSubjects::Tenant),
+        (EntityType::Person, Subjects::Tenant {}) => Err(QueryError::Unanswerable {
+            reason: "a distribution reports the values of a subject's own events, and this \
+                     metric records no event against the tenant itself",
+        }),
+        (EntityType::Tenant, Subjects::Persons { .. }) => Err(QueryError::Unanswerable {
+            reason: PERSON_SUBJECTS_OVER_A_TENANT_METRIC,
         }),
     }
 }
@@ -170,7 +188,9 @@ fn quantiles(asked: Vec<f64>) -> Result<Vec<f64>, QueryError> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::super::super::catalog::product_metric_catalog;
-    use super::super::super::fixtures::{SHIPPED_DISTRIBUTION_METRIC, SHIPPED_METRIC};
+    use super::super::super::fixtures::{
+        SHIPPED_DISTRIBUTION_METRIC, SHIPPED_METRIC, SHIPPED_TENANT_DISTRIBUTION_METRIC,
+    };
     use super::*;
 
     fn catalog() -> &'static MetricCatalog {
@@ -315,7 +335,51 @@ mod tests {
         })))
         .expect("a repeated subject is one subject");
 
-        assert_eq!(validated.queries[0].subjects, vec![person()]);
+        assert_eq!(
+            validated.queries[0].subjects,
+            ValidatedSubjects::Persons(vec![person()])
+        );
         assert_eq!(validated.subject_ids(), vec![person()]);
+    }
+
+    #[test]
+    fn a_tenant_metric_distributes_the_tenants_own_events() {
+        let validated = validate(&query(&serde_json::json!({
+            "metric": SHIPPED_TENANT_DISTRIBUTION_METRIC,
+            "subjects": { "type": "tenant" },
+        })))
+        .expect("a tenant metric taken over per-row values distributes");
+
+        assert_eq!(validated.queries[0].subjects, ValidatedSubjects::Tenant);
+        assert!(validated.asks_about_the_tenant());
+        assert!(validated.subject_ids().is_empty());
+    }
+
+    #[test]
+    fn a_distribution_is_refused_where_the_subjects_are_not_the_grain_the_metric_records() {
+        let cases = [
+            (
+                "a tenant metric asked about a person",
+                serde_json::json!({
+                    "metric": SHIPPED_TENANT_DISTRIBUTION_METRIC,
+                    "subjects": { "type": "persons", "ids": [person().to_string()] },
+                }),
+            ),
+            (
+                "a person metric asked about the tenant",
+                serde_json::json!({
+                    "metric": SHIPPED_DISTRIBUTION_METRIC,
+                    "subjects": { "type": "tenant" },
+                }),
+            ),
+        ];
+
+        for (named, overrides) in cases {
+            let refused = validate(&query(&overrides)).expect_err(named);
+            assert!(
+                matches!(refused, QueryError::Unanswerable { .. }),
+                "{named}: {refused}"
+            );
+        }
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_query/fixtures.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/fixtures.rs
@@ -2,13 +2,37 @@
 
 use uuid::Uuid;
 
+use crate::domain::field_catalog::model::EntityType;
+
 use super::catalog::product_metric_catalog;
 
 pub const SHIPPED_METRIC: &str = "git.commits";
+/// A shipped metric whose values are keyed by the tenant rather than a person.
+pub const SHIPPED_TENANT_METRIC: &str = "ci.runs";
+/// A shipped tenant metric whose computation is taken over per-row values.
+pub const SHIPPED_TENANT_DISTRIBUTION_METRIC: &str = "ci.run_duration_min";
 /// A shipped metric whose computation is taken over per-row values.
 pub const SHIPPED_DISTRIBUTION_METRIC: &str = "git.pr_size";
 /// A shipped metric composing two inputs, so a page must be told which to read.
 pub const SHIPPED_RATIO_METRIC: &str = "git.merge_rate";
+
+/// The subjects a question about a shipped metric names, at the grain that
+/// metric records — so a sweep over every shipped metric asks each one a
+/// question it can answer rather than one its grain refuses.
+pub fn shipped_subjects(metric_key: &str) -> serde_json::Value {
+    let catalog = product_metric_catalog().expect("the shipped definitions load");
+    let metric = catalog
+        .metric(metric_key)
+        .unwrap_or_else(|| panic!("`{metric_key}` is shipped"));
+
+    match metric.entity_type {
+        EntityType::Person => serde_json::json!({
+            "type": "persons",
+            "ids": [Uuid::from_u128(1).to_string()],
+        }),
+        EntityType::Tenant => serde_json::json!({ "type": "tenant" }),
+    }
+}
 
 /// Every shipped metric beside the parts of its computation a page may read.
 pub fn shipped_input_roles() -> Vec<(&'static str, Vec<String>)> {

--- a/src/backend/services/analytics/src/domain/metric_query/question.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/question.rs
@@ -9,6 +9,7 @@ use chrono::NaiveDate;
 use uuid::Uuid;
 
 use crate::domain::compiler::request::DimensionFilter;
+use crate::domain::field_catalog::model::EntityType;
 
 use super::catalog::MetricCatalog;
 use super::dto::DimensionFilter as FilterDto;
@@ -35,6 +36,49 @@ pub const fn row_limit() -> usize {
 pub const fn query_row_limit() -> u64 {
     ROW_LIMIT as u64 + 1
 }
+
+/// Whose values a question turned out to be about, once the wire shape was
+/// parsed. INVARIANT: `Tenant` carries no id — the tenant a question is about
+/// is the caller's own, taken from the session and never from the request.
+#[derive(Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidatedSubjects {
+    Persons(Vec<Uuid>),
+    Tenant,
+}
+
+impl ValidatedSubjects {
+    /// The people this question names: what the visibility gate checks and what
+    /// the identity mapping is read for. Empty for a tenant question — there is
+    /// nobody to resolve and nobody's visibility to decide.
+    #[must_use]
+    pub fn person_ids(&self) -> &[Uuid] {
+        match self {
+            Self::Persons(ids) => ids,
+            Self::Tenant => &[],
+        }
+    }
+}
+
+/// What the metric's values are keyed by, taken from the catalogue.
+/// INVARIANT: `defined_metric` already refused a key the catalogue does not
+/// carry, so this resolves for every metric key that reached it.
+pub(super) fn metric_entity_type(
+    catalog: &MetricCatalog,
+    metric_key: &str,
+) -> Result<EntityType, QueryError> {
+    catalog
+        .metric(metric_key)
+        .map(|metric| metric.entity_type)
+        .ok_or_else(|| QueryError::UnknownMetric {
+            metric: metric_key.to_owned(),
+        })
+}
+
+/// The refusal a surface reporting one row per subject owes a question whose
+/// subjects are not the grain the metric records.
+pub(super) const PERSON_SUBJECTS_OVER_A_TENANT_METRIC: &str = "this metric measures the tenant rather than the people in it, so it is asked \
+     about the tenant and never about a person";
 
 /// How many questions one request may carry.
 pub(super) fn batch_size(asked: usize) -> Result<(), QueryError> {

--- a/src/backend/services/analytics/src/domain/metric_query/rows/cursor.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/rows/cursor.rs
@@ -68,7 +68,7 @@ pub(super) fn fingerprint(tenant_id: Uuid, request: &ValidatedRows) -> Result<St
     let asked = serde_json::json!({
         "tenant": tenant_id.to_string(),
         "metric": request.metric_key,
-        "subjects": request.subjects.iter().map(Uuid::to_string).collect::<Vec<_>>(),
+        "subjects": request.subjects,
         "from": request.from.to_string(),
         "to": request.to.to_string(),
         "filters": filters,
@@ -176,6 +176,7 @@ mod tests {
     use chrono::NaiveDate;
 
     use crate::domain::compiler::request::{DimensionFilter, SortDirection};
+    use crate::domain::metric_query::question::ValidatedSubjects;
 
     use super::super::super::fixtures::{SHIPPED_METRIC, offline_clickhouse, tenant};
     use super::super::validation::ValidatedSort;
@@ -191,7 +192,7 @@ mod tests {
     fn validated() -> ValidatedRows {
         ValidatedRows {
             metric_key: SHIPPED_METRIC.to_owned(),
-            subjects: vec![Uuid::from_u128(1)],
+            subjects: ValidatedSubjects::Persons(vec![Uuid::from_u128(1)]),
             from: NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
             to: NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
             filters: Vec::new(),

--- a/src/backend/services/analytics/src/domain/metric_query/rows/plan.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/rows/plan.rs
@@ -18,8 +18,14 @@ use crate::domain::identity_binding::{IdentitySet, identity_epoch, resolve_ident
 
 use super::super::catalog::MetricCatalog;
 use super::super::error::QueryError;
+use super::super::question::ValidatedSubjects;
 use super::cursor::Resume;
 use super::validation::ValidatedRows;
+
+/// What a page anchors on when no identity mapping was read for it. INVARIANT:
+/// the same value a mapping with no marker of its own contributes, so a tenant
+/// page and an unmarked person page anchor alike.
+const UNREAD_IDENTITY_EPOCH: u64 = 0;
 
 #[derive(Debug)]
 pub(super) enum PlannedPage {
@@ -42,20 +48,15 @@ pub(super) async fn plan(
     request: &ValidatedRows,
     resume: Option<&Resume>,
 ) -> Result<PlannedPage, QueryError> {
-    // INVARIANT: the marker is read beside the mapping it describes, so it is
-    // the epoch this page's pool was actually built from.
-    let (identities, epoch) = tokio::join!(
-        resolve_identities(clickhouse, tenant_id, &request.subjects),
-        identity_epoch(clickhouse, tenant_id)
-    );
-    let identities = identities.map_err(|error| {
-        tracing::error!(%error, "a page could not resolve the people it asks about");
-        QueryError::SubjectsUnresolved
-    })?;
-    let identity_epoch = epoch.map_err(|error| {
-        tracing::error!(%error, "a page could not mark the identity mapping it read");
-        QueryError::SubjectsUnresolved
-    })?;
+    let (identities, identity_epoch) = match &request.subjects {
+        // A tenant page attributes nothing through the identity mapping, so it
+        // reads neither the mapping nor its marker, and anchors on the epoch an
+        // unread mapping contributes.
+        ValidatedSubjects::Tenant => (BTreeMap::new(), UNREAD_IDENTITY_EPOCH),
+        ValidatedSubjects::Persons(people) => {
+            resolved_people(clickhouse, tenant_id, people).await?
+        }
+    };
 
     compile(
         catalog,
@@ -65,6 +66,31 @@ pub(super) async fn plan(
         resume,
         identity_epoch,
     )
+}
+
+/// The identities the page's people are known by, and the marker of the mapping
+/// that named them.
+async fn resolved_people(
+    clickhouse: &insight_clickhouse::Client,
+    tenant_id: Uuid,
+    people: &[Uuid],
+) -> Result<(BTreeMap<Uuid, IdentitySet>, u64), QueryError> {
+    // INVARIANT: the marker is read beside the mapping it describes, so it is
+    // the epoch this page's pool was actually built from.
+    let (identities, epoch) = tokio::join!(
+        resolve_identities(clickhouse, tenant_id, people),
+        identity_epoch(clickhouse, tenant_id)
+    );
+    let identities = identities.map_err(|error| {
+        tracing::error!(%error, "a page could not resolve the people it asks about");
+        QueryError::SubjectsUnresolved
+    })?;
+    let epoch = epoch.map_err(|error| {
+        tracing::error!(%error, "a page could not mark the identity mapping it read");
+        QueryError::SubjectsUnresolved
+    })?;
+
+    Ok((identities, epoch))
 }
 
 fn compile(
@@ -178,19 +204,24 @@ fn refused(error: CompileError) -> QueryError {
 
 /// INVARIANT: a person is carried with their own identities rather than merged
 /// into one list, because every row is keyed by the person it is credited to.
-fn entity_scope(subjects: &[Uuid], identities: &BTreeMap<Uuid, IdentitySet>) -> EntityScope {
-    EntityScope::People(
-        subjects
-            .iter()
-            .map(|id| ResolvedPerson {
-                person_ref: id.to_string(),
-                identities: identities
-                    .get(id)
-                    .map(IdentitySet::values)
-                    .unwrap_or_default(),
-            })
-            .collect(),
-    )
+fn entity_scope(
+    subjects: &ValidatedSubjects,
+    identities: &BTreeMap<Uuid, IdentitySet>,
+) -> EntityScope {
+    match subjects {
+        ValidatedSubjects::Tenant => EntityScope::Tenant,
+        ValidatedSubjects::Persons(ids) => EntityScope::People(
+            ids.iter()
+                .map(|id| ResolvedPerson {
+                    person_ref: id.to_string(),
+                    identities: identities
+                        .get(id)
+                        .map(IdentitySet::values)
+                        .unwrap_or_default(),
+                })
+                .collect(),
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -204,7 +235,8 @@ mod tests {
 
     use super::super::super::catalog::product_metric_catalog;
     use super::super::super::fixtures::{
-        SHIPPED_METRIC, SHIPPED_RATIO_METRIC, offline_clickhouse, shipped_input_roles, tenant,
+        SHIPPED_METRIC, SHIPPED_RATIO_METRIC, SHIPPED_TENANT_METRIC, offline_clickhouse,
+        shipped_input_roles, tenant,
     };
     use super::super::cursor::Anchor;
     use super::super::validation::ValidatedSort;
@@ -221,7 +253,7 @@ mod tests {
     fn request(metric_key: &str, input_role: &str) -> ValidatedRows {
         ValidatedRows {
             metric_key: metric_key.to_owned(),
-            subjects: vec![person()],
+            subjects: ValidatedSubjects::Persons(vec![person()]),
             from: NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
             to: NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
             filters: Vec::new(),
@@ -354,7 +386,7 @@ mod tests {
     #[test]
     fn a_page_one_of_whose_people_resolves_is_read_for_that_person() {
         let asked = ValidatedRows {
-            subjects: vec![person(), Uuid::from_u128(9)],
+            subjects: ValidatedSubjects::Persons(vec![person(), Uuid::from_u128(9)]),
             ..request(SHIPPED_METRIC, "value")
         };
 
@@ -510,6 +542,39 @@ mod tests {
         assert!(
             matches!(error, QueryError::UnknownSortColumn { .. }),
             "{error}"
+        );
+    }
+
+    #[test]
+    fn a_tenant_page_reads_no_identity_mapping_and_anchors_on_the_epoch_an_unread_one_contributes()
+    {
+        let mut asked = request(SHIPPED_TENANT_METRIC, "value");
+        asked.subjects = ValidatedSubjects::Tenant;
+
+        // A closed port answers nothing, so planning at all proves the page
+        // asked the mapping for neither its identities nor its marker.
+        let planned = futures::executor::block_on(plan(
+            catalog(),
+            &offline_clickhouse(),
+            tenant(),
+            &asked,
+            None,
+        ))
+        .expect("a tenant page needs no identity mapping");
+
+        let PlannedPage::Read {
+            compiled,
+            identity_epoch,
+        } = planned
+        else {
+            panic!("a tenant page reads the tenant's own rows");
+        };
+        assert_eq!(identity_epoch, UNREAD_IDENTITY_EPOCH);
+        assert!(!compiled.sql.contains("pool"), "{}", compiled.sql);
+        assert!(
+            compiled.sql.contains("entity_id AS entity_id"),
+            "a tenant page keys its rows by the tenant column itself: {}",
+            compiled.sql
         );
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_query/rows/service.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/rows/service.rs
@@ -144,6 +144,8 @@ fn paged(mut read: Vec<ReadRow>, page_size: u32) -> Page {
 mod tests {
     use chrono::NaiveDate;
 
+    use crate::domain::metric_query::question::ValidatedSubjects;
+
     use super::super::super::catalog::product_metric_catalog;
     use super::super::super::fixtures::{SHIPPED_METRIC, offline_clickhouse, tenant};
     use super::*;
@@ -185,7 +187,7 @@ mod tests {
     async fn a_position_issued_for_another_question_is_refused_before_anything_is_read() {
         let asked = |to: u32| ValidatedRows {
             metric_key: SHIPPED_METRIC.to_owned(),
-            subjects: vec![Uuid::from_u128(1)],
+            subjects: ValidatedSubjects::Persons(vec![Uuid::from_u128(1)]),
             from: NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
             to: NaiveDate::from_ymd_opt(2026, 1, to).expect("valid date"),
             filters: Vec::new(),

--- a/src/backend/services/analytics/src/domain/metric_query/rows/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/rows/validation.rs
@@ -7,14 +7,17 @@
 use std::collections::BTreeSet;
 
 use chrono::NaiveDate;
-use uuid::Uuid;
 
 use crate::domain::compiler::request::{DimensionFilter, SortDirection};
+use crate::domain::field_catalog::model::EntityType;
 
 use super::super::catalog::MetricCatalog;
 use super::super::dto::Subjects;
 use super::super::error::QueryError;
-use super::super::question::{defined_metric, filters, person_ids, window};
+use super::super::question::{
+    PERSON_SUBJECTS_OVER_A_TENANT_METRIC, ValidatedSubjects, defined_metric, filters,
+    metric_entity_type, person_ids, window,
+};
 use super::dto::{RowSort, RowsRequest, SortDirection as AskedDirection};
 
 /// The field a page names its people in.
@@ -27,7 +30,7 @@ const MAX_DISPLAY_DIMENSIONS: usize = 10;
 #[derive(Debug, PartialEq, Eq)]
 pub struct ValidatedRows {
     pub metric_key: String,
-    pub subjects: Vec<Uuid>,
+    pub subjects: ValidatedSubjects,
     pub from: NaiveDate,
     pub to: NaiveDate,
     pub filters: Vec<DimensionFilter>,
@@ -50,12 +53,19 @@ pub struct ValidatedSort {
     pub direction: SortDirection,
 }
 
+impl ValidatedRows {
+    #[must_use]
+    pub fn asks_about_the_tenant(&self) -> bool {
+        matches!(self.subjects, ValidatedSubjects::Tenant)
+    }
+}
+
 pub fn validate_request(
     catalog: &MetricCatalog,
     request: RowsRequest,
 ) -> Result<ValidatedRows, QueryError> {
     let metric_key = defined_metric(catalog, &request.metric)?;
-    let subjects = subjects(request.subjects)?;
+    let subjects = subjects(metric_entity_type(catalog, &metric_key)?, request.subjects)?;
     let (from, to) = window(&request.time.from, &request.time.to)?;
     let filters = filters(catalog, &metric_key, request.filters)?;
     let display_dimensions = display_dimensions(catalog, &metric_key, request.display_dimensions)?;
@@ -124,14 +134,20 @@ fn direction(asked: AskedDirection) -> SortDirection {
     }
 }
 
-/// A page reports the events credited to a subject, and a dataset records no
-/// event keyed by the tenant.
-fn subjects(subjects: Subjects) -> Result<Vec<Uuid>, QueryError> {
-    match subjects {
-        Subjects::Persons { ids } => person_ids(SUBJECTS_FIELD, ids),
-        Subjects::Tenant {} => Err(QueryError::Unanswerable {
-            reason: "a page reports the events credited to a subject, and no event is recorded \
-                     against the tenant itself",
+/// A page reports the events credited to a subject, so it answers only where
+/// the subjects the question names are the grain the metric records.
+fn subjects(entity_type: EntityType, subjects: Subjects) -> Result<ValidatedSubjects, QueryError> {
+    match (entity_type, subjects) {
+        (EntityType::Person, Subjects::Persons { ids }) => {
+            Ok(ValidatedSubjects::Persons(person_ids(SUBJECTS_FIELD, ids)?))
+        }
+        (EntityType::Tenant, Subjects::Tenant {}) => Ok(ValidatedSubjects::Tenant),
+        (EntityType::Person, Subjects::Tenant {}) => Err(QueryError::Unanswerable {
+            reason: "a page reports the events credited to a subject, and this metric records \
+                     no event against the tenant itself",
+        }),
+        (EntityType::Tenant, Subjects::Persons { .. }) => Err(QueryError::Unanswerable {
+            reason: PERSON_SUBJECTS_OVER_A_TENANT_METRIC,
         }),
     }
 }
@@ -219,9 +235,12 @@ fn named(roles: &[String]) -> String {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use uuid::Uuid;
+
     use super::super::super::catalog::product_metric_catalog;
     use super::super::super::fixtures::{
-        SHIPPED_METRIC, SHIPPED_RATIO_METRIC, shipped_input_roles,
+        SHIPPED_METRIC, SHIPPED_RATIO_METRIC, SHIPPED_TENANT_METRIC, shipped_input_roles,
+        shipped_subjects,
     };
     use super::*;
 
@@ -355,7 +374,10 @@ mod tests {
         }))
         .expect("a repeated subject is one subject");
 
-        assert_eq!(validated.subjects, vec![person()]);
+        assert_eq!(
+            validated.subjects,
+            ValidatedSubjects::Persons(vec![person()])
+        );
     }
 
     #[test]
@@ -374,7 +396,10 @@ mod tests {
     #[test]
     fn every_shipped_metric_pages_each_input_it_composes() {
         for (metric_key, roles) in shipped_input_roles() {
-            let unnamed = validate(&serde_json::json!({ "metric": metric_key }));
+            let unnamed = validate(&serde_json::json!({
+                "metric": metric_key,
+                "subjects": shipped_subjects(metric_key),
+            }));
             if roles.len() == 1 {
                 assert_eq!(
                     unnamed.map(|validated| validated.input_role).ok().as_ref(),
@@ -391,6 +416,7 @@ mod tests {
             for role in &roles {
                 let validated = validate(&serde_json::json!({
                     "metric": metric_key,
+                    "subjects": shipped_subjects(metric_key),
                     "input": role,
                 }));
 
@@ -481,6 +507,46 @@ mod tests {
                     "`{metric_key}` pages its `{role}` by event time"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn a_tenant_metric_pages_the_rows_behind_the_tenants_own_value() {
+        let validated = validate(&serde_json::json!({
+            "metric": SHIPPED_TENANT_METRIC,
+            "subjects": { "type": "tenant" },
+        }))
+        .expect("a tenant metric pages");
+
+        assert_eq!(validated.subjects, ValidatedSubjects::Tenant);
+        assert!(validated.asks_about_the_tenant());
+    }
+
+    #[test]
+    fn a_page_is_refused_where_the_subjects_are_not_the_grain_the_metric_records() {
+        let cases = [
+            (
+                "a tenant metric asked about a person",
+                serde_json::json!({
+                    "metric": SHIPPED_TENANT_METRIC,
+                    "subjects": { "type": "persons", "ids": [person().to_string()] },
+                }),
+            ),
+            (
+                "a person metric asked about the tenant",
+                serde_json::json!({
+                    "metric": SHIPPED_METRIC,
+                    "subjects": { "type": "tenant" },
+                }),
+            ),
+        ];
+
+        for (named, overrides) in cases {
+            let refused = validate(&overrides).expect_err(named);
+            assert!(
+                matches!(refused, QueryError::Unanswerable { .. }),
+                "{named}: {refused}"
+            );
         }
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_query/values/answerable.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/answerable.rs
@@ -2,7 +2,10 @@
 //! alone. INVARIANT: validation and the catalogue both decide here, so every
 //! combination advertised is one a request may name, and no other is.
 
+use crate::domain::field_catalog::model::EntityType;
+
 use super::super::error::QueryError;
+use super::super::question::PERSON_SUBJECTS_OVER_A_TENANT_METRIC;
 use super::dto::{CompareOffset, Fold, Grain};
 
 /// INVARIANT: these enumerate their enums; a variant added and not listed here
@@ -48,6 +51,9 @@ pub(super) enum SubjectsAsk {
 /// no dimension names — only the shape.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct Ask {
+    /// What the metric's values are keyed by, which decides whose subjects a
+    /// question about it may name.
+    pub entity_type: EntityType,
     pub grain: Grain,
     pub fold: Fold,
     pub split: SplitAsk,
@@ -83,27 +89,43 @@ pub(super) fn shape_of(ask: Ask) -> Result<QueryShape, QueryError> {
         }
     };
 
-    answerable_for(ask.subjects, shape)
+    answerable_for(ask.entity_type, ask.subjects, shape)
 }
 
-/// INVARIANT: a dataset records rows per observed person and never for the
-/// tenant, so a tenant-wide question must report no subject of its own.
-fn answerable_for(subjects: SubjectsAsk, shape: QueryShape) -> Result<QueryShape, QueryError> {
-    match (subjects, shape) {
-        (SubjectsAsk::Persons, _) | (SubjectsAsk::Tenant, QueryShape::CombinedSplit) => Ok(shape),
-        (
-            SubjectsAsk::Tenant,
-            QueryShape::SubjectTotal | QueryShape::SubjectSplit | QueryShape::SubjectSeries,
-        ) => Err(QueryError::Unanswerable {
-            reason: "no dataset records a row keyed by the tenant, so a tenant-wide question is \
-                     answered with its subjects folded together",
+/// Whose subjects a question may name is decided by what the metric's rows are
+/// keyed by: a person-grain metric answers about people and folds them together
+/// for a tenant-wide reading, while a tenant-grain metric records no person at
+/// all and answers only about the tenant.
+fn answerable_for(
+    entity_type: EntityType,
+    subjects: SubjectsAsk,
+    shape: QueryShape,
+) -> Result<QueryShape, QueryError> {
+    match (entity_type, subjects) {
+        (EntityType::Person, SubjectsAsk::Persons) | (EntityType::Tenant, SubjectsAsk::Tenant) => {
+            Ok(shape)
+        }
+        // A person-grain metric has no row keyed by the tenant, so a
+        // tenant-wide reading of it is its people folded together — which is
+        // reported per split group and never per subject.
+        (EntityType::Person, SubjectsAsk::Tenant) => match shape {
+            QueryShape::CombinedSplit => Ok(shape),
+            QueryShape::SubjectTotal | QueryShape::SubjectSplit | QueryShape::SubjectSeries => {
+                Err(QueryError::Unanswerable {
+                    reason: "no dataset records a row keyed by the tenant, so a tenant-wide \
+                             question is answered with its subjects folded together",
+                })
+            }
+        },
+        (EntityType::Tenant, SubjectsAsk::Persons) => Err(QueryError::Unanswerable {
+            reason: PERSON_SUBJECTS_OVER_A_TENANT_METRIC,
         }),
     }
 }
 
 /// Every question shape that is answerable at all for a metric, where
 /// `splittable` says whether the metric declares a dimension to break out by.
-fn answerable(splittable: bool) -> impl Iterator<Item = Ask> {
+fn answerable(entity_type: EntityType, splittable: bool) -> impl Iterator<Item = Ask> {
     let splits: &'static [SplitAsk] = if splittable {
         &[SplitAsk::None, SplitAsk::EveryGroup, SplitAsk::TopGroups]
     } else {
@@ -114,6 +136,7 @@ fn answerable(splittable: bool) -> impl Iterator<Item = Ask> {
         FOLDS.into_iter().flat_map(move |fold| {
             splits.iter().flat_map(move |split| {
                 SUBJECTS.into_iter().map(move |subjects| Ask {
+                    entity_type,
                     grain,
                     fold,
                     split: *split,
@@ -125,20 +148,30 @@ fn answerable(splittable: bool) -> impl Iterator<Item = Ask> {
 }
 
 /// The grains a metric's values may be asked at.
-pub(in crate::domain::metric_query) fn offered_grains(splittable: bool) -> Vec<Grain> {
+pub(in crate::domain::metric_query) fn offered_grains(
+    entity_type: EntityType,
+    splittable: bool,
+) -> Vec<Grain> {
     GRAINS
         .into_iter()
         .filter(|grain| {
-            answerable(splittable).any(|ask| ask.grain == *grain && shape_of(ask).is_ok())
+            answerable(entity_type, splittable)
+                .any(|ask| ask.grain == *grain && shape_of(ask).is_ok())
         })
         .collect()
 }
 
 /// The folds a metric's values may be asked with.
-pub(in crate::domain::metric_query) fn offered_folds(splittable: bool) -> Vec<Fold> {
+pub(in crate::domain::metric_query) fn offered_folds(
+    entity_type: EntityType,
+    splittable: bool,
+) -> Vec<Fold> {
     FOLDS
         .into_iter()
-        .filter(|fold| answerable(splittable).any(|ask| ask.fold == *fold && shape_of(ask).is_ok()))
+        .filter(|fold| {
+            answerable(entity_type, splittable)
+                .any(|ask| ask.fold == *fold && shape_of(ask).is_ok())
+        })
         .collect()
 }
 
@@ -155,6 +188,7 @@ mod tests {
 
     fn ask(grain: Grain, fold: Fold, split: SplitAsk) -> Ask {
         Ask {
+            entity_type: EntityType::Person,
             grain,
             fold,
             split,
@@ -162,18 +196,32 @@ mod tests {
         }
     }
 
+    fn tenant_metric(grain: Grain, fold: Fold, split: SplitAsk) -> Ask {
+        Ask {
+            entity_type: EntityType::Tenant,
+            subjects: SubjectsAsk::Tenant,
+            ..ask(grain, fold, split)
+        }
+    }
+
     #[test]
     fn a_metric_without_a_dimension_is_asked_per_subject_only() {
-        assert_eq!(offered_folds(false), vec![Fold::PerSubject]);
         assert_eq!(
-            offered_grains(false),
+            offered_folds(EntityType::Person, false),
+            vec![Fold::PerSubject]
+        );
+        assert_eq!(
+            offered_grains(EntityType::Person, false),
             vec![Grain::Total, Grain::Day, Grain::Week, Grain::Month]
         );
     }
 
     #[test]
     fn a_dimension_is_what_makes_a_combined_fold_answerable() {
-        assert_eq!(offered_folds(true), vec![Fold::PerSubject, Fold::Combined]);
+        assert_eq!(
+            offered_folds(EntityType::Person, true),
+            vec![Fold::PerSubject, Fold::Combined]
+        );
 
         assert!(shape_of(ask(Grain::Total, Fold::Combined, SplitAsk::None)).is_err());
         assert_eq!(
@@ -192,7 +240,7 @@ mod tests {
     }
 
     #[test]
-    fn only_a_combined_split_is_answered_for_the_tenant() {
+    fn only_a_combined_split_is_answered_for_the_tenant_over_a_person_metric() {
         for split in [SplitAsk::None, SplitAsk::EveryGroup] {
             assert!(
                 shape_of(Ask {
@@ -212,5 +260,63 @@ mod tests {
             .ok(),
             Some(QueryShape::CombinedSplit)
         );
+    }
+
+    #[test]
+    fn a_tenant_metric_answers_the_tenant_at_every_shape_its_own_grain_allows() {
+        let cases = [
+            (
+                tenant_metric(Grain::Total, Fold::PerSubject, SplitAsk::None),
+                QueryShape::SubjectTotal,
+            ),
+            (
+                tenant_metric(Grain::Total, Fold::PerSubject, SplitAsk::EveryGroup),
+                QueryShape::SubjectSplit,
+            ),
+            (
+                tenant_metric(Grain::Total, Fold::Combined, SplitAsk::EveryGroup),
+                QueryShape::CombinedSplit,
+            ),
+            (
+                tenant_metric(Grain::Week, Fold::PerSubject, SplitAsk::None),
+                QueryShape::SubjectSeries,
+            ),
+        ];
+
+        for (asked, expected) in cases {
+            assert_eq!(shape_of(asked).ok(), Some(expected), "{asked:?}");
+        }
+    }
+
+    #[test]
+    fn a_tenant_metric_refuses_a_question_naming_people() {
+        for split in [SplitAsk::None, SplitAsk::EveryGroup] {
+            for grain in [Grain::Total, Grain::Month] {
+                assert!(
+                    shape_of(Ask {
+                        subjects: SubjectsAsk::Persons,
+                        ..tenant_metric(grain, Fold::PerSubject, split)
+                    })
+                    .is_err(),
+                    "should refuse: {grain:?} {split:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_tenant_metric_offers_the_same_grains_and_folds_a_person_metric_does() {
+        for splittable in [false, true] {
+            assert_eq!(
+                offered_grains(EntityType::Tenant, splittable),
+                offered_grains(EntityType::Person, splittable),
+                "grains, splittable={splittable}"
+            );
+            assert_eq!(
+                offered_folds(EntityType::Tenant, splittable),
+                offered_folds(EntityType::Person, splittable),
+                "folds, splittable={splittable}"
+            );
+        }
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_query/values/assemble.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/assemble.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::domain::compiler::dimensions::dimension_aliases;
+use crate::domain::field_catalog::model::EntityType;
 
 use super::super::error::QueryError;
 use super::dto::{
@@ -61,10 +62,11 @@ pub(super) fn subject_values(
     rows: Vec<SubjectValueRow>,
     compared: Option<Vec<SubjectValueRow>>,
     dimensions: &[String],
+    entity_type: EntityType,
 ) -> Result<ResultBody, QueryError> {
-    let mut values = subject_value_index(rows, dimensions)?;
+    let mut values = subject_value_index(rows, dimensions, entity_type)?;
     if let Some(compared) = compared {
-        let previous = subject_value_index(compared, dimensions)?;
+        let previous = subject_value_index(compared, dimensions, entity_type)?;
         attach_comparisons(&mut values, &previous);
     }
 
@@ -76,6 +78,7 @@ pub(super) fn subject_values(
 fn subject_value_index(
     rows: Vec<SubjectValueRow>,
     dimensions: &[String],
+    entity_type: EntityType,
 ) -> Result<BTreeMap<(String, GroupOrder), GroupedValue>, QueryError> {
     let mut values = BTreeMap::new();
     for row in rows {
@@ -83,7 +86,7 @@ fn subject_value_index(
         values.insert(
             (row.entity_id.clone(), order),
             GroupedValue {
-                subject: Some(row.entity_id),
+                subject: reported_subject(entity_type, row.entity_id),
                 group,
                 value: row.value,
                 compare: None,
@@ -156,6 +159,16 @@ fn comparison(current: Option<f64>, previous: Option<f64>) -> Comparison {
 
 /// INVARIANT: the total arrives as its own row, so it stays absent until that
 /// row is read rather than being derived from the points.
+/// A person-grain row names the person it belongs to. A tenant-grain row
+/// belongs to the tenant the question was asked in, which the caller already
+/// named, so echoing its id back states nothing.
+fn reported_subject(entity_type: EntityType, entity_id: String) -> Option<String> {
+    match entity_type {
+        EntityType::Person => Some(entity_id),
+        EntityType::Tenant => None,
+    }
+}
+
 #[derive(Debug, Default)]
 struct SeriesUnderway {
     group: Option<Group>,
@@ -167,6 +180,7 @@ pub(super) fn subject_series(
     rows: Vec<SubjectSeriesRow>,
     compared: Option<Vec<SubjectSeriesRow>>,
     dimensions: &[String],
+    entity_type: EntityType,
 ) -> Result<ResultBody, QueryError> {
     let series = series_index(rows, dimensions)?;
     let previous = compared
@@ -185,7 +199,7 @@ pub(super) fn subject_series(
                     )
                 });
                 GroupedSeries {
-                    subject: Some(key.0),
+                    subject: reported_subject(entity_type, key.0),
                     group: underway.group,
                     points: underway.points,
                     total: underway.total,
@@ -339,6 +353,7 @@ mod tests {
             }],
             None,
             &[],
+            EntityType::Person,
         )
         .expect("an ungrouped row needs no dimension column");
 
@@ -363,6 +378,7 @@ mod tests {
             }],
             None,
             &dimensions(),
+            EntityType::Person,
         )
         .expect("the row carries its dimension");
 
@@ -387,6 +403,7 @@ mod tests {
             }],
             None,
             &dimensions(),
+            EntityType::Person,
         );
 
         assert!(matches!(
@@ -513,6 +530,7 @@ mod tests {
             ],
             None,
             &[],
+            EntityType::Person,
         )
         .expect("an ungrouped series needs no dimension column");
 
@@ -569,8 +587,10 @@ mod tests {
             },
         ];
 
-        let series =
-            series_of(subject_series(rows, None, &dimensions()).expect("every row groups"));
+        let series = series_of(
+            subject_series(rows, None, &dimensions(), EntityType::Person)
+                .expect("every row groups"),
+        );
 
         assert_eq!(
             series
@@ -632,6 +652,7 @@ mod tests {
             ],
             Some(vec![value_row("person-1", Some(3.0))]),
             &[],
+            EntityType::Person,
         )
         .expect("both windows assemble");
 
@@ -664,8 +685,13 @@ mod tests {
 
     #[test]
     fn a_question_that_asked_for_no_comparison_carries_none() {
-        let body = subject_values(vec![value_row("person-1", Some(9.0))], None, &[])
-            .expect("one window assembles");
+        let body = subject_values(
+            vec![value_row("person-1", Some(9.0))],
+            None,
+            &[],
+            EntityType::Person,
+        )
+        .expect("one window assembles");
 
         assert_eq!(values_of(body)[0].compare, None);
     }
@@ -696,7 +722,8 @@ mod tests {
         };
 
         let series = series_of(
-            subject_series(window(8.0), Some(window(2.0)), &[]).expect("both windows assemble"),
+            subject_series(window(8.0), Some(window(2.0)), &[], EntityType::Person)
+                .expect("both windows assemble"),
         );
 
         assert_eq!(
@@ -724,9 +751,51 @@ mod tests {
             }],
             None,
             &[],
+            EntityType::Person,
         )
         .expect("a series without its total row still reports its points");
 
         assert_eq!(series_of(body)[0].total, None);
+    }
+
+    #[test]
+    fn a_tenant_answer_carries_no_subject_because_the_question_already_named_the_tenant() {
+        let body = subject_values(
+            vec![value_row("acme-tenant", Some(4.0))],
+            None,
+            &[],
+            EntityType::Tenant,
+        )
+        .expect("a tenant total assembles");
+
+        assert_eq!(values_of(body)[0].subject, None);
+    }
+
+    #[test]
+    fn a_tenant_series_carries_no_subject_either() {
+        let rows = vec![
+            SubjectSeriesRow {
+                entity_id: "acme-tenant".to_owned(),
+                bucket_start: "2026-01-01".to_owned(),
+                value: Some(2.0),
+                is_total: 0,
+                rank: None,
+                remainder: 0,
+                columns: BTreeMap::new(),
+            },
+            SubjectSeriesRow {
+                entity_id: "acme-tenant".to_owned(),
+                bucket_start: "1970-01-01".to_owned(),
+                value: Some(2.0),
+                is_total: 1,
+                rank: None,
+                remainder: 0,
+                columns: BTreeMap::new(),
+            },
+        ];
+
+        let body = subject_series(rows, None, &[], EntityType::Tenant).expect("a series assembles");
+
+        assert_eq!(series_of(body)[0].subject, None);
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_query/values/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/mod.rs
@@ -22,6 +22,8 @@ mod fixtures {
     use chrono::NaiveDate;
     use uuid::Uuid;
 
+    use crate::domain::field_catalog::model::EntityType;
+
     use super::super::fixtures::SHIPPED_METRIC;
     use super::dto::Grain;
     use super::validation::{QueryShape, ValidatedQuery, ValidatedSplit, ValidatedSubjects};
@@ -29,6 +31,7 @@ mod fixtures {
     pub fn validated(shape: QueryShape, grain: Grain, dimensions: &[&str]) -> ValidatedQuery {
         ValidatedQuery {
             metric_key: SHIPPED_METRIC.to_owned(),
+            entity_type: EntityType::Person,
             subjects: ValidatedSubjects::Persons(vec![Uuid::from_u128(1)]),
             from: NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
             to: NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),

--- a/src/backend/services/analytics/src/domain/metric_query/values/plan.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/plan.rs
@@ -13,6 +13,7 @@ use crate::domain::compiler::request::{
     MetricQuery, RankedGroup, ResolvedPerson, SubjectSeriesView, SubjectSplitView, ViewKind,
 };
 use crate::domain::compiler::sql::CompiledMeasureQuery;
+use crate::domain::field_catalog::model::EntityType;
 use crate::domain::identity_binding::{IdentitySet, resolve_all_identities, resolve_identities};
 
 use super::super::catalog::MetricCatalog;
@@ -79,7 +80,7 @@ pub(super) async fn plan(
     let mut rankings: BTreeMap<RankingKey, Vec<RankedGroup>> = BTreeMap::new();
     let mut compiled = Vec::with_capacity(batch.queries.len());
     for query in &batch.queries {
-        let scope = entity_scope(&query.subjects, &identities, &tenant);
+        let scope = entity_scope(query, &identities, &tenant);
         if !scope.reaches_any_row() {
             compiled.push(PlannedQuery::NoIdentities);
             continue;
@@ -203,18 +204,19 @@ async fn identities(
 }
 
 /// Everyone the tenant's identity mapping knows, read once for the whole
-/// request and only when a question asks about the tenant.
+/// request and only when a question folds the tenant's people together.
 ///
-/// INVARIANT: no dataset records a row keyed by the tenant, so a tenant-wide
-/// value is its people's rows folded together. Reading them through the
-/// mapping is what makes the fold count people rather than source identities,
-/// and what leaves out the identities the mapping resolves nobody for.
+/// INVARIANT: a person-grain dataset records no row keyed by the tenant, so a
+/// tenant-wide value of one is its people's rows folded together. Reading them
+/// through the mapping is what makes the fold count people rather than source
+/// identities, and what leaves out the identities the mapping resolves nobody
+/// for.
 async fn tenant_pool(
     clickhouse: &insight_clickhouse::Client,
     tenant_id: Uuid,
     batch: &ValidatedBatch,
 ) -> Result<Vec<ResolvedPerson>, QueryError> {
-    if !batch.asks_about_the_tenant() {
+    if !batch.folds_the_tenants_people() {
         return Ok(Vec::new());
     }
 
@@ -239,27 +241,32 @@ async fn tenant_pool(
 
 /// INVARIANT: a person is carried with their own identities rather than merged
 /// into one list, because the answer is keyed per person. A tenant-wide
-/// question carries the whole tenant's people for the same reason: what it
-/// reports as having contributed is people, not the identities they are
-/// recorded under.
+/// reading of a person-grain metric carries the whole tenant's people for the
+/// same reason: what it reports as having contributed is people, not the
+/// identities they are recorded under.
 fn entity_scope(
-    subjects: &ValidatedSubjects,
+    query: &ValidatedQuery,
     identities: &BTreeMap<Uuid, IdentitySet>,
     tenant: &[ResolvedPerson],
 ) -> EntityScope {
-    match subjects {
-        ValidatedSubjects::Tenant => EntityScope::People(tenant.to_vec()),
-        ValidatedSubjects::Persons(ids) => EntityScope::People(
-            ids.iter()
-                .map(|id| ResolvedPerson {
-                    person_ref: id.to_string(),
-                    identities: identities
-                        .get(id)
-                        .map(IdentitySet::values)
-                        .unwrap_or_default(),
-                })
-                .collect(),
-        ),
+    match query.entity_type {
+        // INVARIANT: a tenant-grain metric records one row per tenant, so
+        // tenancy is the whole narrowing and there is nobody to resolve.
+        EntityType::Tenant => EntityScope::Tenant,
+        EntityType::Person => match &query.subjects {
+            ValidatedSubjects::Tenant => EntityScope::People(tenant.to_vec()),
+            ValidatedSubjects::Persons(ids) => EntityScope::People(
+                ids.iter()
+                    .map(|id| ResolvedPerson {
+                        person_ref: id.to_string(),
+                        identities: identities
+                            .get(id)
+                            .map(IdentitySet::values)
+                            .unwrap_or_default(),
+                    })
+                    .collect(),
+            ),
+        },
     }
 }
 
@@ -328,7 +335,9 @@ fn scoped_refs(scope: &EntityScope) -> Vec<String> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::super::super::catalog::product_metric_catalog;
-    use super::super::super::fixtures::{SHIPPED_METRIC, offline_clickhouse};
+    use super::super::super::fixtures::{
+        SHIPPED_METRIC, SHIPPED_TENANT_METRIC, offline_clickhouse,
+    };
     use super::super::fixtures::validated;
     use super::*;
     use crate::domain::compiler::sql::QueryParam;
@@ -346,6 +355,16 @@ mod tests {
             person_ref: person().to_string(),
             identities: vec!["dev@example.com".to_owned()],
         }])
+    }
+
+    /// The question `entity_scope` is asked about, stripped to what decides the
+    /// scope: what the metric's values are keyed by, and whose values it names.
+    fn asking(entity_type: EntityType, subjects: ValidatedSubjects) -> ValidatedQuery {
+        ValidatedQuery {
+            entity_type,
+            subjects,
+            ..validated(QueryShape::SubjectTotal, Grain::Total, &[])
+        }
     }
 
     /// The tenant's mapping as one pooled person, so a tenant-wide read has
@@ -443,7 +462,7 @@ mod tests {
     fn a_tenant_question_folds_the_tenants_people_and_counts_them_rather_than_their_identities() {
         let query = validated(QueryShape::CombinedSplit, Grain::Total, &["repository"]);
         let scope = entity_scope(
-            &ValidatedSubjects::Tenant,
+            &asking(EntityType::Person, ValidatedSubjects::Tenant),
             &BTreeMap::new(),
             &tenant_people(),
         );
@@ -474,12 +493,47 @@ mod tests {
     #[test]
     fn a_tenant_question_reaches_only_the_people_the_mapping_resolves() {
         let scope = entity_scope(
-            &ValidatedSubjects::Tenant,
+            &asking(EntityType::Person, ValidatedSubjects::Tenant),
             &BTreeMap::new(),
             &tenant_people(),
         );
 
         assert_eq!(scope, EntityScope::People(tenant_people()));
+    }
+
+    /// A tenant-grain metric records one row per tenant, so its values need no
+    /// pool: there is nobody to attribute a row to.
+    #[test]
+    fn a_tenant_grain_metric_reads_under_tenancy_alone_and_opens_no_pool() {
+        let query = ValidatedQuery {
+            metric_key: SHIPPED_TENANT_METRIC.to_owned(),
+            ..asking(EntityType::Tenant, ValidatedSubjects::Tenant)
+        };
+
+        let scope = entity_scope(&query, &BTreeMap::new(), &tenant_people());
+
+        assert_eq!(scope, EntityScope::Tenant);
+        assert!(
+            !compiled(&query, &scope).sql.contains("pool"),
+            "{}",
+            compiled(&query, &scope).sql
+        );
+    }
+
+    #[tokio::test]
+    async fn a_tenant_grain_question_never_enumerates_the_tenants_people() {
+        let batch = ValidatedBatch {
+            queries: vec![ValidatedQuery {
+                metric_key: SHIPPED_TENANT_METRIC.to_owned(),
+                ..asking(EntityType::Tenant, ValidatedSubjects::Tenant)
+            }],
+        };
+
+        let pooled = tenant_pool(&offline_clickhouse(), tenant(), &batch)
+            .await
+            .expect("a tenant-grain question resolves nobody");
+
+        assert!(pooled.is_empty());
     }
 
     #[tokio::test]
@@ -552,7 +606,10 @@ mod tests {
         ]);
 
         let scope = entity_scope(
-            &ValidatedSubjects::Persons(vec![alice, bob]),
+            &asking(
+                EntityType::Person,
+                ValidatedSubjects::Persons(vec![alice, bob]),
+            ),
             &resolved,
             &[],
         );
@@ -582,7 +639,14 @@ mod tests {
             },
         )]);
 
-        let scope = entity_scope(&ValidatedSubjects::Persons(vec![person()]), &resolved, &[]);
+        let scope = entity_scope(
+            &asking(
+                EntityType::Person,
+                ValidatedSubjects::Persons(vec![person()]),
+            ),
+            &resolved,
+            &[],
+        );
 
         assert_eq!(
             scope,
@@ -596,7 +660,10 @@ mod tests {
     #[test]
     fn a_person_the_mapping_answers_nothing_for_is_named_with_no_identity_at_all() {
         let scope = entity_scope(
-            &ValidatedSubjects::Persons(vec![person()]),
+            &asking(
+                EntityType::Person,
+                ValidatedSubjects::Persons(vec![person()]),
+            ),
             &BTreeMap::new(),
             &[],
         );

--- a/src/backend/services/analytics/src/domain/metric_query/values/service.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/service.rs
@@ -92,7 +92,7 @@ async fn body(
         QueryShape::SubjectTotal | QueryShape::SubjectSplit => {
             let (rows, compared) =
                 read_both::<SubjectValueRow>(clickhouse, planned, &comment).await?;
-            subject_values(rows, compared, dimensions)
+            subject_values(rows, compared, dimensions, query.entity_type)
         }
         QueryShape::CombinedSplit => {
             let (rows, compared) =
@@ -102,7 +102,7 @@ async fn body(
         QueryShape::SubjectSeries => {
             let (rows, compared) =
                 read_both::<SubjectSeriesRow>(clickhouse, planned, &comment).await?;
-            subject_series(rows, compared, dimensions)
+            subject_series(rows, compared, dimensions, query.entity_type)
         }
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_query/values/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/validation.rs
@@ -9,16 +9,20 @@ use chrono::{Days, Months, NaiveDate};
 use uuid::Uuid;
 
 use crate::domain::compiler::request::DimensionFilter;
+use crate::domain::field_catalog::model::EntityType;
 
 use super::super::catalog::MetricCatalog;
 use super::super::dto::Subjects;
 use super::super::error::QueryError;
-use super::super::question::{batch_size, defined_metric, filters, person_ids, window};
+use super::super::question::{
+    batch_size, defined_metric, filters, metric_entity_type, person_ids, window,
+};
 use super::answerable::{Ask, SplitAsk, SubjectsAsk, shape_of};
 use super::dto::{
     Compare, CompareOffset, Fold, Grain, Split, SplitLimit, ValuesQuery, ValuesRequest,
 };
 
+pub use super::super::question::ValidatedSubjects;
 pub use super::answerable::QueryShape;
 
 const MAX_SPLIT_DIMENSIONS: usize = 10;
@@ -26,12 +30,6 @@ const MAX_SPLIT_TOP: u32 = 50;
 
 /// The field a values question names its people in.
 const SUBJECTS_FIELD: &str = "queries.subjects.ids";
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum ValidatedSubjects {
-    Persons(Vec<Uuid>),
-    Tenant,
-}
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ValidatedSplitLimit {
@@ -57,6 +55,9 @@ pub struct ComparedWindow {
 #[derive(Debug, PartialEq)]
 pub struct ValidatedQuery {
     pub metric_key: String,
+    /// What the metric's values are keyed by, carried from the catalogue so
+    /// the answer names a subject only where one exists.
+    pub entity_type: EntityType,
     pub subjects: ValidatedSubjects,
     pub from: NaiveDate,
     pub to: NaiveDate,
@@ -103,6 +104,16 @@ impl ValidatedBatch {
             .iter()
             .any(|query| matches!(query.subjects, ValidatedSubjects::Tenant))
     }
+
+    /// Whether any question reads a person-grain metric tenant-wide, which is
+    /// the one shape answered by folding the tenant's whole roster of people.
+    #[must_use]
+    pub fn folds_the_tenants_people(&self) -> bool {
+        self.queries.iter().any(|query| {
+            query.entity_type == EntityType::Person
+                && matches!(query.subjects, ValidatedSubjects::Tenant)
+        })
+    }
 }
 
 pub fn validate_request(
@@ -125,6 +136,7 @@ fn validate_query(
     query: ValuesQuery,
 ) -> Result<ValidatedQuery, QueryError> {
     let metric_key = defined_metric(catalog, &query.metric)?;
+    let entity_type = metric_entity_type(catalog, &metric_key)?;
     let subjects = subjects(query.subjects)?;
     let (from, to) = window(&query.time.from, &query.time.to)?;
     let filters = filters(catalog, &metric_key, query.filters)?;
@@ -136,10 +148,17 @@ fn validate_query(
         .compare
         .map(|compare| compared_window(from, to, compare))
         .transpose()?;
-    let shape = shape(query.time.grain, query.fold, split.as_ref(), &subjects)?;
+    let shape = shape(
+        entity_type,
+        query.time.grain,
+        query.fold,
+        split.as_ref(),
+        &subjects,
+    )?;
 
     Ok(ValidatedQuery {
         metric_key,
+        entity_type,
         subjects,
         from,
         to,
@@ -263,6 +282,7 @@ fn validate_limit(
 /// The question stripped to its shape, so answerability is decided by the one
 /// predicate the catalogue also reads.
 fn shape(
+    entity_type: EntityType,
     grain: Grain,
     fold: Fold,
     split: Option<&ValidatedSplit>,
@@ -279,6 +299,7 @@ fn shape(
     };
 
     shape_of(Ask {
+        entity_type,
         grain,
         fold,
         split,
@@ -290,7 +311,7 @@ fn shape(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::super::super::catalog::product_metric_catalog;
-    use super::super::super::fixtures::SHIPPED_METRIC;
+    use super::super::super::fixtures::{SHIPPED_METRIC, SHIPPED_TENANT_METRIC};
     use super::super::super::question::{
         DATE_FORMAT, MAX_FILTER_VALUE_BYTES, MAX_FILTER_VALUES, MAX_FILTERS, MAX_QUERIES,
         MAX_SUBJECTS,
@@ -624,6 +645,7 @@ mod tests {
             validated,
             ValidatedQuery {
                 metric_key: SHIPPED_METRIC.to_owned(),
+                entity_type: EntityType::Person,
                 subjects: ValidatedSubjects::Persons(vec![person()]),
                 from: NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
                 to: NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
@@ -896,5 +918,95 @@ mod tests {
             validated.subjects,
             ValidatedSubjects::Persons(vec![person()])
         );
+    }
+
+    fn tenant_query(grain: &str, fold: &str, split: serde_json::Value) -> serde_json::Value {
+        let mut query = serde_json::json!({
+            "metric": SHIPPED_TENANT_METRIC,
+            "subjects": { "type": "tenant" },
+            "time": { "from": "2026-01-01", "to": "2026-01-31", "grain": grain },
+            "fold": fold,
+        });
+        if !split.is_null() {
+            query["split"] = split;
+        }
+        query
+    }
+
+    #[test]
+    fn a_tenant_metric_is_answered_about_the_tenant_at_every_shape_a_person_metric_offers() {
+        let cases = [
+            (
+                tenant_query("total", "per_subject", serde_json::Value::Null),
+                QueryShape::SubjectTotal,
+            ),
+            (
+                tenant_query("total", "per_subject", split(None)),
+                QueryShape::SubjectSplit,
+            ),
+            (
+                tenant_query("total", "combined", split(None)),
+                QueryShape::CombinedSplit,
+            ),
+            (
+                tenant_query("week", "per_subject", serde_json::Value::Null),
+                QueryShape::SubjectSeries,
+            ),
+        ];
+
+        for (query, expected) in cases {
+            let named = query.to_string();
+            let validated = one(query).unwrap_or_else(|error| panic!("{named}: {error}"));
+
+            assert_eq!(validated.shape, expected, "{named}");
+            assert_eq!(validated.subjects, ValidatedSubjects::Tenant, "{named}");
+            assert_eq!(validated.entity_type, EntityType::Tenant, "{named}");
+        }
+    }
+
+    #[test]
+    fn a_tenant_metric_refuses_a_question_that_names_a_person() {
+        let mut query = tenant_query("total", "per_subject", serde_json::Value::Null);
+        query["subjects"] = serde_json::json!({
+            "type": "persons",
+            "ids": [person().to_string()],
+        });
+
+        let refused = one(query).expect_err("a tenant metric measures no person");
+
+        assert!(
+            matches!(refused, QueryError::Unanswerable { .. }),
+            "{refused}"
+        );
+    }
+
+    #[test]
+    fn a_person_metric_asked_about_the_tenant_still_answers_only_a_combined_split() {
+        let mut folded = persons_query("total", "combined", split(None));
+        folded["subjects"] = serde_json::json!({ "type": "tenant" });
+        let mut per_subject = persons_query("total", "per_subject", serde_json::Value::Null);
+        per_subject["subjects"] = serde_json::json!({ "type": "tenant" });
+
+        assert_eq!(
+            one(folded)
+                .expect("a person metric folds its people for the tenant")
+                .shape,
+            QueryShape::CombinedSplit
+        );
+        assert!(matches!(
+            one(per_subject).expect_err("the tenant is not a subject of a person metric"),
+            QueryError::Unanswerable { .. }
+        ));
+    }
+
+    #[test]
+    fn a_tenant_question_names_no_person_for_the_visibility_gate_to_check() {
+        let batch = request(serde_json::json!({
+            "queries": [tenant_query("total", "per_subject", serde_json::Value::Null)],
+        }))
+        .expect("a tenant metric answers about the tenant");
+
+        assert!(batch.subject_ids().is_empty());
+        assert!(batch.asks_about_the_tenant());
     }
 }

--- a/src/backend/services/analytics/src/domain/person_visibility.rs
+++ b/src/backend/services/analytics/src/domain/person_visibility.rs
@@ -13,6 +13,10 @@ pub(crate) async fn authorize_person_ids(
     authorization: Option<&str>,
     person_ids: &[Uuid],
 ) -> Result<(), CanonicalError> {
+    if person_ids.is_empty() {
+        return Ok(());
+    }
+
     if ctx.subject_type() == Some(SERVICE_SUBJECT_TYPE) {
         return Ok(());
     }

--- a/src/ingestion/dbt/tests/gold/assert_ai_seat_days_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_ai_seat_days_unique.sql
@@ -1,0 +1,11 @@
+-- One reading per seat per day: the step between readings is only a day's spend
+-- while the day holds a single one.
+SELECT
+    tenant_id,
+    source_id,
+    account_id,
+    snapshot_date,
+    count() AS row_count
+FROM {{ ref('ai_seat_days') }}
+GROUP BY tenant_id, source_id, account_id, snapshot_date
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_ai_seat_months_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_ai_seat_months_unique.sql
@@ -1,0 +1,11 @@
+-- A seat is unique only within the connector instance that reported it, and it
+-- is priced once per billing month.
+SELECT
+    tenant_id,
+    source_id,
+    account_id,
+    period_month,
+    count() AS row_count
+FROM {{ ref('ai_seat_months') }}
+GROUP BY tenant_id, source_id, account_id, period_month
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_ai_usage_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_ai_usage_unique.sql
@@ -1,0 +1,14 @@
+-- One row per person, day, tool, surface and seat state: the counters of every
+-- connector instance reporting that combination are summed into it, never
+-- repeated across it.
+SELECT
+    tenant_id,
+    email,
+    usage_date,
+    tool,
+    surface,
+    seat_status,
+    count() AS row_count
+FROM {{ ref('ai_usage') }}
+GROUP BY tenant_id, email, usage_date, tool, surface, seat_status
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_ci_commits_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_ci_commits_unique.sql
@@ -1,0 +1,14 @@
+-- Build-integrity check (untagged → error severity under `dbt build`).
+-- One row per commit within the repository that collected it. A commit reached
+-- through two branches is one commit; counting it twice overstates the
+-- denominator the run-to-commit coverage reading divides by.
+SELECT
+    tenant_id,
+    source_id,
+    project_key,
+    repo_slug,
+    commit_hash,
+    count() AS row_count
+FROM {{ ref('ci_commits') }}
+GROUP BY tenant_id, source_id, project_key, repo_slug, commit_hash
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_ci_datasets_entity_id_is_the_tenant.sql
+++ b/src/ingestion/dbt/tests/gold/assert_ci_datasets_entity_id_is_the_tenant.sql
@@ -1,0 +1,20 @@
+-- Build-integrity check (untagged → error severity under `dbt build`).
+-- A tenant-grain dataset keys every row by the tenant itself. The semantic
+-- compiler groups these relations by entity_id and never joins an identity
+-- pool, so an entity_id that is not the tenant id would split one tenant's
+-- value into rows no caller can ask for.
+{% set tenant_grain_models = ['ci_runs', 'ci_deployments', 'ci_commits'] %}
+
+{% for model in tenant_grain_models %}
+SELECT
+    '{{ model }}' AS dataset,
+    tenant_id,
+    entity_id,
+    count() AS row_count
+FROM {{ ref(model) }}
+WHERE entity_id != tenant_id
+GROUP BY tenant_id, entity_id
+{% if not loop.last %}
+UNION ALL
+{% endif %}
+{% endfor %}

--- a/src/ingestion/dbt/tests/gold/assert_ci_deployments_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_ci_deployments_unique.sql
@@ -1,0 +1,12 @@
+-- Build-integrity check (untagged → error severity under `dbt build`).
+-- One row per deployment: the status events fold to one outcome before the
+-- join, so a second row means a deployment gained an outcome per status event
+-- and the deployment count is inflated.
+SELECT
+    tenant_id,
+    source_id,
+    deployment_id,
+    count() AS row_count
+FROM {{ ref('ci_deployments') }}
+GROUP BY tenant_id, source_id, deployment_id
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_ci_runs_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_ci_runs_unique.sql
@@ -1,0 +1,13 @@
+-- Build-integrity check (untagged → error severity under `dbt build`).
+-- One row per run: the model's `LIMIT 1 BY` keeps the latest attempt and drops
+-- the rest, so a second row means a retried run is being counted once per
+-- attempt and every run measure over it is inflated.
+SELECT
+    tenant_id,
+    source_id,
+    repository_value,
+    run_id,
+    count() AS row_count
+FROM {{ ref('ci_runs') }}
+GROUP BY tenant_id, source_id, repository_value, run_id
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_collab_active_modalities_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_collab_active_modalities_unique.sql
@@ -1,0 +1,12 @@
+-- A modality is claimed once per person, day and tool, so counting rows and
+-- counting distinct modalities cannot disagree.
+SELECT
+    tenant_id,
+    person_email,
+    activity_date,
+    tool,
+    modality,
+    count() AS row_count
+FROM {{ ref('collab_active_modalities') }}
+GROUP BY tenant_id, person_email, activity_date, tool, modality
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_collab_activity_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_collab_activity_unique.sql
@@ -1,0 +1,11 @@
+-- One row per person, day and tool: every tool's chat, meeting, email and
+-- document facts are folded into that grain, never repeated across it.
+SELECT
+    tenant_id,
+    person_email,
+    activity_date,
+    tool,
+    count() AS row_count
+FROM {{ ref('collab_activity') }}
+GROUP BY tenant_id, person_email, activity_date, tool
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_collab_file_shares_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_collab_file_shares_unique.sql
@@ -1,0 +1,12 @@
+-- One row per share scope per person, day and tool: the internal and external
+-- counts unpivot into that grain, never repeated across it.
+SELECT
+    tenant_id,
+    person_email,
+    activity_date,
+    tool,
+    scope,
+    count() AS row_count
+FROM {{ ref('collab_file_shares') }}
+GROUP BY tenant_id, person_email, activity_date, tool, scope
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_git_review_events_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_git_review_events_unique.sql
@@ -1,0 +1,10 @@
+-- One row per review or comment: the silver event key separates several events
+-- by one person on one request, and the pull-request join must not fan it out.
+SELECT
+    tenant_id,
+    source_id,
+    event_key,
+    count() AS row_count
+FROM {{ ref('git_review_events') }}
+GROUP BY tenant_id, source_id, event_key
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_task_close_events_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_task_close_events_unique.sql
@@ -1,0 +1,10 @@
+-- One row per close transition: an issue closed more than once contributes one
+-- row per close time, never two rows for the same one.
+SELECT
+    insight_source_id,
+    issue_id,
+    close_at,
+    count() AS row_count
+FROM {{ ref('task_close_events') }}
+GROUP BY insight_source_id, issue_id, close_at
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_task_closed_issues_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_task_closed_issues_unique.sql
@@ -1,0 +1,9 @@
+-- An issue id is unique only within the source that tracks it, and a closed
+-- issue contributes exactly one row.
+SELECT
+    insight_source_id,
+    issue_id,
+    count() AS row_count
+FROM {{ ref('task_closed_issues') }}
+GROUP BY insight_source_id, issue_id
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_task_estimation_days_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_task_estimation_days_unique.sql
@@ -1,0 +1,10 @@
+-- One row per person and closing day: the day is the unit the estimate ratio
+-- is taken over, so it may not appear twice.
+SELECT
+    tenant_id,
+    assignee_email,
+    closed_date,
+    count() AS row_count
+FROM {{ ref('task_estimation_days') }}
+GROUP BY tenant_id, assignee_email, closed_date
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_task_open_issues_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_task_open_issues_unique.sql
@@ -1,0 +1,9 @@
+-- An issue id is unique only within the source that tracks it, and an open
+-- issue contributes exactly one row.
+SELECT
+    insight_source_id,
+    issue_id,
+    count() AS row_count
+FROM {{ ref('task_open_issues') }}
+GROUP BY insight_source_id, issue_id
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_task_person_days_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_task_person_days_unique.sql
@@ -1,0 +1,10 @@
+-- One row per person and day: in-progress time and logged time are summed into
+-- that grain, never repeated across it.
+SELECT
+    tenant_id,
+    entity_id,
+    metric_date,
+    count() AS row_count
+FROM {{ ref('task_worklog_flow') }}
+GROUP BY tenant_id, entity_id, metric_date
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_wiki_pages_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_wiki_pages_unique.sql
@@ -1,0 +1,9 @@
+-- A page id is unique only within the source that published it.
+SELECT
+    tenant_id,
+    source_id,
+    page_id,
+    count() AS row_count
+FROM {{ ref('wiki_pages') }}
+GROUP BY tenant_id, source_id, page_id
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_wiki_person_days_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_wiki_person_days_unique.sql
@@ -1,0 +1,11 @@
+-- One row per person and day within a source: edits and comments received are
+-- summed into that grain, never repeated across it.
+SELECT
+    tenant_id,
+    source_id,
+    author_email,
+    activity_date,
+    count() AS row_count
+FROM {{ ref('wiki_person_days') }}
+GROUP BY tenant_id, source_id, author_email, activity_date
+HAVING count() > 1

--- a/src/ingestion/gold/ai_seat_days.sql
+++ b/src/ingestion/gold/ai_seat_days.sql
@@ -1,0 +1,93 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'email', 'snapshot_date'],
+    partition_by='toYYYYMM(snapshot_date)',
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- One AI seat's billed extra usage placed on the day it was spent. The vendor
+-- reports a cumulative month-to-date figure, so a day's spend is the step
+-- between two readings and nothing else — exact in sum over the month,
+-- approximate in placement within it.
+
+WITH
+-- Every reading of a seat inside its billing month.
+seat_day_source AS (
+    SELECT
+        insight_tenant_id                       AS tenant_id,
+        source,
+        source_id,
+        account_id,
+        {{ normalized_email('email') }}         AS email,
+        tool,
+        seat_tier,
+        snapshot_date,
+        period_month,
+        used_amount_cents
+    FROM {{ ref('class_ai_overage_daily') }} FINAL
+    WHERE insight_tenant_id IS NOT NULL
+      AND email IS NOT NULL
+      AND email != ''
+      AND snapshot_date IS NOT NULL
+),
+-- INVARIANT: a reading on the month's last calendar day may raise the month,
+-- never lower it. No billing period is reported, so a drop there cannot be told
+-- from a rolled-over counter, and the suffix minimum would spread it monthwide.
+seat_day_held AS (
+    SELECT
+        *,
+        -- INVARIANT: the PRECEDING reading, never the largest. The suffix
+        -- minimum erases an earlier reading that was too high; a maximum over
+        -- them would restore it.
+        if(
+            snapshot_date = toLastDayOfMonth(period_month),
+            greatest(
+                used_amount_cents,
+                lagInFrame(used_amount_cents, 1, toUInt32(0)) OVER (
+                    PARTITION BY tenant_id, source, source_id, account_id, period_month
+                    ORDER BY snapshot_date
+                )
+            ),
+            used_amount_cents
+        )                                       AS held_cents
+    FROM seat_day_source
+),
+-- INVARIANT: the suffix minimum is what keeps every step non-negative and makes
+-- the steps add up to the month's final reading, which the monthly dataset
+-- serves.
+seat_day_corrected AS (
+    SELECT
+        *,
+        min(held_cents) OVER (
+            PARTITION BY tenant_id, source, source_id, account_id, period_month
+            ORDER BY snapshot_date
+            ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+        )                                       AS corrected_cents
+    FROM seat_day_held
+),
+seat_day_step AS (
+    SELECT
+        *,
+        corrected_cents - lagInFrame(corrected_cents, 1, toUInt32(0)) OVER (
+            PARTITION BY tenant_id, source, source_id, account_id, period_month
+            ORDER BY snapshot_date
+        )                                       AS step_cents
+    FROM seat_day_corrected
+)
+
+SELECT
+    -- SAFETY: all three are safe under the WHERE in `seat_day_source`.
+    assumeNotNull(tenant_id)                    AS tenant_id,
+    source_id                                   AS source_id,
+    account_id                                  AS account_id,
+    assumeNotNull(email)                        AS email,
+    assumeNotNull(snapshot_date)                AS snapshot_date,
+    tool                                        AS tool,
+    {{ ai_tool_label('tool') }}                 AS tool_label,
+    coalesce(seat_tier, 'unknown')              AS seat_tier,
+    toFloat64(step_cents) / 100                 AS daily_extra_usage_usd
+FROM seat_day_step

--- a/src/ingestion/gold/ai_seat_months.sql
+++ b/src/ingestion/gold/ai_seat_months.sql
@@ -1,0 +1,186 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'email', 'period_month'],
+    partition_by='toYYYYMM(period_month)',
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- What one AI seat cost in one billing month: the fee the invoice priced it at,
+-- the usage billed on top of that fee, and the ceiling that usage runs against.
+-- A semantic-layer dataset — measures sum it and a ratio reads the ceiling.
+
+WITH
+-- What the vendor charged for one seat in a billing month. Only a non-proration
+-- `subscriptions` line states a per-seat amount: the invoice total covers every
+-- seat and every proration together, and `num_seats` reports one line's quantity
+-- while an invoice can price several tiers. Collected per tier so a month with
+-- more than one priced tier stays distinguishable from an unambiguous one.
+--
+-- Each price carries the seat population it may reach. One tenant can hold
+-- several instances of a vendor's connector, and the invoice instance and the
+-- seat instance are separate connectors whose source_id never matches — so the
+-- only thing that can say which seats an invoice billed is the operator's
+-- binding. `invoice_sources` counts the instances that priced anything, which is
+-- what tells an unscoped price whether it is the tenant's only one.
+month_seat_prices AS (
+    SELECT
+        tenant_id,
+        source,
+        period_month,
+        groupUniqArray(tuple(seat_source_id, tier, price)) AS scoped_prices,
+        uniqExact(invoice_source_id)            AS invoice_sources
+    FROM (
+        SELECT
+            invoice.insight_tenant_id           AS tenant_id,
+            invoice.source                      AS source,
+            invoice.period_month                AS period_month,
+            invoice.source_id                   AS invoice_source_id,
+            -- The seat connector instance this price applies to. Empty when the
+            -- binding names none, which only a single-instance tenant can use.
+            coalesce(binding.seat_source_id, '') AS seat_source_id,
+            -- What a seat would call this line's tier, per the operator's
+            -- binding. Unbound leaves it empty, and no seat tier is empty, so an
+            -- unrecognised plan prices nothing rather than pricing a guess.
+            coalesce(binding.seat_tier, '')      AS tier,
+            invoice.seat_unit_cents             AS price
+        FROM {{ ref('class_ai_invoice') }} AS invoice FINAL
+        LEFT JOIN (
+            SELECT
+                tenant_id,
+                insight_source_id,
+                source,
+                tier_ref,
+                seat_source_id,
+                seat_tier
+            FROM {{ source('config', 'ai_seat_tier_map') }} FINAL
+            WHERE is_deleted = 0
+        ) AS binding
+            ON  binding.tenant_id = invoice.insight_tenant_id
+            AND binding.insight_source_id = invoice.source_id
+            AND binding.source = invoice.source
+            AND binding.tier_ref = invoice.tier_ref
+        WHERE invoice.line_id IS NOT NULL
+          AND invoice.category = 'subscriptions'
+          AND invoice.is_proration = 0
+          AND invoice.seat_unit_cents IS NOT NULL
+        GROUP BY tenant_id, source, period_month, invoice_source_id, seat_source_id, tier, price
+    )
+    GROUP BY tenant_id, source, period_month
+),
+seat_month_source AS (
+    SELECT
+        insight_tenant_id                       AS tenant_id,
+        source,
+        source_id,
+        account_id,
+        {{ normalized_email('email') }}         AS email,
+        tool,
+        seat_tier,
+        period_month,
+        used_amount_cents,
+        credit_limit_cents
+    FROM {{ ref('class_ai_overage') }} FINAL
+    WHERE insight_tenant_id IS NOT NULL
+      AND email IS NOT NULL
+      AND email != ''
+      AND collected_at IS NOT NULL
+),
+-- How many seat populations the tenant holds for this vendor in this month. An
+-- unscoped price may only be taken when there is exactly one, because with two
+-- nothing says which of them the invoice billed — not even when only one of them
+-- produced an invoice at all.
+month_seat_populations AS (
+    SELECT
+        tenant_id,
+        source,
+        period_month,
+        uniqExact(source_id)                    AS seat_sources
+    FROM seat_month_source
+    GROUP BY tenant_id, source, period_month
+),
+-- How many populations the seat's own month holds, carried onto the seat.
+--
+-- INVARIANT: one join per level. Two joins in one SELECT beside `seat.*`, where
+-- both joined relations carry a `tenant_id` of their own, leave the unqualified
+-- name unresolvable and the model fails to build.
+seat_month_scoped AS (
+    SELECT
+        seat.*,
+        populations.seat_sources                AS seat_sources
+    FROM seat_month_source AS seat
+    LEFT JOIN month_seat_populations AS populations
+        ON  populations.tenant_id = seat.tenant_id
+        AND populations.source = seat.source
+        AND populations.period_month = seat.period_month
+),
+-- The prices that can reach this seat: those the operator bound to the seat's
+-- own connector instance, plus the unscoped ones when the tenant runs a single
+-- instance on both sides. A tenant running two therefore never lends one
+-- instance's price to the other's seats, whichever of them the invoice came from.
+seat_month_offers AS (
+    SELECT
+        scoped.* EXCEPT (seat_sources),
+        arrayFilter(
+            p -> p.1 = scoped.source_id
+                 OR (p.1 = '' AND prices.invoice_sources = 1 AND scoped.seat_sources = 1),
+            prices.scoped_prices
+        )                                       AS offers
+    FROM seat_month_scoped AS scoped
+    LEFT JOIN month_seat_prices AS prices
+        ON  prices.tenant_id = scoped.tenant_id
+        AND prices.source = scoped.source
+        AND prices.period_month = scoped.period_month
+),
+-- The price this seat was billed at. One priced tier among the offers prices
+-- every seat billed in it, which is the common shape and the only one the vendor
+-- states unambiguously. With several, the seat's own tier has to name one of
+-- them, which needs the operator's binding above: no vendor states that an
+-- invoice line's tier and a seat's tier are the same tier. A seat that names
+-- none is left without a price rather than given a share of the invoice total.
+seat_month_priced AS (
+    SELECT
+        * EXCEPT (offers),
+        multiIf(
+            length(offers) = 1,
+            offers[1].3,
+            length(arrayFilter(p -> p.2 = coalesce(seat_tier, ''), offers)) = 1,
+            arrayFilter(p -> p.2 = coalesce(seat_tier, ''), offers)[1].3,
+            CAST(NULL AS Nullable(Int64))
+        )                                       AS seat_price_cents
+    FROM seat_month_offers
+)
+
+SELECT
+    -- SAFETY: both are safe under the WHERE in `seat_month_source`.
+    assumeNotNull(tenant_id)                    AS tenant_id,
+    source_id                                   AS source_id,
+    account_id                                  AS account_id,
+    assumeNotNull(email)                        AS email,
+    period_month                                AS period_month,
+    tool                                        AS tool,
+    {{ ai_tool_label('tool') }}                 AS tool_label,
+    coalesce(seat_tier, 'unknown')              AS seat_tier,
+    -- The money: what the vendor billed once the seat exhausted the usage
+    -- included in its fee. NOT the excess over the ceiling below — that
+    -- difference is where spending stopped, not what it cost.
+    toFloat64(used_amount_cents) / 100          AS extra_usage_usd,
+    -- Honest-NULL: a seat with no ceiling carries no denominator, so the ratio
+    -- metric has no value for it rather than a fabricated one.
+    if(
+        credit_limit_cents IS NOT NULL,
+        toNullable(toFloat64(credit_limit_cents) / 100),
+        CAST(NULL AS Nullable(Float64))
+    )                                           AS extra_usage_limit_usd,
+    -- The seat fee itself, which the extra usage above sits on top of. Gated on
+    -- the ceiling because that is what marks a seat as carrying a tier, and an
+    -- untiered seat is not one the invoice billed for.
+    if(
+        seat_price_cents IS NOT NULL AND credit_limit_cents IS NOT NULL,
+        toNullable(toFloat64(seat_price_cents) / 100),
+        CAST(NULL AS Nullable(Float64))
+    )                                           AS seat_cost_usd
+FROM seat_month_priced

--- a/src/ingestion/gold/ai_usage.sql
+++ b/src/ingestion/gold/ai_usage.sql
@@ -1,0 +1,115 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'email', 'usage_date'],
+    partition_by='toYYYYMM(usage_date)',
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- AI usage per person and day: what coding assistants and chat assistants each
+-- reported, in one relation told apart by `surface`.
+--
+-- INVARIANT: cost and active days span both kinds of usage and a measure reads
+-- one dataset, so the two class relations meet here and not at query time.
+--
+-- INVARIANT: a counter the source did not report stays NULL rather than
+-- becoming zero, so a sum over a person who was never measured is no value.
+
+WITH
+dev_usage AS (
+    SELECT
+        insight_tenant_id AS tenant_id,
+        {{ normalized_email('email') }} AS email,
+        day AS usage_date,
+        tool AS tool,
+        'dev' AS surface,
+        -- Seat state as of the last read, not as of the usage day: the sources
+        -- restate it for every day they re-read. 'unknown' where the source has
+        -- no seat lifecycle concept.
+        coalesce(seat_status, 'unknown') AS seat_status,
+        toNullable(lines_added) AS lines_added,
+        lines_removed AS lines_removed,
+        tool_use_offered AS tool_use_offered,
+        tool_use_accepted AS tool_use_accepted,
+        conversation_count AS dev_conversations,
+        CAST(NULL AS Nullable(UInt32)) AS assistant_messages,
+        CAST(NULL AS Nullable(UInt32)) AS assistant_actions,
+        CAST(NULL AS Nullable(UInt32)) AS chat_conversations,
+        prs_with_cc_count AS prs_with_assistant,
+        prs_total_count AS prs_total,
+        cost_cents AS cost_cents
+    FROM {{ ref('class_ai_dev_usage') }} FINAL
+    WHERE insight_tenant_id IS NOT NULL
+      AND email IS NOT NULL
+      AND email != ''
+      AND day IS NOT NULL
+),
+assistant_usage AS (
+    SELECT
+        insight_tenant_id AS tenant_id,
+        {{ normalized_email('email') }} AS email,
+        day AS usage_date,
+        tool AS tool,
+        surface AS surface,
+        -- Assistant sources report no seat lifecycle, so the same 'unknown' the
+        -- dev branch falls back to.
+        'unknown' AS seat_status,
+        CAST(NULL AS Nullable(UInt32)) AS lines_added,
+        CAST(NULL AS Nullable(UInt32)) AS lines_removed,
+        CAST(NULL AS Nullable(UInt32)) AS tool_use_offered,
+        CAST(NULL AS Nullable(UInt32)) AS tool_use_accepted,
+        CAST(NULL AS Nullable(UInt32)) AS dev_conversations,
+        message_count AS assistant_messages,
+        action_count AS assistant_actions,
+        conversation_count AS chat_conversations,
+        CAST(NULL AS Nullable(UInt32)) AS prs_with_assistant,
+        CAST(NULL AS Nullable(UInt32)) AS prs_total,
+        cost_cents AS cost_cents
+    FROM {{ ref('class_ai_assistant_usage') }} FINAL
+    WHERE insight_tenant_id IS NOT NULL
+      AND email IS NOT NULL
+      AND email != ''
+      AND day IS NOT NULL
+),
+reported_usage AS (
+    SELECT * FROM dev_usage
+
+    UNION ALL
+
+    SELECT * FROM assistant_usage
+)
+
+SELECT
+    -- SAFETY: both branches admit only non-null keys.
+    assumeNotNull(tenant_id) AS tenant_id,
+    assumeNotNull(email) AS email,
+    assumeNotNull(usage_date) AS usage_date,
+    tool AS tool,
+    {{ ai_tool_label('tool') }} AS tool_label,
+    surface AS surface,
+    {{ ai_surface_label('surface') }} AS surface_label,
+    seat_status AS seat_status,
+    sum(lines_added) AS lines_added,
+    sum(lines_removed) AS lines_removed,
+    sum(tool_use_offered) AS tool_use_offered,
+    sum(tool_use_accepted) AS tool_use_accepted,
+    sum(dev_conversations) AS dev_conversations,
+    sum(assistant_messages) AS assistant_messages,
+    sum(assistant_actions) AS assistant_actions,
+    sum(chat_conversations) AS chat_conversations,
+    sum(prs_with_assistant) AS prs_with_assistant,
+    sum(prs_total) AS prs_total,
+    sum(cost_cents) / 100 AS cost_usd
+FROM reported_usage
+GROUP BY
+    tenant_id,
+    email,
+    usage_date,
+    tool,
+    tool_label,
+    surface,
+    surface_label,
+    seat_status

--- a/src/ingestion/gold/ci_commits.sql
+++ b/src/ingestion/gold/ci_commits.sql
@@ -1,0 +1,38 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'entity_id', 'metric_date'],
+    partition_by='toYYYYMM(metric_date)',
+    schema=var('gold_database'),
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- One row per collected commit, dated at its commit time — the denominator of
+-- the run-to-commit join-coverage reading: set beside runs and the runs whose
+-- head commit was collected, it shows how far the two streams overlap, and so
+-- how much any commit-joined CI reading can be trusted.
+--
+-- TENANT grain: this counts what the connector collected, not what anyone
+-- wrote, so entity_id IS the tenant id. The commit's author is deliberately
+-- not carried here — git_commits serves the person-grain reading.
+SELECT
+    assumeNotNull(tenant_id)                                   AS tenant_id,
+    assumeNotNull(tenant_id)                                   AS entity_id,
+    coalesce(source_id, '')                                    AS source_id,
+    project_key                                                AS project_key,
+    repo_slug                                                  AS repo_slug,
+    commit_hash                                                AS commit_hash,
+    toDate(assumeNotNull(date))                                AS metric_date,
+    toDateTime64(assumeNotNull(date), 3)                       AS committed_at,
+    substring(commit_hash, 1, 10)                              AS commit_reference,
+    concat(project_key, '/', repo_slug)                        AS repository_value,
+    concat(project_key, '/', repo_slug)                        AS repository_label
+FROM {{ ref('class_git_commits') }} FINAL
+WHERE tenant_id IS NOT NULL
+  AND commit_hash != ''
+  AND date IS NOT NULL
+-- One row per commit within the repository that collected it: a commit reached
+-- through two branches is one commit, and counting it twice would overstate
+-- the coverage denominator.
+LIMIT 1 BY tenant_id, source_id, project_key, repo_slug, commit_hash

--- a/src/ingestion/gold/ci_deployments.sql
+++ b/src/ingestion/gold/ci_deployments.sql
@@ -1,0 +1,91 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'entity_id', 'metric_date'],
+    partition_by='toYYYYMM(metric_date)',
+    schema=var('gold_database'),
+    tags=['gold'],
+    query_settings=metric_serving_query_settings(join_use_nulls=1)
+) }}
+
+-- One row per deployment, with the latest status event folded in as its
+-- outcome. A semantic-layer dataset: measures count it, drilldown projects it.
+--
+-- TENANT grain: a deployment belongs to the organization, so entity_id IS the
+-- tenant id and no identity join happens. The creator the source names is
+-- deliberately not carried into gold.
+--
+-- A deployment with no status event yet is 'pending' and stays visible rather
+-- than rounded away.
+WITH deployment_outcomes AS (
+    SELECT
+        tenant_id,
+        source_id,
+        deployment_id,
+        -- The vendor status id breaks created_at ties: two events in one
+        -- second would otherwise pick a nondeterministic outcome.
+        argMax(state, (created_at, event_id)) AS state
+    FROM {{ ref('class_git_deployment_events') }} FINAL
+    GROUP BY tenant_id, source_id, deployment_id
+),
+
+deployments AS (
+    SELECT
+        tenant_id,
+        source_id,
+        repo_full_name,
+        deployment_id,
+        environment,
+        is_production,
+        is_transient,
+        created_at
+    FROM {{ ref('class_git_deployments') }} FINAL
+    WHERE created_at IS NOT NULL
+),
+
+resolved AS (
+    SELECT
+        assumeNotNull(d.tenant_id)                         AS tenant_id,
+        coalesce(toString(d.source_id), '')                AS source_id,
+        d.deployment_id                                    AS deployment_id,
+        d.repo_full_name                                   AS repo_full_name,
+        d.environment                                      AS environment,
+        assumeNotNull(d.created_at)                        AS created_at,
+        -- coalesce against a literal so the outer relation carries a plain
+        -- String: `join_use_nulls` makes every column of the right side
+        -- nullable, and a nullable dimension groups a missing outcome under
+        -- NULL instead of under the visible 'pending'.
+        coalesce(nullIf(o.state, ''), 'pending')           AS outcome,
+        -- Non-production splits by the vendor's transient flag: 'preview' is
+        -- an environment that exists to be torn down, 'static' one that
+        -- persists (staging, QA).
+        multiIf(
+            d.is_production = 1, 'production',
+            d.is_transient = 1, 'preview',
+            'static'
+        )                                                  AS env_kind
+    FROM deployments AS d
+    LEFT JOIN deployment_outcomes AS o
+        ON d.tenant_id = o.tenant_id
+       AND d.source_id = o.source_id
+       AND d.deployment_id = o.deployment_id
+    WHERE d.tenant_id IS NOT NULL
+)
+
+SELECT
+    tenant_id                                AS tenant_id,
+    tenant_id                                AS entity_id,
+    source_id                                AS source_id,
+    deployment_id                            AS deployment_id,
+    toDate(created_at)                       AS metric_date,
+    toDateTime64(created_at, 3)              AS created_at,
+    concat(environment, ' · ', outcome)      AS deployment_label,
+    repo_full_name                           AS repository_value,
+    repo_full_name                           AS repository_label,
+    environment                              AS environment_value,
+    environment                              AS environment_label,
+    outcome                                  AS outcome_value,
+    outcome                                  AS outcome_label,
+    env_kind                                 AS env_kind_value,
+    env_kind                                 AS env_kind_label
+FROM resolved

--- a/src/ingestion/gold/ci_runs.sql
+++ b/src/ingestion/gold/ci_runs.sql
@@ -1,0 +1,96 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'entity_id', 'metric_date'],
+    partition_by='toYYYYMM(metric_date)',
+    schema=var('gold_database'),
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- One row per decided pipeline run, with its dimensions resolved and its
+-- duration expressed in the units the measures read. A semantic-layer dataset:
+-- measures count and fold it, drilldown projects it.
+--
+-- TENANT grain: a pipeline run belongs to the organization, not to a person,
+-- so entity_id IS the tenant id and no identity join happens. The actor the
+-- source names is deliberately not carried into gold.
+--
+-- One row per RUN, not per attempt: the source lists only the latest attempt
+-- of a retried run, so the latest attempt is the run's state and `attempt > 1`
+-- is the retry marker. Undecided (in-flight) runs are excluded — they
+-- re-arrive decided on a later sync.
+WITH known_commits AS (
+    SELECT DISTINCT
+        tenant_id,
+        commit_hash
+    FROM {{ ref('class_git_commits') }} FINAL
+    WHERE commit_hash != ''
+),
+
+runs AS (
+    SELECT
+        tenant_id,
+        source_id,
+        repo_full_name,
+        pipeline_key,
+        pipeline_name,
+        run_id,
+        run_number,
+        attempt,
+        is_retry,
+        trigger_category,
+        outcome,
+        is_gate,
+        branch,
+        started_at,
+        duration_s,
+        -- Whether the run's head commit was ever collected by the commits
+        -- stream. PR runs build synthetic merge refs and fork commits the
+        -- stream never sees, so this is the honest joinability ceiling for
+        -- any run-to-commit analysis — served as its own measure.
+        (tenant_id, commit_sha) IN (
+            SELECT tenant_id, commit_hash FROM known_commits
+        ) AS commit_known
+    FROM {{ ref('class_git_ci_runs') }} FINAL
+    WHERE outcome != ''
+      AND started_at IS NOT NULL
+    ORDER BY attempt DESC
+    LIMIT 1 BY tenant_id, source_id, repo_full_name, run_id
+)
+
+SELECT
+    assumeNotNull(tenant_id)                                     AS tenant_id,
+    assumeNotNull(tenant_id)                                     AS entity_id,
+    coalesce(toString(source_id), '')                            AS source_id,
+    toString(run_id)                                             AS run_id,
+    toString(run_number)                                         AS run_number,
+    toDate(assumeNotNull(started_at))                            AS metric_date,
+    toDateTime64(assumeNotNull(started_at), 3)                   AS started_at,
+    toUInt8(is_gate)                                             AS is_gate,
+    toUInt8(is_retry)                                            AS is_retry,
+    toUInt32(attempt)                                            AS attempt,
+    toUInt8(commit_known)                                        AS commit_known,
+    branch                                                       AS branch,
+    -- Duration in both units the measures serve, so neither measure divides at
+    -- read time and a zero-duration run reads as the exclusion its filter
+    -- expresses rather than as a converted NULL.
+    toFloat64(coalesce(duration_s, 0)) / 60                      AS duration_min,
+    toFloat64(coalesce(duration_s, 0)) / 3600                    AS duration_h,
+    concat(pipeline_name, ' #', toString(run_number))            AS run_label,
+    repo_full_name                                               AS repository_value,
+    repo_full_name                                               AS repository_label,
+    pipeline_key                                                 AS pipeline_value,
+    pipeline_name                                                AS pipeline_label,
+    trigger_category                                             AS trigger_value,
+    trigger_category                                             AS trigger_label,
+    coalesce(outcome, '')                                        AS outcome_value,
+    coalesce(outcome, '')                                        AS outcome_label,
+    leftPad(toString(intDiv(toHour(started_at), 2) * 2), 2, '0') AS hour_block_value,
+    concat(
+        leftPad(toString(intDiv(toHour(started_at), 2) * 2), 2, '0'),
+        '–',
+        leftPad(toString(intDiv(toHour(started_at), 2) * 2 + 2), 2, '0')
+    )                                                            AS hour_block_label
+FROM runs
+WHERE tenant_id IS NOT NULL

--- a/src/ingestion/gold/collab_active_modalities.sql
+++ b/src/ingestion/gold/collab_active_modalities.sql
@@ -1,0 +1,56 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'person_email', 'activity_date'],
+    partition_by='toYYYYMM(activity_date)',
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- The collaboration modalities a person was deliberately active in: one row per
+-- modality per person, day and tool, so counting distinct modalities is a
+-- distinct count over rows rather than a fold over four flag columns.
+
+SELECT
+    tenant_id,
+    person_email,
+    activity_date,
+    tool,
+    'chat' AS modality
+FROM {{ ref('collab_activity') }}
+WHERE is_chat_active = 1
+
+UNION ALL
+
+SELECT
+    tenant_id,
+    person_email,
+    activity_date,
+    tool,
+    'email' AS modality
+FROM {{ ref('collab_activity') }}
+WHERE is_email_active = 1
+
+UNION ALL
+
+SELECT
+    tenant_id,
+    person_email,
+    activity_date,
+    tool,
+    'documents' AS modality
+FROM {{ ref('collab_activity') }}
+WHERE is_documents_active = 1
+
+UNION ALL
+
+SELECT
+    tenant_id,
+    person_email,
+    activity_date,
+    tool,
+    'meetings' AS modality
+FROM {{ ref('collab_activity') }}
+WHERE is_meetings_active = 1

--- a/src/ingestion/gold/collab_activity.sql
+++ b/src/ingestion/gold/collab_activity.sql
@@ -1,0 +1,328 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'person_email', 'activity_date'],
+    partition_by='toYYYYMM(activity_date)',
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Collaboration work per person, day and tool: the chat, meeting, email and
+-- document facts each tool reported, the focus hours the day was measured at,
+-- and the flags saying which modalities the person was deliberately active in.
+--
+-- INVARIANT: identity is the person email the source recorded, normalized and
+-- nothing more; the person is bound when a query runs.
+
+WITH
+chat_activity AS (
+    SELECT
+        tenant_id,
+        {{ normalized_email('person_key') }} AS person_email,
+        date AS activity_date,
+        replaceOne(data_source, 'insight_', '') AS tool,
+        total_chat_messages,
+        channel_posts + ifNull(channel_replies, 0) AS channel_posts_total,
+        direct_and_group_messages,
+        toUInt8(total_chat_messages > 0) AS is_chat_active
+    FROM {{ ref('class_collab_chat_activity') }} FINAL
+    WHERE tenant_id IS NOT NULL
+      AND person_key LIKE '%@%'
+      AND date IS NOT NULL
+),
+meeting_activity AS (
+    SELECT
+        tenant_id,
+        {{ normalized_email('person_key') }} AS person_email,
+        date AS activity_date,
+        replaceOne(data_source, 'insight_', '') AS tool,
+        meetings_attended,
+        meetings_organized,
+        adhoc_meetings_attended,
+        scheduled_meetings_attended,
+        -- SAFETY: `greatest` ignores NULL arguments, so every duration is
+        -- grounded first — a meeting with no reported duration is zero time,
+        -- not an unknown one.
+        ifNull(audio_duration_seconds, 0)
+            + ifNull(video_duration_seconds, 0)
+            + ifNull(screen_share_duration_seconds, 0) AS meeting_seconds,
+        greatest(
+            ifNull(audio_duration_seconds, 0),
+            ifNull(video_duration_seconds, 0),
+            ifNull(screen_share_duration_seconds, 0)
+        ) / 3600.0 AS meeting_hours,
+        toUInt8(meetings_attended > 0) AS is_meetings_active
+    FROM {{ ref('class_collab_meeting_activity') }} FINAL
+    WHERE tenant_id IS NOT NULL
+      AND person_key LIKE '%@%'
+      AND date IS NOT NULL
+),
+email_activity AS (
+    SELECT
+        tenant_id,
+        {{ normalized_email('person_key') }} AS person_email,
+        date AS activity_date,
+        replaceOne(data_source, 'insight_', '') AS tool,
+        CAST(sent_count AS Nullable(Float64)) AS emails_sent,
+        CAST(received_count AS Nullable(Float64)) AS emails_received,
+        CAST(read_count AS Nullable(Float64)) AS emails_read,
+        toUInt8(ifNull(sent_count, 0) > 0) AS is_email_active
+    FROM {{ ref('class_collab_email_activity') }} FINAL
+    WHERE tenant_id IS NOT NULL
+      AND person_key LIKE '%@%'
+      AND date IS NOT NULL
+),
+document_activity AS (
+    SELECT
+        tenant_id,
+        {{ normalized_email('person_key') }} AS person_email,
+        date AS activity_date,
+        replaceOne(data_source, 'insight_', '') AS tool,
+        CAST(viewed_or_edited_count AS Nullable(Float64)) AS files_engaged,
+        CAST(shared_internally_count AS Nullable(Float64)) AS files_shared_internal,
+        CAST(shared_externally_count AS Nullable(Float64)) AS files_shared_external,
+        toUInt8(
+            ifNull(viewed_or_edited_count, 0) > 0
+            OR ifNull(shared_internally_count, 0) > 0
+            OR ifNull(shared_externally_count, 0) > 0
+        ) AS is_documents_active
+    FROM {{ ref('class_collab_document_activity') }} FINAL
+    WHERE tenant_id IS NOT NULL
+      AND person_key LIKE '%@%'
+      AND date IS NOT NULL
+),
+-- Focus hours are a property of the day, not of any one tool, so they ride the
+-- day's lowest-named tool row. Fanning them onto every tool row of the day
+-- would multiply them by the tool count.
+focus_carrier_tool AS (
+    SELECT
+        tenant_id,
+        person_email,
+        activity_date,
+        min(tool) AS tool
+    FROM (
+        SELECT tenant_id, person_email, activity_date, tool FROM chat_activity
+        UNION ALL
+        SELECT tenant_id, person_email, activity_date, tool FROM meeting_activity
+        UNION ALL
+        SELECT tenant_id, person_email, activity_date, tool FROM email_activity
+        UNION ALL
+        SELECT tenant_id, person_email, activity_date, tool FROM document_activity
+    )
+    GROUP BY tenant_id, person_email, activity_date
+),
+focus_activity AS (
+    SELECT
+        carrier.tenant_id AS tenant_id,
+        carrier.person_email AS person_email,
+        carrier.activity_date AS activity_date,
+        carrier.tool AS tool,
+        focus.focus_hours AS focus_hours,
+        focus.working_hours AS working_hours
+    FROM (
+        SELECT
+            insight_tenant_id AS tenant_id,
+            {{ normalized_email('email') }} AS person_email,
+            day AS activity_date,
+            dev_time_h AS focus_hours,
+            working_hours_per_day AS working_hours
+        FROM {{ ref('class_focus_metrics') }} FINAL
+        WHERE insight_tenant_id IS NOT NULL
+          AND email LIKE '%@%'
+          AND day IS NOT NULL
+    ) AS focus
+    INNER JOIN focus_carrier_tool AS carrier
+        ON carrier.tenant_id = focus.tenant_id
+       AND carrier.person_email = focus.person_email
+       AND carrier.activity_date = focus.activity_date
+),
+-- A tool reports whichever modalities it covers, so each branch carries its own
+-- facts and leaves the rest unknown; the fold below sums past the unknowns.
+person_day_tool_contributions AS (
+    SELECT
+        tenant_id,
+        person_email,
+        activity_date,
+        tool,
+        total_chat_messages,
+        channel_posts_total,
+        direct_and_group_messages,
+        CAST(NULL AS Nullable(Float64)) AS emails_sent,
+        CAST(NULL AS Nullable(Float64)) AS emails_received,
+        CAST(NULL AS Nullable(Float64)) AS emails_read,
+        CAST(NULL AS Nullable(Float64)) AS files_engaged,
+        CAST(NULL AS Nullable(Float64)) AS files_shared_internal,
+        CAST(NULL AS Nullable(Float64)) AS files_shared_external,
+        CAST(NULL AS Nullable(Int64)) AS meeting_seconds,
+        CAST(NULL AS Nullable(Float64)) AS meeting_hours,
+        CAST(NULL AS Nullable(Int64)) AS meetings_attended,
+        CAST(NULL AS Nullable(Int64)) AS meetings_organized,
+        CAST(NULL AS Nullable(Int64)) AS adhoc_meetings_attended,
+        CAST(NULL AS Nullable(Int64)) AS scheduled_meetings_attended,
+        CAST(NULL AS Nullable(Float64)) AS focus_hours,
+        CAST(NULL AS Nullable(Float64)) AS working_hours,
+        is_chat_active,
+        toUInt8(0) AS is_email_active,
+        toUInt8(0) AS is_documents_active,
+        toUInt8(0) AS is_meetings_active,
+        is_chat_active AS is_deliberately_active
+    FROM chat_activity
+
+    UNION ALL
+
+    SELECT
+        tenant_id,
+        person_email,
+        activity_date,
+        tool,
+        CAST(NULL AS Nullable(Int64)) AS total_chat_messages,
+        CAST(NULL AS Nullable(Int64)) AS channel_posts_total,
+        CAST(NULL AS Nullable(Int64)) AS direct_and_group_messages,
+        emails_sent,
+        emails_received,
+        emails_read,
+        CAST(NULL AS Nullable(Float64)) AS files_engaged,
+        CAST(NULL AS Nullable(Float64)) AS files_shared_internal,
+        CAST(NULL AS Nullable(Float64)) AS files_shared_external,
+        CAST(NULL AS Nullable(Int64)) AS meeting_seconds,
+        CAST(NULL AS Nullable(Float64)) AS meeting_hours,
+        CAST(NULL AS Nullable(Int64)) AS meetings_attended,
+        CAST(NULL AS Nullable(Int64)) AS meetings_organized,
+        CAST(NULL AS Nullable(Int64)) AS adhoc_meetings_attended,
+        CAST(NULL AS Nullable(Int64)) AS scheduled_meetings_attended,
+        CAST(NULL AS Nullable(Float64)) AS focus_hours,
+        CAST(NULL AS Nullable(Float64)) AS working_hours,
+        toUInt8(0) AS is_chat_active,
+        is_email_active,
+        toUInt8(0) AS is_documents_active,
+        toUInt8(0) AS is_meetings_active,
+        is_email_active AS is_deliberately_active
+    FROM email_activity
+
+    UNION ALL
+
+    SELECT
+        tenant_id,
+        person_email,
+        activity_date,
+        tool,
+        CAST(NULL AS Nullable(Int64)) AS total_chat_messages,
+        CAST(NULL AS Nullable(Int64)) AS channel_posts_total,
+        CAST(NULL AS Nullable(Int64)) AS direct_and_group_messages,
+        CAST(NULL AS Nullable(Float64)) AS emails_sent,
+        CAST(NULL AS Nullable(Float64)) AS emails_received,
+        CAST(NULL AS Nullable(Float64)) AS emails_read,
+        files_engaged,
+        files_shared_internal,
+        files_shared_external,
+        CAST(NULL AS Nullable(Int64)) AS meeting_seconds,
+        CAST(NULL AS Nullable(Float64)) AS meeting_hours,
+        CAST(NULL AS Nullable(Int64)) AS meetings_attended,
+        CAST(NULL AS Nullable(Int64)) AS meetings_organized,
+        CAST(NULL AS Nullable(Int64)) AS adhoc_meetings_attended,
+        CAST(NULL AS Nullable(Int64)) AS scheduled_meetings_attended,
+        CAST(NULL AS Nullable(Float64)) AS focus_hours,
+        CAST(NULL AS Nullable(Float64)) AS working_hours,
+        toUInt8(0) AS is_chat_active,
+        toUInt8(0) AS is_email_active,
+        is_documents_active,
+        toUInt8(0) AS is_meetings_active,
+        is_documents_active AS is_deliberately_active
+    FROM document_activity
+
+    UNION ALL
+
+    SELECT
+        tenant_id,
+        person_email,
+        activity_date,
+        tool,
+        CAST(NULL AS Nullable(Int64)) AS total_chat_messages,
+        CAST(NULL AS Nullable(Int64)) AS channel_posts_total,
+        CAST(NULL AS Nullable(Int64)) AS direct_and_group_messages,
+        CAST(NULL AS Nullable(Float64)) AS emails_sent,
+        CAST(NULL AS Nullable(Float64)) AS emails_received,
+        CAST(NULL AS Nullable(Float64)) AS emails_read,
+        CAST(NULL AS Nullable(Float64)) AS files_engaged,
+        CAST(NULL AS Nullable(Float64)) AS files_shared_internal,
+        CAST(NULL AS Nullable(Float64)) AS files_shared_external,
+        meeting_seconds,
+        meeting_hours,
+        meetings_attended,
+        meetings_organized,
+        adhoc_meetings_attended,
+        scheduled_meetings_attended,
+        CAST(NULL AS Nullable(Float64)) AS focus_hours,
+        CAST(NULL AS Nullable(Float64)) AS working_hours,
+        toUInt8(0) AS is_chat_active,
+        toUInt8(0) AS is_email_active,
+        toUInt8(0) AS is_documents_active,
+        is_meetings_active,
+        is_meetings_active AS is_deliberately_active
+    FROM meeting_activity
+
+    UNION ALL
+
+    SELECT
+        tenant_id,
+        person_email,
+        activity_date,
+        tool,
+        CAST(NULL AS Nullable(Int64)) AS total_chat_messages,
+        CAST(NULL AS Nullable(Int64)) AS channel_posts_total,
+        CAST(NULL AS Nullable(Int64)) AS direct_and_group_messages,
+        CAST(NULL AS Nullable(Float64)) AS emails_sent,
+        CAST(NULL AS Nullable(Float64)) AS emails_received,
+        CAST(NULL AS Nullable(Float64)) AS emails_read,
+        CAST(NULL AS Nullable(Float64)) AS files_engaged,
+        CAST(NULL AS Nullable(Float64)) AS files_shared_internal,
+        CAST(NULL AS Nullable(Float64)) AS files_shared_external,
+        CAST(NULL AS Nullable(Int64)) AS meeting_seconds,
+        CAST(NULL AS Nullable(Float64)) AS meeting_hours,
+        CAST(NULL AS Nullable(Int64)) AS meetings_attended,
+        CAST(NULL AS Nullable(Int64)) AS meetings_organized,
+        CAST(NULL AS Nullable(Int64)) AS adhoc_meetings_attended,
+        CAST(NULL AS Nullable(Int64)) AS scheduled_meetings_attended,
+        focus_hours,
+        working_hours,
+        toUInt8(0) AS is_chat_active,
+        toUInt8(0) AS is_email_active,
+        toUInt8(0) AS is_documents_active,
+        toUInt8(0) AS is_meetings_active,
+        toUInt8(0) AS is_deliberately_active
+    FROM focus_activity
+)
+
+SELECT
+    -- SAFETY: every contributing branch admits only non-null keys.
+    assumeNotNull(tenant_id) AS tenant_id,
+    assumeNotNull(person_email) AS person_email,
+    assumeNotNull(activity_date) AS activity_date,
+    tool AS tool,
+    {{ collab_tool_label('tool') }} AS tool_label,
+    sum(total_chat_messages) AS total_chat_messages,
+    sum(channel_posts_total) AS channel_posts_total,
+    sum(direct_and_group_messages) AS direct_and_group_messages,
+    sum(emails_sent) AS emails_sent,
+    sum(emails_received) AS emails_received,
+    sum(emails_read) AS emails_read,
+    sum(files_engaged) AS files_engaged,
+    sum(files_shared_internal) AS files_shared_internal,
+    sum(files_shared_external) AS files_shared_external,
+    sum(meeting_seconds) AS meeting_seconds,
+    sum(meeting_hours) AS meeting_hours,
+    sum(meetings_attended) AS meetings_attended,
+    sum(meetings_organized) AS meetings_organized,
+    sum(adhoc_meetings_attended) AS adhoc_meetings_attended,
+    sum(scheduled_meetings_attended) AS scheduled_meetings_attended,
+    sum(focus_hours) AS focus_hours,
+    sum(working_hours) AS working_hours,
+    max(is_chat_active) AS is_chat_active,
+    max(is_email_active) AS is_email_active,
+    max(is_documents_active) AS is_documents_active,
+    max(is_meetings_active) AS is_meetings_active,
+    max(is_deliberately_active) AS is_deliberately_active
+FROM person_day_tool_contributions
+GROUP BY tenant_id, person_email, activity_date, tool

--- a/src/ingestion/gold/collab_file_shares.sql
+++ b/src/ingestion/gold/collab_file_shares.sql
@@ -1,0 +1,41 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'person_email', 'activity_date'],
+    partition_by='toYYYYMM(activity_date)',
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Files a person shared, split by who the recipients were: one row per share
+-- scope per person, day and tool, so the combined count is a fold over rows and
+-- the split is a breakdown of it.
+--
+-- INVARIANT: a scope the source did not report leaves no row, so an unreported
+-- scope stays unknown instead of reading zero.
+
+SELECT
+    tenant_id,
+    person_email,
+    activity_date,
+    tool,
+    'internal' AS scope,
+    'Internal' AS scope_label,
+    files_shared_internal AS files_shared
+FROM {{ ref('collab_activity') }}
+WHERE files_shared_internal IS NOT NULL
+
+UNION ALL
+
+SELECT
+    tenant_id,
+    person_email,
+    activity_date,
+    tool,
+    'external' AS scope,
+    'External' AS scope_label,
+    files_shared_external AS files_shared
+FROM {{ ref('collab_activity') }}
+WHERE files_shared_external IS NOT NULL

--- a/src/ingestion/gold/git_pull_requests.sql
+++ b/src/ingestion/gold/git_pull_requests.sql
@@ -51,6 +51,23 @@ pull_request_review_summary AS (
         maxIfOrNull(reviewed_at, approved = 1 AND reviewed_at IS NOT NULL) AS approved_at
     FROM {{ ref('class_git_pull_requests_reviewers') }} FINAL
     GROUP BY tenant_id, source_id, project_key, repo_slug, pr_id
+),
+-- uniqExact, not count(): the link table is append-only per sync, so one link
+-- can arrive more than once and the count must not inflate.
+--
+-- INVARIANT: toNullable fixes the column's type whatever `join_use_nulls` is,
+-- and keeps a request the source linked nothing for NULL rather than a merge
+-- of zero commits.
+pull_request_commit_counts AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        pr_id,
+        toNullable(uniqExact(commit_hash)) AS linked_commit_count
+    FROM {{ ref('class_git_pull_requests_commits') }} FINAL
+    GROUP BY tenant_id, source_id, project_key, repo_slug, pr_id
 )
 
 SELECT
@@ -101,6 +118,7 @@ SELECT
     prs.lines_added AS lines_added,
     prs.lines_removed AS lines_removed,
     prs.files_changed AS files_changed,
+    commit_counts.linked_commit_count AS linked_commit_count,
     -- INVARIANT: every duration is NULL unless its pair of timestamps exists and
     -- runs forwards; a negative span is a source disagreeing with its own clock.
     if(
@@ -149,6 +167,12 @@ LEFT JOIN pull_request_review_summary AS review_summary
     AND review_summary.project_key = prs.project_key
     AND review_summary.repo_slug = prs.repo_slug
     AND review_summary.pr_id = prs.pr_id
+LEFT JOIN pull_request_commit_counts AS commit_counts
+    ON commit_counts.tenant_id = prs.tenant_id
+    AND commit_counts.source_id = prs.source_id
+    AND commit_counts.project_key = prs.project_key
+    AND commit_counts.repo_slug = prs.repo_slug
+    AND commit_counts.pr_id = prs.pr_id
 LEFT JOIN repository_default_branches AS defaults
     ON defaults.tenant_id = prs.tenant_id
     AND defaults.source_id = prs.source_id

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -1196,6 +1196,68 @@ models:
           Array(Tuple(key, value, label)). Empty for every wiki measure — the
           family carries no breakdown dimension.
 
+  - name: wiki_pages
+    description: >
+      Authored wiki pages: one row per page a person created, with the space it
+      lives in and the day the source dated its creation. A semantic-layer
+      dataset — measures count it and drilldown projects it. Identity stays as
+      the source gave it; the person is bound when a query runs.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: source_id
+        description: "Connector source the page was published by; a page id is unique only within it"
+      - name: page_id
+        description: "Page identifier within its source"
+        tests:
+          - not_null
+      - name: title
+        description: "Page title as the source records it"
+      - name: space_name
+        description: "Name of the space the page lives in"
+      - name: author_email
+        description: "Lowercased author email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: created_at
+        description: >
+          When the page was created; the dataset's event time. Nullable — a
+          source that dates no creation still described a page, and that row
+          falls outside every period until the source dates it.
+      - name: created_date
+        description: "Creation day, the partition key; nullable with created_at"
+
+  - name: wiki_person_days
+    description: >
+      Wiki work per person and day: the edits a person made, the pages those
+      edits touched, and the comments other people left on pages that person
+      authored. A semantic-layer dataset — measures sum it. Wiki engagement
+      carries no person of its own, so authorship of the commented page
+      attributes it.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: source_id
+        description: "Connector source the activity was reported by"
+      - name: author_email
+        description: "Lowercased person email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: activity_date
+        description: "Day the work was reported on; the dataset's event time and the partition key"
+        tests:
+          - not_null
+      - name: edits
+        description: "Edit sessions the person recorded on that day"
+      - name: pages_edited
+        description: "Distinct pages the person's edits touched on that day"
+      - name: comments_received
+        description: "Comments left that day on pages the person authored"
+
   - name: account_attribute_values
     description: >
       Effective-dated person-attribute values per stable source account, built

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -1522,6 +1522,13 @@ models:
       class relations meet here rather than at query time. A counter the source
       did not report stays NULL rather than becoming zero. Identity stays as the
       source gave it; the person is bound when a query runs.
+  - name: collab_activity
+    description: >
+      Collaboration work per person, day and tool: the chat, meeting, email and
+      document facts each tool reported, folded into one row. A semantic-layer
+      dataset — measures sum it, count distinct days over it, and filter it by
+      the deliberate-activity flags. Identity stays as the source gave it; the
+      person is bound when a query runs.
     columns:
       - name: tenant_id
         description: "Owning tenant"
@@ -1591,6 +1598,91 @@ models:
       ceiling. A seat the invoice does not price, and a seat with no ceiling,
       carry NULL rather than a share of the invoice total or a fabricated
       denominator.
+      - name: person_email
+        description: "Lowercased person email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: activity_date
+        description: "Day the work was reported on; the dataset's event time and the partition key"
+        tests:
+          - not_null
+      - name: tool
+        description: >
+          Collaboration tool the facts on this row came from, as the value half
+          of the `tool` dimension.
+      - name: tool_label
+        description: >
+          Display label for the tool. The row spans every modality one tool
+          reported, so a multi-surface suite carries its suite-level name rather
+          than the name of any one surface.
+      - name: total_chat_messages
+        description: "Chat messages the person sent through this tool that day"
+      - name: channel_posts_total
+        description: >
+          Channel posts plus thread replies, folded so tools that report the two
+          separately stay comparable with tools that do not.
+      - name: direct_and_group_messages
+        description: >
+          Chat messages sent in direct and group conversations; unknown for a
+          tool that does not distinguish conversation types.
+      - name: emails_sent
+        description: "Emails the person sent"
+      - name: emails_received
+        description: "Emails the person received"
+      - name: emails_read
+        description: "Emails the person read"
+      - name: files_engaged
+        description: "Files the person viewed or edited"
+      - name: files_shared_internal
+        description: "Files the person shared with people inside the organization"
+      - name: files_shared_external
+        description: "Files the person shared with people outside the organization"
+      - name: meeting_seconds
+        description: >
+          Audio, video and screen-share seconds added together — the presence
+          test a meeting-free day is the absence of, not a duration to report.
+      - name: meeting_hours
+        description: >
+          Hours in meetings, taking the longest active modality per meeting so
+          audio, video and screen share of one meeting count once.
+      - name: meetings_attended
+        description: "Meetings the person attended"
+      - name: meetings_organized
+        description: "Meetings the person organized; unknown for a tool that reports no organizer"
+      - name: adhoc_meetings_attended
+        description: "Unscheduled meetings attended; unknown for a tool that does not classify meetings"
+      - name: scheduled_meetings_attended
+        description: "Scheduled meetings attended; unknown for a tool that does not classify meetings"
+      - name: focus_hours
+        description: >
+          Working hours the person spent outside meetings. A property of the day
+          rather than of any tool, so it is carried by exactly one row per person
+          and day — the one whose tool sorts first — and is unknown on every
+          other row of that day. Fanning it across the day's tools would multiply
+          it by the tool count.
+      - name: working_hours
+        description: >
+          Scheduled working hours for that day, carried by the same single row
+          per person and day as focus_hours and for the same reason.
+      - name: is_chat_active
+        description: "1 when the person sent at least one chat message through this tool that day"
+      - name: is_email_active
+        description: "1 when the person sent at least one email through this tool that day"
+      - name: is_documents_active
+        description: "1 when the person viewed, edited or shared at least one file through this tool that day"
+      - name: is_meetings_active
+        description: "1 when the person attended at least one meeting through this tool that day"
+      - name: is_deliberately_active
+        description: >
+          1 when any of the four modality flags is set — the person took a
+          deliberate collaboration action. Receiving and reading email are
+          passive and do not set it.
+
+  - name: collab_active_modalities
+    description: >
+      The collaboration modalities a person was deliberately active in: one row
+      per modality per person, day and tool. A semantic-layer dataset —
+      collaboration breadth is a distinct count of its modality column.
     columns:
       - name: tenant_id
         description: "Owning tenant"
@@ -1635,6 +1727,28 @@ models:
       step between two readings and nothing else — exact in sum over the month,
       approximate in placement within it. A semantic-layer dataset — a measure
       sums it.
+      - name: person_email
+        description: "Lowercased person email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: activity_date
+        description: "Day the activity was reported on; the dataset's event time and the partition key"
+        tests:
+          - not_null
+      - name: tool
+        description: "Collaboration tool the activity came from; part of the grain, not a reported breakdown"
+      - name: modality
+        description: "One of chat, email, documents, meetings — the subject breadth counts distinctly"
+        tests:
+          - not_null
+          - accepted_values:
+              values: [chat, email, documents, meetings]
+
+  - name: collab_file_shares
+    description: >
+      Files a person shared, split by who the recipients were: one row per share
+      scope per person, day and tool. A semantic-layer dataset — the combined
+      count sums it and the internal/external split is a breakdown of it.
     columns:
       - name: tenant_id
         description: "Owning tenant"
@@ -1667,6 +1781,28 @@ models:
           The day's share of the month's billed extra usage. Never negative: a
           reading that drops is held at the preceding one, and the suffix
           minimum keeps the steps summing to the month's final reading.
+      - name: person_email
+        description: "Lowercased person email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: activity_date
+        description: "Day the share was reported on; the dataset's event time and the partition key"
+        tests:
+          - not_null
+      - name: tool
+        description: "Collaboration tool the share came from; part of the grain, not a reported breakdown"
+      - name: scope
+        description: "Who the file reached: internal or external"
+        tests:
+          - not_null
+          - accepted_values:
+              values: [internal, external]
+      - name: scope_label
+        description: "Display label for the scope dimension"
+      - name: files_shared
+        description: >
+          Files shared into that scope. A scope the source did not report leaves
+          no row, so it stays unknown rather than reading zero.
 
   - name: account_attribute_values
     description: >

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -269,6 +269,10 @@ models:
         description: "Lines the request removes, nullable when the source reports no stats"
       - name: files_changed
         description: "Files the request touches, nullable when the source reports no stats"
+      - name: linked_commit_count
+        description: >
+          Distinct commits the source links to the request; NULL when it links
+          none, which reports a silent source rather than an empty merge.
       - name: cycle_hours
         description: "Hours from opening to merge, nullable unless the request merged"
       - name: first_review_hours
@@ -296,21 +300,77 @@ models:
   - name: git_review_events
     description: >
       One row per pull-request review or comment, with the actor resolved, the
-      request it sits on joined, and its dimension tuple built. Materialized so
-      the identity map and the pull-request join run once per build in their own
-      query budget rather than competing for memory with every other git measure
-      inside the evidence query.
+      request it sits on joined, and its dimension tuple built. Keyed by the
+      person who acted, not the person whose request was acted on. A
+      semantic-layer dataset — measures count it and drilldown projects it.
+      Materialized so the identity map and the pull-request join run once per
+      build in their own query budget rather than competing for memory with
+      every other git measure inside the evidence query.
     columns:
+      - name: tenant_id
+        description: "Owning tenant"
+      - name: source_id
+        description: "Connector source the event was collected through; an event key is unique only within it"
       - name: event_key
         description: "The silver event's unique key — several events by one person on one request stay distinct"
         tests:
           - not_null
       - name: event_kind
         description: "'review' for a submitted verdict, 'comment' for a conversation or review-thread comment"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['review', 'comment']
+      - name: pr_id
+        description: "Identifier of the request the event sits on, within its repository"
+      - name: pr_number
+        description: "Number the request is quoted by in its source"
       - name: entity_id
         description: "The actor's normalized e-mail; rows without one are dropped here, not downstream"
         tests:
           - not_null
+      - name: metric_date
+        description: "Day the review was submitted or the comment posted"
+      - name: observed_at
+        description: "When the review was submitted or the comment posted; the dataset's event time"
+      - name: title
+        description: "Title of the request the event sits on, '' when the join finds none"
+      - name: author_name
+        description: "Display name of the request's author — not the actor, who is named only by e-mail here"
+      - name: author_email
+        description: "Normalized e-mail of the request's author, '' when the join finds none"
+      - name: actor_person_id
+        description: "Canonical person the actor's e-mail resolves to, '' when it resolves to none"
+      - name: author_person_id
+        description: "Canonical person the request author's e-mail resolves to, '' when it resolves to none"
+      - name: comment_target_value
+        description: "Whether the event sits on the actor's own request: own | others"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['own', 'others']
+      - name: comment_target_label
+        description: "Display label of the comment target"
+      - name: project_value
+        description: "Project dimension value, qualified by source, or __unknown__"
+      - name: project_label
+        description: "Display label of the project"
+      - name: repository_value
+        description: "Repository dimension value, qualified by source"
+      - name: repository_label
+        description: "Display label of the repository"
+      - name: destination_branch_value
+        description: "Branch the request targets, or __unknown__"
+      - name: destination_branch_label
+        description: "Display label of the destination branch"
+      - name: source_value
+        description: "Source system dimension value"
+      - name: source_label
+        description: "Display label of the source system"
+      - name: source_dimensions
+        description: >
+          The event's dimension tuple as Array(Tuple(key, value, label)), the
+          shape the evidence build carries breakdowns in.
 
   - name: git_derived_commits
     description: >

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -1513,6 +1513,161 @@ models:
       - name: comments_received
         description: "Comments left that day on pages the person authored"
 
+  - name: ai_usage
+    description: >
+      AI usage per person and day: what coding assistants and chat assistants
+      each reported, in one relation told apart by `surface`. A semantic-layer
+      dataset — measures sum it and count distinct days over it. Cost and active
+      days span both kinds of usage and a measure reads one dataset, so the two
+      class relations meet here rather than at query time. A counter the source
+      did not report stays NULL rather than becoming zero. Identity stays as the
+      source gave it; the person is bound when a query runs.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: email
+        description: "Normalized person email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: usage_date
+        description: "Day the usage was reported on; the dataset's event time and the partition key"
+        tests:
+          - not_null
+      - name: tool
+        description: "Vendor tool code the usage came from; a breakdown dimension"
+        tests:
+          - not_null
+      - name: tool_label
+        description: "Display label for `tool`; an unmapped code falls through as itself"
+      - name: surface
+        description: >
+          Where the usage happened. 'dev' marks a coding assistant; every other
+          value is the assistant surface the source named. A breakdown dimension.
+        tests:
+          - not_null
+      - name: surface_label
+        description: "Display label for `surface`; an unmapped code falls through as itself"
+      - name: seat_status
+        description: >
+          Seat state as of the last read, not as of the usage day: the sources
+          restate it for every day they re-read. 'unknown' where the source has
+          no seat lifecycle concept. A breakdown dimension.
+        tests:
+          - not_null
+      - name: lines_added
+        description: "Lines the person accepted from a coding assistant; NULL where none were reported"
+      - name: lines_removed
+        description: "Lines the person accepted a coding assistant's deletion of; NULL where none were reported"
+      - name: tool_use_offered
+        description: "Edit or tool suggestions a coding assistant offered; NULL where none were reported"
+      - name: tool_use_accepted
+        description: "Edit or tool suggestions the person accepted; NULL where none were reported"
+      - name: dev_conversations
+        description: >
+          Conversations with a coding assistant, counted as that vendor counts
+          them. NULL for tools that publish no such unit.
+      - name: assistant_messages
+        description: "Messages exchanged with an AI assistant; NULL where none were reported"
+      - name: assistant_actions
+        description: "Actions an AI assistant took; NULL where none were reported"
+      - name: chat_conversations
+        description: "Conversations held with an AI assistant; NULL where none were reported"
+      - name: prs_with_assistant
+        description: "Pull requests a coding assistant reported itself active in; NULL where the source does not reach the code host"
+      - name: prs_total
+        description: "Pull requests a coding assistant observed over its own window; NULL where the source does not reach the code host"
+      - name: cost_usd
+        description: >
+          What the usage would cost at the vendor's token rates, in dollars.
+          NULL where the vendor prices no per-person usage.
+
+  - name: ai_seat_months
+    description: >
+      What one AI seat cost in one billing month: the fee the invoice priced it
+      at, the usage billed on top of that fee, and the ceiling that usage runs
+      against. A semantic-layer dataset — measures sum it and a ratio reads the
+      ceiling. A seat the invoice does not price, and a seat with no ceiling,
+      carry NULL rather than a share of the invoice total or a fabricated
+      denominator.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: source_id
+        description: "Connector instance the seat was reported by; a seat id is unique only within it"
+      - name: account_id
+        description: "The vendor's own stable seat identifier"
+      - name: email
+        description: "Normalized person email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: period_month
+        description: "First day of the billing month; the dataset's event time and the partition key"
+        tests:
+          - not_null
+      - name: tool
+        description: "Vendor tool code the seat belongs to; a breakdown dimension"
+        tests:
+          - not_null
+      - name: tool_label
+        description: "Display label for `tool`; an unmapped code falls through as itself"
+      - name: seat_tier
+        description: "Plan tier the seat carries, 'unknown' where the source names none; a breakdown dimension"
+        tests:
+          - not_null
+      - name: extra_usage_usd
+        description: >
+          What the vendor billed once the seat exhausted the usage included in
+          its fee. Not the excess over the ceiling — that difference is where
+          spending stopped, not what it cost.
+      - name: extra_usage_limit_usd
+        description: "The ceiling the vendor stops extra usage at; NULL for a seat with no ceiling"
+      - name: seat_cost_usd
+        description: "The invoiced price of the seat for the month; NULL for a seat whose tier the invoice does not price"
+
+  - name: ai_seat_days
+    description: >
+      One AI seat's billed extra usage placed on the day it was spent. The
+      vendor reports a cumulative month-to-date figure, so a day's spend is the
+      step between two readings and nothing else — exact in sum over the month,
+      approximate in placement within it. A semantic-layer dataset — a measure
+      sums it.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: source_id
+        description: "Connector instance the seat was reported by; a seat id is unique only within it"
+      - name: account_id
+        description: "The vendor's own stable seat identifier"
+      - name: email
+        description: "Normalized person email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: snapshot_date
+        description: "Day the seat was read on; the dataset's event time and the partition key"
+        tests:
+          - not_null
+      - name: tool
+        description: "Vendor tool code the seat belongs to; a breakdown dimension"
+        tests:
+          - not_null
+      - name: tool_label
+        description: "Display label for `tool`; an unmapped code falls through as itself"
+      - name: seat_tier
+        description: "Plan tier the seat carries, 'unknown' where the source names none; a breakdown dimension"
+        tests:
+          - not_null
+      - name: daily_extra_usage_usd
+        description: >
+          The day's share of the month's billed extra usage. Never negative: a
+          reading that drops is held at the preceding one, and the suffix
+          minimum keeps the steps summing to the month's final reading.
+
   - name: account_attribute_values
     description: >
       Effective-dated person-attribute values per stable source account, built

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -1373,6 +1373,172 @@ models:
           the run, UTC); deployments carry repository / environment /
           outcome / env_kind.
 
+  - name: ci_runs
+    description: >
+      One row per decided pipeline run, with its dimensions resolved and its
+      duration carried in both units the measures read. A semantic-layer
+      dataset — measures count and fold it, drilldown projects it. TENANT
+      grain: entity_id is the tenant id and no identity join happens, because
+      a pipeline run belongs to the organization rather than to a person.
+      Undecided runs are excluded; a retried run appears once, at its latest
+      attempt.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: entity_id
+        description: >
+          The tenant id, verbatim — what a tenant-grain read keys its rows by.
+        tests:
+          - not_null
+      - name: source_id
+        description: "Connector source the run was collected through; a run id is unique only within it"
+      - name: run_id
+        description: "Source identifier of the run within its repository"
+      - name: run_number
+        description: "Number the run is quoted by in its source"
+      - name: metric_date
+        description: "Day the run started"
+      - name: started_at
+        description: "When the run started; the dataset's event time"
+      - name: is_gate
+        description: "1 when the run is commit-triggered and reached a decided outcome — the population pass rates are taken over"
+        tests:
+          - accepted_values:
+              arguments:
+                values: [0, 1]
+      - name: is_retry
+        description: "1 when the run's final state came from a re-run"
+        tests:
+          - accepted_values:
+              arguments:
+                values: [0, 1]
+      - name: attempt
+        description: "Attempt number the run's state was read from; 1 means it was never re-run"
+      - name: commit_known
+        description: "1 when the run's head commit exists among the collected commits"
+        tests:
+          - accepted_values:
+              arguments:
+                values: [0, 1]
+      - name: branch
+        description: "Head branch the run built, '' when the source reports none"
+      - name: duration_min
+        description: "Wall-clock minutes from start to decision; 0 when the run recorded no duration"
+      - name: duration_h
+        description: "The same span in hours, so the hours measure divides nothing at read time"
+      - name: run_label
+        description: "Pipeline name and run number, as a drilldown row names the run"
+      - name: repository_value
+        description: "Repository dimension value"
+      - name: repository_label
+        description: "Display label of the repository"
+      - name: pipeline_value
+        description: "Pipeline dimension value — the workflow file, which is stable where the display name is not"
+      - name: pipeline_label
+        description: "Display name of the pipeline"
+      - name: trigger_value
+        description: "What started the run: push | pull_request | merge_queue | schedule | manual | other"
+      - name: trigger_label
+        description: "Display label of the trigger"
+      - name: outcome_value
+        description: "Decided outcome of the run; undecided runs are not in this relation"
+      - name: outcome_label
+        description: "Display label of the outcome"
+      - name: hour_block_value
+        description: "Two-hour block of the run's start hour, UTC, zero-padded"
+      - name: hour_block_label
+        description: "Display label of the two-hour block, as a range"
+
+  - name: ci_deployments
+    description: >
+      One row per deployment, with the latest status event folded in as its
+      outcome. A semantic-layer dataset — measures count it, drilldown
+      projects it. TENANT grain: entity_id is the tenant id and no identity
+      join happens. A deployment with no status event yet reads as the visible
+      'pending' outcome rather than being rounded away.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: entity_id
+        description: >
+          The tenant id, verbatim — what a tenant-grain read keys its rows by.
+        tests:
+          - not_null
+      - name: source_id
+        description: "Connector source the deployment was collected through; a deployment id is unique only within it"
+      - name: deployment_id
+        description: "Source identifier of the deployment"
+        tests:
+          - not_null
+      - name: metric_date
+        description: "Day the deployment was created"
+      - name: created_at
+        description: "When the deployment was created; the dataset's event time"
+      - name: deployment_label
+        description: "Environment and outcome, as a drilldown row names the deployment"
+      - name: repository_value
+        description: "Repository dimension value"
+      - name: repository_label
+        description: "Display label of the repository"
+      - name: environment_value
+        description: "Environment dimension value, as the source names it"
+      - name: environment_label
+        description: "Display label of the environment"
+      - name: outcome_value
+        description: "Latest status the deployment reached, or pending when it has none"
+      - name: outcome_label
+        description: "Display label of the outcome"
+      - name: env_kind_value
+        description: "Environment class: production | preview | static"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['production', 'preview', 'static']
+      - name: env_kind_label
+        description: "Display label of the environment class"
+
+  - name: ci_commits
+    description: >
+      One row per collected commit, dated at its commit time — the denominator
+      of the run-to-commit join-coverage reading. A semantic-layer dataset.
+      TENANT grain: this counts what the connector collected rather than what
+      anyone wrote, so entity_id is the tenant id and the commit's author is
+      not carried here; git_commits serves the person-grain reading.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: entity_id
+        description: >
+          The tenant id, verbatim — what a tenant-grain read keys its rows by.
+        tests:
+          - not_null
+      - name: source_id
+        description: "Connector source the commit was collected through"
+      - name: project_key
+        description: "Project the repository belongs to, as the source names it"
+      - name: repo_slug
+        description: "Repository the commit was collected from"
+      - name: commit_hash
+        description: "Full commit hash; one row per hash within the repository that collected it"
+        tests:
+          - not_null
+      - name: metric_date
+        description: "Day the commit was made"
+      - name: committed_at
+        description: "When the commit was made; the dataset's event time"
+      - name: commit_reference
+        description: "Short hash, as a drilldown row quotes the commit"
+      - name: repository_value
+        description: "Repository the commit was collected from, qualified by project"
+      - name: repository_label
+        description: "Display label of the repository"
+
   - name: wiki_metric_observations
     description: >
       Source measure observations for the unified metrics runtime, wiki

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -1087,6 +1087,201 @@ models:
         tests:
           - not_null
 
+  - name: task_closed_issues
+    description: >
+      Closed issues: one row per issue that reached a close, with the outcome
+      the assignee delivered and the durations the work took. A semantic-layer
+      dataset — measures count and fold it and drilldown projects it. An issue
+      reopened after its close keeps its durations and loses its outcome flags.
+      Accepted measure keys: tasks_closed, bugs_fixed, closed_non_bug,
+      due_date_on_time, due_date_with_due, late_count, slip_days_total,
+      dev_hours, resolution_days, pickup_days, flow_dev_seconds,
+      flow_lead_seconds.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: insight_source_id
+        description: "Connector source that tracks the issue; an issue id is unique only within it"
+      - name: issue_id
+        description: "Issue identifier within its source"
+        tests:
+          - not_null
+      - name: id_readable
+        description: "The key the tracker shows a human; the handle an issue's own page is addressed by"
+      - name: title
+        description: "Issue title as the tracker records it"
+      - name: assignee_email
+        description: "Lowercased assignee email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: closed_at
+        description: "Last transition into a done status; the dataset's event time"
+        tests:
+          - not_null
+      - name: closed_date
+        description: "Closing day, the partition key"
+      - name: issue_type
+        description: "Type breakdown value; '__unknown__' where the tracker's type carries no key"
+      - name: issue_type_label
+        description: "Human label for issue_type"
+      - name: source
+        description: "Tracker breakdown value, so two trackers do not blend into one figure"
+      - name: source_label
+        description: "Human label for source"
+      - name: is_closed
+        description: "1 where the issue rests in a done status now; every outcome flag is conjoined with it"
+      - name: is_bug
+        description: "1 where a closed issue is of a bug type"
+      - name: is_non_bug
+        description: "1 where a closed issue is of a known non-bug type; an unclassifiable type is neither"
+      - name: has_due_date
+        description: "1 where a closed issue carried a due date"
+      - name: on_time
+        description: "1 where a closed issue had a due date and closed on or before it"
+      - name: is_late
+        description: "1 where a closed issue had a due date and closed after it"
+      - name: slip_days
+        description: "Days past the due date for a late close; NULL otherwise"
+      - name: dev_seconds
+        description: "Seconds spent in in-progress statuses entered before the close; 0 where none were"
+      - name: dev_hours
+        description: "dev_seconds in hours, the unit the development-time distribution is read in"
+      - name: lead_seconds
+        description: "Seconds from creation to close, floored at zero"
+      - name: resolution_days
+        description: "lead_seconds in days, the unit the resolution-time distribution is read in"
+      - name: pickup_days
+        description: >
+          Days from creation to the first in-progress status entered before the
+          close; NULL where the issue never entered one.
+      - name: estimate_seconds
+        description: "Original estimate in seconds, where the tracker states one in a time unit"
+      - name: spent_seconds
+        description: "Time spent in seconds, where the tracker states one in a time unit"
+
+  - name: task_close_events
+    description: >
+      Close transitions: one row per time an issue entered a done status, and
+      whether it came back out within a fortnight. A semantic-layer dataset —
+      an issue closed, reopened and closed again contributes one row per close,
+      so a rate over these rows is a rate over closing acts, not over issues.
+      Accepted measure keys: close_events, reopened_within_14d.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: insight_source_id
+        description: "Connector source that tracks the issue"
+      - name: issue_id
+        description: "Issue identifier within its source"
+        tests:
+          - not_null
+      - name: id_readable
+        description: "The key the tracker shows a human"
+      - name: title
+        description: "Issue title as the tracker records it"
+      - name: assignee_email
+        description: "Lowercased assignee email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: close_at
+        description: "When the issue entered a done status; the dataset's event time"
+        tests:
+          - not_null
+      - name: close_date
+        description: "Closing day, the partition key"
+      - name: reopened_within_14d
+        description: "1 where the issue left the done status again within 14 days of this close"
+
+  - name: task_estimation_days
+    description: >
+      Estimation against reality, per person and closing day: the day's average
+      estimate as a percentage of the day's average time spent. A semantic-layer
+      dataset. The ratio is taken between two daily averages, never between per
+      issue pairs, so one long-running issue cannot dominate it. Accepted
+      measure keys: estimation_error_pct, estimation_samples.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: assignee_email
+        description: "Lowercased assignee email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: closed_date
+        description: "Day whose closes the ratio was taken over; the dataset's event time and the partition key"
+        tests:
+          - not_null
+      - name: estimation_pct
+        description: >
+          The day's average estimate as a percentage of its average time spent.
+          100 means estimates matched reality; below 100 is under-estimation.
+      - name: estimation_error_pct
+        description: "Distance of estimation_pct from 100, so over- and under-estimation weigh equally"
+
+  - name: task_open_issues
+    description: >
+      Issues still open: one row per issue that rests outside a done status,
+      dated by the last time its status moved. A semantic-layer dataset.
+      idle_days is measured against the moment the table is built and is
+      rewritten on every run; the event time is the status event, which never
+      moves. Accepted measure keys: stale_open_issues.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: insight_source_id
+        description: "Connector source that tracks the issue"
+      - name: issue_id
+        description: "Issue identifier within its source"
+        tests:
+          - not_null
+      - name: id_readable
+        description: "The key the tracker shows a human"
+      - name: title
+        description: "Issue title as the tracker records it"
+      - name: assignee_email
+        description: "Lowercased assignee email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: last_status_event_at
+        description: "Last status transition on the issue; the dataset's event time"
+        tests:
+          - not_null
+      - name: last_status_event_date
+        description: "Day of the last status transition, the partition key"
+      - name: idle_days
+        description: "Days between the last status transition and the build"
+
+  - name: task_worklog_flow
+    description: >
+      Task work per person and day: seconds issues spent in in-progress
+      statuses that day, and seconds the person logged against them. Feeds the
+      worklog-accuracy observation and serves as a semantic-layer dataset.
+      Accepted measure keys: worklog_seconds, in_progress_seconds.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: entity_id
+        description: "Lowercased person email exactly as the source reports it"
+        tests:
+          - not_null
+      - name: metric_date
+        description: "Day the work fell on; the dataset's event time"
+        tests:
+          - not_null
+      - name: in_progress_seconds
+        description: "Seconds the person's issues spent in in-progress statuses that day"
+      - name: worklog_seconds
+        description: "Seconds the person logged against issues on that day"
+
   - name: ci_metric_observations
     description: >
       Source measure observations for the unified metrics runtime, CI family —

--- a/src/ingestion/gold/task_close_events.sql
+++ b/src/ingestion/gold/task_close_events.sql
@@ -1,0 +1,73 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'assignee_email', 'close_at'],
+    partition_by='toYYYYMM(close_date)',
+    schema=var('gold_database'),
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Close transitions: one row per time an issue entered a done status, and
+-- whether it came back out within a fortnight. An issue closed, reopened and
+-- closed again contributes one row per close, so a rate over these rows is a
+-- rate over closing acts rather than over issues.
+
+WITH
+transitions AS (
+    SELECT
+        insight_source_id                                                    AS insight_source_id,
+        issue_id                                                             AS issue_id,
+        interval_start                                                       AS event_at,
+        status_category                                                      AS status_category,
+        lagInFrame(status_category) OVER (
+            PARTITION BY insight_source_id, issue_id ORDER BY interval_start
+        )                                                                    AS prev_category
+    FROM {{ ref('task_status_spans') }}
+),
+closes AS (
+    SELECT
+        insight_source_id                                                    AS insight_source_id,
+        issue_id                                                             AS issue_id,
+        event_at                                                             AS close_at
+    FROM transitions
+    WHERE status_category = 'done'
+      AND ifNull(prev_category, '') != 'done'
+),
+reopens AS (
+    SELECT
+        insight_source_id                                                    AS insight_source_id,
+        issue_id                                                             AS issue_id,
+        event_at                                                             AS reopen_at
+    FROM transitions
+    WHERE prev_category = 'done'
+      AND ifNull(status_category, '') != 'done'
+)
+
+SELECT
+    assumeNotNull(any(issues.tenant_id))                                     AS tenant_id,
+    closes.insight_source_id                                                 AS insight_source_id,
+    closes.issue_id                                                          AS issue_id,
+    any(issues.id_readable)                                                  AS id_readable,
+    any(issues.title)                                                        AS title,
+    assumeNotNull(any(issues.entity_id))                                     AS assignee_email,
+    closes.close_at                                                          AS close_at,
+    toDate(closes.close_at)                                                  AS close_date,
+    -- SAFETY: minIfOrNull, not minIf — over a non-nullable column with nothing
+    -- matching, minIf returns the type default and reads as a reopen at epoch.
+    toUInt8(ifNull(
+        minIfOrNull(reopens.reopen_at, reopens.reopen_at > closes.close_at)
+            <= closes.close_at + INTERVAL 14 DAY,
+        0))                                                                  AS reopened_within_14d
+FROM closes
+INNER JOIN {{ ref('task_issue_state') }} AS issues
+    ON issues.insight_source_id = closes.insight_source_id
+   AND issues.issue_id = closes.issue_id
+LEFT JOIN reopens
+    ON reopens.insight_source_id = closes.insight_source_id
+   AND reopens.issue_id = closes.issue_id
+-- SAFETY: the assumeNotNull calls above are sound under this guard.
+WHERE issues.tenant_id IS NOT NULL
+  AND issues.entity_id IS NOT NULL
+  AND issues.entity_id != ''
+GROUP BY closes.insight_source_id, closes.issue_id, closes.close_at

--- a/src/ingestion/gold/task_closed_issues.sql
+++ b/src/ingestion/gold/task_closed_issues.sql
@@ -1,0 +1,108 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'assignee_email', 'closed_at'],
+    partition_by='toYYYYMM(closed_date)',
+    schema=var('gold_database'),
+    tags=['gold'],
+    query_settings=metric_serving_query_settings(join_use_nulls=1)
+) }}
+
+-- Closed issues: one row per issue that reached a close, carrying the outcome
+-- an assignee delivered and the durations the work took.
+--
+-- INVARIANT: an issue reopened after its close keeps its durations and loses
+-- its outcome flags — `is_closed` says whether the issue rests in a done
+-- status now, and every outcome flag is conjoined with it.
+--
+-- INVARIANT: the config pins join_use_nulls, so an issue with no in-progress
+-- span reads as absent rather than as one starting at the epoch.
+
+WITH
+closed AS (
+    SELECT
+        assumeNotNull(tenant_id)                                             AS tenant_id,
+        assumeNotNull(entity_id)                                             AS assignee_email,
+        insight_source_id                                                    AS insight_source_id,
+        data_source                                                          AS data_source,
+        issue_id                                                             AS issue_id,
+        id_readable                                                          AS id_readable,
+        title                                                                AS title,
+        issue_kind                                                           AS issue_kind,
+        issue_type_key                                                       AS issue_type_key,
+        issue_type_name                                                      AS issue_type_name,
+        toUInt8(status_category = 'done')                                    AS is_done,
+        due_date                                                             AS due_date,
+        time_estimate_seconds                                                AS estimate_seconds,
+        time_spent_seconds                                                   AS spent_seconds,
+        created_at                                                           AS created_at,
+        assumeNotNull(final_close_at)                                        AS closed_at
+    FROM {{ ref('task_issue_state') }}
+    -- SAFETY: the assumeNotNull calls above are all sound under this guard.
+    WHERE final_close_at IS NOT NULL
+      AND tenant_id IS NOT NULL
+      AND entity_id IS NOT NULL
+      AND entity_id != ''
+),
+-- Development time is the in-progress spans that began before the close; one
+-- opened afterwards belongs to whatever happened next, not to this delivery.
+in_progress_before_close AS (
+    SELECT
+        spans.insight_source_id                                              AS insight_source_id,
+        spans.issue_id                                                       AS issue_id,
+        sum(spans.duration_seconds)                                          AS dev_seconds,
+        min(spans.interval_start)                                            AS first_in_progress_at
+    FROM {{ ref('task_status_spans') }} AS spans
+    INNER JOIN closed
+        ON closed.insight_source_id = spans.insight_source_id
+       AND closed.issue_id = spans.issue_id
+    WHERE spans.status_category = 'in_progress'
+      AND spans.interval_start < closed.closed_at
+    GROUP BY spans.insight_source_id, spans.issue_id
+)
+
+SELECT
+    closed.tenant_id                                                         AS tenant_id,
+    closed.insight_source_id                                                 AS insight_source_id,
+    closed.issue_id                                                          AS issue_id,
+    closed.id_readable                                                       AS id_readable,
+    closed.title                                                             AS title,
+    closed.assignee_email                                                    AS assignee_email,
+    closed.closed_at                                                         AS closed_at,
+    toDate(closed.closed_at)                                                 AS closed_date,
+    ifNull(closed.issue_type_key, '__unknown__')                             AS issue_type,
+    ifNull(closed.issue_type_name, 'Type unknown')                           AS issue_type_label,
+    closed.data_source                                                       AS source,
+    closed.data_source                                                       AS source_label,
+    closed.is_done                                                           AS is_closed,
+    toUInt8(closed.is_done AND closed.issue_kind = 'bug')                    AS is_bug,
+    -- A type the tracker reports but the contract cannot classify is neither a
+    -- bug nor a known non-bug; it counts only in the closed total.
+    toUInt8(closed.is_done AND closed.issue_kind = 'other')                  AS is_non_bug,
+    toUInt8(closed.is_done AND closed.due_date IS NOT NULL)                  AS has_due_date,
+    toUInt8(closed.is_done
+            AND ifNull(toDate(closed.closed_at) <= closed.due_date, 0))      AS on_time,
+    toUInt8(closed.is_done
+            AND ifNull(toDate(closed.closed_at) > closed.due_date, 0))       AS is_late,
+    if(closed.is_done AND ifNull(toDate(closed.closed_at) > closed.due_date, 0),
+       toFloat64(dateDiff('day', closed.due_date, toDate(closed.closed_at))),
+       CAST(NULL AS Nullable(Float64)))                                      AS slip_days,
+    ifNull(spans.dev_seconds, toFloat64(0))                                  AS dev_seconds,
+    ifNull(spans.dev_seconds, toFloat64(0)) / 3600.0                         AS dev_hours,
+    toFloat64(greatest(toInt64(0),
+        dateDiff('second', closed.created_at, closed.closed_at)))            AS lead_seconds,
+    toFloat64(greatest(toInt64(0),
+        dateDiff('second', closed.created_at, closed.closed_at))) / 86400.0  AS resolution_days,
+    -- An issue that never entered an in-progress status before its close has no
+    -- pickup to time, which is not the same as having been picked up at once.
+    if(spans.first_in_progress_at IS NULL,
+       CAST(NULL AS Nullable(Float64)),
+       toFloat64(greatest(toInt64(0),
+           dateDiff('second', closed.created_at, spans.first_in_progress_at)))
+           / 86400.0)                                                        AS pickup_days,
+    closed.estimate_seconds                                                  AS estimate_seconds,
+    closed.spent_seconds                                                     AS spent_seconds
+FROM closed
+LEFT JOIN in_progress_before_close AS spans
+    ON spans.insight_source_id = closed.insight_source_id
+   AND spans.issue_id = closed.issue_id

--- a/src/ingestion/gold/task_estimation_days.sql
+++ b/src/ingestion/gold/task_estimation_days.sql
@@ -1,0 +1,41 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'assignee_email', 'closed_date'],
+    partition_by='toYYYYMM(closed_date)',
+    schema=var('gold_database'),
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Estimation against reality, per person and closing day: the day's average
+-- estimate as a percentage of the day's average time spent.
+--
+-- INVARIANT: the ratio is taken between two daily averages, never between per
+-- issue pairs — a person's day is the unit of estimation, so one long-running
+-- issue cannot dominate the figure the way a per-issue ratio lets it.
+
+WITH
+estimated AS (
+    SELECT
+        tenant_id                                                            AS tenant_id,
+        assignee_email                                                       AS assignee_email,
+        closed_date                                                          AS closed_date,
+        100 * avgIf(estimate_seconds, is_closed = 1
+                                      AND ifNull(estimate_seconds, 0) > 0
+                                      AND spent_seconds IS NOT NULL)
+            / nullIf(avgIf(spent_seconds, is_closed = 1
+                                          AND ifNull(estimate_seconds, 0) > 0
+                                          AND spent_seconds IS NOT NULL), 0) AS estimation_pct
+    FROM {{ ref('task_closed_issues') }}
+    GROUP BY tenant_id, assignee_email, closed_date
+)
+
+SELECT
+    tenant_id                                                                AS tenant_id,
+    assignee_email                                                           AS assignee_email,
+    closed_date                                                              AS closed_date,
+    estimation_pct                                                           AS estimation_pct,
+    abs(100 - estimation_pct)                                                AS estimation_error_pct
+FROM estimated
+WHERE estimation_pct IS NOT NULL

--- a/src/ingestion/gold/task_open_issues.sql
+++ b/src/ingestion/gold/task_open_issues.sql
@@ -1,0 +1,33 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'assignee_email', 'last_status_event_at'],
+    partition_by='toYYYYMM(last_status_event_date)',
+    schema=var('gold_database'),
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Issues still open: one row per issue that rests outside a done status, dated
+-- by the last time its status moved and carrying how long it has sat there.
+--
+-- INVARIANT: `idle_days` is measured against the moment this table is built,
+-- so it answers "how idle is this issue now" and is rewritten on every run —
+-- the event time is the status event itself, which never moves.
+
+SELECT
+    assumeNotNull(tenant_id)                                                 AS tenant_id,
+    insight_source_id                                                        AS insight_source_id,
+    issue_id                                                                 AS issue_id,
+    id_readable                                                              AS id_readable,
+    title                                                                    AS title,
+    assumeNotNull(entity_id)                                                 AS assignee_email,
+    last_status_event_at                                                     AS last_status_event_at,
+    toDate(last_status_event_at)                                             AS last_status_event_date,
+    toInt64(dateDiff('day', last_status_event_at, now()))                    AS idle_days
+FROM {{ ref('task_issue_state') }}
+-- SAFETY: the assumeNotNull calls above are sound under this guard.
+WHERE ifNull(status_category, '') != 'done'
+  AND tenant_id IS NOT NULL
+  AND entity_id IS NOT NULL
+  AND entity_id != ''

--- a/src/ingestion/gold/wiki_pages.sql
+++ b/src/ingestion/gold/wiki_pages.sql
@@ -1,0 +1,33 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'author_email', 'created_at'],
+    partition_by='toYYYYMM(created_date)',
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Authored wiki pages: one row per page a person created, with the space it
+-- lives in and the day the source dated its creation.
+--
+-- INVARIANT: identity is the author email the source recorded, normalized and
+-- nothing more; the person is bound when a query runs.
+
+SELECT
+    -- SAFETY: both are safe under the WHERE below.
+    assumeNotNull(pages.tenant_id) AS tenant_id,
+    pages.source_id AS source_id,
+    assumeNotNull(pages.page_id) AS page_id,
+    pages.title AS title,
+    pages.space_name AS space_name,
+    assumeNotNull(lower(trimBoth(pages.author_email))) AS author_email,
+    -- A source that dates no creation still described a page; the row stays and
+    -- falls outside every period until the source dates it.
+    pages.created_at AS created_at,
+    toDate(pages.created_at) AS created_date
+FROM {{ ref('class_wiki_pages') }} AS pages FINAL
+WHERE pages.tenant_id IS NOT NULL
+  AND pages.page_id IS NOT NULL
+  AND pages.author_email LIKE '%@%'

--- a/src/ingestion/gold/wiki_person_days.sql
+++ b/src/ingestion/gold/wiki_person_days.sql
@@ -1,0 +1,99 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'author_email', 'activity_date'],
+    partition_by='toYYYYMM(activity_date)',
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Wiki work per person and day: the edits a person made, the pages those edits
+-- touched, and the comments other people left on pages that person authored.
+
+WITH
+-- The only route from a comment to a person: wiki engagement names the page it
+-- sits on and never the person, so authorship of the page carries it.
+page_authors AS (
+    SELECT
+        tenant_id,
+        source_id,
+        page_id,
+        lower(trimBoth(author_email)) AS author_email
+    FROM {{ ref('class_wiki_pages') }} FINAL
+    WHERE author_email LIKE '%@%'
+),
+edit_activity AS (
+    SELECT
+        tenant_id,
+        source_id,
+        lower(trimBoth(author_email)) AS author_email,
+        day AS activity_date,
+        total_edits AS edits,
+        pages_edited AS pages_edited
+    FROM {{ ref('class_wiki_activity') }} FINAL
+    WHERE tenant_id IS NOT NULL
+      AND author_email LIKE '%@%'
+      AND day IS NOT NULL
+),
+page_comments AS (
+    SELECT
+        engagement.tenant_id AS tenant_id,
+        engagement.source_id AS source_id,
+        authors.author_email AS author_email,
+        engagement.day AS activity_date,
+        engagement.total_comments AS comments_received
+    FROM (
+        SELECT
+            tenant_id,
+            source_id,
+            page_id,
+            day,
+            total_comments
+        FROM {{ ref('class_wiki_engagement') }} FINAL
+        WHERE tenant_id IS NOT NULL
+          AND day IS NOT NULL
+    ) AS engagement
+    INNER JOIN page_authors AS authors
+        ON engagement.tenant_id = authors.tenant_id
+       AND engagement.source_id = authors.source_id
+       AND engagement.page_id = authors.page_id
+),
+-- A person may have edited without being commented on, or been commented on
+-- without editing; the union carries both key sets into one grain.
+person_day_contributions AS (
+    SELECT
+        tenant_id,
+        source_id,
+        author_email,
+        activity_date,
+        edits,
+        pages_edited,
+        toUInt32(0) AS comments_received
+    FROM edit_activity
+
+    UNION ALL
+
+    SELECT
+        tenant_id,
+        source_id,
+        author_email,
+        activity_date,
+        toUInt32(0) AS edits,
+        toUInt32(0) AS pages_edited,
+        comments_received
+    FROM page_comments
+)
+
+SELECT
+    -- SAFETY: every contributing branch admits only non-null keys.
+    assumeNotNull(tenant_id) AS tenant_id,
+    source_id AS source_id,
+    assumeNotNull(author_email) AS author_email,
+    assumeNotNull(activity_date) AS activity_date,
+    sum(edits) AS edits,
+    sum(pages_edited) AS pages_edited,
+    sum(comments_received) AS comments_received
+FROM person_day_contributions
+GROUP BY tenant_id, source_id, author_email, activity_date

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -194,6 +194,50 @@ ORDER BY (tenant_id, email, usage_date)
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS insight.ci_commits
+(
+    `tenant_id` String,
+    `entity_id` String,
+    `source_id` String,
+    `project_key` String,
+    `repo_slug` String,
+    `commit_hash` String,
+    `metric_date` Date,
+    `committed_at` DateTime64(3),
+    `commit_reference` String,
+    `repository_value` String,
+    `repository_label` String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(metric_date)
+ORDER BY (tenant_id, entity_id, metric_date)
+SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.ci_deployments
+(
+    `tenant_id` String,
+    `entity_id` String,
+    `source_id` String,
+    `deployment_id` String,
+    `metric_date` Date,
+    `created_at` DateTime64(3),
+    `deployment_label` String,
+    `repository_value` String,
+    `repository_label` String,
+    `environment_value` String,
+    `environment_label` String,
+    `outcome_value` String,
+    `outcome_label` String,
+    `env_kind_value` String,
+    `env_kind_label` String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(metric_date)
+ORDER BY (tenant_id, entity_id, metric_date)
+SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS insight.ci_metric_evidence
 (
     `tenant_id` String,
@@ -247,6 +291,40 @@ CREATE TABLE IF NOT EXISTS insight.ci_metric_observations
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(metric_date)
 ORDER BY (tenant_id, source_key, entity_type, entity_id, measure_key, metric_date)
+SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.ci_runs
+(
+    `tenant_id` String,
+    `entity_id` String,
+    `source_id` String,
+    `run_id` String,
+    `run_number` String,
+    `metric_date` Date,
+    `started_at` DateTime64(3),
+    `is_gate` UInt8,
+    `is_retry` UInt8,
+    `attempt` UInt32,
+    `commit_known` UInt8,
+    `branch` String,
+    `duration_min` Float64,
+    `duration_h` Float64,
+    `run_label` String,
+    `repository_value` String,
+    `repository_label` String,
+    `pipeline_value` String,
+    `pipeline_label` String,
+    `trigger_value` String,
+    `trigger_label` String,
+    `outcome_value` String,
+    `outcome_label` String,
+    `hour_block_value` String,
+    `hour_block_label` String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(metric_date)
+ORDER BY (tenant_id, entity_id, metric_date)
 SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
 ;
 

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -128,6 +128,72 @@ ORDER BY (tenant_id, source_key, entity_type, entity_id, measure_key, metric_dat
 SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS insight.ai_seat_days
+(
+    `tenant_id` String,
+    `source_id` Nullable(String),
+    `account_id` Nullable(String),
+    `email` String,
+    `snapshot_date` Date,
+    `tool` String,
+    `tool_label` String,
+    `seat_tier` String,
+    `daily_extra_usage_usd` Float64
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(snapshot_date)
+ORDER BY (tenant_id, email, snapshot_date)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.ai_seat_months
+(
+    `tenant_id` String,
+    `source_id` Nullable(String),
+    `account_id` Nullable(String),
+    `email` String,
+    `period_month` Date,
+    `tool` String,
+    `tool_label` String,
+    `seat_tier` String,
+    `extra_usage_usd` Float64,
+    `extra_usage_limit_usd` Nullable(Float64),
+    `seat_cost_usd` Nullable(Float64)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(period_month)
+ORDER BY (tenant_id, email, period_month)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.ai_usage
+(
+    `tenant_id` String,
+    `email` String,
+    `usage_date` Date,
+    `tool` String,
+    `tool_label` String,
+    `surface` String,
+    `surface_label` String,
+    `seat_status` String,
+    `lines_added` Nullable(UInt64),
+    `lines_removed` Nullable(UInt64),
+    `tool_use_offered` Nullable(UInt64),
+    `tool_use_accepted` Nullable(UInt64),
+    `dev_conversations` Nullable(UInt64),
+    `assistant_messages` Nullable(UInt64),
+    `assistant_actions` Nullable(UInt64),
+    `chat_conversations` Nullable(UInt64),
+    `prs_with_assistant` Nullable(UInt64),
+    `prs_total` Nullable(UInt64),
+    `cost_usd` Nullable(Float64)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(usage_date)
+ORDER BY (tenant_id, email, usage_date)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS insight.ci_metric_evidence
 (
     `tenant_id` String,

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -294,6 +294,35 @@ ORDER BY (tenant_id, data_source, commit_hash)
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS insight.git_commits
+(
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `project_key` String,
+    `repo_slug` String,
+    `commit_hash` String,
+    `author_email` String,
+    `author_name` String,
+    `message` String,
+    `authored_at` DateTime,
+    `authored_date` Date,
+    `branch_scope` String,
+    `branch_scope_label` String,
+    `repository` String,
+    `repository_label` String,
+    `project` String,
+    `project_label` String,
+    `source` String,
+    `source_label` String,
+    `lines_added` Nullable(Int64),
+    `lines_removed` Nullable(Int64)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(authored_date)
+ORDER BY (tenant_id, author_email, authored_at)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS insight.git_default_branch_commits
 (
     `tenant_id` Nullable(String),
@@ -316,6 +345,41 @@ CREATE TABLE IF NOT EXISTS insight.git_derived_commits
 )
 ENGINE = MergeTree
 ORDER BY (tenant_id, data_source, commit_hash)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.git_file_changes
+(
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `project_key` String,
+    `repo_slug` String,
+    `commit_hash` String,
+    `file_path` String,
+    `author_email` String,
+    `author_name` String,
+    `authored_at` DateTime,
+    `authored_date` Date,
+    `category` String,
+    `category_label` String,
+    `file_extension` String,
+    `file_extension_label` String,
+    `change_type` String,
+    `change_type_label` String,
+    `branch_scope` String,
+    `branch_scope_label` String,
+    `repository` String,
+    `repository_label` String,
+    `project` String,
+    `project_label` String,
+    `source` String,
+    `source_label` String,
+    `lines_added` Nullable(Int64),
+    `lines_removed` Nullable(Int64)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(authored_date)
+ORDER BY (tenant_id, author_email, authored_at)
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
@@ -372,6 +436,52 @@ ENGINE = MergeTree
 PARTITION BY toYYYYMM(metric_date)
 ORDER BY (tenant_id, source_key, entity_type, entity_id, measure_key, metric_date)
 SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.git_pull_requests
+(
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `project_key` String,
+    `repo_slug` String,
+    `pr_id` Int64,
+    `pr_number` Int64,
+    `title` String,
+    `author_email` String,
+    `author_account_id` String,
+    `author_name` String,
+    `created_at` DateTime,
+    `created_date` Date,
+    `closed_at` Nullable(DateTime),
+    `merged` UInt8,
+    `abandoned` UInt8,
+    `merged_without_approval` UInt8,
+    `reviewer_count` UInt64,
+    `first_reviewed_at` Nullable(DateTime),
+    `approved_at` Nullable(DateTime),
+    `branch_scope` String,
+    `branch_scope_label` String,
+    `destination_branch` String,
+    `destination_branch_label` String,
+    `repository` String,
+    `repository_label` String,
+    `project` String,
+    `project_label` String,
+    `source` String,
+    `source_label` String,
+    `lines_added` Nullable(Int64),
+    `lines_removed` Nullable(Int64),
+    `files_changed` Nullable(Int64),
+    `cycle_hours` Nullable(Float64),
+    `first_review_hours` Nullable(Float64),
+    `review_to_merge_hours` Nullable(Float64),
+    `approval_to_merge_hours` Nullable(Float64),
+    `review_wait_share` Nullable(Float64)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(created_date)
+ORDER BY (tenant_id, author_email, created_at)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
 CREATE TABLE IF NOT EXISTS insight.git_review_events
@@ -571,6 +681,39 @@ ENGINE = MergeTree
 PARTITION BY toYYYYMM(metric_date)
 ORDER BY (tenant_id, source_key, entity_type, entity_id, measure_key, metric_date)
 SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.wiki_pages
+(
+    `tenant_id` String,
+    `source_id` Nullable(String),
+    `page_id` String,
+    `title` Nullable(String),
+    `space_name` Nullable(String),
+    `author_email` String,
+    `created_at` Nullable(DateTime64(3)),
+    `created_date` Nullable(Date)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(created_date)
+ORDER BY (tenant_id, author_email, created_at)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.wiki_person_days
+(
+    `tenant_id` String,
+    `source_id` Nullable(String),
+    `author_email` String,
+    `activity_date` Date,
+    `edits` UInt64,
+    `pages_edited` UInt64,
+    `comments_received` UInt64
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(activity_date)
+ORDER BY (tenant_id, author_email, activity_date)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
 CREATE OR REPLACE VIEW insight.identity_resolution_coverage

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -250,6 +250,72 @@ ORDER BY (tenant_id, source_key, entity_type, entity_id, measure_key, metric_dat
 SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS insight.collab_active_modalities
+(
+    `tenant_id` String,
+    `person_email` String,
+    `activity_date` Date,
+    `tool` String,
+    `modality` String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(activity_date)
+ORDER BY (tenant_id, person_email, activity_date)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.collab_activity
+(
+    `tenant_id` String,
+    `person_email` String,
+    `activity_date` Date,
+    `tool` String,
+    `tool_label` String,
+    `total_chat_messages` Nullable(Int64),
+    `channel_posts_total` Nullable(Int64),
+    `direct_and_group_messages` Nullable(Int64),
+    `emails_sent` Nullable(Float64),
+    `emails_received` Nullable(Float64),
+    `emails_read` Nullable(Float64),
+    `files_engaged` Nullable(Float64),
+    `files_shared_internal` Nullable(Float64),
+    `files_shared_external` Nullable(Float64),
+    `meeting_seconds` Nullable(Int64),
+    `meeting_hours` Nullable(Float64),
+    `meetings_attended` Nullable(Int64),
+    `meetings_organized` Nullable(Int64),
+    `adhoc_meetings_attended` Nullable(Int64),
+    `scheduled_meetings_attended` Nullable(Int64),
+    `focus_hours` Nullable(Float64),
+    `working_hours` Nullable(Float64),
+    `is_chat_active` UInt8,
+    `is_email_active` UInt8,
+    `is_documents_active` UInt8,
+    `is_meetings_active` UInt8,
+    `is_deliberately_active` UInt8
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(activity_date)
+ORDER BY (tenant_id, person_email, activity_date)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.collab_file_shares
+(
+    `tenant_id` String,
+    `person_email` String,
+    `activity_date` Date,
+    `tool` String,
+    `scope` String,
+    `scope_label` String,
+    `files_shared` Nullable(Float64)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(activity_date)
+ORDER BY (tenant_id, person_email, activity_date)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS insight.collab_metric_evidence
 (
     `tenant_id` String,

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -472,6 +472,7 @@ CREATE TABLE IF NOT EXISTS insight.git_pull_requests
     `lines_added` Nullable(Int64),
     `lines_removed` Nullable(Int64),
     `files_changed` Nullable(Int64),
+    `linked_commit_count` Nullable(UInt64),
     `cycle_hours` Nullable(Float64),
     `first_review_hours` Nullable(Float64),
     `review_to_merge_hours` Nullable(Float64),

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -521,6 +521,73 @@ ORDER BY (tenant_id, entity_id, metric_date)
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS insight.task_close_events
+(
+    `tenant_id` String,
+    `insight_source_id` String,
+    `issue_id` String,
+    `id_readable` String,
+    `title` Nullable(String),
+    `assignee_email` String,
+    `close_at` DateTime64(3),
+    `close_date` Date,
+    `reopened_within_14d` UInt8
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(close_date)
+ORDER BY (tenant_id, assignee_email, close_at)
+SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.task_closed_issues
+(
+    `tenant_id` String,
+    `insight_source_id` String,
+    `issue_id` String,
+    `id_readable` String,
+    `title` Nullable(String),
+    `assignee_email` String,
+    `closed_at` DateTime64(3),
+    `closed_date` Date,
+    `issue_type` String,
+    `issue_type_label` String,
+    `source` String,
+    `source_label` String,
+    `is_closed` UInt8,
+    `is_bug` UInt8,
+    `is_non_bug` UInt8,
+    `has_due_date` UInt8,
+    `on_time` UInt8,
+    `is_late` UInt8,
+    `slip_days` Nullable(Float64),
+    `dev_seconds` Float64,
+    `dev_hours` Float64,
+    `lead_seconds` Float64,
+    `resolution_days` Float64,
+    `pickup_days` Nullable(Float64),
+    `estimate_seconds` Nullable(Float64),
+    `spent_seconds` Nullable(Float64)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(closed_date)
+ORDER BY (tenant_id, assignee_email, closed_at)
+SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.task_estimation_days
+(
+    `tenant_id` String,
+    `assignee_email` String,
+    `closed_date` Date,
+    `estimation_pct` Nullable(Float64),
+    `estimation_error_pct` Nullable(Float64)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(closed_date)
+ORDER BY (tenant_id, assignee_email, closed_date)
+SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS insight.task_issue_state
 (
     `tenant_id` Nullable(String),
@@ -599,6 +666,24 @@ CREATE TABLE IF NOT EXISTS insight.task_metric_observations
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(metric_date)
 ORDER BY (tenant_id, source_key, entity_type, entity_id, measure_key, metric_date)
+SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.task_open_issues
+(
+    `tenant_id` String,
+    `insight_source_id` String,
+    `issue_id` String,
+    `id_readable` String,
+    `title` Nullable(String),
+    `assignee_email` String,
+    `last_status_event_at` DateTime64(3),
+    `last_status_event_date` Date,
+    `idle_days` Int64
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(last_status_event_date)
+ORDER BY (tenant_id, assignee_email, last_status_event_at)
 SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
 ;
 

--- a/tests/stand/api/analytics/drilldown_matrix.py
+++ b/tests/stand/api/analytics/drilldown_matrix.py
@@ -52,6 +52,9 @@ class Tier(StrEnum):
     #: Percentile over event rows passed through one-for-one, like
     #: `EXACT_MEDIAN` but at a quantile the expectation carries.
     EXACT_PERCENTILE = "exact_percentile"
+    #: Sample standard deviation over event rows passed through to observations
+    #: one-for-one: the spread of the projected values IS the period scalar.
+    EXACT_STDDEV = "exact_stddev"
     #: Ratio of two additive measures: the summed numerator over the summed
     #: denominator, scaled, then transformed.
     EXACT_RATIO = "exact_ratio"
@@ -132,6 +135,25 @@ MATRIX: Sequence[Expectation] = (
     Expectation("ai.removed_lines", "ai", Tier.EXACT_SUM),
     Expectation("ai.seat_cost", "ai_cost", Tier.EXACT_SUM),
     Expectation("ai.tool_acceptance_rate", "ai", Tier.EXACT_RATIO, scale=100.0),
+    # The CI family is TENANT grain: a run belongs to the organization, so its
+    # evidence carries no person and the sweep asks for it with the tenant
+    # entity. Counting measures contribute a constant 1 and their presentation
+    # shows no value column, so one evidence row is one run, one deployment or
+    # one collected commit. Duration is the exception the observations model
+    # already makes: `run_duration_min` alone passes through at event grain, so
+    # its median, its p90 and its spread are all statements about the very rows
+    # the page projects.
+    Expectation("ci.commits_observed", "ci", Tier.EXACT_COUNT),
+    Expectation("ci.deployments", "ci", Tier.EXACT_COUNT),
+    Expectation("ci.gate_first_try_pass_rate", "ci", Tier.EXACT_RATIO, scale=100.0),
+    Expectation("ci.gate_pass_rate", "ci", Tier.EXACT_RATIO, scale=100.0),
+    Expectation("ci.gate_retry_share", "ci", Tier.EXACT_RATIO, scale=100.0),
+    Expectation("ci.run_duration_min", "ci", Tier.EXACT_MEDIAN),
+    Expectation("ci.run_duration_min_p90", "ci", Tier.EXACT_PERCENTILE, quantile=0.9),
+    Expectation("ci.run_duration_min_stddev", "ci", Tier.EXACT_STDDEV),
+    Expectation("ci.run_hours", "ci", Tier.EXACT_SUM),
+    Expectation("ci.runs", "ci", Tier.EXACT_COUNT),
+    Expectation("ci.runs_matched_commit", "ci", Tier.EXACT_COUNT),
     Expectation("collab.active_days", "collab", Tier.EXACT_DISTINCT_DATES),
     Expectation("collab.adhoc_meetings", "collab", Tier.EXACT_SUM),
     Expectation("collab.breadth", "collab", Tier.STRUCTURAL_ONLY),

--- a/tests/stand/api/analytics/test_catalog.py
+++ b/tests/stand/api/analytics/test_catalog.py
@@ -29,12 +29,23 @@ CATALOG_METRICS = analytics_path("/v1/catalog/metrics")
 #: distribution at all.
 _DISTRIBUTABLE = frozenset({"percentile", "stddev"})
 
-#: A ratio is folded from two measures, so a page of rows names which side it
-#: reads; every other shipped computation reads one.
-_INPUTS_PER_COMPUTATION = {"ratio": 2}
+#: How many drilldown pages a computation advertises, as `(minimum, maximum)`
+#: with `None` for unbounded: a ratio names its two sides, a derived metric one
+#: page per input its definition folds — never fewer than the two that make it
+#: composed — and every other computation the single measure it reads.
+_INPUTS_PER_COMPUTATION: dict[str, tuple[int, int | None]] = {
+    "ratio": (2, 2),
+    "derived": (2, None),
+}
+_ONE_MEASURE: tuple[int, int | None] = (1, 1)
 
 TENANT = {"type": "tenant"}
 COHORT = {"type": "cohort"}
+
+
+def _advertises_one_page_per_input(computation: str, pages: int) -> bool:
+    minimum, maximum = _INPUTS_PER_COMPUTATION.get(computation, _ONE_MEASURE)
+    return pages >= minimum and (maximum is None or pages <= maximum)
 
 
 @pytest.mark.reliability
@@ -92,7 +103,7 @@ def test_every_question_a_metric_advertises_agrees_with_the_rest_of_its_entry(
         )
 
         inputs = questions["rows"]["inputs"]
-        assert len(inputs) == _INPUTS_PER_COMPUTATION.get(computation, 1), (
+        assert _advertises_one_page_per_input(computation, len(inputs)), (
             f"`{key}` is a {computation} and names {inputs} as the pages behind it"
         )
         assert len(inputs) == len(set(inputs)), f"`{key}` names one page twice: {inputs}"

--- a/tests/stand/api/analytics/test_catalog.py
+++ b/tests/stand/api/analytics/test_catalog.py
@@ -42,6 +42,11 @@ _ONE_MEASURE: tuple[int, int | None] = (1, 1)
 TENANT = {"type": "tenant"}
 COHORT = {"type": "cohort"}
 
+#: What a metric's values are keyed by. A tenant-grain metric measures the
+#: organization itself, so it names no person and has no peers.
+_PERSON = "person"
+_TENANT = "tenant"
+
 
 def _advertises_one_page_per_input(computation: str, pages: int) -> bool:
     minimum, maximum = _INPUTS_PER_COMPUTATION.get(computation, _ONE_MEASURE)
@@ -90,17 +95,32 @@ def test_every_question_a_metric_advertises_agrees_with_the_rest_of_its_entry(
             f"`{key}` advertises split={values['split']} with {len(metric['dimensions'])} "
             f"dimensions"
         )
+        # Both grains report one value per subject: a person metric per person,
+        # a tenant metric for the one tenant its rows are keyed by.
         assert "per_subject" in values["folds"], f"`{key}` advertises folds {values['folds']}"
         assert ("combined" in values["folds"]) == splittable, (
             f"`{key}` advertises a combined fold with nothing to fold into: {values['folds']}"
         )
         assert values["compare"], f"`{key}` advertises no comparable window"
 
+        entity_type = metric["entity_type"]
+        assert entity_type in {_PERSON, _TENANT}, f"`{key}` is keyed by {entity_type!r}"
+
         populations = questions["comparisons"]["populations"]
-        assert TENANT in populations, f"`{key}` advertises populations {populations}"
-        assert (COHORT in populations) == ("cohort_key" in metric), (
-            f"`{key}` advertises {populations} while its cohort_key is {metric.get('cohort_key')!r}"
-        )
+        if entity_type == _TENANT:
+            assert populations == [], (
+                f"`{key}` measures the tenant, which has no peers, yet advertises {populations}"
+            )
+            assert "cohort_key" not in metric, (
+                f"`{key}` measures the tenant and declares the cohort "
+                f"{metric.get('cohort_key')!r} to be grouped by"
+            )
+        else:
+            assert TENANT in populations, f"`{key}` advertises populations {populations}"
+            assert (COHORT in populations) == ("cohort_key" in metric), (
+                f"`{key}` advertises {populations} while its cohort_key is "
+                f"{metric.get('cohort_key')!r}"
+            )
 
         inputs = questions["rows"]["inputs"]
         assert _advertises_one_page_per_input(computation, len(inputs)), (
@@ -120,3 +140,19 @@ def test_catalog_metrics_discloses_no_value_of_any_dimension(api: ApiClient) -> 
             assert sorted(dimension) == ["key", "label"], (
                 f"`{metric['key']}` advertises a dimension carrying more than its name: {dimension}"
             )
+
+
+@pytest.mark.versatility
+def test_catalog_metrics_advertises_the_grains_this_installation_answers(api: ApiClient) -> None:
+    """A stand serving tenant metrics advertises them; the two grains are both present.
+
+    The catalogue is filtered by the same installation gate the query surfaces
+    enforce, so a metric advertised here is one a question about it can reach.
+    """
+    response = api.get(CATALOG_METRICS)
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+
+    grains = {metric["entity_type"] for metric in response.json()["metrics"]}
+    assert grains == {_PERSON, _TENANT}, (
+        f"the catalogue advertises metrics keyed by {sorted(grains)}"
+    )

--- a/tests/stand/api/analytics/test_drilldown.py
+++ b/tests/stand/api/analytics/test_drilldown.py
@@ -42,6 +42,7 @@ import datetime as dt
 import io
 import json
 import math
+import statistics
 import uuid
 import warnings
 import zipfile
@@ -62,10 +63,13 @@ from ..schemas import (
     ProblemDocument,
 )
 from ..schemas.analytics import (
+    EntityType,
+    MetricDefinitionView,
     MetricDrilldownCapability,
     MetricDrilldownColumnType,
     MetricDrilldownEntity,
     MetricDrilldownEntity1,
+    MetricDrilldownEntity3,
     MetricDrilldownResponse,
 )
 from . import query_window
@@ -126,14 +130,27 @@ class _Walk:
 
 
 @pytest.fixture(scope="session")
-def drilldown_capabilities(
-    lead_session: PersonaSession,
-) -> Mapping[str, MetricDrilldownCapability | None]:
-    """What the catalogue says each metric supports, read once for the sweep.
+def metric_definitions(lead_session: PersonaSession) -> Mapping[str, MetricDefinitionView]:
+    """The catalogue the sweep is driven off, read once for the whole run.
 
     Session-scoped because it is one answer for the whole run, and because the
     alternative — a listing request per parametrized case — would make the sweep
-    cost twice what it needs to.
+    cost twice what it needs to. Both the drilldown capability and the grain a
+    request must name are read from it, so the sweep asks each metric the
+    question its own definition says it answers.
+    """
+    response = lead_session.client.get(METRIC_DEFINITIONS)
+    assert response.status_code == 200, f"definitions: {response.status_code}"
+    metrics = response.parse(MetricDefinitionListResponse).metrics
+    assert metrics, "no metric definitions — did the migrations run?"
+    return {metric.metric_key: metric for metric in metrics}
+
+
+@pytest.fixture(scope="session")
+def drilldown_capabilities(
+    metric_definitions: Mapping[str, MetricDefinitionView],
+) -> Mapping[str, MetricDrilldownCapability | None]:
+    """What the catalogue says each metric supports.
 
     Capability is derived per request from the health of the evidence relation,
     so this is a claim the endpoint can contradict, and it does: the catalogue's
@@ -143,17 +160,36 @@ def drilldown_capabilities(
     `test_advertised_capability_matches_what_the_endpoint_serves` carries the
     other as a strict xfail.
     """
-    response = lead_session.client.get(METRIC_DEFINITIONS)
-    assert response.status_code == 200, f"definitions: {response.status_code}"
-    metrics = response.parse(MetricDefinitionListResponse).metrics
-    assert metrics, "no metric definitions — did the migrations run?"
-    return {metric.metric_key: metric.drilldown for metric in metrics}
+    return {key: metric.drilldown for key, metric in metric_definitions.items()}
+
+
+def _drilldown_entity(
+    manifest: Manifest, entity_type: EntityType, entity_id: str | None
+) -> JsonValue:
+    """Whose evidence a selection names, spelled as the drilldown takes it.
+
+    A tenant selection carries no id at all: the tenant is the caller's own,
+    taken from the session, and the wire shape forbids naming one.
+    """
+    match entity_type:
+        case EntityType.person:
+            return {
+                "type": "person",
+                # Not `or`: an empty id is a case a caller may want to send, and
+                # falling back to a real person would quietly test something else.
+                "id": manifest.fixture("dev_lead").uuid if entity_id is None else entity_id,
+            }
+        case EntityType.tenant:
+            return {"type": "tenant"}
+        case unhandled:
+            assert_never(unhandled)
 
 
 def _request_for(
     manifest: Manifest,
     metric_key: str,
     *,
+    entity_type: EntityType = EntityType.person,
     entity_id: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
@@ -163,12 +199,7 @@ def _request_for(
     start, end = query_window(manifest)
     request: dict[str, JsonValue] = {
         "metric_key": metric_key,
-        "entity": {
-            "type": "person",
-            # Not `or`: an empty id is a case a caller may want to send, and
-            # falling back to a real person would quietly test something else.
-            "id": manifest.fixture("dev_lead").uuid if entity_id is None else entity_id,
-        },
+        "entity": _drilldown_entity(manifest, entity_type, entity_id),
         "period": {"from": start, "to": end},
         "filters": list(filters),
         "display_dimensions": list(display_dimensions),
@@ -204,6 +235,7 @@ def _page(
     metric_key: str,
     *,
     limit: int,
+    entity_type: EntityType = EntityType.person,
     cursor: str | None = None,
     filters: Sequence[JsonValue] = (),
     display_dimensions: Sequence[str] = (),
@@ -213,6 +245,7 @@ def _page(
         json_body=_request_for(
             manifest,
             metric_key,
+            entity_type=entity_type,
             limit=limit,
             cursor=cursor,
             filters=filters,
@@ -227,6 +260,7 @@ def _walk(
     metric_key: str,
     *,
     limit: int,
+    entity_type: EntityType = EntityType.person,
     filters: Sequence[JsonValue] = (),
     display_dimensions: Sequence[str] = (),
     page_budget: int | None = None,
@@ -242,6 +276,7 @@ def _walk(
         manifest,
         metric_key,
         limit=limit,
+        entity_type=entity_type,
         filters=filters,
         display_dimensions=display_dimensions,
     )
@@ -270,6 +305,7 @@ def _walk(
             manifest,
             metric_key,
             limit=limit,
+            entity_type=entity_type,
             cursor=cursor,
             filters=filters,
             display_dimensions=display_dimensions,
@@ -279,25 +315,45 @@ def _walk(
     return _Walk(first=first, rows=rows, complete=True)
 
 
+def _results_entity(manifest: Manifest, entity_type: EntityType) -> tuple[JsonValue, str]:
+    """The same subject as `_drilldown_entity`, spelled as `/v1/metric-results`
+    takes it, beside the `entity_id` its answer is keyed by.
+
+    The two endpoints disagree on the wire — one id, a list of ids, or none —
+    so the spelling lives in one place per endpoint rather than at each call.
+    """
+    match entity_type:
+        case EntityType.person:
+            person_id = manifest.fixture("dev_lead").uuid
+            return {"type": "person", "ids": [person_id]}, person_id
+        case EntityType.tenant:
+            # A tenant read is keyed by the tenant itself, which the service
+            # takes from the session; the manifest names the one it seeded.
+            return {"type": "tenant"}, manifest.tenant
+        case unhandled:
+            assert_never(unhandled)
+
+
 def _period_value(
     api: ApiClient,
     manifest: Manifest,
     metric_key: str,
     *,
+    entity_type: EntityType = EntityType.person,
     filters: Sequence[JsonValue] = (),
 ) -> float | None:
-    """The scalar the dashboard shows for the same person, period and filters.
+    """The scalar the dashboard shows for the same subject, period and filters.
 
     `None` is a real answer rather than a failure: nothing zero-fills, so a
-    person with no observations in the period has no value at all, and that is
+    subject with no observations in the period has no value at all, and that is
     what an empty evidence page has to agree with.
     """
     start, end = query_window(manifest)
-    person_id = manifest.fixture("dev_lead").uuid
+    entity, entity_id = _results_entity(manifest, entity_type)
     response = api.post(
         METRIC_RESULTS,
         json_body={
-            "entity": {"type": "person", "ids": [person_id]},
+            "entity": entity,
             "period": {"from": start, "to": end},
             "metrics": [
                 {
@@ -316,7 +372,7 @@ def _period_value(
     assert isinstance(views[0].root, PeriodView)
     values = views[0].root.values
     assert len(values) == 1
-    assert values[0].entity_id == person_id
+    assert values[0].entity_id == entity_id
     return values[0].value
 
 
@@ -487,10 +543,32 @@ def _person_entity_id(entity: MetricDrilldownEntity) -> str:
     return person.id
 
 
-def _assert_shape(walk: _Walk, expectation: Expectation, person_id: str) -> None:
+def _assert_selection_subject(
+    entity: MetricDrilldownEntity, entity_type: EntityType, manifest: Manifest, metric_key: str
+) -> None:
+    """The selection echoed back names the subject the request asked about.
+
+    A tenant selection carries no id to compare — the shape itself is the
+    claim, and the service reading a different tenant would be a tenancy defect
+    the cross-tenant refusal cases own, not something an echo could show.
+    """
+    match entity_type:
+        case EntityType.person:
+            assert _person_entity_id(entity) == manifest.fixture("dev_lead").uuid, metric_key
+        case EntityType.tenant:
+            assert isinstance(entity.root, MetricDrilldownEntity3), (
+                f"{metric_key}: a tenant-grain metric answered a {entity.root.type} selection"
+            )
+        case unhandled:
+            assert_never(unhandled)
+
+
+def _assert_shape(
+    walk: _Walk, expectation: Expectation, entity_type: EntityType, manifest: Manifest
+) -> None:
     selection = walk.first.selection
     assert selection.metric_key == expectation.metric_key
-    assert _person_entity_id(selection.entity) == person_id
+    _assert_selection_subject(selection.entity, entity_type, manifest, expectation.metric_key)
     assert selection.filters == []
     assert selection.display_dimensions == []
 
@@ -522,6 +600,7 @@ def _assert_shape(walk: _Walk, expectation: Expectation, person_id: str) -> None
             Tier.EXACT_SUM
             | Tier.EXACT_MEDIAN
             | Tier.EXACT_PERCENTILE
+            | Tier.EXACT_STDDEV
             | Tier.EXACT_DISTINCT_DATES
             | Tier.COLLAPSE_BOUNDED_SUM
             | Tier.STRUCTURAL_ONLY
@@ -563,6 +642,28 @@ def _assert_percentile(
     assert period in candidates, (
         f"{metric_key}: period {period} is not the p{quantile:.0%} element of "
         f"{len(ordered)} evidence rows, nor its neighbour {sorted(candidates)}"
+    )
+
+
+def _assert_stddev(period: float | None, values: Sequence[float], metric_key: str) -> None:
+    """`stddevSampIfOrNull` is the SAMPLE deviation of the projected values.
+
+    Sample, not population, so a single observation measures no spread at all
+    and the metric is null rather than a fabricated zero — the same honest-null
+    the median takes. With two or more, the spread of the rows the page shows
+    is the number the dashboard shows, so this is an equality.
+    """
+    if len(values) < 2:
+        assert period is None, (
+            f"{metric_key}: {len(values)} evidence row(s) measure no spread, "
+            f"yet the metric answered {period}"
+        )
+        return
+
+    evidence = statistics.stdev(values)
+    assert period is not None and _close(period, evidence), (
+        f"{metric_key}: {len(values)} evidence rows have a sample deviation of {evidence}, "
+        f"and the metric answered {period}"
     )
 
 
@@ -636,6 +737,8 @@ def _reconcile(period: float | None, walk: _Walk, expectation: Expectation) -> N
                 expectation.quantile,
                 metric_key,
             )
+        case Tier.EXACT_STDDEV:
+            _assert_stddev(period, _numbers(walk.rows, "value", metric_key), metric_key)
         case Tier.DERIVED_MEDIAN:
             parts = [_numbers(walk.rows, column, metric_key) for column in expectation.derived_from]
             _assert_median(period, [sum(row) for row in zip(*parts, strict=True)], metric_key)
@@ -753,6 +856,7 @@ def test_advertised_capability_matches_what_the_endpoint_serves(
 def test_drilldown_reconciles_with_the_metric_value(
     api: ApiClient,
     stand_manifest: Manifest,
+    metric_definitions: Mapping[str, MetricDefinitionView],
     drilldown_capabilities: Mapping[str, MetricDrilldownCapability | None],
     expectation: Expectation,
 ) -> None:
@@ -767,12 +871,26 @@ def test_drilldown_reconciles_with_the_metric_value(
     An empty page is a legitimate answer, and it is still an assertion: nothing
     zero-fills, so evidence and metric have to be empty together.
 
+    Both sides are asked about the subject the definition says the metric is
+    keyed by, read from the catalogue rather than decided per metric key here:
+    naming a person for a tenant-grain metric is a request the service refuses
+    on its shape, which would read as missing evidence.
+
     Driven off what the endpoint answers rather than off the advertised
     capability, because the two do not agree today and the endpoint is the side
     that decides whether evidence exists.
     """
-    person_id = stand_manifest.fixture("dev_lead").uuid
-    probe = _page(api, stand_manifest, expectation.metric_key, limit=_PAGE_LIMIT)
+    definition = metric_definitions.get(expectation.metric_key)
+    assert definition is not None, f"{expectation.metric_key} is not in the catalogue"
+    entity_type = definition.entity_type
+
+    probe = _page(
+        api,
+        stand_manifest,
+        expectation.metric_key,
+        limit=_PAGE_LIMIT,
+        entity_type=entity_type,
+    )
     if probe.status_code != 200:
         _assert_evidence_unavailable(
             probe, expectation.metric_key, drilldown_capabilities.get(expectation.metric_key)
@@ -784,12 +902,13 @@ def test_drilldown_reconciles_with_the_metric_value(
         stand_manifest,
         expectation.metric_key,
         limit=_PAGE_LIMIT,
+        entity_type=entity_type,
         page_budget=_PAGE_BUDGET,
         initial=probe,
     )
-    _assert_shape(walk, expectation, person_id)
+    _assert_shape(walk, expectation, entity_type, stand_manifest)
 
-    period = _period_value(api, stand_manifest, expectation.metric_key)
+    period = _period_value(api, stand_manifest, expectation.metric_key, entity_type=entity_type)
     if not walk.rows:
         assert period is None, (
             f"{expectation.metric_key}: no evidence rows, but the metric answered {period}"

--- a/tests/stand/api/analytics/test_query_distributions.py
+++ b/tests/stand/api/analytics/test_query_distributions.py
@@ -32,6 +32,10 @@ GIT_PR_SIZE = "git.pr_size"
 #: not a spelling rejection dressed as one.
 UNKNOWN_METRIC = "stand.does_not_exist"
 
+#: A percentile computation over per-run duration, keyed by the tenant rather
+#: than by a person.
+CI_RUN_DURATION = "ci.run_duration_min"
+
 #: Asked sorted and distinct, which is how the service reports them back.
 _QUANTILES: tuple[float, ...] = (0.25, 0.5, 0.75)
 
@@ -153,3 +157,68 @@ def test_query_distributions_refuses_a_quantile_that_is_not_a_position(
     response = api.post(QUERY_DISTRIBUTIONS, json_body={"queries": [question]})
     assert response.status_code == 400, f"status={response.status_code} {response.text[:300]}"
     assert response.parse(ProblemDocument).status == 400
+
+
+def _tenant_question(manifest: Manifest, metric: str) -> dict[str, JsonValue]:
+    start, end = query_window(manifest)
+    return {
+        "metric": metric,
+        "subjects": {"type": "tenant"},
+        "time": {"from": start, "to": end},
+        "bins": _BINS,
+        "quantiles": list(_QUANTILES),
+    }
+
+
+@pytest.mark.reliability
+def test_query_distributions_shapes_a_tenant_metric_without_naming_a_subject(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """One distribution comes back, and it names nobody: the tenant is not a subject.
+
+    The CI connector streams are not part of the sample seed, so this pins that
+    exactly one distribution is reported for the one entity a tenant read groups
+    by, and that it carries no subject — an unobserved range is a legitimate
+    answer here.
+    """
+    response = api.post(
+        QUERY_DISTRIBUTIONS,
+        json_body={"queries": [_tenant_question(stand_manifest, CI_RUN_DURATION)]},
+    )
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+
+    results = response.parse(DistributionsResponse).results
+    assert len(results) == 1
+    subjects = results[0].subjects
+    assert len(subjects) == 1, f"a tenant question answered {len(subjects)} distributions"
+    assert subjects[0].subject is None
+
+    histogram = subjects[0].histogram
+    assert histogram is not None, "a question naming bins is answered with a histogram"
+    _assert_bins_tile_the_range(histogram)
+
+    quantiles = subjects[0].quantiles
+    assert quantiles is not None, "a question naming quantiles is answered with positions"
+    assert [quantile.q for quantile in quantiles] == list(_QUANTILES)
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_query_distributions_refuses_subjects_that_are_not_the_metrics_grain(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """Each surface answers one grain: naming the other side is unanswerable, not empty."""
+    person = stand_manifest.fixture("dev_lead")
+    cases = {
+        "a tenant metric asked about a person": _question(
+            stand_manifest, CI_RUN_DURATION, person.uuid
+        ),
+        "a person metric asked about the tenant": _tenant_question(stand_manifest, GIT_PR_SIZE),
+    }
+
+    for named, query in cases.items():
+        response = api.post(QUERY_DISTRIBUTIONS, json_body={"queries": [query]})
+        assert response.status_code == 400, (
+            f"{named} answered {response.status_code}: {response.text[:300]}"
+        )
+        assert response.parse(ProblemDocument).status == 400

--- a/tests/stand/api/analytics/test_query_rows.py
+++ b/tests/stand/api/analytics/test_query_rows.py
@@ -40,6 +40,10 @@ GIT_COMMITS = "git.commits"
 #: not a spelling rejection dressed as one.
 UNKNOWN_METRIC = "stand.does_not_exist"
 
+#: Keyed by the tenant rather than by a person: the CI family measures the
+#: organization's pipelines, which belong to nobody in particular.
+CI_RUNS = "ci.runs"
+
 #: One row a page, so the walk issues a cursor from as little seeded evidence as
 #: possible.
 _PAGE_SIZE = 1
@@ -364,3 +368,56 @@ def test_query_rows_refuses_a_column_the_page_does_not_report(
         f"{response.text[:300]}"
     )
     assert response.parse(ProblemDocument).status == 400
+
+
+def _tenant_request(manifest: Manifest, metric: str) -> dict[str, JsonValue]:
+    start, end = query_window(manifest)
+    return {
+        "metric": metric,
+        "subjects": {"type": "tenant"},
+        "time": {"from": start, "to": end},
+        "page_size": _PAGE_SIZE,
+    }
+
+
+@pytest.mark.reliability
+def test_query_rows_pages_a_tenant_metric_over_the_input_it_composes(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A tenant-grain page is served like any other: named input, columns, ordered rows.
+
+    The CI connector streams are not part of the sample seed, so this pins the
+    page's shape rather than its contents — an empty page is a legitimate
+    answer here and a refusal is not.
+    """
+    response = api.post(QUERY_ROWS, json_body=_tenant_request(stand_manifest, CI_RUNS))
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+
+    page = response.parse(RowsResponse)
+    assert page.metric == CI_RUNS
+    assert page.input == "value", f"a metric composing one input paged its `{page.input}`"
+    assert page.columns, "a page reports the columns its rows are read under"
+    for row in page.rows:
+        assert len(row) == len(page.columns), (
+            f"a row carries {len(row)} values for {len(page.columns)} columns"
+        )
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_query_rows_refuses_a_page_whose_subjects_are_not_the_metrics_grain(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """Each surface answers one grain: naming the other side is unanswerable, not empty."""
+    person = stand_manifest.fixture("dev_lead")
+    cases = {
+        "a tenant metric asked about a person": _request(stand_manifest, CI_RUNS, person.uuid),
+        "a person metric asked about the tenant": _tenant_request(stand_manifest, GIT_COMMITS),
+    }
+
+    for named, body in cases.items():
+        response = api.post(QUERY_ROWS, json_body=body)
+        assert response.status_code == 400, (
+            f"{named} answered {response.status_code}: {response.text[:300]}"
+        )
+        assert response.parse(ProblemDocument).status == 400

--- a/tests/stand/api/analytics/test_query_values.py
+++ b/tests/stand/api/analytics/test_query_values.py
@@ -34,6 +34,10 @@ GIT_COMMITS = "git.commits"
 #: not a spelling rejection dressed as one.
 UNKNOWN_METRIC = "stand.does_not_exist"
 
+#: Keyed by the tenant rather than by a person: the CI family measures the
+#: organization's pipelines, which belong to nobody in particular.
+CI_RUNS = "ci.runs"
+
 #: The service folds a window with a vectorized sum and this suite adds points
 #: in row order, so the two agree to floating-point accumulation and no further.
 _REL_TOL = 1e-9
@@ -45,6 +49,16 @@ def _question(manifest: Manifest, metric: str, subject_id: str, grain: str) -> d
     return {
         "metric": metric,
         "subjects": {"type": "persons", "ids": [subject_id]},
+        "time": {"from": start, "to": end, "grain": grain},
+        "fold": "per_subject",
+    }
+
+
+def _tenant_question(manifest: Manifest, metric: str, grain: str) -> dict[str, JsonValue]:
+    start, end = query_window(manifest)
+    return {
+        "metric": metric,
+        "subjects": {"type": "tenant"},
         "time": {"from": start, "to": end, "grain": grain},
         "fold": "per_subject",
     }
@@ -138,4 +152,98 @@ def test_query_values_refuses_a_request_that_asks_nothing(api: ApiClient) -> Non
     """A request carrying no question is malformed, not an empty answer."""
     response = api.post(QUERY_VALUES, json_body={"queries": []})
     assert response.status_code == 400, f"status={response.status_code} {response.text[:300]}"
+    assert response.parse(ProblemDocument).status == 400
+
+
+@pytest.mark.reliability
+def test_query_values_answers_a_tenant_metric_naming_no_subject(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A tenant-grain answer names nobody, and folds and cuts to the same number.
+
+    The answer is about the caller's own tenant, which the question already
+    named, so echoing an id back would state nothing — every entry carries an
+    absent subject. Asserted over whatever the stand holds: the CI connector
+    streams are not part of the sample seed, so this pins the contract's shape
+    and the agreement between the two grains, not a count.
+    """
+    response = api.post(
+        QUERY_VALUES,
+        json_body={
+            "queries": [
+                _tenant_question(stand_manifest, CI_RUNS, "total"),
+                _tenant_question(stand_manifest, CI_RUNS, "day"),
+            ]
+        },
+    )
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+
+    results = response.parse(ValuesResponse).results
+    assert [result.metric for result in results] == [CI_RUNS, CI_RUNS]
+
+    folded = results[0].result.root
+    cut = results[1].result.root
+    assert isinstance(folded, ResultBody1), f"a total grain answered {type(folded).__name__}"
+    assert isinstance(cut, ResultBody2), f"a day grain answered {type(cut).__name__}"
+
+    assert all(value.subject is None for value in folded.values), (
+        f"a tenant answer named {[value.subject for value in folded.values]}"
+    )
+    assert all(series.subject is None for series in cut.series), (
+        f"a tenant series named {[series.subject for series in cut.series]}"
+    )
+    assert len(folded.values) <= 1, (
+        f"the tenant is one subject, yet {len(folded.values)} values came back"
+    )
+    assert len(cut.series) <= 1, (
+        f"the tenant is one subject, yet {len(cut.series)} series came back"
+    )
+
+    if not folded.values or folded.values[0].value is None:
+        return
+
+    total = folded.values[0].value
+    assert cut.series, "the total grain answered a number the day grain reported no series for"
+    series_total = cut.series[0].total
+    assert series_total is not None and math.isclose(
+        series_total, total, rel_tol=_REL_TOL, abs_tol=_ABS_TOL
+    ), f"the series reports {series_total} for the window the total grain answered {total} for"
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_query_values_refuses_a_tenant_metric_asked_about_a_person(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A metric measuring the tenant records no person, so naming one is unanswerable."""
+    person = stand_manifest.fixture("dev_lead")
+
+    response = api.post(
+        QUERY_VALUES,
+        json_body={"queries": [_question(stand_manifest, CI_RUNS, person.uuid, "total")]},
+    )
+    assert response.status_code == 400, (
+        f"a tenant metric asked about a person answered {response.status_code}: "
+        f"{response.text[:300]}"
+    )
+    assert response.parse(ProblemDocument).status == 400
+
+
+@pytest.mark.reliability
+def test_query_values_refuses_a_person_metric_asked_about_the_tenant_per_subject(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A person metric folds its people for a tenant-wide reading, reporting no subject.
+
+    Which means it needs a dimension to report that folded value under; asked
+    per subject, there is no subject for it to be about.
+    """
+    response = api.post(
+        QUERY_VALUES,
+        json_body={"queries": [_tenant_question(stand_manifest, GIT_COMMITS, "total")]},
+    )
+    assert response.status_code == 400, (
+        f"a person metric asked about the tenant per subject answered "
+        f"{response.status_code}: {response.text[:300]}"
+    )
     assert response.parse(ProblemDocument).status == 400

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -1487,6 +1487,8 @@ class ValidationErrorKind(StrEnum):
     unknown_derived_input = 'unknown_derived_input'
     unused_derived_input = 'unused_derived_input'
     dimension_bindings_disagree = 'dimension_bindings_disagree'
+    entity_grain_mismatch = 'entity_grain_mismatch'
+    cohort_without_peers = 'cohort_without_peers'
 
 
 class ValidationFailure(BaseModel):
@@ -1733,7 +1735,7 @@ class MetricDefinition(BaseModel):
     computation: Computation
     description: str | None = None
     direction: Direction
-    entity_type: str
+    entity_type: EntityType = Field(..., description="What the metric's values are keyed by. INVARIANT: equal to the grain of\nevery dataset its measures read — see `validate`.")
     format: Format
     key: str
     label: str | None = None
@@ -2022,7 +2024,7 @@ class SubjectDistribution(BaseModel):
     )
     histogram: Histogram | None = None
     quantiles: list[Quantile] | None = Field(None, description='Absent when the question named no quantiles.')
-    subject: str
+    subject: str | None = Field(None, description="Absent when the metric measures the tenant: the answer is about the\ncaller's own tenant, which the question already named.")
 
 
 class TimeseriesDto(BaseModel):
@@ -2088,7 +2090,7 @@ class CatalogMetric(BaseModel):
     description: str | None = None
     dimensions: list[CatalogDimension]
     direction: Direction
-    entity_type: str = Field(..., description="What the metric's values are keyed by, such as `person`.")
+    entity_type: EntityType = Field(..., description="What the metric's values are keyed by.")
     format: Format
     key: str = Field(..., description='The key a question names, such as `git.commits`.')
     label: str | None = None


### PR DESCRIPTION
**Why.** The semantic store serves only the git family; every other dashboard metric still exists solely as hand-written legacy SQL.

**What changed.** Six families transcribed into definitions with their gold relations: wiki (4 metrics), reviewer-side and p75 git (5), tasks (15), AI usage and cost (16), collab (20), CI (11) — 71 new metrics, 105 total. New gold relations carry the grains the definitions need, each with a grain-uniqueness dbt test.

**CI required tenant-grain serving.** The 11 `ci.*` metrics attach to the installation, not a person. Datasets now declare an entity grain (`person` default, `tenant`), answerability is grain-aware (tenant metrics answer tenant asks, refuse person asks), tenant answers carry `subject: null`, and the whole family sits behind `tenant_metrics_enabled` exactly as legacy gates it — catalog hides it when off.

**A NULL fold condition now collapses to false.** A conditional aggregate over a nullable column answered NULL where zero is true; `coalesce(<cond>, 0)` at the single rendering seam fixes it, and cached distinct-count re-folds now report zero like live reads.

**Out of scope.** A CI seed generator for the stand — tenant stand cases pin the contract and refusals; number-asserting cases need seeded CI streams.

**Verified.** `cargo test -p analytics --bin analytics`: 1144 passed, 0 failed; clippy `-D warnings`, fmt, `dbt parse` clean; full stand API suite green at this tip; snapshot and connectors DDL regenerate byte-identical from a clean bootstrap warehouse.
