### PR TITLE
feat(observability): enable OTel metrics and tracing export in Helm values

### DIFF
--- a/charts/insight/templates/platform-config.yaml
+++ b/charts/insight/templates/platform-config.yaml
@@ -69,9 +69,15 @@ data:
   # vars → services log to stdout only and whoever runs the cluster collects.
   INSIGHT_LOG_LEVEL: {{ $obsLogs.level | default "info" | quote }}
   {{- if $otlpEndpoint }}
+  {{- $otlpProtocol := $obsOtlp.protocol | default "grpc" }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ $otlpEndpoint | quote }}
-  OTEL_EXPORTER_OTLP_PROTOCOL: {{ $obsOtlp.protocol | default "grpc" | quote }}
+  OTEL_EXPORTER_OTLP_PROTOCOL: {{ $otlpProtocol | quote }}
   OTEL_LOGS_EXPORTER:          "otlp"
-  # Hardcoded off until the tracing phase (Tempo) — flip to "otlp" then.
-  OTEL_TRACES_EXPORTER:        "none"
+  OTEL_TRACES_EXPORTER:        "otlp"
+  # Same contract for the gears-rust toolkit, which reads APP__* config
+  # paths (figment), not the OTEL_* names.
+  APP__opentelemetry__exporter__kind: {{ eq $otlpProtocol "grpc" | ternary "otlp_grpc" "otlp_http" | quote }}
+  APP__opentelemetry__exporter__endpoint: {{ $otlpEndpoint | quote }}
+  APP__opentelemetry__metrics__enabled: "true"
+  APP__opentelemetry__tracing__enabled: "true"
   {{- end }}

--- a/charts/insight/templates/platform-config.yaml
+++ b/charts/insight/templates/platform-config.yaml
@@ -3,7 +3,9 @@ Anchor `insight.validate` in a normal template so it runs under
 `helm lint` (which does not render NOTES.txt). The validator emits
 no output on success — `fail`s on missing required fields. */ -}}
 {{- include "insight.validate" . }}
-{{- $obs := default dict .Values.observability -}}
+{{- /* Canonical location is global.observability (subcharts hash it to roll
+pods); a legacy top-level observability block still overrides the defaults. */ -}}
+{{- $obs := mergeOverwrite (deepCopy (default dict (default dict .Values.global).observability)) (deepCopy (default dict .Values.observability)) -}}
 {{- $obsLogs := default dict $obs.logs -}}
 {{- $obsOtlp := default dict $obs.otlp -}}
 {{- $otlpEndpoint := default "" $obsOtlp.endpoint -}}

--- a/charts/insight/values.schema.json
+++ b/charts/insight/values.schema.json
@@ -86,7 +86,8 @@
         "imageRegistry":    { "type": "string" },
         "imagePullPolicy":  { "enum": ["Always", "IfNotPresent", "Never"] },
         "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
-        "storageClass":     { "type": "string" }
+        "storageClass":     { "type": "string" },
+        "observability":    { "$ref": "#/definitions/observability" }
       }
     },
 
@@ -120,6 +121,10 @@
     "identity":           { "$ref": "#/definitions/appService" },
     "frontend":           { "$ref": "#/definitions/appService" },
 
+    "observability": { "$ref": "#/definitions/observability" }
+  },
+
+  "definitions": {
     "observability": {
       "type": "object",
       "properties": {
@@ -137,10 +142,7 @@
           }
         }
       }
