### PR TITLE
feat(previews): self-service UI + per-user capability gate on the JWT roles claim

### DIFF
--- a/docs/components/backend/previews/openapi.json
+++ b/docs/components/backend/previews/openapi.json
@@ -338,7 +338,7 @@
             "bearerAuth": []
           }
         ],
-        "summary": "Create a preview experiment (name + FE image tag)"
+        "summary": "Create a preview experiment (name + FE image tag); requires the previews-admin or admin role"
       }
     },
     "/v1/experiments/{name}": {
@@ -435,7 +435,7 @@
             "bearerAuth": []
           }
         ],
-        "summary": "Delete a preview experiment"
+        "summary": "Delete a preview experiment; requires the previews-admin or admin role"
       }
     }
   }

--- a/src/backend/services/authenticator/src/api/handlers.rs
+++ b/src/backend/services/authenticator/src/api/handlers.rs
@@ -644,9 +644,8 @@ async fn mint_and_store_session(
     let token = csprng_token();
     let csrf_token = csprng_token();
 
-    // Per-user identity roles ride the JWT (#2374); `default_roles` stays the
-    // fallback when identity is unreachable or grants nothing. The values
-    // change, never the claim shape (DD-AUTH-07).
+    // Identity roles, `default_roles` as fallback; values only, never the
+    // claim shape (DD-AUTH-07).
     let roles = session_roles(state, &identity.person_id, &identity.tenant_id).await;
 
     // exp clamped to the session absolute cap (cheap hygiene, G3).
@@ -715,8 +714,7 @@ async fn mint_and_store_session(
 }
 
 /// The roles a session carries, freshly asked of identity. A roles blip must
-/// not fail a login or a refresh, so the error folds into the fallback here
-/// and is only logged.
+/// not fail a login, so an error folds into the fallback and is only logged.
 async fn session_roles(state: &AppState, person_id: &str, tenant_id: &str) -> Vec<String> {
     let fetched = state.resolver.active_roles(person_id, tenant_id).await;
     if let Err(e) = &fetched {
@@ -728,9 +726,7 @@ async fn session_roles(state: &AppState, person_id: &str, tenant_id: &str) -> Ve
     effective_roles(fetched.ok(), &state.cfg.default_roles)
 }
 
-/// Fold an identity roles answer into the claim values: grants win; no answer
-/// or no grants falls back to `default_roles`, the pre-#2374 baseline every
-/// session used to carry.
+/// Grants win; no answer or no grants falls back to `default_roles`.
 fn effective_roles(fetched: Option<Vec<String>>, default_roles: &[String]) -> Vec<String> {
     match fetched {
         Some(roles) if !roles.is_empty() => roles,
@@ -896,9 +892,6 @@ pub async fn me(Extension(state): Extension<Arc<AppState>>, jar: CookieJar) -> R
         "expires_at": record.expires_at,
         "refresh_at": refresh_at,
         "csrf_token": record.csrf_token,
-        // The stand-level preview-experiments capability (#2374): false keeps
-        // the whole previews surface structurally inert, so the SPA can drop
-        // it without asking anything else.
         "experiments_enabled": state.cfg.experiments_enabled,
     });
     // View-as session (#1941): name the real principal so the SPA can show a
@@ -1007,12 +1000,9 @@ pub async fn refresh(
             Err(e) => internal_problem("session_store", &e),
         };
     }
-    // Roles converge on refresh (#2374): re-ask identity and store the answer
-    // so the next JWT reissue mints current values — a grant or revoke needs
-    // no re-login, only the accepted staleness window (JWT reissue + gateway
-    // exchange cache). An unreachable identity keeps the roles the session
-    // already carries; a refresh must not fail, or downgrade a session, over
-    // a roles blip.
+    // Roles converge on refresh; the JWT catches up at its next reissue. An
+    // unreachable identity keeps the current roles — a refresh must not fail,
+    // or downgrade a session, over a roles blip.
     match state
         .resolver
         .active_roles(&record.person_id, &record.tenant_id)

--- a/src/backend/services/authenticator/src/api/handlers.rs
+++ b/src/backend/services/authenticator/src/api/handlers.rs
@@ -644,9 +644,10 @@ async fn mint_and_store_session(
     let token = csprng_token();
     let csrf_token = csprng_token();
 
-    // Default roles only — RBAC/ACL is a later initiative (DD-AUTH-07); the
-    // permissions service will replace these values, never the claim shape.
-    let roles = cfg.default_roles.clone();
+    // Per-user identity roles ride the JWT (#2374); `default_roles` stays the
+    // fallback when identity is unreachable or grants nothing. The values
+    // change, never the claim shape (DD-AUTH-07).
+    let roles = session_roles(state, &identity.person_id, &identity.tenant_id).await;
 
     // exp clamped to the session absolute cap (cheap hygiene, G3).
     let exp = (now + cfg.jwt_ttl_seconds).min(absolute_expires_at);
@@ -711,6 +712,30 @@ async fn mint_and_store_session(
         .await?;
 
     Ok((session_id, token))
+}
+
+/// The roles a session carries, freshly asked of identity. A roles blip must
+/// not fail a login or a refresh, so the error folds into the fallback here
+/// and is only logged.
+async fn session_roles(state: &AppState, person_id: &str, tenant_id: &str) -> Vec<String> {
+    let fetched = state.resolver.active_roles(person_id, tenant_id).await;
+    if let Err(e) = &fetched {
+        tracing::warn!(
+            error = format!("{e:#}"),
+            "identity roles fetch failed: falling back to default_roles"
+        );
+    }
+    effective_roles(fetched.ok(), &state.cfg.default_roles)
+}
+
+/// Fold an identity roles answer into the claim values: grants win; no answer
+/// or no grants falls back to `default_roles`, the pre-#2374 baseline every
+/// session used to carry.
+fn effective_roles(fetched: Option<Vec<String>>, default_roles: &[String]) -> Vec<String> {
+    match fetched {
+        Some(roles) if !roles.is_empty() => roles,
+        Some(_) | None => default_roles.to_vec(),
+    }
 }
 
 // ── /internal/authz ─────────────────────────────────────────────────────────
@@ -871,6 +896,10 @@ pub async fn me(Extension(state): Extension<Arc<AppState>>, jar: CookieJar) -> R
         "expires_at": record.expires_at,
         "refresh_at": refresh_at,
         "csrf_token": record.csrf_token,
+        // The stand-level preview-experiments capability (#2374): false keeps
+        // the whole previews surface structurally inert, so the SPA can drop
+        // it without asking anything else.
+        "experiments_enabled": state.cfg.experiments_enabled,
     });
     // View-as session (#1941): name the real principal so the SPA can show a
     // "viewing as X" banner. Absent on normal sessions.
@@ -978,6 +1007,37 @@ pub async fn refresh(
             Err(e) => internal_problem("session_store", &e),
         };
     }
+    // Roles converge on refresh (#2374): re-ask identity and store the answer
+    // so the next JWT reissue mints current values — a grant or revoke needs
+    // no re-login, only the accepted staleness window (JWT reissue + gateway
+    // exchange cache). An unreachable identity keeps the roles the session
+    // already carries; a refresh must not fail, or downgrade a session, over
+    // a roles blip.
+    match state
+        .resolver
+        .active_roles(&record.person_id, &record.tenant_id)
+        .await
+    {
+        Ok(fetched) => {
+            let roles = effective_roles(Some(fetched), &state.cfg.default_roles);
+            if roles != record.roles
+                && let Err(e) = state
+                    .sessions
+                    .update_session_roles(&session_id, &roles)
+                    .await
+            {
+                tracing::warn!(error = %e, session_id = %session_id, "refresh: storing re-fetched roles failed");
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = format!("{e:#}"),
+                session_id = %session_id,
+                "refresh: roles re-fetch failed; keeping the session's current roles"
+            );
+        }
+    }
+
     tracing::debug!(session_id = %session_id, expires_at = new_expires_at, "session refreshed (credential rotated)");
     state.audit.emit(session_audit(
         "session_refresh",
@@ -1692,6 +1752,26 @@ fn internal_problem(context: &str, err: &anyhow::Error) -> Response {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn identity_grants_win_and_everything_else_is_the_default_roles() {
+        let defaults = vec!["user".to_owned()];
+        for (case, fetched, expected) in [
+            (
+                "grants win",
+                Some(vec!["admin".to_owned(), "previews-admin".to_owned()]),
+                vec!["admin".to_owned(), "previews-admin".to_owned()],
+            ),
+            ("no grants falls back", Some(vec![]), defaults.clone()),
+            ("no answer falls back", None, defaults.clone()),
+        ] {
+            assert_eq!(
+                effective_roles(fetched, &defaults),
+                expected,
+                "wrong roles for: {case}"
+            );
+        }
+    }
 
     #[test]
     fn cache_control_keeps_60s_travel_margin() {

--- a/src/backend/services/authenticator/src/identity.rs
+++ b/src/backend/services/authenticator/src/identity.rs
@@ -100,11 +100,9 @@ pub trait PersonResolver: Send + Sync {
         Ok(None)
     }
 
-    /// The ACTIVE identity role names the person holds in the tenant — minted
-    /// into the JWT `roles` claim at login and re-fetched on `/auth/refresh`
-    /// (#2374). An empty list is a real answer ("no grants"); the caller then
-    /// falls back to its configured `default_roles`, so a resolver without a
-    /// roles source (this default) yields exactly the pre-#2374 behaviour.
+    /// The ACTIVE identity role names the person holds in the tenant. An
+    /// empty list means "no grants" — the caller falls back to its
+    /// `default_roles`, so this default keeps the prior behaviour.
     ///
     /// # Errors
     /// Fails when the Identity Service is unreachable or errors.
@@ -463,8 +461,6 @@ mod tests {
 
     #[tokio::test]
     async fn a_resolver_without_a_roles_source_grants_nothing() -> anyhow::Result<()> {
-        // The trait default answers "no grants", which the caller folds into
-        // its configured default_roles — exactly the pre-roles behaviour.
         let roles = LookupOnly.active_roles("person", "tenant").await?;
 
         assert!(roles.is_empty());

--- a/src/backend/services/authenticator/src/identity.rs
+++ b/src/backend/services/authenticator/src/identity.rs
@@ -99,6 +99,19 @@ pub trait PersonResolver: Send + Sync {
         let _ = id;
         Ok(None)
     }
+
+    /// The ACTIVE identity role names the person holds in the tenant — minted
+    /// into the JWT `roles` claim at login and re-fetched on `/auth/refresh`
+    /// (#2374). An empty list is a real answer ("no grants"); the caller then
+    /// falls back to its configured `default_roles`, so a resolver without a
+    /// roles source (this default) yields exactly the pre-#2374 behaviour.
+    ///
+    /// # Errors
+    /// Fails when the Identity Service is unreachable or errors.
+    async fn active_roles(&self, person_id: &str, tenant_id: &str) -> anyhow::Result<Vec<String>> {
+        let _ = (person_id, tenant_id);
+        Ok(Vec::new())
+    }
 }
 
 /// `PersonResolver` backed by the Identity Service.
@@ -306,6 +319,12 @@ impl IdentityPersonResolver {
     }
 }
 
+/// Wire shape of `GET /internal/persons/active-roles` — only the names.
+#[derive(serde::Deserialize)]
+struct ActiveRolesProfile {
+    roles: Vec<String>,
+}
+
 #[async_trait]
 impl PersonResolver for IdentityPersonResolver {
     async fn resolve(&self, id: &IdpIdentity) -> anyhow::Result<Option<PersonResolution>> {
@@ -331,6 +350,29 @@ impl PersonResolver for IdentityPersonResolver {
             person_id: person_id.to_string(),
             tenant_id: id.tenant_id.clone(),
         }))
+    }
+
+    async fn active_roles(&self, person_id: &str, tenant_id: &str) -> anyhow::Result<Vec<String>> {
+        if self.base_url.is_empty() {
+            return Ok(Vec::new());
+        }
+        let url = format!("{}/internal/persons/active-roles", self.base_url);
+        let token = self.mint_service_token(tenant_id)?;
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[("person_id", person_id)])
+            .bearer_auth(token)
+            .send()
+            .await
+            .context("Identity active-roles request")?;
+        anyhow::ensure!(
+            resp.status().is_success(),
+            "Identity returned {} for /internal/persons/active-roles",
+            resp.status()
+        );
+        let profile: ActiveRolesProfile = resp.json().await.context("decode ActiveRolesProfile")?;
+        Ok(profile.roles)
     }
 }
 
@@ -417,6 +459,16 @@ mod tests {
                 "{target:?} must not send source_type",
             );
         }
