### PR TITLE
feat(observability): server-side RED metrics middleware (http.server.request.duration)

### DIFF
--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -136,8 +136,9 @@ dependencies = [
  "futures-util",
  "hex",
  "insight-clickhouse",
+ "insight-http-metrics",
  "insight-migration",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "redis",
  "reqwest 0.12.28",
  "rust_xlsxwriter",
@@ -539,9 +540,10 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "insight-http-metrics",
  "jsonwebtoken",
  "openidconnect",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "p256 0.14.0",
  "rand 0.10.2",
  "rdkafka",
@@ -979,7 +981,7 @@ dependencies = [
  "inventory",
  "matchit 0.9.2",
  "nanoid",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "parking_lot",
  "rust-embed",
  "serde",
@@ -1136,7 +1138,7 @@ dependencies = [
  "humantime",
  "inventory",
  "jsonwebtoken",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "parking_lot",
  "rand 0.10.2",
  "regex",
@@ -1285,7 +1287,7 @@ dependencies = [
  "http",
  "inventory",
  "nix 0.31.3",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
@@ -2906,7 +2908,8 @@ dependencies = [
  "chrono",
  "clap",
  "hex",
- "opentelemetry 0.32.0",
+ "insight-http-metrics",
+ "opentelemetry",
  "reqwest 0.12.28",
  "rustix",
  "serde",
@@ -3484,6 +3487,7 @@ dependencies = [
  "clap",
  "clickhouse",
  "insight-clickhouse",
+ "insight-http-metrics",
  "insight-migration",
  "sea-orm 2.0.2",
  "sea-orm-migration 2.0.2",
@@ -3588,6 +3592,17 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "insight-http-metrics"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "tokio",
+ "tower",
 ]
 
 [[package]]
@@ -4525,20 +4540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
 name = "opentelemetry-http"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4547,7 +4548,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "reqwest 0.12.28",
 ]
 
@@ -4558,7 +4559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -4576,7 +4577,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry_sdk",
  "prost",
  "tonic",
@@ -4592,7 +4593,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.4",
  "thiserror 2.0.18",
@@ -7879,7 +7880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "libs/insight-clickhouse",
+    "libs/insight-http-metrics",
     "libs/insight-migration",
     "libs/authenticator-sdk",
     "services/analytics",
@@ -138,8 +139,13 @@ k8s-openapi = { version = "0.27", default-features = false }
 # Config
 figment = { version = "0.10", features = ["yaml", "env"] }
 
+# INVARIANT: must match the toolkit's opentelemetry major — a different major
+# is a different global meter provider and instruments silently no-op.
+opentelemetry = "0.31"
+
 # Internal crates
 insight-clickhouse = { path = "libs/insight-clickhouse" }
+insight-http-metrics = { path = "libs/insight-http-metrics" }
 insight-migration = { path = "libs/insight-migration" }
 authenticator-sdk = { path = "libs/authenticator-sdk" }
 

--- a/src/backend/libs/insight-http-metrics/Cargo.toml
+++ b/src/backend/libs/insight-http-metrics/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "insight-http-metrics"
+version = "0.1.0"
+description = "Server-side RED metrics middleware (http.server.request.duration)"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+axum = { workspace = true }
+opentelemetry = { workspace = true }
+tower = "0.5"
+
+[dev-dependencies]
+tokio = { workspace = true }
+tower = { version = "0.5", features = ["util"] }
+opentelemetry_sdk = { version = "0.31", features = ["metrics", "testing"] }

--- a/src/backend/libs/insight-http-metrics/src/lib.rs
+++ b/src/backend/libs/insight-http-metrics/src/lib.rs
@@ -1,0 +1,287 @@
+//! Axum middleware emitting `http.server.request.duration` (seconds) with
+//! `http.request.method`, `http.response.status_code` and `http.route`, per
+//! `OTel` HTTP server semconv.
+//!
+//! INVARIANT: instruments record into the global meter provider, so this
+//! crate's `opentelemetry` major must match the toolkit's — a different
+//! major is a different global, and recording silently no-ops.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use axum::extract::MatchedPath;
+use axum::http::Request;
+use axum::response::Response;
+use opentelemetry::metrics::{Histogram, Meter};
+use opentelemetry::{KeyValue, global};
+use tower::{Layer, Service};
+
+// Same buckets as the toolkit's client layer, so the two sides' percentiles
+// stay comparable.
+const DURATION_BOUNDARIES_SECS: &[f64] = &[
+    0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 150.0, 300.0, 600.0,
+];
+
+/// Unknown methods collapse to `_OTHER` to bound attribute cardinality.
+fn normalize_method(method: &axum::http::Method) -> &'static str {
+    use axum::http::Method;
+    match *method {
+        Method::GET => "GET",
+        Method::POST => "POST",
+        Method::PUT => "PUT",
+        Method::DELETE => "DELETE",
+        Method::PATCH => "PATCH",
+        Method::HEAD => "HEAD",
+        Method::OPTIONS => "OPTIONS",
+        Method::CONNECT => "CONNECT",
+        Method::TRACE => "TRACE",
+        _ => "_OTHER",
+    }
+}
+
+/// Records `http.server.request.duration` for every request on the router
+/// it wraps.
+#[derive(Clone)]
+pub struct ServerMetricsLayer {
+    duration: Histogram<f64>,
+}
+
+impl ServerMetricsLayer {
+    /// Registers against the global meter; `gear_name` is the
+    /// instrumentation scope.
+    #[must_use]
+    pub fn new(gear_name: &str) -> Self {
+        let scope = opentelemetry::InstrumentationScope::builder(gear_name.to_owned()).build();
+        let meter = global::meter_with_scope(scope);
+        Self::with_meter(&meter)
+    }
+
+    #[must_use]
+    pub fn with_meter(meter: &Meter) -> Self {
+        let duration = meter
+            .f64_histogram("http.server.request.duration")
+            .with_description("Duration of inbound HTTP server requests")
+            .with_unit("s")
+            .with_boundaries(DURATION_BOUNDARIES_SECS.to_vec())
+            .build();
+        Self { duration }
+    }
+}
+
+impl<S> Layer<S> for ServerMetricsLayer {
+    type Service = ServerMetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ServerMetricsService {
+            inner,
+            duration: self.duration.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ServerMetricsService<S> {
+    inner: S,
+    duration: Histogram<f64>,
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for ServerMetricsService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response> + Clone + Send + 'static,
+    S::Future: Send,
+    ReqBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        // INVARIANT: the label is the matched route template, never the raw
+        // path — raw paths make the label set unbounded.
+        let route = req
+            .extensions()
+            .get::<MatchedPath>()
+            .map(|matched| matched.as_str().to_owned());
+        let method = normalize_method(req.method());
+        let duration = self.duration.clone();
+
+        // INVARIANT: call the instance that was poll_ready'd (Tower contract).
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move {
+            let start = Instant::now();
+            let result = inner.call(req).await;
+            let elapsed = start.elapsed().as_secs_f64();
+
+            if let Ok(response) = &result {
+                let mut attrs = vec![
+                    KeyValue::new("http.request.method", method),
+                    KeyValue::new(
+                        "http.response.status_code",
+                        i64::from(response.status().as_u16()),
+                    ),
+                ];
+                if let Some(route) = route {
+                    attrs.push(KeyValue::new("http.route", route));
+                }
+                duration.record(elapsed, &attrs);
+            }
+
+            result
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::StatusCode;
+    use axum::routing::get;
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, HistogramDataPoint, MetricData};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+    use tower::ServiceExt;
+
+    type R = Result<(), Box<dyn std::error::Error>>;
+
+    fn test_provider() -> (SdkMeterProvider, InMemoryMetricExporter) {
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter.clone())
+            .build();
+        (provider, exporter)
+    }
+
+    fn find_duration_point(
+        exporter: &InMemoryMetricExporter,
+        expected: &[(&str, &str)],
+    ) -> Option<HistogramDataPoint<f64>> {
+        let batches = exporter.get_finished_metrics().ok()?;
+        for rm in &batches {
+            for sm in rm.scope_metrics() {
+                for metric in sm.metrics() {
+                    if metric.name() != "http.server.request.duration" {
+                        continue;
+                    }
+                    let AggregatedMetrics::F64(MetricData::Histogram(hist)) = metric.data() else {
+                        continue;
+                    };
+                    for dp in hist.data_points() {
+                        let matches = expected.iter().all(|(k, v)| {
+                            dp.attributes()
+                                .any(|kv| kv.key.as_str() == *k && kv.value.to_string() == *v)
+                        });
+                        if matches {
+                            return Some(dp.clone());
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    #[tokio::test]
+    async fn records_route_template_not_raw_path() -> R {
+        let (provider, exporter) = test_provider();
+        let layer = ServerMetricsLayer::with_meter(&provider.meter("test"));
+
+        let app = Router::new()
+            .route("/users/{id}", get(async || StatusCode::OK))
+            .layer(layer);
+        let req = Request::builder()
+            .method(axum::http::Method::GET)
+            .uri("/users/123")
+            .body(Body::empty())?;
+
+        let resp = app.oneshot(req).await?;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        provider.force_flush()?;
+        let point = find_duration_point(
+            &exporter,
+            &[
+                ("http.request.method", "GET"),
+                ("http.route", "/users/{id}"),
+                ("http.response.status_code", "200"),
+            ],
+        )
+        .ok_or("a data point with the route template should be exported")?;
+        assert_eq!(point.count(), 1, "exactly one observation recorded");
+        assert!(
+            point
+                .attributes()
+                .all(|kv| kv.value.to_string() != "/users/123"),
+            "raw path must never become a label"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn records_error_status_codes() -> R {
+        let (provider, exporter) = test_provider();
+        let layer = ServerMetricsLayer::with_meter(&provider.meter("test"));
+
+        let app = Router::new()
+            .route("/boom", get(async || StatusCode::INTERNAL_SERVER_ERROR))
+            .layer(layer);
+        let req = Request::builder().uri("/boom").body(Body::empty())?;
+
+        app.oneshot(req).await?;
+
+        provider.force_flush()?;
+        let point = find_duration_point(
+            &exporter,
+            &[
+                ("http.route", "/boom"),
+                ("http.response.status_code", "500"),
+            ],
+        )
+        .ok_or("a data point for the 5xx response should be exported")?;
+        assert_eq!(point.count(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unmatched_request_omits_route_attribute() -> R {
+        let (provider, exporter) = test_provider();
+        let layer = ServerMetricsLayer::with_meter(&provider.meter("test"));
+
+        let app = Router::new()
+            .route("/known", get(async || StatusCode::OK))
+            .layer(layer);
+        let req = Request::builder().uri("/nope").body(Body::empty())?;
+
+        let resp = app.oneshot(req).await?;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        provider.force_flush()?;
+        let point = find_duration_point(&exporter, &[("http.response.status_code", "404")])
+            .ok_or("the 404 should still be observed")?;
+        assert!(
+            point.attributes().all(|kv| kv.key.as_str() != "http.route"),
+            "no matched route means no http.route label"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn normalize_method_caps_unknown() {
+        assert_eq!(normalize_method(&axum::http::Method::GET), "GET");
+        let custom = axum::http::Method::from_bytes(b"PROPFIND").ok();
+        assert_eq!(
+            custom.as_ref().map(normalize_method),
+            Some("_OTHER"),
+            "unknown verbs must collapse to _OTHER"
+        );
+    }
+}

--- a/src/backend/services/analytics/Cargo.toml
+++ b/src/backend/services/analytics/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 insight-clickhouse = { workspace = true }
+insight-http-metrics = { workspace = true }
 insight-migration = { workspace = true }
 # Direct `clickhouse` dep is for the `Row` derive on `system.columns` probe
 # rows (Refs #521 schema-validator). `insight-clickhouse` wraps the client
@@ -79,7 +80,7 @@ csv = { workspace = true }
 rust_xlsxwriter = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-opentelemetry = "0.31"
+opentelemetry = { workspace = true }
 clap = { workspace = true }
 
 [dev-dependencies]

--- a/src/backend/services/analytics/Dockerfile
+++ b/src/backend/services/analytics/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /build
 # --- Dependency caching layer ---
 COPY Cargo.toml Cargo.lock ./
 COPY libs/insight-clickhouse/Cargo.toml ./libs/insight-clickhouse/Cargo.toml
+COPY libs/insight-http-metrics/Cargo.toml ./libs/insight-http-metrics/Cargo.toml
 COPY libs/authenticator-sdk/Cargo.toml ./libs/authenticator-sdk/Cargo.toml
 COPY libs/insight-migration/Cargo.toml ./libs/insight-migration/Cargo.toml
 COPY services/analytics/Cargo.toml ./services/analytics/Cargo.toml
@@ -35,6 +36,7 @@ COPY services/previews/Cargo.toml ./services/previews/Cargo.toml
 COPY tools/routegen/Cargo.toml ./tools/routegen/Cargo.toml
 
 RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/src/lib.rs && \
+    mkdir -p libs/insight-http-metrics/src && echo "" > libs/insight-http-metrics/src/lib.rs && \
     mkdir -p libs/authenticator-sdk/src && echo "" > libs/authenticator-sdk/src/lib.rs && \
     mkdir -p libs/insight-migration/src && echo "" > libs/insight-migration/src/lib.rs && \
     mkdir -p services/analytics/src && echo "fn main() {}" > services/analytics/src/main.rs && \
@@ -47,12 +49,14 @@ RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/sr
 RUN cargo build --release --bin analytics 2>/dev/null || true
 
 # --- Source layer ---
-RUN rm -rf libs/insight-clickhouse/src libs/insight-migration/src services/analytics/src \
+RUN rm -rf libs/insight-clickhouse/src libs/insight-http-metrics/src libs/insight-migration/src services/analytics/src \
+    target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
     target/release/analytics target/release/deps/analytics* \
     target/release/deps/insight_clickhouse* target/release/deps/libinsight_clickhouse* \
     target/release/deps/insight_migration* target/release/deps/libinsight_migration*
 
 COPY libs/insight-clickhouse/src/ ./libs/insight-clickhouse/src/
+COPY libs/insight-http-metrics/src/ ./libs/insight-http-metrics/src/
 COPY libs/insight-migration/src/ ./libs/insight-migration/src/
 COPY services/analytics/src/ ./services/analytics/src/
 COPY services/analytics/config/ ./services/analytics/config/

--- a/src/backend/services/analytics/src/api/http_live_tests.rs
+++ b/src/backend/services/analytics/src/api/http_live_tests.rs
@@ -153,10 +153,8 @@ fn app_with_identity_and_ch(
 ) -> Router {
     let openapi = OpenApiRegistryImpl::new();
     let state = Arc::new(build_state_with_ch(db, identity, ch));
-    let api = super::build_operations(Router::new(), &openapi)
+    super::register_routes(Router::new(), &openapi, state)
         .layer(from_fn_with_state(tenant, inject_host_context))
-        .layer(axum::Extension(state));
-    Router::new().merge(api)
 }
 
 /// Loopback identity serving `POST /v1/visible-persons` — answers with the
@@ -1068,10 +1066,8 @@ fn app_with_usage_collection_off(db: DatabaseConnection, tenant: Uuid) -> Router
         config,
         external_links: crate::domain::external_links::ExternalSourceRegistry::default(),
     });
-    let api = super::build_operations(Router::new(), &openapi)
+    super::register_routes(Router::new(), &openapi, state)
         .layer(from_fn_with_state(tenant, inject_host_context))
-        .layer(axum::Extension(state));
-    Router::new().merge(api)
 }
 
 /// One SDK v2 beacon carrying a single page view.

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -129,7 +129,9 @@ pub fn register_routes(
     openapi: &dyn OpenApiRegistry,
     state: Arc<AppState>,
 ) -> Router {
-    let api = build_operations(Router::new(), openapi).layer(Extension(state));
+    let api = build_operations(Router::new(), openapi)
+        .layer(Extension(state))
+        .layer(insight_http_metrics::ServerMetricsLayer::new("analytics"));
 
     host_router.merge(api)
 }

--- a/src/backend/services/authenticator/Cargo.toml
+++ b/src/backend/services/authenticator/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 authenticator-sdk = { workspace = true }
+insight-http-metrics = { workspace = true }
 
 # ToolKit host runtime. The authenticator runs as a gears-rust host: routes are
 # declared via `OperationBuilder` and served by the `api-gateway` system gear
@@ -52,7 +53,7 @@ futures = { workspace = true }
 uuid = { workspace = true, features = ["v5"] }
 chrono = { workspace = true }
 tracing = { workspace = true }
-opentelemetry = "0.32"
+opentelemetry = { workspace = true }
 # Audit events to the platform Redpanda topic (Kafka-compatible rdkafka API
 # only — backend PRD migration constraint). cmake-build vendors librdkafka.
 rdkafka = { version = "0.39", features = ["cmake-build", "tokio"] }

--- a/src/backend/services/authenticator/Dockerfile
+++ b/src/backend/services/authenticator/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /build
 #     real code. ---
 COPY Cargo.toml Cargo.lock ./
 COPY libs/insight-clickhouse/Cargo.toml ./libs/insight-clickhouse/Cargo.toml
+COPY libs/insight-http-metrics/Cargo.toml ./libs/insight-http-metrics/Cargo.toml
 COPY libs/authenticator-sdk/Cargo.toml ./libs/authenticator-sdk/Cargo.toml
 COPY libs/insight-migration/Cargo.toml ./libs/insight-migration/Cargo.toml
 COPY services/analytics/Cargo.toml ./services/analytics/Cargo.toml
@@ -34,6 +35,7 @@ COPY services/previews/Cargo.toml ./services/previews/Cargo.toml
 COPY tools/routegen/Cargo.toml ./tools/routegen/Cargo.toml
 
 RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/src/lib.rs && \
+    mkdir -p libs/insight-http-metrics/src && echo "" > libs/insight-http-metrics/src/lib.rs && \
     mkdir -p libs/authenticator-sdk/src && echo "" > libs/authenticator-sdk/src/lib.rs && \
     mkdir -p libs/insight-migration/src && echo "" > libs/insight-migration/src/lib.rs && \
     mkdir -p services/analytics/src && echo "fn main() {}" > services/analytics/src/main.rs && \
@@ -46,11 +48,13 @@ RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/sr
 RUN cargo build --release --bin authenticator 2>/dev/null || true
 
 # --- Source layer ---
-RUN rm -rf libs/authenticator-sdk/src services/authenticator/src \
+RUN rm -rf libs/authenticator-sdk/src libs/insight-http-metrics/src services/authenticator/src \
+    target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
     target/release/authenticator target/release/deps/authenticator* \
     target/release/deps/libauthenticator*
 
 COPY libs/authenticator-sdk/src/ ./libs/authenticator-sdk/src/
+COPY libs/insight-http-metrics/src/ ./libs/insight-http-metrics/src/
 COPY services/authenticator/src/ ./services/authenticator/src/
 COPY services/authenticator/config/ ./services/authenticator/config/
 

--- a/src/backend/services/authenticator/src/api/mod.rs
+++ b/src/backend/services/authenticator/src/api/mod.rs
@@ -53,7 +53,10 @@ pub fn register_routes(
             state.clone(),
             crate::csrf::middleware,
         ))
-        .layer(Extension(state));
+        .layer(Extension(state))
+        .layer(insight_http_metrics::ServerMetricsLayer::new(
+            "authenticator",
+        ));
     host_router.merge(api)
 }
 

--- a/src/backend/services/git-cli-proxy/Cargo.toml
+++ b/src/backend/services/git-cli-proxy/Cargo.toml
@@ -24,9 +24,8 @@ toolkit-canonical-errors = { workspace = true }
 # Pinned to match the `ToSchema` the toolkit OperationBuilder compiles against.
 utoipa = { version = "5.5" }
 chrono = { workspace = true }
-# Pinned to the toolkit's major: instruments must register against the global
-# meter provider the host installs, and a different major is a different global.
-opentelemetry = "0.32"
+insight-http-metrics = { workspace = true }
+opentelemetry = { workspace = true }
 # statvfs: the volume is the ground truth the per-entry accounting cannot
 # see. rustix rather than libc — the workspace forbids unsafe code.
 rustix = { version = "1.1", features = ["fs"] }

--- a/src/backend/services/git-cli-proxy/Dockerfile
+++ b/src/backend/services/git-cli-proxy/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /build
 # workspace, even the ones this image never builds or ships.
 COPY Cargo.toml Cargo.lock ./
 COPY libs/insight-clickhouse/Cargo.toml ./libs/insight-clickhouse/Cargo.toml
+COPY libs/insight-http-metrics/Cargo.toml ./libs/insight-http-metrics/Cargo.toml
 COPY libs/authenticator-sdk/Cargo.toml ./libs/authenticator-sdk/Cargo.toml
 COPY libs/insight-migration/Cargo.toml ./libs/insight-migration/Cargo.toml
 COPY services/analytics/Cargo.toml ./services/analytics/Cargo.toml
@@ -29,6 +30,7 @@ COPY services/previews/Cargo.toml ./services/previews/Cargo.toml
 COPY tools/routegen/Cargo.toml ./tools/routegen/Cargo.toml
 
 RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/src/lib.rs && \
+    mkdir -p libs/insight-http-metrics/src && echo "" > libs/insight-http-metrics/src/lib.rs && \
     mkdir -p libs/authenticator-sdk/src && echo "" > libs/authenticator-sdk/src/lib.rs && \
     mkdir -p libs/insight-migration/src && echo "" > libs/insight-migration/src/lib.rs && \
     mkdir -p services/analytics/src && echo "fn main() {}" > services/analytics/src/main.rs && \
@@ -41,9 +43,11 @@ RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/sr
 RUN cargo build --release --bin git-cli-proxy 2>/dev/null || true
 
 # --- Source layer ---
-RUN rm -rf services/git-cli-proxy/src \
+RUN rm -rf libs/insight-http-metrics/src services/git-cli-proxy/src \
+    target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
     target/release/git-cli-proxy target/release/deps/git_cli_proxy*
 
+COPY libs/insight-http-metrics/src/ ./libs/insight-http-metrics/src/
 COPY services/git-cli-proxy/src/ ./services/git-cli-proxy/src/
 COPY services/git-cli-proxy/config/ ./services/git-cli-proxy/config/
 

--- a/src/backend/services/git-cli-proxy/src/api/mod.rs
+++ b/src/backend/services/git-cli-proxy/src/api/mod.rs
@@ -56,7 +56,10 @@ pub fn register_routes(
         .layer(Extension(state))
         // Outside the bearer layer, so a rejected request is timed too — an
         // operator watching a token rotation needs exactly those.
-        .layer(axum::middleware::from_fn(observe));
+        .layer(axum::middleware::from_fn(observe))
+        .layer(insight_http_metrics::ServerMetricsLayer::new(
+            "git-cli-proxy",
+        ));
 
     host_router.merge(v1)
 }

--- a/src/backend/services/identity-resolution/Cargo.toml
+++ b/src/backend/services/identity-resolution/Cargo.toml
@@ -60,6 +60,7 @@ base64 = { workspace = true }
 # `insight-clickhouse` wraps the client; the direct `clickhouse` dep is for the
 # `Row` derive on the query row struct.
 insight-clickhouse = { workspace = true }
+insight-http-metrics = { workspace = true }
 insight-migration = { workspace = true }
 clickhouse = { workspace = true }
 

--- a/src/backend/services/identity-resolution/Dockerfile
+++ b/src/backend/services/identity-resolution/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR /build
 # workspace, even the ones this image never builds or ships.
 COPY Cargo.toml Cargo.lock ./
 COPY libs/insight-clickhouse/Cargo.toml ./libs/insight-clickhouse/Cargo.toml
+COPY libs/insight-http-metrics/Cargo.toml ./libs/insight-http-metrics/Cargo.toml
 COPY libs/authenticator-sdk/Cargo.toml ./libs/authenticator-sdk/Cargo.toml
 COPY libs/insight-migration/Cargo.toml ./libs/insight-migration/Cargo.toml
 COPY services/analytics/Cargo.toml ./services/analytics/Cargo.toml
@@ -28,6 +29,7 @@ COPY services/previews/Cargo.toml ./services/previews/Cargo.toml
 COPY tools/routegen/Cargo.toml ./tools/routegen/Cargo.toml
 
 RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/src/lib.rs && \
+    mkdir -p libs/insight-http-metrics/src && echo "" > libs/insight-http-metrics/src/lib.rs && \
     mkdir -p libs/authenticator-sdk/src && echo "" > libs/authenticator-sdk/src/lib.rs && \
     mkdir -p libs/insight-migration/src && echo "" > libs/insight-migration/src/lib.rs && \
     mkdir -p services/analytics/src && echo "fn main() {}" > services/analytics/src/main.rs && \
@@ -40,12 +42,14 @@ RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/sr
 RUN cargo build --release --bin identity-resolution 2>/dev/null || true
 
 # --- Source layer ---
-RUN rm -rf libs/insight-clickhouse/src libs/insight-migration/src services/identity-resolution/src \
+RUN rm -rf libs/insight-clickhouse/src libs/insight-http-metrics/src libs/insight-migration/src services/identity-resolution/src \
+    target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
     target/release/identity-resolution target/release/deps/identity_resolution* \
     target/release/deps/insight_clickhouse* target/release/deps/libinsight_clickhouse* \
     target/release/deps/insight_migration* target/release/deps/libinsight_migration*
 
 COPY libs/insight-clickhouse/src/ ./libs/insight-clickhouse/src/
+COPY libs/insight-http-metrics/src/ ./libs/insight-http-metrics/src/
 COPY libs/insight-migration/src/ ./libs/insight-migration/src/
 COPY services/identity-resolution/src/ ./services/identity-resolution/src/
 COPY services/identity-resolution/config/ ./services/identity-resolution/config/

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -52,7 +52,11 @@ pub fn register_routes(
     openapi: &dyn OpenApiRegistry,
     state: Arc<AppState>,
 ) -> Router {
-    let api = build_operations(Router::new(), openapi).layer(Extension(state));
+    let api = build_operations(Router::new(), openapi)
+        .layer(Extension(state))
+        .layer(insight_http_metrics::ServerMetricsLayer::new(
+            "identity-resolution",
+        ));
 
     host_router.merge(api)
 }

--- a/src/backend/services/previews/Dockerfile
+++ b/src/backend/services/previews/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR /build
 # workspace, even the ones this image never builds or ships.
 COPY Cargo.toml Cargo.lock ./
 COPY libs/insight-clickhouse/Cargo.toml ./libs/insight-clickhouse/Cargo.toml
+COPY libs/insight-http-metrics/Cargo.toml ./libs/insight-http-metrics/Cargo.toml
 COPY libs/authenticator-sdk/Cargo.toml ./libs/authenticator-sdk/Cargo.toml
 COPY libs/insight-migration/Cargo.toml ./libs/insight-migration/Cargo.toml
 COPY services/analytics/Cargo.toml ./services/analytics/Cargo.toml
@@ -28,6 +29,7 @@ COPY services/previews/Cargo.toml ./services/previews/Cargo.toml
 COPY tools/routegen/Cargo.toml ./tools/routegen/Cargo.toml
 
 RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/src/lib.rs && \
+    mkdir -p libs/insight-http-metrics/src && echo "" > libs/insight-http-metrics/src/lib.rs && \
     mkdir -p libs/authenticator-sdk/src && echo "" > libs/authenticator-sdk/src/lib.rs && \
     mkdir -p libs/insight-migration/src && echo "" > libs/insight-migration/src/lib.rs && \
     mkdir -p services/analytics/src && echo "fn main() {}" > services/analytics/src/main.rs && \


### PR DESCRIPTION
Closes #2890.

**Why.** The toolkit only instruments outbound clients (`http.client.request.duration`); nothing records inbound request duration, so per-route request rate, error rate and latency percentiles are not queryable for any service.

**What changed.** New shared crate `insight-http-metrics` (under `src/backend/libs/`): a tower layer emitting `http.server.request.duration` (histogram, seconds) with `http.request.method`, `http.response.status_code` and `http.route` taken from axum's `MatchedPath` — the route template, never the raw path, so the label set stays bounded. Applied as the outermost layer on the gear sub-router in analytics, authenticator, git-cli-proxy and identity-resolution; health probes stay outside it. Bucket boundaries match the toolkit's client layer so server- and client-side percentiles are comparable.

**`opentelemetry` is now a workspace dependency pinned to 0.31 — the toolkit's major.** authenticator and git-cli-proxy pinned 0.32; a different major is a different global meter provider, so their existing instruments silently recorded into a no-op. The pin must track the toolkit's major on every toolkit bump.

**Out of scope.** Upstreaming the layer into the toolkit (follow-up per #2890). git-cli-proxy's own per-endpoint `git_proxy_*` histograms stay as they are.

**Verified.** `cargo fmt`, clippy pedantic and the unit suites of the five touched crates pass locally; the new crate's tests assert route-template labeling, 5xx recording and unmatched-route omission through an in-memory exporter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP server request-duration metrics across analytics, authenticator, Git CLI proxy, and identity resolution services.
  * Metrics include normalized HTTP methods, response status codes, and matched route templates for clearer monitoring.
  * Unmatched routes and uncommon HTTP methods are handled consistently.

* **Improvements**
  * Standardized telemetry configuration across backend services.
  * Updated service builds to include shared metrics support without changing request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->