-    }
-  },
-
-  "definitions": {
+    },
     "infraDep": {
       "type": "object",
       "properties": {

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -120,14 +120,16 @@ global:
 #   endpoint: set  — services additionally export OTLP there: the
 #                    in-cluster Alloy for a self-hosted stack
 #                    (http://alloy.insight-infra.svc.cluster.local:4317),
-#                    or the customer's own collector.
+#                    or the customer's own collector. Gears services then
+#                    export OTel metrics and traces too.
 #
 # The umbrella NEVER installs the collector stack — like Airbyte and Argo
 # it is separate releases, driven by the deploy pipeline (inventory
 # toggles; see deploy/gitops/system/README.md). This block only governs what
 # services EMIT. The values are published into the `{release}-platform`
-# ConfigMap as INSIGHT_LOG_LEVEL / OTEL_* env vars, so every pod that does
-# `envFrom` picks them up uniformly — no per-service wiring.
+# ConfigMap as INSIGHT_LOG_LEVEL / OTEL_* env vars (plus the gears-rust
+# dialect, APP__opentelemetry__*), so every pod that does `envFrom` picks
+# them up uniformly — no per-service wiring.
 observability:
   logs:
     level: info # debug|info|warn|error — default level for all services

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -104,38 +104,40 @@ global:
   # analytics metric-catalog fallback + identity-resolution's bootstrap-admin
   # seed. Empty (default) = no default anywhere; a missing tenant fails closed.
   tenantDefaultId: ""
-# ═══════════════════════════════════════════════════════════════════════════
-#  OBSERVABILITY — logs & traces EMISSION (the product contract)
-# ═══════════════════════════════════════════════════════════════════════════
-#
-# Insight ALWAYS emits structured JSON to stdout — that is the product
-# contract and is not toggleable. WHETHER it ALSO exports OTLP, and WHERE,
-# is driven entirely by `otlp.endpoint`:
-#
-#   endpoint: ""   — stdout only. No OTEL_* vars are published; whoever
-#                    runs the cluster collects stdout (the host's own node
-#                    agent, or the Loki/Alloy/Grafana stack installed via
-#                    the deploy pipeline's system layer). SAFE DEFAULT for
-#                    a drop into an unknown existing cluster.
-#   endpoint: set  — services additionally export OTLP there: the
-#                    in-cluster Alloy for a self-hosted stack
-#                    (http://alloy.insight-infra.svc.cluster.local:4317),
-#                    or the customer's own collector. Gears services then
-#                    export OTel metrics and traces too.
-#
-# The umbrella NEVER installs the collector stack — like Airbyte and Argo
-# it is separate releases, driven by the deploy pipeline (inventory
-# toggles; see deploy/gitops/system/README.md). This block only governs what
-# services EMIT. The values are published into the `{release}-platform`
-# ConfigMap as INSIGHT_LOG_LEVEL / OTEL_* env vars (plus the gears-rust
-# dialect, APP__opentelemetry__*), so every pod that does `envFrom` picks
-# them up uniformly — no per-service wiring.
-observability:
-  logs:
-    level: info # debug|info|warn|error — default level for all services
-  otlp:
-    endpoint: "" # empty = stdout only; set = services export OTLP here
-    protocol: grpc # grpc | http/protobuf
+  # ═════════════════════════════════════════════════════════════════════════
+  #  OBSERVABILITY — logs & traces EMISSION (the product contract)
+  # ═════════════════════════════════════════════════════════════════════════
+  #
+  # Insight ALWAYS emits structured JSON to stdout — that is the product
+  # contract and is not toggleable. WHETHER it ALSO exports OTLP, and WHERE,
+  # is driven entirely by `otlp.endpoint`:
+  #
+  #   endpoint: ""   — stdout only. No OTEL_* vars are published; whoever
+  #                    runs the cluster collects stdout (the host's own node
+  #                    agent, or the Loki/Alloy/Grafana stack installed via
+  #                    the deploy pipeline's system layer). SAFE DEFAULT for
+  #                    a drop into an unknown existing cluster.
+  #   endpoint: set  — services additionally export OTLP there: the
+  #                    in-cluster Alloy for a self-hosted stack
+  #                    (http://alloy.insight-infra.svc.cluster.local:4317),
+  #                    or the customer's own collector. Gears services then
+  #                    export OTel metrics and traces too.
+  #
+  # The umbrella NEVER installs the collector stack — like Airbyte and Argo
+  # it is separate releases, driven by the deploy pipeline (inventory
+  # toggles; see deploy/gitops/system/README.md). This block only governs what
+  # services EMIT. The values are published into the `{release}-platform`
+  # ConfigMap as INSIGHT_LOG_LEVEL / OTEL_* env vars (plus the gears-rust
+  # dialect, APP__opentelemetry__*), so every pod that does `envFrom` picks
+  # them up uniformly. Lives under `global` so the service subcharts can hash
+  # it into a pod-template annotation and roll on change (a top-level
+  # `observability:` block is still honoured, but cannot roll pods).
+  observability:
+    logs:
+      level: info # debug|info|warn|error — default level for all services
+    otlp:
+      endpoint: "" # empty = stdout only; set = services export OTLP here
+      protocol: grpc # grpc | http/protobuf
 # ═══════════════════════════════════════════════════════════════════════════
 #  EXTERNAL — Airbyte (installed as a separate Helm release)
 # ═══════════════════════════════════════════════════════════════════════════

--- a/deploy/gitops/environments/local/inventory.yaml.template
+++ b/deploy/gitops/environments/local/inventory.yaml.template
@@ -50,7 +50,7 @@ system:
   argoWorkflows:   true
   # Observability (LGTM). Off for local dev — flip on to self-host
   # VictoriaMetrics/Loki/Tempo/Alloy/Grafana, and point the umbrella's
-  # observability.otlp.endpoint (environments/<env>/values.yaml) at this
+  # global.observability.otlp.endpoint (environments/<env>/values.yaml) at this
   # stack's Alloy. See system/README.md "Observability".
   victoriametrics: false
   loki:            false

--- a/deploy/gitops/environments/test-stand/inventory.yaml
+++ b/deploy/gitops/environments/test-stand/inventory.yaml
@@ -205,7 +205,7 @@ system:
   airbyte: false
   argoWorkflows: false
   # Observability: this stand exports nothing over OTLP
-  # (`observability.otlp.endpoint` is left at the chart's empty default in
+  # (`global.observability.otlp.endpoint` is left at the chart's empty default in
   # values.yaml, i.e. structured JSON to stdout only). Flipping these on
   # would self-host an LGTM stack that nothing points at.
   victoriametrics: false

--- a/deploy/gitops/environments/test-stand/values.yaml
+++ b/deploy/gitops/environments/test-stand/values.yaml
@@ -269,7 +269,7 @@ global:
   # cluster rather than taking a flag, so a drift here silently seeds a
   # tenant nobody can log into).
   tenantDefaultId: "3f1d8f4e-6c2a-4a9b-91d7-8e5c0b2a7f36"
-  # Not set, and worth knowing why: `observability.otlp.endpoint` is left at
+  # Not set, and worth knowing why: `global.observability.otlp.endpoint` is left at
   # the chart's empty default, which means every service emits structured
   # JSON to stdout and exports no OTLP. There is no collector on this stand
   # to export to (all `system.*` toggles in inventory.yaml are false), and a

--- a/deploy/gitops/system/README.md
+++ b/deploy/gitops/system/README.md
@@ -73,7 +73,7 @@ managed-vs-bundled choice for the data stores above:
    toggles.
    On = self-host the stack in `insight-infra`. Off = don't (the cluster
    already runs observability, or stdout is enough).
-2. **Where do services export?** — the umbrella's `observability.otlp.endpoint`
+2. **Where do services export?** — the umbrella's `global.observability.otlp.endpoint`
    (`environments/<env>/values.yaml`). Point it at this stack's Alloy when the
    toggles are on; at your own collector for an external one; leave it empty
    for stdout-only.

--- a/deploy/gitops/system/alloy/values.yaml
+++ b/deploy/gitops/system/alloy/values.yaml
@@ -4,7 +4,7 @@
 ##   logs: node-local pod stdout → Loki (DaemonSet tail, below);
 ##   OTLP: services push to alloy:4317 (gRPC) / 4318 (HTTP) — metrics
 ##         remote-write to VictoriaMetrics, traces forward to Tempo.
-## The umbrella's `observability.otlp.endpoint` points here when the
+## The umbrella's `global.observability.otlp.endpoint` points here when the
 ## bundled stack is on.
 ##
 ## Chart: grafana/alloy   (https://grafana.github.io/helm-charts)
@@ -103,7 +103,7 @@ alloy:
       }
 
       // ── OTLP entry point for the app services (umbrella