+    }
+
+    #[tokio::test]
+    async fn a_resolver_without_a_roles_source_grants_nothing() -> anyhow::Result<()> {
+        // The trait default answers "no grants", which the caller folds into
+        // its configured default_roles — exactly the pre-roles behaviour.
+        let roles = LookupOnly.active_roles("person", "tenant").await?;
+
+        assert!(roles.is_empty());
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/backend/services/authenticator/src/session.rs
+++ b/src/backend/services/authenticator/src/session.rs
@@ -624,12 +624,10 @@ impl SessionManager {
         Ok(rotated == 1)
     }
 
-    /// Store re-fetched session roles (`POST /auth/refresh`, #2374), guarded
-    /// on the session still existing — an unguarded `HSET` on a key a
-    /// concurrent revoke just deleted would resurrect a TTL-less roles-only
-    /// hash (same zombie shape [`Self::store_idp_refresh`] guards against).
-    /// The linked JWT is untouched: it converges at its next reissue, which is
-    /// the accepted staleness window.
+    /// Store re-fetched session roles (`POST /auth/refresh`), guarded on the
+    /// session still existing — an unguarded `HSET` after a concurrent revoke
+    /// would resurrect a TTL-less hash (see [`Self::store_idp_refresh`]).
+    /// The linked JWT is untouched; it converges at its next reissue.
     ///
     /// # Errors
     /// Fails on a Redis error.

--- a/src/backend/services/authenticator/src/session.rs
+++ b/src/backend/services/authenticator/src/session.rs
@@ -624,6 +624,36 @@ impl SessionManager {
         Ok(rotated == 1)
     }
 
+    /// Store re-fetched session roles (`POST /auth/refresh`, #2374), guarded
+    /// on the session still existing — an unguarded `HSET` on a key a
+    /// concurrent revoke just deleted would resurrect a TTL-less roles-only
+    /// hash (same zombie shape [`Self::store_idp_refresh`] guards against).
+    /// The linked JWT is untouched: it converges at its next reissue, which is
+    /// the accepted staleness window.
+    ///
+    /// # Errors
+    /// Fails on a Redis error.
+    pub async fn update_session_roles(
+        &self,
+        session_id: &str,
+        roles: &[String],
+    ) -> anyhow::Result<()> {
+        const STORE_LUA: &str = r"
+            if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
+            redis.call('HSET', KEYS[1], 'roles', ARGV[1])
+            return 1
+        ";
+        let json = serde_json::to_string(roles).context("serialize session roles")?;
+        let mut conn = self.conn.clone();
+        let _: i64 = redis::Script::new(STORE_LUA)
+            .key(session_key(session_id))
+            .arg(json)
+            .invoke_async(&mut conn)
+            .await
+            .context("store session roles (guarded)")?;
+        Ok(())
+    }
+
     // ── Background workers (G5 refresher, janitor) ─────────────────────────
 
     /// Try to take (or renew) a leader lock. `SET key holder NX PX ttl` wins a

--- a/src/backend/services/identity-resolution/src/api/gate.rs
+++ b/src/backend/services/identity-resolution/src/api/gate.rs
@@ -56,12 +56,17 @@ pub(crate) async fn require_admin(
     ctx: &SecurityContext,
 ) -> Result<Uuid, CanonicalError> {
     let caller = require_caller(ctx)?;
-    let is_admin = roles_repo::has_active_admin(db, ctx.subject_tenant_id(), caller)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "admin role check failed");
-            CanonicalError::internal("failed to verify caller permissions").create()
-        })?;
+    let is_admin = roles_repo::has_active_role(
+        db,
+        ctx.subject_tenant_id(),
+        caller,
+        roles_repo::ADMIN_ROLE_ID,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, "admin role check failed");
+        CanonicalError::internal("failed to verify caller permissions").create()
+    })?;
     if !is_admin {
         tracing::warn!(
             caller = %caller,

--- a/src/backend/services/identity-resolution/src/api/handlers.rs
+++ b/src/backend/services/identity-resolution/src/api/handlers.rs
@@ -421,16 +421,10 @@ struct InternalActiveRolesResponse {
 }
 
 /// `GET /internal/persons/active-roles?person_id=...` — SERVICE-ONLY read of
-/// the ACTIVE identity role names a person holds in the caller's tenant. The
-/// authenticator calls it at login and on `/auth/refresh` to mint the session
-/// roles into the gateway JWT (#2374); an empty list is a real answer ("no
-/// grants"), never an error, so the caller can fall back to its defaults.
-///
-/// Tenant-SCOPED like `by-roster-email`: role grants live per tenant in
-/// `person_roles`, and the authenticator mints its service JWT with the
-/// session's tenant, so it arrives in the `SecurityContext` like any caller's.
-/// Fails closed when the token carries no tenant. Registered as a raw route so
-/// it stays out of the generated OpenAPI, same as the other internal resolvers.
+/// the ACTIVE role names a person holds in the caller's tenant; the
+/// authenticator mints them into the JWT at login and `/auth/refresh`. An
+/// empty list is a real answer, never an error. Tenant-scoped and fail-closed
+/// like `by-roster-email`; raw route, out of the generated OpenAPI.
 pub async fn internal_person_active_roles(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
@@ -974,8 +968,7 @@ mod tests {
         Ok(())
     }
 
-    /// Lock the internal active-roles wire shape (`snake_case`, role NAMES) —
-    /// the authenticator mints these values into the JWT `roles` claim verbatim.
+    /// The authenticator mints these values into the JWT roles claim verbatim.
     #[test]
     fn internal_active_roles_wire_shape() -> anyhow::Result<()> {
         let body = InternalActiveRolesResponse {

--- a/src/backend/services/identity-resolution/src/api/handlers.rs
+++ b/src/backend/services/identity-resolution/src/api/handlers.rs
@@ -26,7 +26,7 @@ use crate::domain::profile::{
     assemble_profile, latest_values,
 };
 use crate::domain::profile_batch::{self, BatchProfilesError};
-use crate::infra::db::{persons_repo, resolution_repo, subchart_repo};
+use crate::infra::db::{persons_repo, resolution_repo, roles_repo, subchart_repo};
 
 /// `POST /v1/profiles` — resolve one identity (email or source-native id) to a
 /// person, then assemble the profile.
@@ -405,6 +405,66 @@ fn person_response(external_id: &str, person_id: Uuid) -> InternalPersonResponse
         insight_source_type: "person",
         insight_source_id: person_id,
     }
+}
+
+/// Query params for `GET /internal/persons/active-roles`.
+#[derive(Debug, serde::Deserialize)]
+pub struct InternalActiveRolesQuery {
+    person_id: Uuid,
+}
+
+/// Wire shape of the internal active-roles response: `{ person_id, roles }`.
+#[derive(Debug, Serialize)]
+struct InternalActiveRolesResponse {
+    person_id: Uuid,
+    roles: Vec<String>,
+}
+
+/// `GET /internal/persons/active-roles?person_id=...` — SERVICE-ONLY read of
+/// the ACTIVE identity role names a person holds in the caller's tenant. The
+/// authenticator calls it at login and on `/auth/refresh` to mint the session
+/// roles into the gateway JWT (#2374); an empty list is a real answer ("no
+/// grants"), never an error, so the caller can fall back to its defaults.
+///
+/// Tenant-SCOPED like `by-roster-email`: role grants live per tenant in
+/// `person_roles`, and the authenticator mints its service JWT with the
+/// session's tenant, so it arrives in the `SecurityContext` like any caller's.
+/// Fails closed when the token carries no tenant. Registered as a raw route so
+/// it stays out of the generated OpenAPI, same as the other internal resolvers.
+pub async fn internal_person_active_roles(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Query(query): Query<InternalActiveRolesQuery>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    require_service(&ctx)?;
+
+    if query.person_id.is_nil() {
+        return Err(ProfileError::invalid_argument()
+            .with_field_violation("person_id", "person_id must not be nil", "REQUIRED")
+            .create());
+    }
+    let tenant = ctx.subject_tenant_id();
+    if tenant.is_nil() {
+        return Err(ProfileError::failed_precondition()
+            .with_precondition_violation(
+                "tenant_id",
+                "reading role grants needs the caller's tenant",
+                "tenant_unresolved",
+            )
+            .create());
+    }
+
+    let roles = roles_repo::active_roles_of_person(&state.db, tenant, query.person_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "internal active-roles lookup failed");
+            CanonicalError::internal("lookup failed").create()
+        })?;
+
+    Ok(Json(InternalActiveRolesResponse {
+        person_id: query.person_id,
+        roles: roles.into_iter().map(|role| role.name).collect(),
+    }))
 }
 
 /// Query params for `GET /internal/persons/by-email-override`.
@@ -910,6 +970,23 @@ mod tests {
         assert_eq!(
             json["insight_source_id"],
             "00000000-0000-0000-0000-000000000001"
+        );
+        Ok(())
+    }
+
+    /// Lock the internal active-roles wire shape (`snake_case`, role NAMES) —
+    /// the authenticator mints these values into the JWT `roles` claim verbatim.
+    #[test]
+    fn internal_active_roles_wire_shape() -> anyhow::Result<()> {
+        let body = InternalActiveRolesResponse {
+            person_id: Uuid::from_u128(1),
+            roles: vec!["admin".to_owned(), "previews-admin".to_owned()],
+        };
+        let json = serde_json::to_value(&body)?;
+        assert_eq!(json["person_id"], "00000000-0000-0000-0000-000000000001");
+        assert_eq!(
+            json["roles"],
+            serde_json::json!(["admin", "previews-admin"])
         );
         Ok(())
     }

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -122,6 +122,10 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         "/internal/persons/provision",
         axum::routing::post(handlers::internal_provision_person),
     );
+    let router = router.route(
+        "/internal/persons/active-roles",
+        axum::routing::get(handlers::internal_person_active_roles),
+    );
 
     let router = OperationBuilder::post("/v1/profiles")
         .operation_id("identity_resolution.profiles.resolve")

--- a/src/backend/services/identity-resolution/src/infra/db/roles_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/roles_repo.rs
@@ -45,19 +45,6 @@ pub async fn has_active_role(
     Ok(db.query_one_raw(stmt).await?.is_some())
 }
 
-/// Convenience: does `person_id` hold the active `admin` role in the tenant?
-///
-/// # Errors
-///
-/// Returns an error if the query fails.
-pub async fn has_active_admin(
-    db: &DatabaseConnection,
-    tenant_id: Uuid,
-    person_id: Uuid,
-) -> anyhow::Result<bool> {
-    has_active_role(db, tenant_id, person_id, ADMIN_ROLE_ID).await
-}
-
 /// One row of the global `roles` catalogue (no tenant, no audit columns).
 #[derive(Debug, Clone)]
 pub struct Role {

--- a/src/backend/services/identity-resolution/src/infra/db/visible_set_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/visible_set_live_tests.rs
@@ -156,7 +156,7 @@ async fn the_admin_role_confers_no_visibility() -> TestResult {
     f.make_admin(admin).await?;
 
     assert!(
-        roles_repo::has_active_admin(&f.db, f.tenant, admin).await?,
+        roles_repo::has_active_role(&f.db, f.tenant, admin, roles_repo::ADMIN_ROLE_ID).await?,
         "the fixture really did grant the admin role"
     );
     assert!(

--- a/src/backend/services/identity-resolution/src/migration/m20260831_000017_previews_admin_role.rs
+++ b/src/backend/services/identity-resolution/src/migration/m20260831_000017_previews_admin_role.rs
@@ -1,0 +1,15 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        super::apply_sql(manager, include_str!("sql/017_previews_admin_role.sql")).await
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Err(super::irreversible())
+    }
+}

--- a/src/backend/services/identity-resolution/src/migration/mod.rs
+++ b/src/backend/services/identity-resolution/src/migration/mod.rs
@@ -150,10 +150,7 @@ mod tests {
         }
     }
 
-    /// The seeded role ids are stable API: `admin` mirrors
-    /// `roles_repo::ADMIN_ROLE_ID` (and the FE's `ADMIN_ROLE_ID`);
-    /// `previews-admin` is consumed by NAME (JWT roles claim), so the literal
-    /// here is what pins its id against an accidental edit.
+    /// The seeded role ids are stable API; this pins them against edits.
     #[test]
     fn seeded_role_ids_and_names_are_stable() {
         use crate::infra::db::roles_repo::ADMIN_ROLE_ID;

--- a/src/backend/services/identity-resolution/src/migration/mod.rs
+++ b/src/backend/services/identity-resolution/src/migration/mod.rs
@@ -30,6 +30,7 @@ mod m20260724_000013_persons_email_any_tenant_idx;
 mod m20260724_000014_account_person_map_datetime;
 mod m20260817_000015_drop_account_person_map;
 mod m20260817_000016_drop_dbup_ledger;
+mod m20260831_000017_previews_admin_role;
 
 use sea_orm_migration::prelude::*;
 use sea_orm_migration::sea_orm::ConnectionTrait;
@@ -56,6 +57,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260724_000014_account_person_map_datetime::Migration),
             Box::new(m20260817_000015_drop_account_person_map::Migration),
             Box::new(m20260817_000016_drop_dbup_ledger::Migration),
+            Box::new(m20260831_000017_previews_admin_role::Migration),
         ]
     }
 }
@@ -131,6 +133,7 @@ mod tests {
             (include_str!("sql/014_account_person_map_datetime.sql"), 2),
             (include_str!("sql/015_drop_account_person_map.sql"), 1),
             (include_str!("sql/016_drop_dbup_ledger.sql"), 1),
+            (include_str!("sql/017_previews_admin_role.sql"), 1),
         ];
         for (i, (script, expected)) in cases.iter().enumerate() {
             let stmts = split_statements(script);
@@ -144,6 +147,38 @@ mod tests {
             for stmt in &stmts {
                 assert!(!stmt.contains("--"), "comment leaked into statement");
             }
+        }
+    }
+
+    /// The seeded role ids are stable API: `admin` mirrors
+    /// `roles_repo::ADMIN_ROLE_ID` (and the FE's `ADMIN_ROLE_ID`);
+    /// `previews-admin` is consumed by NAME (JWT roles claim), so the literal
+    /// here is what pins its id against an accidental edit.
+    #[test]
+    fn seeded_role_ids_and_names_are_stable() {
+        use crate::infra::db::roles_repo::ADMIN_ROLE_ID;
+
+        let admin_hex = ADMIN_ROLE_ID.simple().to_string();
+        for (script, hex, name) in [
+            (
+                include_str!("sql/007_roles.sql"),
+                admin_hex.as_str(),
+                "admin",
+            ),
+            (
+                include_str!("sql/017_previews_admin_role.sql"),
+                "a4d11000000040008000000000000002",
+                "previews-admin",
+            ),
+        ] {
+            assert!(
+                script.to_lowercase().contains(&format!("unhex('{hex}')")),
+                "{name}: the migration must seed UNHEX('{hex}')"
+            );
+            assert!(
+                script.contains(&format!("'{name}'")),
+                "{name}: the migration must seed that role name"
+            );
         }
     }
 