-      //    `observability.otlp.endpoint` → alloy:4317). Metrics go to
+      //    `global.observability.otlp.endpoint` → alloy:4317). Metrics go to
       //    VictoriaMetrics, traces to Tempo. The logs signal is NOT routed:
       //    logs reach Loki through the stdout tail above, and routing both
       //    would double every line.

--- a/src/backend/services/analytics/helm/templates/configmap.yaml
+++ b/src/backend/services/analytics/helm/templates/configmap.yaml
@@ -25,6 +25,19 @@ data:
       default:
         console_level: info
 
+    opentelemetry:
+      resource:
+        service_name: "insight-analytics"
+      exporter:
+        kind: {{ .Values.opentelemetry.exporter.kind }}
+        {{- with .Values.opentelemetry.exporter.endpoint }}
+        endpoint: {{ . | quote }}
+        {{- end }}
+      tracing:
+        enabled: {{ .Values.opentelemetry.tracing.enabled }}
+      metrics:
+        enabled: {{ .Values.opentelemetry.metrics.enabled }}
+
     gears:
       api-gateway:
         config:

--- a/src/backend/services/analytics/helm/templates/deployment.yaml
+++ b/src/backend/services/analytics/helm/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
           # `.Values.gateway.*` (issuer / discoveryUrl / audience / caCertPaths),
           # so there are no APP__ env overrides for it here.
           envFrom:
+            # Umbrella observability contract; optional so standalone installs schedule.
+            - configMapRef:
+                name: {{ .Release.Name }}-platform
+                optional: true
             # Operator MUST pre-create this Secret (umbrella does it
             # automatically as `insight-analytics-config`). Provides the
             # APP__gears__analytics__config__* leaf overrides.

--- a/src/backend/services/analytics/helm/templates/deployment.yaml
+++ b/src/backend/services/analytics/helm/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       annotations:
         # Roll pods when the gears config changes.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        # Platform CM arrives via envFrom; roll pods when its observability inputs change.
+        checksum/observability: {{ default dict (default dict .Values.global).observability | toYaml | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/src/backend/services/analytics/helm/values.yaml
+++ b/src/backend/services/analytics/helm/values.yaml
@@ -24,6 +24,17 @@ metricCatalog:
 
 externalSources: []
 
+# OpenTelemetry export. Off by default; the umbrella overrides these via
+# APP__opentelemetry__* env vars when `observability.otlp.endpoint` is set.
+opentelemetry:
+  metrics:
+    enabled: false
+  tracing:
+    enabled: false
+  exporter:
+    kind: otlp_grpc # otlp_grpc | otlp_http
+    endpoint: "" # e.g. http://alloy.insight-infra.svc.cluster.local:4317
+
 # Pre-provisioned Secret carrying the gears-rust host's leaf-config overrides
 # (injected via envFrom; they override the mounted config ConfigMap):
 #   APP__gears__analytics__config__database_url

--- a/src/backend/services/analytics/helm/values.yaml
+++ b/src/backend/services/analytics/helm/values.yaml
@@ -25,7 +25,7 @@ metricCatalog:
 externalSources: []
 
 # OpenTelemetry export. Off by default; the umbrella overrides these via
-# APP__opentelemetry__* env vars when `observability.otlp.endpoint` is set.
+# APP__opentelemetry__* env vars when `global.observability.otlp.endpoint` is set.
 opentelemetry:
   metrics:
     enabled: false

--- a/src/backend/services/authenticator/helm/templates/configmap.yaml
+++ b/src/backend/services/authenticator/helm/templates/configmap.yaml
@@ -30,6 +30,19 @@ data:
       default:
         console_level: info
 
+    opentelemetry:
+      resource:
+        service_name: "insight-authenticator"
+      exporter:
+        kind: {{ .Values.opentelemetry.exporter.kind }}
+        {{- with .Values.opentelemetry.exporter.endpoint }}
+        endpoint: {{ . | quote }}
+        {{- end }}
+      tracing:
+        enabled: {{ .Values.opentelemetry.tracing.enabled }}
+      metrics:
+        enabled: {{ .Values.opentelemetry.metrics.enabled }}
+
     gears:
       api-gateway:
         config:

--- a/src/backend/services/authenticator/helm/templates/deployment.yaml
+++ b/src/backend/services/authenticator/helm/templates/deployment.yaml
@@ -94,6 +94,10 @@ spec:
               containerPort: {{ .Values.service.tokenPort }}
               protocol: TCP
           envFrom:
+            # Umbrella observability contract; optional so standalone installs schedule.
+            - configMapRef:
+                name: {{ .Release.Name }}-platform
+                optional: true
             # Operator MUST pre-create this Secret (umbrella does it
             # automatically as `insight-authenticator-config`). Provides the
             # APP__gears__authenticator__config__* leaf overrides.

--- a/src/backend/services/authenticator/helm/templates/deployment.yaml
+++ b/src/backend/services/authenticator/helm/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       annotations:
         # Roll pods when the gears config changes.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        # Platform CM arrives via envFrom; roll pods when its observability inputs change.
+        checksum/observability: {{ default dict (default dict .Values.global).observability | toYaml | sha256sum }}
         {{- if .Values.idp.extraCaCertSecret }}
         # Roll pods when the idp-extra-ca Secret's DATA changes under the
         # same name/key (name/key/path changes already alter the pod

--- a/src/backend/services/authenticator/helm/values.yaml
+++ b/src/backend/services/authenticator/helm/values.yaml
@@ -16,7 +16,7 @@ service:
   tokenPort: 8093
 
 # OpenTelemetry export. Off by default; the umbrella overrides these via
-# APP__opentelemetry__* env vars when `observability.otlp.endpoint` is set.
+# APP__opentelemetry__* env vars when `global.observability.otlp.endpoint` is set.
 opentelemetry:
   metrics:
     enabled: false

--- a/src/backend/services/authenticator/helm/values.yaml
+++ b/src/backend/services/authenticator/helm/values.yaml
@@ -15,6 +15,17 @@ service:
   # from the main port (see networkPolicy.tokenPort below).
   tokenPort: 8093
 
+# OpenTelemetry export. Off by default; the umbrella overrides these via
+# APP__opentelemetry__* env vars when `observability.otlp.endpoint` is set.
+opentelemetry:
+  metrics:
+    enabled: false
+  tracing:
+    enabled: false
+  exporter:
+    kind: otlp_grpc # otlp_grpc | otlp_http
+    endpoint: "" # e.g. http://alloy.insight-infra.svc.cluster.local:4317
+
 # Service tokens (§10 G1 / DD-AUTH-05). The registry holds only PUBLIC keys, so
 # it is gitops-reviewable config: onboarding a service is a PR adding its key.
 # `audience` is the token endpoint URL callers sign assertions for — typically

--- a/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
+++ b/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
@@ -13,6 +13,19 @@ data:
       default:
         console_level: info
 
+    opentelemetry:
+      resource:
+        service_name: "insight-git-cli-proxy"
+      exporter:
+        kind: {{ .Values.opentelemetry.exporter.kind }}
+        {{- with .Values.opentelemetry.exporter.endpoint }}
+        endpoint: {{ . | quote }}
+        {{- end }}
+      tracing:
+        enabled: {{ .Values.opentelemetry.tracing.enabled }}
+      metrics:
+        enabled: {{ .Values.opentelemetry.metrics.enabled }}
+
     gears:
       gear-orchestrator:
         config: {}

--- a/src/backend/services/git-cli-proxy/helm/templates/deployment.yaml
+++ b/src/backend/services/git-cli-proxy/helm/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
       annotations:
         # Roll the pod when the gears config changes.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        # Platform CM arrives via envFrom; roll pods when its observability inputs change.
+        checksum/observability: {{ default dict (default dict .Values.global).observability | toYaml | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/src/backend/services/git-cli-proxy/helm/values.yaml
+++ b/src/backend/services/git-cli-proxy/helm/values.yaml
@@ -35,6 +35,17 @@ resources:
     cpu: "2"
     memory: 8Gi
 
+# OpenTelemetry export. Off by default; the umbrella overrides these via
+# APP__opentelemetry__* env vars when `observability.otlp.endpoint` is set.
+opentelemetry:
+  metrics:
+    enabled: false
+  tracing:
+    enabled: false
+  exporter:
+    kind: otlp_grpc # otlp_grpc | otlp_http
+    endpoint: "" # e.g. http://alloy.insight-infra.svc.cluster.local:4317
+
 # Repository cache volume. The app budget below MUST stay under this size:
 # kubelet enforcement is pod eviction, which is a crash, not a mechanism.
 persistence:

--- a/src/backend/services/git-cli-proxy/helm/values.yaml
+++ b/src/backend/services/git-cli-proxy/helm/values.yaml
@@ -36,7 +36,7 @@ resources:
     memory: 8Gi
 
 # OpenTelemetry export. Off by default; the umbrella overrides these via
-# APP__opentelemetry__* env vars when `observability.otlp.endpoint` is set.
+# APP__opentelemetry__* env vars when `global.observability.otlp.endpoint` is set.
 opentelemetry:
   metrics:
     enabled: false

--- a/src/backend/services/identity-resolution/helm/templates/configmap.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/configmap.yaml
@@ -24,6 +24,19 @@ data:
       default:
         console_level: info
 
+    opentelemetry:
+      resource:
+        service_name: "insight-identity-resolution"
+      exporter:
+        kind: {{ .Values.opentelemetry.exporter.kind }}
+        {{- with .Values.opentelemetry.exporter.endpoint }}
+        endpoint: {{ . | quote }}
+        {{- end }}
+      tracing:
+        enabled: {{ .Values.opentelemetry.tracing.enabled }}
+      metrics:
+        enabled: {{ .Values.opentelemetry.metrics.enabled }}
+
     gears:
       api-gateway:
         config:

--- a/src/backend/services/identity-resolution/helm/templates/deployment.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       annotations:
         # Roll pods when the gears config changes.
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        # Platform CM arrives via envFrom; roll pods when its observability inputs change.
+        checksum/observability: {{ default dict (default dict .Values.global).observability | toYaml | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/src/backend/services/identity-resolution/helm/templates/deployment.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/deployment.yaml
@@ -114,6 +114,10 @@ spec:
           # `.Values.gateway.*` (issuer / discoveryUrl / audience / caCertPaths),
           # so there are no APP__ env overrides for it here.
           envFrom:
+            # Umbrella observability contract; optional so standalone installs schedule.
+            - configMapRef:
+                name: {{ .Release.Name }}-platform
+                optional: true
             # Operator MUST pre-create this Secret (umbrella does it
             # automatically as `insight-identity-resolution-config`). Provides
             # the APP__gears__identity_resolution__config__* leaf overrides.

--- a/src/backend/services/identity-resolution/helm/tests/test_seed_cronjob_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_seed_cronjob_contract.py
@@ -45,9 +45,7 @@ TENANT = "3e1d5a65-434c-95b4-8c1b-eb8f53a39bab"
 # freshness backstop, and a backstop that is red on healthy stands (empty
 # identity_inputs, a raced lock) trains everyone to ignore it — refusals
 # surface as failed operations-journal rows instead.
-JOBS = {
-    "seed": ("*/15 * * * *", ["seed", "--busy-ok", "--guard-ok"]),
-}
+JOBS = {"seed": ("*/15 * * * *", ["seed", "--busy-ok", "--guard-ok"])}
 
 # Minimum viable subchart install (mirrors the umbrella's wiring).
 SUBCHART_BASE = [
@@ -139,13 +137,10 @@ def _cronjob(docs: list[dict], job: str) -> dict:
     release/alias prefix differs).
     """
     matches = {
-        name: doc
-        for name, doc in _cronjobs(docs).items()
-        if "identity-resolution" in name and name.endswith(f"-{job}")
+        name: doc for name, doc in _cronjobs(docs).items() if "identity-resolution" in name and name.endswith(f"-{job}")
     }
     assert len(matches) == 1, (
-        f"expected exactly one identity-resolution {job} CronJob; "
-        f"present: {sorted(_cronjobs(docs))}"
+        f"expected exactly one identity-resolution {job} CronJob; present: {sorted(_cronjobs(docs))}"
     )
     return next(iter(matches.values()))
 
@@ -170,8 +165,7 @@ def _umbrella_gear_config(manifests: str) -> dict:
     named = [
         d
         for d in _docs(manifests)
-        if d.get("kind") == "ConfigMap"
-        and d["metadata"]["name"].endswith("-identity-resolution-gears-config")
+        if d.get("kind") == "ConfigMap" and d["metadata"]["name"].endswith("-identity-resolution-gears-config")
     ]
     assert len(named) == 1, f"expected one identity gears ConfigMap, got {len(named)}"
 
@@ -197,9 +191,7 @@ def test_no_persons_sync_cronjob_is_scheduled(default_docs) -> None:
     """A scheduled sync would put the log and its ClickHouse snapshot back on
     two independent clocks — the ordering hazard the seed's own publish step
     removes. Nothing else in this suite would notice it returning."""
-    assert not [n for n in _cronjobs(default_docs) if n.endswith("-sync")], sorted(
-        _cronjobs(default_docs)
-    )
+    assert not [n for n in _cronjobs(default_docs) if n.endswith("-sync")], sorted(_cronjobs(default_docs))
 
 
 @pytest.mark.parametrize("job", JOBS)
@@ -226,9 +218,11 @@ def test_cronjob_uses_the_deployments_secret_and_configmap(default_docs, job: st
     deploy = _the(default_docs, "Deployment")
     container = _job_container(cj)
 
-    secret_refs = [e["secretRef"]["name"] for e in container["envFrom"]]
+    secret_refs = [e["secretRef"]["name"] for e in container["envFrom"] if "secretRef" in e]
     deploy_secret_refs = [
-        e["secretRef"]["name"] for e in deploy["spec"]["template"]["spec"]["containers"][0]["envFrom"]
+        e["secretRef"]["name"]
+        for e in deploy["spec"]["template"]["spec"]["containers"][0]["envFrom"]
+        if "secretRef" in e
     ]
     assert secret_refs == deploy_secret_refs == ["test-secret"]
 
@@ -269,9 +263,7 @@ def test_job_pod_labels_never_match_the_service_selector(default_docs, job: str)
     it, it would enter the endpoints and blackhole live traffic during every
     run."""
     selector = _the(default_docs, "Service")["spec"]["selector"]
-    pod_labels = _cronjob(default_docs, job)["spec"]["jobTemplate"]["spec"]["template"][
-        "metadata"
-    ]["labels"]
+    pod_labels = _cronjob(default_docs, job)["spec"]["jobTemplate"]["spec"]["template"]["metadata"]["labels"]
     assert any(pod_labels.get(k) != v for k, v in selector.items()), (
         f"{job} pod labels {pod_labels} satisfy the Service selector {selector}"
     )
@@ -290,9 +282,7 @@ def test_umbrella_refuses_enabled_seed_without_a_tenant(umbrella_deps) -> None:
 
 
 def test_umbrella_renders_the_cronjobs_with_a_tenant(umbrella_deps) -> None:
-    rc, out, err = _render(
-        umbrella_deps, *UMBRELLA_BASE, "--set", f"global.tenantDefaultId={TENANT}"
-    )
+    rc, out, err = _render(umbrella_deps, *UMBRELLA_BASE, "--set", f"global.tenantDefaultId={TENANT}")
     assert rc == 0, err
     docs = _docs(out)
     for job in JOBS:
@@ -300,9 +290,7 @@ def test_umbrella_renders_the_cronjobs_with_a_tenant(umbrella_deps) -> None:
 
 
 def test_umbrella_accepts_the_explicit_seed_tenant_alone(umbrella_deps) -> None:
-    rc, out, err = _render(
-        umbrella_deps, *UMBRELLA_BASE, "--set", f"identityResolution.seed.tenantDefaultId={TENANT}"
-    )
+    rc, out, err = _render(umbrella_deps, *UMBRELLA_BASE, "--set", f"identityResolution.seed.tenantDefaultId={TENANT}")
     assert rc == 0, err
     container = _job_container(_cronjob(_docs(out), "seed"))
     env = {e["name"]: e["value"] for e in container.get("env", [])}
@@ -310,14 +298,10 @@ def test_umbrella_accepts_the_explicit_seed_tenant_alone(umbrella_deps) -> None:
 
 
 def test_umbrella_disabled_seed_needs_no_tenant(umbrella_deps) -> None:
-    rc, out, err = _render(
-        umbrella_deps, *UMBRELLA_BASE, "--set", "identityResolution.seed.enabled=false"
-    )
+    rc, out, err = _render(umbrella_deps, *UMBRELLA_BASE, "--set", "identityResolution.seed.enabled=false")
     assert rc == 0, err
     jobs = _cronjobs(_docs(out))
-    assert not any(
-        "identity-resolution" in n and n.endswith("-seed") for n in jobs
-    ), sorted(jobs)
+    assert not any("identity-resolution" in n and n.endswith("-seed") for n in jobs), sorted(jobs)
 
 
 def test_umbrella_carries_the_roster_source_to_the_gear_that_reads_it(umbrella_deps) -> None:
@@ -341,11 +325,7 @@ def test_umbrella_carries_the_roster_source_to_the_gear_that_reads_it(umbrella_d
 
 
 def test_umbrella_names_no_roster_by_default(umbrella_deps) -> None:
-    rc, out, err = _render(
-        umbrella_deps, *UMBRELLA_BASE, "--set", f"global.tenantDefaultId={TENANT}"
-    )
+    rc, out, err = _render(umbrella_deps, *UMBRELLA_BASE, "--set", f"global.tenantDefaultId={TENANT}")
     assert rc == 0, err
 
-    assert _umbrella_gear_config(out)["roster_source_type"] == "", (
-        "an upgrade must not start minting persons by itself"
-    )
+    assert _umbrella_gear_config(out)["roster_source_type"] == "", "an upgrade must not start minting persons by itself"

--- a/src/backend/services/identity-resolution/helm/values.yaml
+++ b/src/backend/services/identity-resolution/helm/values.yaml
@@ -20,6 +20,17 @@ resources:
     cpu: 500m
     memory: 512Mi
 
+# OpenTelemetry export. Off by default; the umbrella overrides these via
+# APP__opentelemetry__* env vars when `observability.otlp.endpoint` is set.
+opentelemetry:
+  metrics:
+    enabled: false
+  tracing:
+    enabled: false
+  exporter:
+    kind: otlp_grpc # otlp_grpc | otlp_http
+    endpoint: "" # e.g. http://alloy.insight-infra.svc.cluster.local:4317
+
 # Pre-provisioned Secret carrying the gears-rust host's leaf-config overrides
 # (injected via envFrom; they override the mounted config ConfigMap):
 #   APP__gears__identity_resolution__config__database_url

--- a/src/backend/services/identity-resolution/helm/values.yaml
+++ b/src/backend/services/identity-resolution/helm/values.yaml
@@ -21,7 +21,7 @@ resources:
     memory: 512Mi
 
 # OpenTelemetry export. Off by default; the umbrella overrides these via
-# APP__opentelemetry__* env vars when `observability.otlp.endpoint` is set.
+# APP__opentelemetry__* env vars when `global.observability.otlp.endpoint` is set.
 opentelemetry:
   metrics:
     enabled: false


### PR DESCRIPTION
Closes #2889.

**Why.** Setting `observability.otlp.endpoint` publishes only the standard `OTEL_*` env vars, which the gears-rust toolkit never reads — the four Rust services compute metrics and spans that export nowhere.

**What changed.** The `{release}-platform` ConfigMap now publishes the same contract in the toolkit's dialect — `APP__opentelemetry__{exporter__kind,exporter__endpoint,metrics__enabled,tracing__enabled}`, figment env layering — flipping OTel metrics and tracing export on in analytics, authenticator, git-cli-proxy and identity-resolution. Each service chart gains an `opentelemetry` values block rendered into its gears config with a per-service `resource.service_name`; analytics, authenticator and the identity-resolution main container now mount the platform ConfigMap (`optional: true`, so standalone installs still schedule). No Rust changes: the pinned toolkit already wires the exporters and runs its startup connectivity probe whenever tracing is enabled, so a wrong endpoint surfaces as a boot-time error log.

**`observability` values moved under `global.observability`.** Subcharts only see `global`, and the four deployments now hash it into a `checksum/observability` annotation so an endpoint change rolls its consumers (CodeRabbit's finding). A legacy top-level `observability` block still works, but cannot roll pods.

**`OTEL_TRACES_EXPORTER` flips from the `"none"` placeholder to `"otlp"`.** Its comment deferred that to the tracing phase (Tempo in the system layer) — this PR is that phase. Endpoint unset still renders zero `OTEL_*`/`APP__*` keys, so stdout-only installs are untouched.

**Out of scope.** Dashboards and alerts over the exported signals — decisions tracked in #2895. No gitops values change: any environment that already sets the endpoint picks this up on its next chart bump.

**Verified.** `helm lint`; umbrella templates with and without an endpoint (contract present in all four service configs / absent everywhere); identity-resolution (42) and git-cli-proxy (27) helm contract suites pass locally.