--- a/src/backend/services/identity-resolution/src/migration/sql/017_previews_admin_role.sql
+++ b/src/backend/services/identity-resolution/src/migration/sql/017_previews_admin_role.sql
@@ -1,8 +1,5 @@
--- Seed the `previews-admin` role (#2374): grants preview-experiment
--- management (create/delete via the previews service) without full `admin`.
--- Same stable-id pattern as the `admin` seed in 007_roles.sql. Consumers gate
--- on the NAME (the JWT roles claim carries names): the previews service's
--- MANAGE_SCOPES and the frontend's previews gate mirror 'previews-admin'.
+-- Seed the `previews-admin` role, same stable-id pattern as `admin` in 007.
+-- Consumers gate on the NAME (the JWT roles claim carries names).
 INSERT INTO roles (role_id, name)
 VALUES (UNHEX('a4d11000000040008000000000000002'), 'previews-admin')
 ON DUPLICATE KEY UPDATE name = name;

--- a/src/backend/services/identity-resolution/src/migration/sql/017_previews_admin_role.sql
+++ b/src/backend/services/identity-resolution/src/migration/sql/017_previews_admin_role.sql
@@ -1,0 +1,8 @@
+-- Seed the `previews-admin` role (#2374): grants preview-experiment
+-- management (create/delete via the previews service) without full `admin`.
+-- Same stable-id pattern as the `admin` seed in 007_roles.sql. Consumers gate
+-- on the NAME (the JWT roles claim carries names): the previews service's
+-- MANAGE_SCOPES and the frontend's previews gate mirror 'previews-admin'.
+INSERT INTO roles (role_id, name)
+VALUES (UNHEX('a4d11000000040008000000000000002'), 'previews-admin')
+ON DUPLICATE KEY UPDATE name = name;

--- a/src/backend/services/previews/src/api/experiments.rs
+++ b/src/backend/services/previews/src/api/experiments.rs
@@ -28,8 +28,7 @@ use crate::domain::objects::{self, ExperimentStamp};
 use crate::infra::cluster::{CreateError, DeleteOutcome};
 
 /// The identity role names (JWT `roles` → `token_scopes`) that may create or
-/// delete experiments (#2374). Seeded by identity migrations 007 / 017; the
-/// names, not the ids, ride the token.
+/// delete experiments.
 const MANAGE_SCOPES: [&str; 2] = ["previews-admin", "admin"];
 
 /// Body of `POST /v1/experiments`. The image repository is fixed server-side;
@@ -246,11 +245,8 @@ fn require_caller(ctx: &SecurityContext) -> Result<Uuid, CanonicalError> {
     Ok(caller)
 }
 
-/// Require a caller whose verified token scopes allow managing experiments
-/// (create/delete). No database and no S2S call: the scopes come from the JWT
-/// `roles` claim the authenticator minted, mapped by the host authn pipeline.
-/// The list stays authenticated-only — read-only, and the FE hides the
-/// section behind the same roles anyway.
+/// Require a caller whose verified token scopes allow managing experiments;
+/// no database and no S2S call.
 fn require_manage_scope(ctx: &SecurityContext) -> Result<Uuid, CanonicalError> {
     let caller = require_caller(ctx)?;
     if !holds_manage_scope(ctx.token_scopes()) {
@@ -259,15 +255,13 @@ fn require_manage_scope(ctx: &SecurityContext) -> Result<Uuid, CanonicalError> {
     Ok(caller)
 }
 
-/// The one scope decision, over values, so a test needs no `SecurityContext`.
 fn holds_manage_scope(scopes: &[String]) -> bool {
     scopes
         .iter()
         .any(|scope| MANAGE_SCOPES.contains(&scope.as_str()))
 }
 
-/// The canonical 403 for a mutation without a managing scope — one helper so
-/// create and delete refuse identically, and every refusal is logged.
+/// The canonical 403 for a mutation without a managing scope, logged.
 fn manage_scope_denied(ctx: &SecurityContext, caller: Uuid) -> CanonicalError {
     tracing::warn!(
         caller = %caller,

--- a/src/backend/services/previews/src/api/experiments.rs
+++ b/src/backend/services/previews/src/api/experiments.rs
@@ -20,11 +20,17 @@ use uuid::Uuid;
 use super::AppState;
 use super::canonical_json::CanonicalJson;
 use super::error::ExperimentError;
+
 use crate::domain::experiment::{
     Experiment, ExperimentName, ExperimentStatus, ImageTag, TtlDays, experiment_url,
 };
 use crate::domain::objects::{self, ExperimentStamp};
 use crate::infra::cluster::{CreateError, DeleteOutcome};
+
+/// The identity role names (JWT `roles` → `token_scopes`) that may create or
+/// delete experiments (#2374). Seeded by identity migrations 007 / 017; the
+/// names, not the ids, ride the token.
+const MANAGE_SCOPES: [&str; 2] = ["previews-admin", "admin"];
 
 /// Body of `POST /v1/experiments`. The image repository is fixed server-side;
 /// only the tag varies.
@@ -111,7 +117,7 @@ pub async fn create_experiment(
     Extension(ctx): Extension<SecurityContext>,
     CanonicalJson(req): CanonicalJson<CreateExperimentRequest>,
 ) -> Result<impl IntoResponse, CanonicalError> {
-    let caller = require_caller(&ctx)?;
+    let caller = require_manage_scope(&ctx)?;
 
     let name = ExperimentName::parse(&req.name).map_err(|why| field_violation("name", &why))?;
     let tag = ImageTag::parse(&req.tag).map_err(|why| field_violation("tag", &why))?;
@@ -205,7 +211,7 @@ pub async fn delete_experiment(
     Extension(ctx): Extension<SecurityContext>,
     Path(raw_name): Path<String>,
 ) -> Result<impl IntoResponse, CanonicalError> {
-    let caller = require_caller(&ctx)?;
+    let caller = require_manage_scope(&ctx)?;
 
     let name = ExperimentName::parse(&raw_name).map_err(|why| field_violation("name", &why))?;
 
@@ -240,6 +246,39 @@ fn require_caller(ctx: &SecurityContext) -> Result<Uuid, CanonicalError> {
     Ok(caller)
 }
 
+/// Require a caller whose verified token scopes allow managing experiments
+/// (create/delete). No database and no S2S call: the scopes come from the JWT
+/// `roles` claim the authenticator minted, mapped by the host authn pipeline.
+/// The list stays authenticated-only — read-only, and the FE hides the
+/// section behind the same roles anyway.
+fn require_manage_scope(ctx: &SecurityContext) -> Result<Uuid, CanonicalError> {
+    let caller = require_caller(ctx)?;
+    if !holds_manage_scope(ctx.token_scopes()) {
+        return Err(manage_scope_denied(ctx, caller));
+    }
+    Ok(caller)
+}
+
+/// The one scope decision, over values, so a test needs no `SecurityContext`.
+fn holds_manage_scope(scopes: &[String]) -> bool {
+    scopes
+        .iter()
+        .any(|scope| MANAGE_SCOPES.contains(&scope.as_str()))
+}
+
+/// The canonical 403 for a mutation without a managing scope — one helper so
+/// create and delete refuse identically, and every refusal is logged.
+fn manage_scope_denied(ctx: &SecurityContext, caller: Uuid) -> CanonicalError {
+    tracing::warn!(
+        caller = %caller,
+        subject_type = ctx.subject_type().unwrap_or(""),
+        "experiment mutation denied: token carries no previews-admin/admin scope"
+    );
+    ExperimentError::permission_denied()
+        .with_reason("managing experiments requires the previews-admin or admin role")
+        .create()
+}
+
 fn field_violation(field: &'static str, why: &str) -> CanonicalError {
     ExperimentError::invalid_argument()
         .with_field_violation(field, why, "INVALID")
@@ -250,4 +289,68 @@ fn field_violation(field: &'static str, why: &str) -> CanonicalError {
 fn list_err(e: anyhow::Error) -> CanonicalError {
     tracing::error!(error = %format!("{e:#}"), "experiment listing failed");
     CanonicalError::internal("failed to list experiments").create()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scopes(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn only_the_previews_admin_or_admin_scope_may_manage() {
+        for (case, held, allowed) in [
+            ("previews-admin", scopes(&["previews-admin"]), true),
+            ("admin", scopes(&["admin"]), true),
+            ("both plus noise", scopes(&["user", "admin"]), true),
+            ("the default user role", scopes(&["user"]), false),
+            ("no scopes at all", scopes(&[]), false),
+            // Exact names, never substrings — a made-up superset must not pass.
+            ("a superset name", scopes(&["previews-admin-plus"]), false),
+            ("a different admin", scopes(&["session_admin"]), false),
+        ] {
+            assert_eq!(
+                holds_manage_scope(&held),
+                allowed,
+                "wrong decision for: {case}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_mutation_without_the_scope_is_a_403_and_without_a_subject_a_401()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let identified = SecurityContext::builder()
+            .subject_id(Uuid::from_u128(1))
+            .subject_tenant_id(Uuid::from_u128(2))
+            .token_scopes(scopes(&["user"]))
+            .build()
+            .map_err(|e| format!("build context: {e:?}"))?;
+        let Err(denied) = require_manage_scope(&identified) else {
+            return Err("the default user role must not manage experiments".into());
+        };
+        assert_eq!(denied.status_code(), StatusCode::FORBIDDEN);
+
+        let anonymous = SecurityContext::builder()
+            .subject_id(Uuid::nil())
+            .subject_tenant_id(Uuid::from_u128(2))
+            .token_scopes(scopes(&["previews-admin"]))
+            .build()
+            .map_err(|e| format!("build context: {e:?}"))?;
+        let Err(refused) = require_manage_scope(&anonymous) else {
+            return Err("a subject-less token must be refused before the scope check".into());
+        };
+        assert_eq!(refused.status_code(), StatusCode::UNAUTHORIZED);
+
+        let granted = SecurityContext::builder()
+            .subject_id(Uuid::from_u128(1))
+            .subject_tenant_id(Uuid::from_u128(2))
+            .token_scopes(scopes(&["previews-admin"]))
+            .build()
+            .map_err(|e| format!("build context: {e:?}"))?;
+        assert_eq!(require_manage_scope(&granted)?, Uuid::from_u128(1));
+        Ok(())
+    }
 }

--- a/src/backend/services/previews/src/api/mod.rs
+++ b/src/backend/services/previews/src/api/mod.rs
@@ -91,7 +91,10 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
 
     let router = OperationBuilder::post("/v1/experiments")
         .operation_id("previews.experiments.create")
-        .summary("Create a preview experiment (name + FE image tag)")
+        .summary(
+            "Create a preview experiment (name + FE image tag); requires the \
+             previews-admin or admin role",
+        )
         .authenticated()
         .no_license_required()
         .json_request::<experiments::CreateExperimentRequest>(openapi, "Experiment to create")
@@ -106,7 +109,7 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
 
     OperationBuilder::delete("/v1/experiments/{name}")
         .operation_id("previews.experiments.delete")
-        .summary("Delete a preview experiment")
+        .summary("Delete a preview experiment; requires the previews-admin or admin role")
         .authenticated()
         .path_param("name", "Experiment slug (the `/exp/<name>` segment)")
         .no_license_required()

--- a/src/frontend/src/api/previews-client.test.ts
+++ b/src/frontend/src/api/previews-client.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api/fetch-with-auth", () => ({ fetchWithAuth: vi.fn() }));
+
+import { fetchWithAuth } from "@/api/fetch-with-auth";
+
+import {
+  createExperiment,
+  deleteExperiment,
+  listExperiments,
+  PreviewsApiError,
+} from "./previews-client";
+
+const mockFetch = fetchWithAuth as unknown as ReturnType<typeof vi.fn>;
+
+function response(
+  body: unknown,
+  init?: { ok?: boolean; status?: number },
+): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const EXPERIMENT = {
+  name: "my-experiment",
+  tag: "preview-my-branch",
+  url: "https://preview.example.com/exp/my-experiment/",
+  creator: "00000000-0000-0000-0000-000000000001",
+  status: "ready",
+} as const;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("listExperiments", () => {
+  it("unwraps the experiments list", async () => {
+    mockFetch.mockResolvedValueOnce(response({ experiments: [EXPERIMENT] }));
+
+    await expect(listExperiments()).resolves.toEqual([EXPERIMENT]);
+    expect(mockFetch).toHaveBeenCalledWith("/api/previews/v1/experiments");
+  });
+
+  it("raises a malformed answer rather than resolving to an empty list", async () => {
+    mockFetch.mockResolvedValueOnce(response({ nope: true }));
+
+    await expect(listExperiments()).rejects.toBeInstanceOf(PreviewsApiError);
+  });
+
+  it("raises the refusal with its status", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ detail: "unauthenticated" }, { ok: false, status: 401 }),
+    );
+
+    await expect(listExperiments()).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe("createExperiment", () => {
+  it("posts name and tag as camelCase JSON", async () => {
+    mockFetch.mockResolvedValueOnce(response(EXPERIMENT, { status: 201 }));
+
+    await createExperiment({ name: "my-experiment", tag: "preview-my-branch" });
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/previews/v1/experiments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "my-experiment", tag: "preview-my-branch" }),
+    });
+  });
+
+  it("raises the server's refusal — the 403 is the boundary, not the UI", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response(
+        { detail: "managing experiments requires the previews-admin or admin role" },
+        { ok: false, status: 403 },
+      ),
+    );
+
+    await expect(
+      createExperiment({ name: "x", tag: "preview-x" }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe("deleteExperiment", () => {
+  it("addresses the experiment by its escaped slug", async () => {
+    mockFetch.mockResolvedValueOnce(response(null, { status: 204 }));
+
+    await deleteExperiment("my-experiment");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/previews/v1/experiments/my-experiment",
+      { method: "DELETE" },
+    );
+  });
+
+  it("raises a refusal rather than reporting a delete that never happened", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ detail: "experiment not found" }, { ok: false, status: 404 }),
+    );
+
+    await expect(deleteExperiment("gone")).rejects.toBeInstanceOf(
+      PreviewsApiError,
+    );
+  });
+});

--- a/src/frontend/src/api/previews-client.ts
+++ b/src/frontend/src/api/previews-client.ts
@@ -1,11 +1,7 @@
 /**
- * Thin client for the previews service (`/api/previews/v1`) — preview
- * experiments, each one frontend build served under `/exp/<name>` on the
- * shared preview host.
- *
- * Create and delete are gated server-side on the `previews-admin` or `admin`
- * role in the verified token; the UI's own gate is a courtesy, never the
- * boundary. The wire is camelCase (unlike identity's snake_case).
+ * Thin client for the previews service (`/api/previews/v1`). Create and
+ * delete are gated server-side on the `previews-admin` or `admin` role; the
+ * wire is camelCase (unlike identity's snake_case).
  */
 
 import { fetchWithAuth } from "@/api/fetch-with-auth";
@@ -55,7 +51,7 @@ async function failure(res: Response): Promise<PreviewsApiError> {
   return new PreviewsApiError(res.status, body);
 }
 
-/** Every live experiment. Authenticated-only — no role needed to look. */
+/** Every live experiment; authenticated-only. */
 export async function listExperiments(): Promise<Experiment[]> {
   const res = await fetchWithAuth(`${BASE}/experiments`);
   if (!res.ok) throw await failure(res);

--- a/src/frontend/src/api/previews-client.ts
+++ b/src/frontend/src/api/previews-client.ts
@@ -1,0 +1,98 @@
+/**
+ * Thin client for the previews service (`/api/previews/v1`) — preview
+ * experiments, each one frontend build served under `/exp/<name>` on the
+ * shared preview host.
+ *
+ * Create and delete are gated server-side on the `previews-admin` or `admin`
+ * role in the verified token; the UI's own gate is a courtesy, never the
+ * boundary. The wire is camelCase (unlike identity's snake_case).
+ */
+
+import { fetchWithAuth } from "@/api/fetch-with-auth";
+
+const BASE =
+  (import.meta.env.VITE_PREVIEWS_BASE as string | undefined) ??
+  "/api/previews/v1";
+
+/** One experiment as the API serves it. */
+export interface Experiment {
+  name: string;
+  tag: string;
+  /** Where the experiment serves: `https://<host>/exp/<name>/`. */
+  url: string;
+  /** The creating gateway-JWT subject (a person id). */
+  creator: string;
+  createdAt?: string | null;
+  expiresAt?: string | null;
+  status: string;
+}
+
+export interface ExperimentListResponse {
+  experiments: Experiment[];
+}
+
+export interface CreateExperimentRequest {
+  /** The `/exp/<name>` slug — the server validates (DNS-1123 label, ≤55). */
+  name: string;
+  /** FE image tag — the server validates (`preview-…` or a CI build tag). */
+  tag: string;
+}
+
+export class PreviewsApiError extends Error {
+  status: number;
+  body: unknown;
+
+  constructor(status: number, body: unknown) {
+    super(`Previews API ${status}`);
+    this.name = "PreviewsApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function failure(res: Response): Promise<PreviewsApiError> {
+  const body = await res.json().catch(() => null);
+  return new PreviewsApiError(res.status, body);
+}
+
+/** Every live experiment. Authenticated-only — no role needed to look. */
+export async function listExperiments(): Promise<Experiment[]> {
+  const res = await fetchWithAuth(`${BASE}/experiments`);
+  if (!res.ok) throw await failure(res);
+  let listed: ExperimentListResponse;
+  try {
+    listed = (await res.json()) as ExperimentListResponse;
+  } catch {
+    throw new PreviewsApiError(res.status, { error: "invalid_json" });
+  }
+  if (!Array.isArray(listed.experiments)) {
+    throw new PreviewsApiError(res.status, { error: "malformed_experiments" });
+  }
+  return listed.experiments;
+}
+
+/** Create an experiment (name + tag). Requires previews-admin or admin. */
+export async function createExperiment(
+  req: CreateExperimentRequest,
+): Promise<Experiment> {
+  const res = await fetchWithAuth(`${BASE}/experiments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(req),
+  });
+  if (!res.ok) throw await failure(res);
+  try {
+    return (await res.json()) as Experiment;
+  } catch {
+    throw new PreviewsApiError(res.status, { error: "invalid_json" });
+  }
+}
+
+/** Delete an experiment by slug. Requires previews-admin or admin. */
+export async function deleteExperiment(name: string): Promise<void> {
+  const res = await fetchWithAuth(
+    `${BASE}/experiments/${encodeURIComponent(name)}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok) throw await failure(res);
+}

--- a/src/frontend/src/auth/session-scope.test.ts
+++ b/src/frontend/src/auth/session-scope.test.ts
@@ -16,6 +16,7 @@ describe("sessionAuthorizationScope", () => {
         csrfToken: "csrf",
         expiresAt: 1,
         refreshAt: 1,
+        experimentsEnabled: false,
       } satisfies Session)
     ).toBe(
       JSON.stringify({

--- a/src/frontend/src/auth/session.test.ts
+++ b/src/frontend/src/auth/session.test.ts
@@ -27,6 +27,7 @@ describe("loadSession", () => {
         csrf_token: "csrf-1",
         expires_at: 1770000600,
         refresh_at: 1770000510,
+        experiments_enabled: true,
       }),
     });
 
@@ -43,6 +44,7 @@ describe("loadSession", () => {
       csrfToken: "csrf-1",
       expiresAt: 1770000600,
       refreshAt: 1770000510,
+      experimentsEnabled: true,
       impersonatorEmail: null,
     });
     const [url, init] = fetchMock().mock.calls[0];
@@ -68,8 +70,27 @@ describe("loadSession", () => {
       csrfToken: "csrf-1",
       expiresAt: 0,
       refreshAt: 0,
+      experimentsEnabled: false,
       impersonatorEmail: null,
     });
+  });
+
+  it("reads experiments_enabled as off unless it is literally true", async () => {
+    // The previews surface exists only where the stand says so; an older
+    // authenticator (absent field) or a malformed value must read as off.
+    for (const wire of [undefined, "true", 1, null]) {
+      fetchMock().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrf_token: "csrf-1", experiments_enabled: wire }),
+      });
+
+      await loadSession();
+
+      expect(
+        authStore.getSnapshot().session?.experimentsEnabled,
+        `wire value: ${String(wire)}`,
+      ).toBe(false);
+    }
   });
 
   it("surfaces impersonator_email from a view-as session (insight#1941)", async () => {

--- a/src/frontend/src/auth/session.test.ts
+++ b/src/frontend/src/auth/session.test.ts
@@ -76,8 +76,6 @@ describe("loadSession", () => {
   });
 
   it("reads experiments_enabled as off unless it is literally true", async () => {
-    // The previews surface exists only where the stand says so; an older
-    // authenticator (absent field) or a malformed value must read as off.
     for (const wire of [undefined, "true", 1, null]) {
       fetchMock().mockResolvedValueOnce({
         ok: true,

--- a/src/frontend/src/auth/session.ts
+++ b/src/frontend/src/auth/session.ts
@@ -62,8 +62,7 @@ export async function loadSession(): Promise<AuthStatus> {
       // only, so guard the wire values like refresh.ts guards its inputs.
       expiresAt: unixSeconds(body.expires_at),
       refreshAt: unixSeconds(body.refresh_at),
-      // Strictly `=== true`: an absent or malformed capability flag reads as
-      // "off", never as "on" (fail closed, like the rest of this probe).
+      // Strictly `=== true`: absent or malformed reads as off (fail closed).
       experimentsEnabled: body.experiments_enabled === true,
       // Present only on `__override` view-as sessions (insight#1941).
       impersonatorEmail: body.impersonator_email || null,

--- a/src/frontend/src/auth/session.ts
+++ b/src/frontend/src/auth/session.ts
@@ -33,6 +33,7 @@ export async function loadSession(): Promise<AuthStatus> {
       csrf_token?: string;
       expires_at?: number;
       refresh_at?: number;
+      experiments_enabled?: boolean;
       impersonator_email?: string;
     };
     // Fail closed on a missing CSRF token. A live session always carries one
@@ -61,6 +62,9 @@ export async function loadSession(): Promise<AuthStatus> {
       // only, so guard the wire values like refresh.ts guards its inputs.
       expiresAt: unixSeconds(body.expires_at),
       refreshAt: unixSeconds(body.refresh_at),
+      // Strictly `=== true`: an absent or malformed capability flag reads as
+      // "off", never as "on" (fail closed, like the rest of this probe).
+      experimentsEnabled: body.experiments_enabled === true,
       // Present only on `__override` view-as sessions (insight#1941).
       impersonatorEmail: body.impersonator_email || null,
     });

--- a/src/frontend/src/auth/types.ts
+++ b/src/frontend/src/auth/types.ts
@@ -38,6 +38,12 @@ export type Session = {
    */
   refreshAt: number;
   /**
+   * The stand-level preview-experiments capability (`experiments_enabled` on
+   * `/auth/me`, insight#2374). False — including on an older authenticator
+   * that omits the field — keeps the whole `/previews` surface absent.
+   */
+  experimentsEnabled: boolean;
+  /**
    * The real principal behind a `__override` view-as session (insight#1941):
    * the authenticator mints the session AS another person and names who is
    * actually signed in here. `null` on normal sessions; non-null drives the

--- a/src/frontend/src/auth/types.ts
+++ b/src/frontend/src/auth/types.ts
@@ -39,8 +39,8 @@ export type Session = {
   refreshAt: number;
   /**
    * The stand-level preview-experiments capability (`experiments_enabled` on
-   * `/auth/me`, insight#2374). False — including on an older authenticator
-   * that omits the field — keeps the whole `/previews` surface absent.
+   * `/auth/me`). False — including when the field is absent — keeps the
+   * `/previews` surface absent.
    */
   experimentsEnabled: boolean;
   /**

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -69,6 +69,7 @@ import {
 import { useActiveZone } from "@/lib/portal/use-active-zone";
 import { cn } from "@/lib/utils";
 import { useIsAdmin, useVisibilityPolicy } from "@/queries/identity-me";
+import { usePreviewsGate } from "@/queries/previews";
 
 const ZONE_SUB: Record<string, string> = {
   overview: "Cross-functional org rollup",
@@ -341,12 +342,13 @@ function ThemeNav({
 }
 
 function ManageNav({ active }: { active: string | null }) {
-  // Admin-only surfaces (Identities) drop from the pane for everyone else;
-  // the view behind them refuses direct URLs on its own.
+  // Gated surfaces (Identities, Previews) drop from the pane for everyone
+  // else; the view behind each refuses direct URLs on its own.
   const { isAdmin } = useIsAdmin();
+  const canManagePreviews = usePreviewsGate();
   return (
     <ItemsNav
-      items={manageItemsFor(isAdmin)}
+      items={manageItemsFor({ isAdmin, canManagePreviews })}
       groupLabel="Manage"
       active={active}
     />

--- a/src/frontend/src/components/portal/manage-view.tsx
+++ b/src/frontend/src/components/portal/manage-view.tsx
@@ -22,6 +22,7 @@ import { PlatformUsage } from "@/components/portal/platform-usage";
 import { useIsAdmin } from "@/queries/identity-me";
 import { useMetricDefinitions } from "@/queries/metric-definitions";
 import { AiAssistantBody } from "@/screens/ai-assistant";
+import { PreviewsBody } from "@/screens/previews";
 import { WhatsNewBody } from "@/screens/whats-new";
 import { cn } from "@/lib/utils";
 
@@ -64,6 +65,9 @@ export function ManageView({ item }: { item: string | null }) {
     );
   if (item === "ai-assistant") return <AiAssistantBody />;
   if (item === "whats-new") return <WhatsNewBody />;
+  // PreviewsBody carries its own session-derived gate (a direct URL lands
+  // here past the hidden nav entry), so no wrapper is needed.
+  if (item === "previews") return <PreviewsBody />;
   return (
     <div className="mx-auto w-full max-w-md p-8">
       <ComingSoon variant="card" state="empty" label="Not built yet" />

--- a/src/frontend/src/components/portal/manage-view.tsx
+++ b/src/frontend/src/components/portal/manage-view.tsx
@@ -65,8 +65,7 @@ export function ManageView({ item }: { item: string | null }) {
     );
   if (item === "ai-assistant") return <AiAssistantBody />;
   if (item === "whats-new") return <WhatsNewBody />;
-  // PreviewsBody carries its own session-derived gate (a direct URL lands
-  // here past the hidden nav entry), so no wrapper is needed.
+  // PreviewsBody carries its own gate, so no wrapper.
   if (item === "previews") return <PreviewsBody />;
   return (
     <div className="mx-auto w-full max-w-md p-8">

--- a/src/frontend/src/lib/portal/instance-hiding.test.ts
+++ b/src/frontend/src/lib/portal/instance-hiding.test.ts
@@ -131,7 +131,7 @@ describe("pane lists under the install policy", () => {
   it("hides a Manage item even for an admin", () => {
     const policy = hide(["zone:manage/item:metric-catalog"]);
 
-    expect(manageItemsFor(true, policy).map((i) => i.id)).not.toContain(
+    expect(manageItemsFor({ isAdmin: true, canManagePreviews: true }, policy).map((i) => i.id)).not.toContain(
       "metric-catalog"
     );
   });
@@ -145,7 +145,7 @@ describe("pane lists under the install policy", () => {
     const people = peopleItemsFor(false, policy).find(
       (i) => i.id === "employees"
     );
-    const manage = manageItemsFor(true, policy).find(
+    const manage = manageItemsFor({ isAdmin: true, canManagePreviews: true }, policy).find(
       (i) => i.id === "metric-catalog"
     );
 

--- a/src/frontend/src/lib/portal/nav-model.test.ts
+++ b/src/frontend/src/lib/portal/nav-model.test.ts
@@ -98,8 +98,6 @@ describe("manageItemsFor", () => {
   });
 
   it("gates previews independently of admin-ness", () => {
-    // The whole point of the previews-admin role: preview rights can go to a
-    // designer without the identities-admin surfaces coming along.
     const previewsOnly = manageItemsFor({
       isAdmin: false,
       canManagePreviews: true,

--- a/src/frontend/src/lib/portal/nav-model.test.ts
+++ b/src/frontend/src/lib/portal/nav-model.test.ts
@@ -78,15 +78,35 @@ describe("resolveZoneItem", () => {
  * reordering would silently reshape the pane every operator already knows.
  */
 describe("manageItemsFor", () => {
-  it("gives an admin the full pane", () => {
-    expect(manageItemsFor(true)).toEqual(MANAGE_ITEMS);
+  it("gives a viewer passing every gate the full pane", () => {
+    expect(
+      manageItemsFor({ isAdmin: true, canManagePreviews: true }),
+    ).toEqual(MANAGE_ITEMS);
   });
 
-  it("drops exactly the admin-only surfaces for everyone else", () => {
-    const visible = manageItemsFor(false);
+  it("drops exactly the gated surfaces for everyone else", () => {
+    const visible = manageItemsFor({
+      isAdmin: false,
+      canManagePreviews: false,
+    });
 
     expect(visible.map((i) => i.id)).not.toContain("identities");
-    expect(visible).toEqual(MANAGE_ITEMS.filter((i) => !i.adminOnly));
+    expect(visible.map((i) => i.id)).not.toContain("previews");
+    expect(visible).toEqual(
+      MANAGE_ITEMS.filter((i) => !i.adminOnly && !i.previewsGated),
+    );
+  });
+
+  it("gates previews independently of admin-ness", () => {
+    // The whole point of the previews-admin role: preview rights can go to a
+    // designer without the identities-admin surfaces coming along.
+    const previewsOnly = manageItemsFor({
+      isAdmin: false,
+      canManagePreviews: true,
+    });
+
+    expect(previewsOnly.map((i) => i.id)).toContain("previews");
+    expect(previewsOnly.map((i) => i.id)).not.toContain("identities");
   });
 });
 

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -9,6 +9,7 @@ import {
   FileText,
   Filter,
   Fingerprint,
+  FlaskConical,
   GitPullRequest,
   LayoutGrid,
   Layers,
@@ -161,6 +162,12 @@ export interface PaneItem {
    * regardless of what the frontend draws.
    */
   adminOnly?: boolean;
+  /**
+   * Rendered only when the previews gate passes (`usePreviewsGate`):
+   * `experiments_enabled` on the stand AND a `previews-admin`/`admin` session
+   * role. The same courtesy-over-server-gate doctrine as `adminOnly`.
+   */
+  previewsGated?: boolean;
 }
 
 export interface PaneGroup {
@@ -320,13 +327,24 @@ export function peopleItemsFor(
 
 /* ── Manage zone ─────────────────────────────────────────────────────── */
 
-/** The Manage pane for one viewer: admin-only surfaces drop for everyone else. */
+/** The viewer facts that decide which gated Manage surfaces exist for them. */
+export interface ManageGates {
+  /** Holds the active `admin` identity role (`useIsAdmin`). */
+  isAdmin: boolean;
+  /** Passes the previews capability gate (`usePreviewsGate`). */
+  canManagePreviews: boolean;
+}
+
+/** The Manage pane for one viewer: gated surfaces drop for everyone else. */
 export function manageItemsFor(
-  isAdmin: boolean,
+  gates: ManageGates,
   policy: InstanceNavPolicy = navPolicy(),
 ): readonly PaneItem[] {
   return MANAGE_ITEMS.filter(
-    (item) => (!item.adminOnly || isAdmin) && !itemHidden("manage", item.id, policy),
+    (item) =>
+      (!item.adminOnly || gates.isAdmin) &&
+      (!item.previewsGated || gates.canManagePreviews) &&
+      !itemHidden("manage", item.id, policy),
   ).map((item) => withConfigReadiness("manage", item, policy));
 }
 
@@ -340,6 +358,7 @@ export const MANAGE_ITEMS: readonly PaneItem[] = [
   { id: "scorecard-mgmt", label: "Scorecard management", icon: BarChart3 },
   { id: "connector-health", label: "Connector health", icon: ShieldCheck, adminOnly: true },
   { id: "platform-usage", label: "Platform usage", icon: Activity, adminOnly: true },
+  { id: "previews", label: "Previews", icon: FlaskConical, previewsGated: true },
   { id: "mcp", label: "MCP servers", icon: Server },
   { id: "config", label: "Config & setup", icon: Settings2 },
   { id: "ai-assistant", label: "AI assistant", icon: Sparkles },

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -163,9 +163,8 @@ export interface PaneItem {
    */
   adminOnly?: boolean;
   /**
-   * Rendered only when the previews gate passes (`usePreviewsGate`):
-   * `experiments_enabled` on the stand AND a `previews-admin`/`admin` session
-   * role. The same courtesy-over-server-gate doctrine as `adminOnly`.
+   * Rendered only when the previews gate passes (`usePreviewsGate`) — the
+   * same courtesy-over-server-gate doctrine as `adminOnly`.
    */
   previewsGated?: boolean;
 }
@@ -329,9 +328,7 @@ export function peopleItemsFor(
 
 /** The viewer facts that decide which gated Manage surfaces exist for them. */
 export interface ManageGates {
-  /** Holds the active `admin` identity role (`useIsAdmin`). */
   isAdmin: boolean;
-  /** Passes the previews capability gate (`usePreviewsGate`). */
   canManagePreviews: boolean;
 }
 

--- a/src/frontend/src/queries/previews.test.tsx
+++ b/src/frontend/src/queries/previews.test.tsx
@@ -1,9 +1,4 @@
-/**
- * The previews gate and hooks. What matters: the gate fails CLOSED — no
- * session, the capability off, or no managing role must all read as "no
- * previews surface"; both layers are required at once; and a mutation
- * invalidates the listing so the console reconciles to the cluster.
- */
+/** The previews gate fails closed, and mutations invalidate the listing. */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
@@ -83,7 +78,6 @@ describe("canManagePreviews", () => {
       ],
       ["no roles at all", previewsSession({ roles: [] }), false],
       [
-        // Exact names, never substrings.
         "a role that merely contains the name",
         previewsSession({ roles: ["previews-admin-plus"] }),
         false,

--- a/src/frontend/src/queries/previews.test.tsx
+++ b/src/frontend/src/queries/previews.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * The previews gate and hooks. What matters: the gate fails CLOSED — no
+ * session, the capability off, or no managing role must all read as "no
+ * previews surface"; both layers are required at once; and a mutation
+ * invalidates the listing so the console reconciles to the cluster.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as previewsClient from "@/api/previews-client";
+import { makeSession } from "@/test/session";
+import type { Session } from "@/auth/types";
+
+vi.mock("@/api/previews-client");
+
+const auth = vi.hoisted(() => ({ session: null as unknown }));
+vi.mock("@/auth/use-auth", () => ({
+  useAuth: () => ({ session: auth.session }),
+}));
+
+import {
+  canManagePreviews,
+  useCreateExperiment,
+  useDeleteExperiment,
+  useExperiments,
+  usePreviewsGate,
+} from "./previews";
+
+const listExperiments = vi.mocked(previewsClient.listExperiments);
+const createExperiment = vi.mocked(previewsClient.createExperiment);
+const deleteExperiment = vi.mocked(previewsClient.deleteExperiment);
+
+function harness() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper, queryClient };
+}
+
+const EXPERIMENT: previewsClient.Experiment = {
+  name: "my-experiment",
+  tag: "preview-my-branch",
+  url: "https://preview.example.com/exp/my-experiment/",
+  creator: "00000000-0000-0000-0000-000000000001",
+  status: "ready",
+};
+
+function previewsSession(overrides: Partial<Session> = {}): Session {
+  return makeSession({
+    experimentsEnabled: true,
+    roles: ["previews-admin"],
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  auth.session = previewsSession();
+});
+
+describe("canManagePreviews", () => {
+  it("opens only when the capability AND a managing role are both present", () => {
+    for (const [caseName, session, allowed] of [
+      ["previews-admin on an enabled stand", previewsSession(), true],
+      [
+        "admin on an enabled stand",
+        previewsSession({ roles: ["user", "admin"] }),
+        true,
+      ],
+      [
+        "managing role but the capability is off",
+        previewsSession({ experimentsEnabled: false }),
+        false,
+      ],
+      [
+        "capability on but only the default role",
+        previewsSession({ roles: ["user"] }),
+        false,
+      ],
+      ["no roles at all", previewsSession({ roles: [] }), false],
+      [
+        // Exact names, never substrings.
+        "a role that merely contains the name",
+        previewsSession({ roles: ["previews-admin-plus"] }),
+        false,
+      ],
+      ["no session", null, false],
+    ] as const) {
+      expect(canManagePreviews(session), `case: ${caseName}`).toBe(allowed);
+    }
+  });
+});
+
+describe("usePreviewsGate", () => {
+  it("reads the live session", () => {
+    const { result } = renderHook(() => usePreviewsGate(), harness());
+    expect(result.current).toBe(true);
+
+    auth.session = null;
+    const { result: closed } = renderHook(() => usePreviewsGate(), harness());
+    expect(closed.current).toBe(false);
+  });
+});
+
+describe("useExperiments", () => {
+  it("serves the listing", async () => {
+    listExperiments.mockResolvedValueOnce([EXPERIMENT]);
+
+    const { result } = renderHook(() => useExperiments(), harness());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.data).toEqual([EXPERIMENT]);
+  });
+
+  it("never asks without a session", async () => {
+    auth.session = null;
+
+    renderHook(() => useExperiments(), harness());
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(listExperiments).not.toHaveBeenCalled();
+  });
+});
+
+describe("mutations", () => {
+  it("create invalidates the listing so the console reconciles", async () => {
+    listExperiments.mockResolvedValue([EXPERIMENT]);
+    createExperiment.mockResolvedValueOnce(EXPERIMENT);
+    const h = harness();
+    const invalidate = vi.spyOn(h.queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateExperiment(), h);
+    result.current.mutate({ name: "my-experiment", tag: "preview-my-branch" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["previews"] });
+  });
+
+  it("delete invalidates the listing too", async () => {
+    deleteExperiment.mockResolvedValueOnce(undefined);
+    const h = harness();
+    const invalidate = vi.spyOn(h.queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useDeleteExperiment(), h);
+    result.current.mutate("my-experiment");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["previews"] });
+  });
+
+  it("a refused create surfaces the error instead of pretending success", async () => {
+    createExperiment.mockRejectedValueOnce(new Error("Previews API 403"));
+
+    const { result } = renderHook(() => useCreateExperiment(), harness());
+    result.current.mutate({ name: "x", tag: "preview-x" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/src/frontend/src/queries/previews.ts
+++ b/src/frontend/src/queries/previews.ts
@@ -1,13 +1,8 @@
 /**
- * Preview-experiment hooks and the capability gate that decides whether the
- * `/previews` surface exists for this viewer at all.
- *
- * The gate is two-layered and entirely session-derived (insight#2374):
- * `experiments_enabled` is the stand-level switch `/auth/me` echoes, and the
- * session `roles` are the identity role names the authenticator minted into
- * the gateway JWT. Both are the same values the previews service enforces
- * server-side — the UI check is a courtesy, never the boundary (the same
- * doctrine as `queries/identity-me.ts`).
+ * Preview-experiment hooks and the session-derived gate for the `/previews`
+ * surface: the stand's `experiments_enabled` AND a managing session role.
+ * The previews service enforces the same roles — the UI check is a courtesy,
+ * never the boundary (same doctrine as `queries/identity-me.ts`).
  */
 import {
   useMutation,
@@ -28,21 +23,13 @@ import { useAuth } from "@/auth/use-auth";
 import { sessionAuthorizationScope } from "@/auth/session-scope";
 import type { Session } from "@/auth/types";
 
-/**
- * The role names that may manage previews — mirrored by the previews
- * service's scope gate and seeded by identity migrations 007 / 017. Names,
- * not ids: the JWT `roles` claim (and therefore the session) carries names.
- */
+/** Mirrors the previews service's scope gate; the session carries NAMES. */
 export const PREVIEWS_MANAGE_ROLES = ["previews-admin", "admin"] as const;
 
 /** Cluster state changes under other operators' hands; half a minute is fine. */
 const EXPERIMENTS_STALE_TIME = 30 * 1000;
 
-/**
- * Whether this viewer gets the previews surface: the stand capability is on
- * AND the session carries a managing role. Pending/absent sessions read as
- * "no" — the shell simply never draws the entry.
- */
+/** Both layers at once; an absent session reads as "no" (fail closed). */
 export function canManagePreviews(session: Session | null): boolean {
   if (!session?.experimentsEnabled) return false;
   return session.roles.some((role) =>
@@ -50,7 +37,6 @@ export function canManagePreviews(session: Session | null): boolean {
   );
 }
 
-/** The session-derived previews gate, as a hook for the nav and the screen. */
 export function usePreviewsGate(): boolean {
   const { session } = useAuth();
   return canManagePreviews(session);
@@ -60,8 +46,7 @@ export function useExperiments(): UseQueryResult<Experiment[]> {
   const { session } = useAuth();
   const sessionScope = sessionAuthorizationScope(session);
   return useQuery({
-    // Keyed by the session scope so a sign-out/sign-in (or view-as) never
-    // serves the previous caller's listing from cache.
+    // Session-scoped key: a sign-in never serves another caller's cache.
     queryKey: ["previews", "experiments", sessionScope],
     queryFn: listExperiments,
     staleTime: EXPERIMENTS_STALE_TIME,
@@ -69,8 +54,7 @@ export function useExperiments(): UseQueryResult<Experiment[]> {
   });
 }
 
-/** Everything previews reads lives under this prefix — one invalidation after
- *  any mutation refreshes the listing. */
+/** One invalidation after any mutation refreshes everything previews reads. */
 const PREVIEWS_KEY = ["previews"] as const;
 
 export function useCreateExperiment(): UseMutationResult<

--- a/src/frontend/src/queries/previews.ts
+++ b/src/frontend/src/queries/previews.ts
@@ -1,0 +1,102 @@
+/**
+ * Preview-experiment hooks and the capability gate that decides whether the
+ * `/previews` surface exists for this viewer at all.
+ *
+ * The gate is two-layered and entirely session-derived (insight#2374):
+ * `experiments_enabled` is the stand-level switch `/auth/me` echoes, and the
+ * session `roles` are the identity role names the authenticator minted into
+ * the gateway JWT. Both are the same values the previews service enforces
+ * server-side — the UI check is a courtesy, never the boundary (the same
+ * doctrine as `queries/identity-me.ts`).
+ */
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+
+import {
+  createExperiment,
+  deleteExperiment,
+  listExperiments,
+  type CreateExperimentRequest,
+  type Experiment,
+} from "@/api/previews-client";
+import { useAuth } from "@/auth/use-auth";
+import { sessionAuthorizationScope } from "@/auth/session-scope";
+import type { Session } from "@/auth/types";
+
+/**
+ * The role names that may manage previews — mirrored by the previews
+ * service's scope gate and seeded by identity migrations 007 / 017. Names,
+ * not ids: the JWT `roles` claim (and therefore the session) carries names.
+ */
+export const PREVIEWS_MANAGE_ROLES = ["previews-admin", "admin"] as const;
+
+/** Cluster state changes under other operators' hands; half a minute is fine. */
+const EXPERIMENTS_STALE_TIME = 30 * 1000;
+
+/**
+ * Whether this viewer gets the previews surface: the stand capability is on
+ * AND the session carries a managing role. Pending/absent sessions read as
+ * "no" — the shell simply never draws the entry.
+ */
+export function canManagePreviews(session: Session | null): boolean {
+  if (!session?.experimentsEnabled) return false;
+  return session.roles.some((role) =>
+    (PREVIEWS_MANAGE_ROLES as readonly string[]).includes(role),
+  );
+}
+
+/** The session-derived previews gate, as a hook for the nav and the screen. */
+export function usePreviewsGate(): boolean {
+  const { session } = useAuth();
+  return canManagePreviews(session);
+}
+
+export function useExperiments(): UseQueryResult<Experiment[]> {
+  const { session } = useAuth();
+  const sessionScope = sessionAuthorizationScope(session);
+  return useQuery({
+    // Keyed by the session scope so a sign-out/sign-in (or view-as) never
+    // serves the previous caller's listing from cache.
+    queryKey: ["previews", "experiments", sessionScope],
+    queryFn: listExperiments,
+    staleTime: EXPERIMENTS_STALE_TIME,
+    enabled: sessionScope != null,
+  });
+}
+
+/** Everything previews reads lives under this prefix — one invalidation after
+ *  any mutation refreshes the listing. */
+const PREVIEWS_KEY = ["previews"] as const;
+
+export function useCreateExperiment(): UseMutationResult<
+  Experiment,
+  unknown,
+  CreateExperimentRequest
+> {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: createExperiment,
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: PREVIEWS_KEY });
+    },
+  });
+}
+
+export function useDeleteExperiment(): UseMutationResult<
+  void,
+  unknown,
+  string
+> {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: deleteExperiment,
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: PREVIEWS_KEY });
+    },
+  });
+}

--- a/src/frontend/src/routeTree.gen.ts
+++ b/src/frontend/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as SplatRouteImport } from './routes/$'
 import { Route as CustomMetricsRouteImport } from './routes/custom-metrics'
 import { Route as MetricsRouteImport } from './routes/metrics'
 import { Route as PortalRouteImport } from './routes/portal'
+import { Route as PreviewsRouteImport } from './routes/previews'
 import { Route as QueriesRouteImport } from './routes/queries'
 import { Route as WhatsNewRouteImport } from './routes/whats-new'
 import { Route as IcPersonRouteImport } from './routes/ic.$person'
@@ -44,6 +45,11 @@ const MetricsRoute = MetricsRouteImport.update({
 const PortalRoute = PortalRouteImport.update({
   id: '/portal',
   path: '/portal',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PreviewsRoute = PreviewsRouteImport.update({
+  id: '/previews',
+  path: '/previews',
   getParentRoute: () => rootRouteImport,
 } as any)
 const QueriesRoute = QueriesRouteImport.update({
@@ -83,6 +89,7 @@ export interface FileRoutesByFullPath {
   '/custom-metrics': typeof CustomMetricsRoute
   '/metrics': typeof MetricsRoute
   '/portal': typeof PortalRoute
+  '/previews': typeof PreviewsRoute
   '/queries': typeof QueriesRoute
   '/whats-new': typeof WhatsNewRoute
   '/ic/$person': typeof IcPersonRouteWithChildren
@@ -96,6 +103,7 @@ export interface FileRoutesByTo {
   '/custom-metrics': typeof CustomMetricsRoute
   '/metrics': typeof MetricsRoute
   '/portal': typeof PortalRoute
+  '/previews': typeof PreviewsRoute
   '/queries': typeof QueriesRoute
   '/whats-new': typeof WhatsNewRoute
   '/ic/$person/personal': typeof IcPersonPersonalRoute
@@ -109,6 +117,7 @@ export interface FileRoutesById {
   '/custom-metrics': typeof CustomMetricsRoute
   '/metrics': typeof MetricsRoute
   '/portal': typeof PortalRoute
+  '/previews': typeof PreviewsRoute
   '/queries': typeof QueriesRoute
   '/whats-new': typeof WhatsNewRoute
   '/ic/$person': typeof IcPersonRouteWithChildren
@@ -124,6 +133,7 @@ export interface FileRouteTypes {
     | '/custom-metrics'
     | '/metrics'
     | '/portal'
+    | '/previews'
     | '/queries'
     | '/whats-new'
     | '/ic/$person'
@@ -137,6 +147,7 @@ export interface FileRouteTypes {
     | '/custom-metrics'
     | '/metrics'
     | '/portal'
+    | '/previews'
     | '/queries'
     | '/whats-new'
     | '/ic/$person/personal'
@@ -149,6 +160,7 @@ export interface FileRouteTypes {
     | '/custom-metrics'
     | '/metrics'
     | '/portal'
+    | '/previews'
     | '/queries'
     | '/whats-new'
     | '/ic/$person'
@@ -163,6 +175,7 @@ export interface RootRouteChildren {
   CustomMetricsRoute: typeof CustomMetricsRoute
   MetricsRoute: typeof MetricsRoute
   PortalRoute: typeof PortalRoute
+  PreviewsRoute: typeof PreviewsRoute
   QueriesRoute: typeof QueriesRoute
   WhatsNewRoute: typeof WhatsNewRoute
   IcPersonRoute: typeof IcPersonRouteWithChildren
@@ -203,6 +216,13 @@ declare module '@tanstack/react-router' {
       path: '/portal'
       fullPath: '/portal'
       preLoaderRoute: typeof PortalRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/previews': {
+      id: '/previews'
+      path: '/previews'
+      fullPath: '/previews'
+      preLoaderRoute: typeof PreviewsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/queries': {
@@ -272,6 +292,7 @@ const rootRouteChildren: RootRouteChildren = {
   CustomMetricsRoute: CustomMetricsRoute,
   MetricsRoute: MetricsRoute,
   PortalRoute: PortalRoute,
+  PreviewsRoute: PreviewsRoute,
   QueriesRoute: QueriesRoute,
   WhatsNewRoute: WhatsNewRoute,
   IcPersonRoute: IcPersonRouteWithChildren,

--- a/src/frontend/src/routes/previews.tsx
+++ b/src/frontend/src/routes/previews.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { PreviewsScreen } from "@/screens/previews";
+
+export const Route = createFileRoute("/previews")({
+  component: PreviewsScreen,
+});

--- a/src/frontend/src/screens/previews.test.tsx
+++ b/src/frontend/src/screens/previews.test.tsx
@@ -1,9 +1,4 @@
-/**
- * The previews screen. What matters: the gate fails CLOSED (a direct URL past
- * the hidden nav entry gets a refusal, not a broken console), the console
- * renders the listing with an open link and a delete, and the create form
- * refuses to submit empty fields.
- */
+/** The previews screen refuses ungated viewers and drives the console. */
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/src/frontend/src/screens/previews.test.tsx
+++ b/src/frontend/src/screens/previews.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * The previews screen. What matters: the gate fails CLOSED (a direct URL past
+ * the hidden nav entry gets a refusal, not a broken console), the console
+ * renders the listing with an open link and a delete, and the create form
+ * refuses to submit empty fields.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Experiment } from "@/api/previews-client";
+
+const gate = vi.hoisted(() => ({ allowed: true }));
+const hooks = vi.hoisted(() => ({
+  experiments: {
+    isPending: false,
+    isError: false,
+    data: [] as Experiment[],
+    refetch: vi.fn(),
+  },
+  create: {
+    isPending: false,
+    isError: false,
+    error: null as unknown,
+    mutate: vi.fn(),
+  },
+  remove: {
+    isPending: false,
+    isError: false,
+    error: null as unknown,
+    mutate: vi.fn(),
+    reset: vi.fn(),
+  },
+}));
+vi.mock("@/queries/previews", () => ({
+  usePreviewsGate: () => gate.allowed,
+  useExperiments: () => hooks.experiments,
+  useCreateExperiment: () => hooks.create,
+  useDeleteExperiment: () => hooks.remove,
+}));
+
+import { PreviewsBody } from "./previews";
+
+const EXPERIMENT: Experiment = {
+  name: "my-experiment",
+  tag: "preview-my-branch",
+  url: "https://preview.example.com/exp/my-experiment/",
+  creator: "00000000-0000-0000-0000-000000000001",
+  status: "ready",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  gate.allowed = true;
+  hooks.experiments.data = [];
+  hooks.experiments.isPending = false;
+  hooks.experiments.isError = false;
+});
+
+describe("PreviewsBody", () => {
+  it("refuses a viewer the gate does not pass — no form, no listing", () => {
+    gate.allowed = false;
+
+    render(<PreviewsBody />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Previews are not available",
+    );
+    expect(
+      screen.queryByRole("form", { name: "Create a preview experiment" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the listing with an open link to the served URL", () => {
+    hooks.experiments.data = [EXPERIMENT];
+
+    render(<PreviewsBody />);
+
+    expect(screen.getByText("my-experiment")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open experiment my-experiment" }),
+    ).toHaveAttribute("href", EXPERIMENT.url);
+  });
+
+  it("delete asks for confirmation before mutating", () => {
+    hooks.experiments.data = [EXPERIMENT];
+
+    render(<PreviewsBody />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(hooks.remove.mutate).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Delete" }).at(-1)!,
+    );
+    expect(hooks.remove.mutate).toHaveBeenCalledWith(
+      "my-experiment",
+      expect.anything(),
+    );
+  });
+
+  it("the create form does not submit while a field is empty", () => {
+    render(<PreviewsBody />);
+
+    const submit = screen.getByRole("button", { name: /Create/ });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "my-experiment" },
+    });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Image tag"), {
+      target: { value: "preview-my-branch" },
+    });
+    expect(submit).toBeEnabled();
+
+    fireEvent.click(submit);
+    expect(hooks.create.mutate).toHaveBeenCalledWith(
+      { name: "my-experiment", tag: "preview-my-branch" },
+      expect.anything(),
+    );
+  });
+});

--- a/src/frontend/src/screens/previews.tsx
+++ b/src/frontend/src/screens/previews.tsx
@@ -1,11 +1,7 @@
 /**
- * Preview experiments — self-service list / create / delete (insight#2374).
- *
- * Rendered only behind {@link usePreviewsGate}: the stand capability
- * (`experiments_enabled`) is on AND the session roles carry `previews-admin`
- * or `admin`. Bookmarks land here past the hidden nav entry, so the screen
- * refuses on its own — a courtesy refusal; the previews service enforces the
- * same roles on every mutation regardless of what the frontend draws.
+ * Preview experiments — self-service list / create / delete, behind
+ * {@link usePreviewsGate}. Bookmarks land here past the hidden nav entry, so
+ * the screen refuses on its own; the server enforces the same roles anyway.
  */
 import { ExternalLink, Plus, TriangleAlert } from "lucide-react";
 import { useState } from "react";
@@ -81,7 +77,7 @@ export function PreviewsBody() {
   );
 }
 
-/** How a refused write reads: the server's problem detail when it says one. */
+/** The server's problem detail when it says one, else a generic line. */
 function errorMessage(error: unknown): string {
   if (error && typeof error === "object") {
     const body = (error as { body?: { detail?: string } }).body;
@@ -231,9 +227,7 @@ function ExperimentList() {
                     variant="outline"
                     size="sm"
                     render={
-                      // The API serves the full URL; the experiment lives on
-                      // the preview host, not this origin, so a plain anchor
-                      // is right where a router Link is not.
+                      // Cross-origin (the preview host), so a plain anchor.
                       <a
                         href={experiment.url}
                         target="_blank"

--- a/src/frontend/src/screens/previews.tsx
+++ b/src/frontend/src/screens/previews.tsx
@@ -1,0 +1,288 @@
+/**
+ * Preview experiments — self-service list / create / delete (insight#2374).
+ *
+ * Rendered only behind {@link usePreviewsGate}: the stand capability
+ * (`experiments_enabled`) is on AND the session roles carry `previews-admin`
+ * or `admin`. Bookmarks land here past the hidden nav entry, so the screen
+ * refuses on its own — a courtesy refusal; the previews service enforces the
+ * same roles on every mutation regardless of what the frontend draws.
+ */
+import { ExternalLink, Plus, TriangleAlert } from "lucide-react";
+import { useState } from "react";
+
+import type { Experiment } from "@/api/previews-client";
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  useCreateExperiment,
+  useDeleteExperiment,
+  useExperiments,
+  usePreviewsGate,
+} from "@/queries/previews";
+
+export function PreviewsScreen() {
+  return (
+    <>
+      <header className="sticky top-0 z-20 flex items-center gap-3 border-b bg-background/95 px-4 py-3 backdrop-blur-sm">
+        <SidebarTrigger />
+        <h1 className="text-lg font-semibold tracking-tight">Previews</h1>
+      </header>
+
+      <PreviewsBody />
+    </>
+  );
+}
+
+/** The previews console alone — the portal's Manage zone brings its own chrome. */
+export function PreviewsBody() {
+  const allowed = usePreviewsGate();
+  if (!allowed) {
+    return (
+      <div className="mx-auto w-full max-w-md p-8" role="alert">
+        <div className="rounded-lg border p-6 text-center">
+          <p className="text-sm font-semibold">Previews are not available</p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Managing preview experiments needs the previews-admin or admin
+            role, on a stand with experiments enabled.
+          </p>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <main className="flex flex-1 flex-col gap-6 p-4 md:p-6">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 pb-12">
+        <section>
+          <h2 className="text-lg font-semibold tracking-tight">
+            Preview experiments
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Each experiment serves one frontend build under /exp/&lt;name&gt;
+            on the preview host, against this stand&apos;s data.
+          </p>
+        </section>
+        <CreateExperimentForm />
+        <ExperimentList />
+      </div>
+    </main>
+  );
+}
+
+/** How a refused write reads: the server's problem detail when it says one. */
+function errorMessage(error: unknown): string {
+  if (error && typeof error === "object") {
+    const body = (error as { body?: { detail?: string } }).body;
+    if (typeof body?.detail === "string" && body.detail) return body.detail;
+    if (error instanceof Error) return error.message;
+  }
+  return "The request failed";
+}
+
+function CreateExperimentForm() {
+  const [name, setName] = useState("");
+  const [tag, setTag] = useState("");
+  const create = useCreateExperiment();
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!name.trim() || !tag.trim() || create.isPending) return;
+    create.mutate(
+      { name: name.trim(), tag: tag.trim() },
+      {
+        onSuccess: () => {
+          setName("");
+          setTag("");
+        },
+      },
+    );
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-3 rounded-lg border bg-card p-4"
+      aria-label="Create a preview experiment"
+    >
+      <div className="grid gap-3 sm:grid-cols-[1fr_1fr_auto] sm:items-end">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="previews-name">Name</Label>
+          <Input
+            id="previews-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="my-experiment"
+            autoComplete="off"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="previews-tag">Image tag</Label>
+          <Input
+            id="previews-tag"
+            value={tag}
+            onChange={(event) => setTag(event.target.value)}
+            placeholder="preview-my-branch"
+            autoComplete="off"
+          />
+        </div>
+        <Button
+          type="submit"
+          disabled={!name.trim() || !tag.trim() || create.isPending}
+        >
+          {create.isPending ? <Spinner /> : <Plus />}
+          Create
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        The server validates both: the name is a DNS label (at most 55
+        characters), the tag a preview- or CI build tag.
+      </p>
+      {create.isError ? (
+        <Alert variant="destructive">
+          <TriangleAlert />
+          <AlertDescription>{errorMessage(create.error)}</AlertDescription>
+        </Alert>
+      ) : null}
+    </form>
+  );
+}
+
+function ExperimentList() {
+  const experiments = useExperiments();
+  const [deleting, setDeleting] = useState<Experiment | null>(null);
+  const remove = useDeleteExperiment();
+
+  if (experiments.isPending) {
+    return (
+      <div className="flex justify-center p-8">
+        <Spinner />
+      </div>
+    );
+  }
+  if (experiments.isError) {
+    return (
+      <Alert variant="destructive">
+        <TriangleAlert />
+        <AlertDescription>
+          Could not list the experiments.{" "}
+          <button
+            type="button"
+            className="underline"
+            onClick={() => void experiments.refetch()}
+          >
+            Retry
+          </button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  if (experiments.data.length === 0) {
+    return (
+      <p className="rounded-lg border p-6 text-center text-sm text-muted-foreground">
+        No experiments are running.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Tag</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Expires</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {experiments.data.map((experiment) => (
+            <TableRow key={experiment.name}>
+              <TableCell className="font-mono text-xs">
+                {experiment.name}
+              </TableCell>
+              <TableCell className="font-mono text-xs">
+                {experiment.tag}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {experiment.status}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {experiment.expiresAt
+                  ? new Date(experiment.expiresAt).toLocaleString()
+                  : "—"}
+              </TableCell>
+              <TableCell className="text-right">
+                <div className="flex justify-end gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    render={
+                      // The API serves the full URL; the experiment lives on
+                      // the preview host, not this origin, so a plain anchor
+                      // is right where a router Link is not.
+                      <a
+                        href={experiment.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        aria-label={`Open experiment ${experiment.name}`}
+                      />
+                    }
+                  >
+                    <ExternalLink />
+                    Open
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => {
+                      remove.reset();
+                      setDeleting(experiment);
+                    }}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <ConfirmDialog
+        open={deleting != null}
+        onOpenChange={(open) => {
+          if (!open) setDeleting(null);
+        }}
+        title="Delete this experiment?"
+        description={
+          deleting
+            ? `${deleting.name} stops serving immediately; the build itself is untouched.`
+            : undefined
+        }
+        confirmLabel="Delete"
+        destructive
+        isPending={remove.isPending}
+        error={remove.isError ? errorMessage(remove.error) : null}
+        onConfirm={() => {
+          if (!deleting) return;
+          remove.mutate(deleting.name, {
+            onSuccess: () => setDeleting(null),
+          });
+        }}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/test/session.ts
+++ b/src/frontend/src/test/session.ts
@@ -15,6 +15,7 @@ export function makeSession(overrides: Partial<Session> = {}): Session {
     // Unix seconds; far enough out that no test trips an accidental refresh.
     expiresAt: 4102444800, // 2100-01-01
     refreshAt: 4102444710,
+    experimentsEnabled: false,
     impersonatorEmail: null,
     ...overrides,
   };


### PR DESCRIPTION
Closes #2374.

**Why.** Every session's JWT minted the same `default_roles`, so the previews API could not tell an authorized operator from any signed-in user.

**What changed.** The authenticator fetches the person's active identity role names at login (new service-only identity route), stores them in the session, mints them into the existing `roles` claim, and re-fetches on `/auth/refresh`; `default_roles` stays the fallback. Identity seeds `previews-admin`; previews create/delete now require the `previews-admin` or `admin` scope. `/auth/me` echoes `experiments_enabled`, and the SPA adds a gated `/previews` screen plus a Manage-pane entry.

**Verified.** cargo fmt/clippy/tests for the three services; previews OpenAPI and stand models regenerated, `--check` clean; FE vitest/typecheck/lint. Not run: the gateway e2e lane (CI) and a stand screenshot.
