### PR TITLE
feat(previews): registry tag listing, count/cap and TTL surfacing (#2375)

### DIFF
--- a/docs/components/backend/previews/openapi.json
+++ b/docs/components/backend/previews/openapi.json
@@ -31,15 +31,27 @@
       "ExperimentListResponse": {
         "description": "List wrapper for `GET /v1/experiments`.",
         "properties": {
+          "cap": {
+            "description": "The configured live-experiment cap; a create at the cap is refused.",
+            "minimum": 0,
+            "type": "integer"
+          },
           "experiments": {
             "items": {
               "$ref": "#/components/schemas/ExperimentResponse"
             },
             "type": "array"
+          },
+          "liveCount": {
+            "description": "How many experiments count against the cap (expired ones do not).",
+            "minimum": 0,
+            "type": "integer"
           }
         },
         "required": [
-          "experiments"
+          "experiments",
+          "liveCount",
+          "cap"
         ],
         "type": "object"
       },
@@ -94,6 +106,27 @@
           "expired"
         ],
         "type": "string"
+      },
+      "ImageListResponse": {
+        "description": "Body of `GET /v1/images`.",
+        "properties": {
+          "configured": {
+            "description": "False when the service holds no registry read credential; `tags` is\nthen empty and the create form keeps free-text entry.",
+            "type": "boolean"
+          },
+          "tags": {
+            "description": "The `preview-…` tags of the fixed FE image repository, deduped and\nsorted.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "configured",
+          "tags"
+        ],
+        "type": "object"
       },
       "Problem": {
         "description": "RFC 9457 problem+json. `context` varies by error category.",
@@ -436,6 +469,99 @@
           }
         ],
         "summary": "Delete a preview experiment; requires the previews-admin or admin role"
+      }
+    },
+    "/v1/images": {
+      "get": {
+        "operationId": "previews.images.list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageListResponse"
+                }
+              }
+            },
+            "description": "The preview- tags of the FE image repository, or an explicit unconfigured answer when the service holds no registry credential"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List the preview- image tags available in the registry"
       }
     }
   }

--- a/docs/components/backend/previews/openapi.json
+++ b/docs/components/backend/previews/openapi.json
@@ -32,7 +32,6 @@
         "description": "List wrapper for `GET /v1/experiments`.",
         "properties": {
           "cap": {
-            "description": "The configured live-experiment cap; a create at the cap is refused.",
             "minimum": 0,
             "type": "integer"
           },
@@ -43,7 +42,7 @@
             "type": "array"
           },
           "liveCount": {
-            "description": "How many experiments count against the cap (expired ones do not).",
+            "description": "Experiments counting against the cap; expired ones do not.",
             "minimum": 0,
             "type": "integer"
           }
@@ -111,11 +110,11 @@
         "description": "Body of `GET /v1/images`.",
         "properties": {
           "configured": {
-            "description": "False when the service holds no registry read credential; `tags` is\nthen empty and the create form keeps free-text entry.",
+            "description": "False when tag listing is disabled server-side; `tags` is then empty.",
             "type": "boolean"
           },
           "tags": {
-            "description": "The `preview-…` tags of the fixed FE image repository, deduped and\nsorted.",
+            "description": "The repository's `preview-…` tags, deduped and sorted.",
             "items": {
               "type": "string"
             },
@@ -483,7 +482,7 @@
                 }
               }
             },
-            "description": "The preview- tags of the FE image repository, or an explicit unconfigured answer when the service holds no registry credential"
+            "description": "The preview- tags of the FE image repository; configured=false when tag listing is disabled"
           },
           "400": {
             "content": {

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -5076,6 +5076,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "regex-lite",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",

--- a/src/backend/services/previews/Cargo.toml
+++ b/src/backend/services/previews/Cargo.toml
@@ -48,6 +48,9 @@ uuid = { workspace = true }
 # Image-tag shape validation (anchored, ASCII-only patterns).
 regex-lite = { workspace = true }
 
+# OCI registry tag listing (GET /v1/images).
+reqwest = { workspace = true }
+
 # Kubernetes: the Deployment/Service/HTTPRoute trio IS the experiment store.
 kube = { workspace = true, features = ["client", "rustls-tls", "aws-lc-rs"] }
 k8s-openapi = { workspace = true, features = ["latest"] }

--- a/src/backend/services/previews/config/insight.yaml
+++ b/src/backend/services/previews/config/insight.yaml
@@ -122,9 +122,7 @@ gears:
       default_ttl_days: 7
       max_ttl_days: 30
       sweep_interval_secs: 300
-      # OCI registry tag listing (GET /v1/images). The token is a credential:
-      # injected per-deployment via APP__gears__previews__config__registry_token
-      # (for GHCR, the base64-encoded read token). Empty = the endpoint
-      # answers configured:false and the UI keeps free-text tag entry.
+      # Tag listing (GET /v1/images); empty disables it. A private repository
+      # additionally needs APP__gears__previews__config__registry_token.
       registry_url: "https://ghcr.io"
       registry_token: ""

--- a/src/backend/services/previews/config/insight.yaml
+++ b/src/backend/services/previews/config/insight.yaml
@@ -122,3 +122,9 @@ gears:
       default_ttl_days: 7
       max_ttl_days: 30
       sweep_interval_secs: 300
+      # OCI registry tag listing (GET /v1/images). The token is a credential:
+      # injected per-deployment via APP__gears__previews__config__registry_token
+      # (for GHCR, the base64-encoded read token). Empty = the endpoint
+      # answers configured:false and the UI keeps free-text tag entry.
+      registry_url: "https://ghcr.io"
+      registry_token: ""

--- a/src/backend/services/previews/helm/templates/configmap.yaml
+++ b/src/backend/services/previews/helm/templates/configmap.yaml
@@ -127,8 +127,8 @@ data:
           route_host: {{ .Values.experiments.routeHost | quote }}
           base_path: {{ .Values.experiments.basePath | quote }}
           max_experiments: {{ .Values.experiments.maxExperiments }}
-          # The registry token is a credential and NEVER rides this ConfigMap;
-          # it arrives as a Secret-backed env override (see deployment.yaml).
+          # The registry token is a credential; it rides a Secret-backed env
+          # override, never this ConfigMap.
           registry_url: {{ .Values.experiments.registryUrl | quote }}
           default_ttl_days: {{ .Values.experiments.defaultTtlDays }}
           max_ttl_days: {{ .Values.experiments.maxTtlDays }}

--- a/src/backend/services/previews/helm/templates/configmap.yaml
+++ b/src/backend/services/previews/helm/templates/configmap.yaml
@@ -127,6 +127,9 @@ data:
           route_host: {{ .Values.experiments.routeHost | quote }}
           base_path: {{ .Values.experiments.basePath | quote }}
           max_experiments: {{ .Values.experiments.maxExperiments }}
+          # The registry token is a credential and NEVER rides this ConfigMap;
+          # it arrives as a Secret-backed env override (see deployment.yaml).
+          registry_url: {{ .Values.experiments.registryUrl | quote }}
           default_ttl_days: {{ .Values.experiments.defaultTtlDays }}
           max_ttl_days: {{ .Values.experiments.maxTtlDays }}
           sweep_interval_secs: {{ .Values.experiments.sweepIntervalSecs }}

--- a/src/backend/services/previews/helm/templates/deployment.yaml
+++ b/src/backend/services/previews/helm/templates/deployment.yaml
@@ -46,9 +46,8 @@ spec:
         - name: previews
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          # gears-rust host: structural config from the mounted ConfigMap.
-          # The one credential (the registry read token) rides a Secret-backed
-          # env override, never the ConfigMap.
+          # gears-rust host: structural config from the mounted ConfigMap; the
+          # registry token is the one Secret-backed env override.
           command: ["/app/previews"]
           args: ["-c", "/app/config/insight.yaml"]
           {{- if .Values.experiments.registryTokenSecret }}

--- a/src/backend/services/previews/helm/templates/deployment.yaml
+++ b/src/backend/services/previews/helm/templates/deployment.yaml
@@ -47,10 +47,18 @@ spec:
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           # gears-rust host: structural config from the mounted ConfigMap.
-          # There is no Secret: the only per-stand leaf (routeHost) is not a
-          # credential and rides the ConfigMap.
+          # The one credential (the registry read token) rides a Secret-backed
+          # env override, never the ConfigMap.
           command: ["/app/previews"]
           args: ["-c", "/app/config/insight.yaml"]
+          {{- if .Values.experiments.registryTokenSecret }}
+          env:
+            - name: APP__gears__previews__config__registry_token
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.experiments.registryTokenSecret | quote }}
+                  key: token
+          {{- end }}
           volumeMounts:
             - name: previews-config
               mountPath: /app/config/insight.yaml

--- a/src/backend/services/previews/helm/tests/test_experiments_rbac_contract.py
+++ b/src/backend/services/previews/helm/tests/test_experiments_rbac_contract.py
@@ -104,6 +104,25 @@ def test_route_host_defaults_empty_so_creates_fail_closed() -> None:
     assert _gear_config(_docs())["route_host"] == ""
 
 
+def test_the_registry_token_rides_a_secret_env_and_never_the_configmap() -> None:
+    docs = _docs("--set", "experiments.registryTokenSecret=registry-read")
+
+    config = _gear_config(docs)
+    assert config["registry_url"] == "https://ghcr.io"
+    assert "registry_token" not in config
+
+    container = _kind(docs, "Deployment")[0]["spec"]["template"]["spec"]["containers"][0]
+    (env,) = container["env"]
+    assert env["name"] == "APP__gears__previews__config__registry_token"
+    assert env["valueFrom"]["secretKeyRef"] == {"name": "registry-read", "key": "token"}
+
+
+def test_without_a_registry_secret_no_env_is_rendered() -> None:
+    container = _kind(_docs(), "Deployment")[0]["spec"]["template"]["spec"]["containers"][0]
+
+    assert "env" not in container
+
+
 def test_experiment_knobs_reach_the_gear_config() -> None:
     config = _gear_config(
         _docs(

--- a/src/backend/services/previews/helm/values.yaml
+++ b/src/backend/services/previews/helm/values.yaml
@@ -45,6 +45,12 @@ experiments:
   defaultTtlDays: 7
   maxTtlDays: 30
   sweepIntervalSecs: 300
+  # OCI registry tag listing (GET /v1/images). The token names an EXISTING
+  # Secret (key `token`) holding the read credential — for GHCR, the
+  # base64-encoded read token. Empty = the endpoint answers configured:false
+  # and the UI keeps free-text tag entry.
+  registryUrl: https://ghcr.io
+  registryTokenSecret: ""
 
 # The shared Gateway an experiment's HTTPRoute attaches to. The Gateway's
 # `allowedRoutes` namespace selector must admit `experiments.namespace`

--- a/src/backend/services/previews/helm/values.yaml
+++ b/src/backend/services/previews/helm/values.yaml
@@ -45,10 +45,8 @@ experiments:
   defaultTtlDays: 7
   maxTtlDays: 30
   sweepIntervalSecs: 300
-  # OCI registry tag listing (GET /v1/images). The token names an EXISTING
-  # Secret (key `token`) holding the read credential — for GHCR, the
-  # base64-encoded read token. Empty = the endpoint answers configured:false
-  # and the UI keeps free-text tag entry.
+  # Tag listing for GET /v1/images; empty URL disables it. The Secret (key
+  # `token`) is needed only for a private repository.
   registryUrl: https://ghcr.io
   registryTokenSecret: ""
 

--- a/src/backend/services/previews/src/api/experiments.rs
+++ b/src/backend/services/previews/src/api/experiments.rs
@@ -64,8 +64,13 @@ impl toolkit::api::api_dto::ResponseApiDto for ExperimentResponse {}
 
 /// List wrapper for `GET /v1/experiments`.
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ExperimentListResponse {
     pub experiments: Vec<ExperimentResponse>,
+    /// How many experiments count against the cap (expired ones do not).
+    pub live_count: usize,
+    /// The configured live-experiment cap; a create at the cap is refused.
+    pub cap: usize,
 }
 impl toolkit::api::api_dto::ResponseApiDto for ExperimentListResponse {}
 
@@ -107,7 +112,11 @@ pub async fn list_experiments(
         .collect();
     experiments.sort_by(|a, b| a.name.cmp(&b.name));
 
-    Ok(Json(ExperimentListResponse { experiments }))
+    Ok(Json(ExperimentListResponse {
+        experiments,
+        live_count: objects::live_experiment_count(&deployments, now),
+        cap: state.config.max_experiments,
+    }))
 }
 
 /// `POST /v1/experiments` — create the Deployment/Service/HTTPRoute trio.
@@ -235,7 +244,7 @@ pub async fn delete_experiment(
 }
 
 /// Require an identified caller (gateway-JWT subject); 401 otherwise.
-fn require_caller(ctx: &SecurityContext) -> Result<Uuid, CanonicalError> {
+pub(crate) fn require_caller(ctx: &SecurityContext) -> Result<Uuid, CanonicalError> {
     let caller = ctx.subject_id();
     if caller.is_nil() {
         return Err(CanonicalError::unauthenticated()

--- a/src/backend/services/previews/src/api/experiments.rs
+++ b/src/backend/services/previews/src/api/experiments.rs
@@ -67,9 +67,8 @@ impl toolkit::api::api_dto::ResponseApiDto for ExperimentResponse {}
 #[serde(rename_all = "camelCase")]
 pub struct ExperimentListResponse {
     pub experiments: Vec<ExperimentResponse>,
-    /// How many experiments count against the cap (expired ones do not).
+    /// Experiments counting against the cap; expired ones do not.
     pub live_count: usize,
-    /// The configured live-experiment cap; a create at the cap is refused.
     pub cap: usize,
 }
 impl toolkit::api::api_dto::ResponseApiDto for ExperimentListResponse {}

--- a/src/backend/services/previews/src/api/images.rs
+++ b/src/backend/services/previews/src/api/images.rs
@@ -1,0 +1,57 @@
+//! Image-tag listing surface — the registry tags the create form can offer.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::Extension;
+use axum::response::IntoResponse;
+use serde::Serialize;
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::SecurityContext;
+use utoipa::ToSchema;
+
+use super::AppState;
+use super::experiments::require_caller;
+use crate::domain::experiment::preview_tags;
+
+/// Body of `GET /v1/images`.
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ImageListResponse {
+    /// False when the service holds no registry read credential; `tags` is
+    /// then empty and the create form keeps free-text entry.
+    pub configured: bool,
+    /// The `preview-…` tags of the fixed FE image repository, deduped and
+    /// sorted.
+    pub tags: Vec<String>,
+}
+impl toolkit::api::api_dto::ResponseApiDto for ImageListResponse {}
+
+/// `GET /v1/images` — the `preview-…` tags available in the registry.
+pub async fn list_images(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    require_caller(&ctx)?;
+
+    let Some(registry) = &state.registry else {
+        return Ok(Json(ImageListResponse {
+            configured: false,
+            tags: Vec::new(),
+        }));
+    };
+
+    let tags = registry.list_tags().await.map_err(tags_err)?;
+    Ok(Json(ImageListResponse {
+        configured: true,
+        tags: preview_tags(tags),
+    }))
+}
+
+#[expect(clippy::needless_pass_by_value, reason = "used directly as map_err")]
+fn tags_err(e: anyhow::Error) -> CanonicalError {
+    tracing::error!(error = %format!("{e:#}"), "registry tag listing failed");
+    CanonicalError::service_unavailable()
+        .with_detail("the image registry could not be listed")
+        .create()
+}

--- a/src/backend/services/previews/src/api/images.rs
+++ b/src/backend/services/previews/src/api/images.rs
@@ -1,4 +1,4 @@
-//! Image-tag listing surface — the registry tags the create form can offer.
+//! Image-tag listing surface.
 
 use std::sync::Arc;
 
@@ -18,11 +18,9 @@ use crate::domain::experiment::preview_tags;
 #[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageListResponse {
-    /// False when the service holds no registry read credential; `tags` is
-    /// then empty and the create form keeps free-text entry.
+    /// False when tag listing is disabled server-side; `tags` is then empty.
     pub configured: bool,
-    /// The `preview-…` tags of the fixed FE image repository, deduped and
-    /// sorted.
+    /// The repository's `preview-…` tags, deduped and sorted.
     pub tags: Vec<String>,
 }
 impl toolkit::api::api_dto::ResponseApiDto for ImageListResponse {}

--- a/src/backend/services/previews/src/api/mod.rs
+++ b/src/backend/services/previews/src/api/mod.rs
@@ -21,8 +21,7 @@ use crate::infra::registry::Registry;
 pub struct AppState {
     /// Kubernetes access, scoped to the one configured namespace.
     pub cluster: Cluster,
-    /// Registry read access for tag listing; `None` when no credential is
-    /// configured (`GET /v1/images` then answers `configured: false`).
+    /// `None` when tag listing is disabled (empty registry URL).
     pub registry: Option<Registry>,
     pub config: GearConfig,
     /// Serializes create admission (count-then-create); see the INVARIANT at
@@ -102,8 +101,8 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         .json_response_with_schema::<images::ImageListResponse>(
             openapi,
             StatusCode::OK,
-            "The preview- tags of the FE image repository, or an explicit \
-             unconfigured answer when the service holds no registry credential",
+            "The preview- tags of the FE image repository; configured=false \
+             when tag listing is disabled",
         )
         .standard_errors(openapi)
         .handler(images::list_images)

--- a/src/backend/services/previews/src/api/mod.rs
+++ b/src/backend/services/previews/src/api/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod canonical_json;
 pub mod error;
 pub mod experiments;
+pub mod images;
 
 use std::sync::Arc;
 
@@ -13,12 +14,16 @@ use toolkit::api::{OpenApiInfo, OpenApiRegistry, OpenApiRegistryImpl, OperationB
 
 use crate::config::GearConfig;
 use crate::infra::cluster::Cluster;
+use crate::infra::registry::Registry;
 
 /// Shared application state, injected into handlers via `Extension` (as one
 /// `Arc`, never cloned per request).
 pub struct AppState {
     /// Kubernetes access, scoped to the one configured namespace.
     pub cluster: Cluster,
+    /// Registry read access for tag listing; `None` when no credential is
+    /// configured (`GET /v1/images` then answers `configured: false`).
+    pub registry: Option<Registry>,
     pub config: GearConfig,
     /// Serializes create admission (count-then-create); see the INVARIANT at
     /// its lock site.
@@ -89,6 +94,21 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         .handler(experiments::list_experiments)
         .register(router, openapi);
 
+    let router = OperationBuilder::get("/v1/images")
+        .operation_id("previews.images.list")
+        .summary("List the preview- image tags available in the registry")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<images::ImageListResponse>(
+            openapi,
+            StatusCode::OK,
+            "The preview- tags of the FE image repository, or an explicit \
+             unconfigured answer when the service holds no registry credential",
+        )
+        .standard_errors(openapi)
+        .handler(images::list_images)
+        .register(router, openapi);
+
     let router = OperationBuilder::post("/v1/experiments")
         .operation_id("previews.experiments.create")
         .summary(
@@ -127,7 +147,7 @@ mod openapi_tests {
     fn the_document_builds_without_state_or_a_cluster() -> anyhow::Result<()> {
         let document = openapi_document()?;
 
-        for path in ["/v1/experiments", "/v1/experiments/{name}"] {
+        for path in ["/v1/experiments", "/v1/experiments/{name}", "/v1/images"] {
             assert!(
                 document.paths.paths.contains_key(path),
                 "missing {path}: {:?}",

--- a/src/backend/services/previews/src/config.rs
+++ b/src/backend/services/previews/src/config.rs
@@ -36,6 +36,13 @@ pub struct GearConfig {
     pub max_ttl_days: u32,
     /// How often the TTL sweep looks for expired experiments.
     pub sweep_interval_secs: u64,
+    /// Base URL of the OCI registry holding the FE image repository; read
+    /// only for tag listing.
+    pub registry_url: String,
+    /// Bearer credential for the tag listing (for GHCR, the base64-encoded
+    /// read token). Empty means listing is unconfigured and `GET /v1/images`
+    /// answers `configured: false`.
+    pub registry_token: String,
 }
 
 impl Default for GearConfig {
@@ -51,6 +58,8 @@ impl Default for GearConfig {
             default_ttl_days: 7,
             max_ttl_days: 30,
             sweep_interval_secs: 300,
+            registry_url: "https://ghcr.io".to_owned(),
+            registry_token: String::new(),
         }
     }
 }
@@ -81,6 +90,10 @@ impl GearConfig {
         anyhow::ensure!(
             self.max_experiments >= 1,
             "max_experiments must be at least 1"
+        );
+        anyhow::ensure!(
+            self.registry_token.is_empty() || !self.registry_url.is_empty(),
+            "registry_token is set but registry_url is empty"
         );
         Ok(())
     }
@@ -123,7 +136,11 @@ mod tests {
     fn a_config_the_request_path_could_only_mis_serve_refuses_to_boot() {
         type BreakIt = fn(&mut GearConfig);
 
-        let cases: [(&str, BreakIt); 4] = [
+        let cases: [(&str, BreakIt); 5] = [
+            ("a registry token without a url", |c| {
+                c.registry_token = "token".to_owned();
+                c.registry_url = String::new();
+            }),
             ("zero default ttl", |c| c.default_ttl_days = 0),
             ("default above max", |c| {
                 c.default_ttl_days = c.max_ttl_days + 1;

--- a/src/backend/services/previews/src/config.rs
+++ b/src/backend/services/previews/src/config.rs
@@ -36,12 +36,10 @@ pub struct GearConfig {
     pub max_ttl_days: u32,
     /// How often the TTL sweep looks for expired experiments.
     pub sweep_interval_secs: u64,
-    /// Base URL of the OCI registry holding the FE image repository; read
-    /// only for tag listing.
+    /// OCI registry for tag listing; empty disables `GET /v1/images`.
     pub registry_url: String,
-    /// Bearer credential for the tag listing (for GHCR, the base64-encoded
-    /// read token). Empty means listing is unconfigured and `GET /v1/images`
-    /// answers `configured: false`.
+    /// Bearer credential, needed only for a private repository (for GHCR,
+    /// the base64-encoded read token); empty lists anonymously.
     pub registry_token: String,
 }
 

--- a/src/backend/services/previews/src/domain/experiment.rs
+++ b/src/backend/services/previews/src/domain/experiment.rs
@@ -104,6 +104,19 @@ fn is_build_tag(s: &str) -> bool {
     BUILD_TAG.is_match(s)
 }
 
+/// The registry tags the create form may offer: only `preview-…` tags a
+/// create would accept, deduped and sorted.
+#[must_use]
+pub fn preview_tags(tags: Vec<String>) -> Vec<String> {
+    let mut offered: Vec<String> = tags
+        .into_iter()
+        .filter(|tag| tag.len() <= MAX_TAG_LEN && is_preview_tag(tag))
+        .collect();
+    offered.sort();
+    offered.dedup();
+    offered
+}
+
 /// A validated time-to-live in whole days, clamped nowhere: a request outside
 /// `1..=max` is refused, not adjusted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -258,6 +271,24 @@ mod tests {
         ] {
             assert!(ImageTag::parse(bad).is_err(), "should reject: {bad:?}");
         }
+    }
+
+    #[test]
+    fn the_form_is_offered_only_creatable_preview_tags_deduped_and_sorted() {
+        let listed = vec![
+            "preview-zeta".to_owned(),
+            "latest".to_owned(),
+            "2026.08.06.14.05-abc1234".to_owned(),
+            "preview-alpha".to_owned(),
+            "preview-alpha".to_owned(),
+            "preview-a b".to_owned(),
+            format!("preview-{}", "a".repeat(128)),
+        ];
+
+        assert_eq!(
+            preview_tags(listed),
+            vec!["preview-alpha".to_owned(), "preview-zeta".to_owned()]
+        );
     }
 
     #[test]

--- a/src/backend/services/previews/src/gear.rs
+++ b/src/backend/services/previews/src/gear.rs
@@ -16,6 +16,7 @@ use toolkit::{Gear, GearCtx, RestApiCapability};
 use crate::api::AppState;
 use crate::config::GearConfig;
 use crate::infra::cluster::Cluster;
+use crate::infra::registry::Registry;
 
 /// Previews gear. Capability: `rest` (HTTP surface). Config key is the gear
 /// name `previews`; env overrides are `APP__gears__previews__config__*`.
@@ -42,8 +43,18 @@ impl Gear for PreviewsGear {
             config.sweep_interval_secs,
         ));
 
+        let registry = if config.registry_token.is_empty() {
+            None
+        } else {
+            Some(Registry::connect(
+                &config.registry_url,
+                &config.registry_token,
+            )?)
+        };
+
         let state = AppState {
             cluster,
+            registry,
             config,
             create_gate: tokio::sync::Mutex::new(()),
         };

--- a/src/backend/services/previews/src/gear.rs
+++ b/src/backend/services/previews/src/gear.rs
@@ -43,7 +43,7 @@ impl Gear for PreviewsGear {
             config.sweep_interval_secs,
         ));
 
-        let registry = if config.registry_token.is_empty() {
+        let registry = if config.registry_url.is_empty() {
             None
         } else {
             Some(Registry::connect(

--- a/src/backend/services/previews/src/infra/mod.rs
+++ b/src/backend/services/previews/src/infra/mod.rs
@@ -1,3 +1,5 @@
-//! I/O shell: the Kubernetes API is the only backend.
+//! I/O shell: the Kubernetes API for the experiment store, the OCI registry
+//! for tag listing.
 
 pub mod cluster;
+pub mod registry;

--- a/src/backend/services/previews/src/infra/registry.rs
+++ b/src/backend/services/previews/src/infra/registry.rs
@@ -1,11 +1,10 @@
-//! OCI registry read access: list the tags of the fixed FE image repository
-//! (`/v2/<repo>/tags/list`, `Link`-header pagination). Read-only — nothing
-//! here can push or delete.
+//! OCI registry read access: list the tags of the FE image repository.
 
 use std::time::Duration;
 
 use anyhow::{Context, anyhow};
-use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, LINK};
+use reqwest::StatusCode;
+use reqwest::header::{AUTHORIZATION, HeaderValue, LINK, WWW_AUTHENTICATE};
 
 use crate::domain::objects::IMAGE_REPOSITORY;
 
@@ -13,51 +12,48 @@ const REGISTRY_TIMEOUT: Duration = Duration::from_secs(10);
 const PAGE_SIZE: usize = 1000;
 const MAX_PAGES: usize = 20;
 
-/// A client for the one registry the FE image repository lives in, carrying
-/// the read credential on every request.
 pub struct Registry {
     http: reqwest::Client,
     base_url: String,
+    static_bearer: Option<HeaderValue>,
 }
 
 impl Registry {
-    /// Build the client. Fails when the token cannot form a header value.
     pub fn connect(base_url: &str, token: &str) -> anyhow::Result<Self> {
-        let mut bearer = HeaderValue::from_str(&format!("Bearer {token}"))
-            .context("registry token is not a valid header value")?;
-        bearer.set_sensitive(true);
-
-        let mut headers = HeaderMap::new();
-        headers.insert(AUTHORIZATION, bearer);
+        let static_bearer = if token.is_empty() {
+            None
+        } else {
+            Some(bearer(token)?)
+        };
         let http = reqwest::Client::builder()
             .timeout(REGISTRY_TIMEOUT)
-            .default_headers(headers)
             .build()
             .context("registry http client")?;
 
         Ok(Self {
             http,
             base_url: base_url.trim_end_matches('/').to_owned(),
+            static_bearer,
         })
     }
 
-    /// Every tag of the FE image repository, following pagination up to
-    /// [`MAX_PAGES`]; a repository larger than that is truncated and logged.
+    /// All tags, following `Link` pagination; past [`MAX_PAGES`] the rest is
+    /// dropped and logged.
     pub async fn list_tags(&self) -> anyhow::Result<Vec<String>> {
         let mut url = format!(
             "{}/v2/{}/tags/list?n={PAGE_SIZE}",
             self.base_url,
             repository_path()
         );
+        let mut auth = self.static_bearer.clone();
 
         let mut tags = Vec::new();
         for _ in 0..MAX_PAGES {
-            let response = self
-                .http
-                .get(&url)
-                .send()
-                .await
-                .context("registry tags request")?;
+            let mut response = self.get(&url, auth.as_ref()).await?;
+            if response.status() == StatusCode::UNAUTHORIZED && auth.is_none() {
+                auth = Some(self.anonymous_bearer(&response).await?);
+                response = self.get(&url, auth.as_ref()).await?;
+            }
             let status = response.status();
             if !status.is_success() {
                 return Err(anyhow!("registry answered {status} listing tags"));
@@ -83,25 +79,90 @@ impl Registry {
         );
         Ok(tags)
     }
+
+    async fn get(
+        &self,
+        url: &str,
+        auth: Option<&HeaderValue>,
+    ) -> anyhow::Result<reqwest::Response> {
+        let mut request = self.http.get(url);
+        if let Some(auth) = auth {
+            request = request.header(AUTHORIZATION, auth);
+        }
+        request.send().await.context("registry request")
+    }
+
+    /// Even public repositories answer 401 anonymously; the challenge names
+    /// the endpoint that mints a pull token with no credential.
+    async fn anonymous_bearer(&self, refused: &reqwest::Response) -> anyhow::Result<HeaderValue> {
+        let challenge = refused
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .and_then(|value| value.to_str().ok())
+            .ok_or_else(|| anyhow!("registry 401 without a bearer challenge"))?;
+        let token_url = token_url(challenge, repository_path())
+            .ok_or_else(|| anyhow!("registry challenge names no token endpoint"))?;
+
+        let minted: MintedToken = self
+            .http
+            .get(&token_url)
+            .send()
+            .await
+            .context("registry token request")?
+            .error_for_status()
+            .context("registry token endpoint")?
+            .json()
+            .await
+            .context("registry token body")?;
+        bearer(&minted.token)
+    }
 }
 
-/// The tags-list body of the OCI distribution spec; `tags` is null for an
-/// empty repository on some registries.
+fn bearer(token: &str) -> anyhow::Result<HeaderValue> {
+    let mut value = HeaderValue::from_str(&format!("Bearer {token}"))
+        .context("registry token is not a valid header value")?;
+    value.set_sensitive(true);
+    Ok(value)
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct MintedToken {
+    token: String,
+}
+
+/// `Bearer realm="…",service="…"` →
+/// `{realm}?service={service}&scope=repository:{repo}:pull`.
+fn token_url(challenge: &str, repo: &str) -> Option<String> {
+    let params = challenge.strip_prefix("Bearer ")?;
+    let realm = challenge_field(params, "realm")?;
+    let service = challenge_field(params, "service").unwrap_or_default();
+    Some(format!(
+        "{realm}?service={service}&scope=repository:{repo}:pull"
+    ))
+}
+
+fn challenge_field(params: &str, name: &str) -> Option<String> {
+    params.split(',').find_map(|part| {
+        part.trim()
+            .strip_prefix(name)?
+            .strip_prefix("=\"")?
+            .strip_suffix('"')
+            .map(str::to_owned)
+    })
+}
+
+/// WORKAROUND: some registries serve `tags: null` for an empty repository.
 #[derive(Debug, serde::Deserialize)]
 struct TagsPage {
     tags: Option<Vec<String>>,
 }
 
-/// The repository path within the registry: [`IMAGE_REPOSITORY`] minus its
-/// registry-host segment.
 fn repository_path() -> &'static str {
     IMAGE_REPOSITORY
         .split_once('/')
         .map_or(IMAGE_REPOSITORY, |(_host, path)| path)
 }
 
-/// The follow-up URL out of an OCI `Link` header (`<url>; rel="next"`),
-/// resolved against the registry base when the URL is host-relative.
 fn next_page_url(link: Option<&str>, base_url: &str) -> Option<String> {
     let target = link?
         .split(',')
@@ -122,6 +183,36 @@ mod tests {
     #[test]
     fn the_repository_path_drops_the_registry_host() {
         assert_eq!(repository_path(), "constructorfabric/insight-frontend");
+    }
+
+    #[test]
+    fn the_token_endpoint_comes_from_the_bearer_challenge() {
+        for (case, challenge, expected) in [
+            (
+                "ghcr-shaped challenge",
+                "Bearer realm=\"https://registry.example.com/token\",service=\"registry.example.com\",scope=\"repository:example/app:pull\"",
+                Some(
+                    "https://registry.example.com/token?service=registry.example.com&scope=repository:example/app:pull"
+                        .to_owned(),
+                ),
+            ),
+            (
+                "no service",
+                "Bearer realm=\"https://registry.example.com/token\"",
+                Some(
+                    "https://registry.example.com/token?service=&scope=repository:example/app:pull"
+                        .to_owned(),
+                ),
+            ),
+            ("basic challenge", "Basic realm=\"registry\"", None),
+            ("no realm", "Bearer service=\"registry.example.com\"", None),
+        ] {
+            assert_eq!(
+                token_url(challenge, "example/app"),
+                expected,
+                "for: {case}"
+            );
+        }
     }
 
     #[test]

--- a/src/backend/services/previews/src/infra/registry.rs
+++ b/src/backend/services/previews/src/infra/registry.rs
@@ -1,0 +1,156 @@
+//! OCI registry read access: list the tags of the fixed FE image repository
+//! (`/v2/<repo>/tags/list`, `Link`-header pagination). Read-only — nothing
+//! here can push or delete.
+
+use std::time::Duration;
+
+use anyhow::{Context, anyhow};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue, LINK};
+
+use crate::domain::objects::IMAGE_REPOSITORY;
+
+const REGISTRY_TIMEOUT: Duration = Duration::from_secs(10);
+const PAGE_SIZE: usize = 1000;
+const MAX_PAGES: usize = 20;
+
+/// A client for the one registry the FE image repository lives in, carrying
+/// the read credential on every request.
+pub struct Registry {
+    http: reqwest::Client,
+    base_url: String,
+}
+
+impl Registry {
+    /// Build the client. Fails when the token cannot form a header value.
+    pub fn connect(base_url: &str, token: &str) -> anyhow::Result<Self> {
+        let mut bearer = HeaderValue::from_str(&format!("Bearer {token}"))
+            .context("registry token is not a valid header value")?;
+        bearer.set_sensitive(true);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, bearer);
+        let http = reqwest::Client::builder()
+            .timeout(REGISTRY_TIMEOUT)
+            .default_headers(headers)
+            .build()
+            .context("registry http client")?;
+
+        Ok(Self {
+            http,
+            base_url: base_url.trim_end_matches('/').to_owned(),
+        })
+    }
+
+    /// Every tag of the FE image repository, following pagination up to
+    /// [`MAX_PAGES`]; a repository larger than that is truncated and logged.
+    pub async fn list_tags(&self) -> anyhow::Result<Vec<String>> {
+        let mut url = format!(
+            "{}/v2/{}/tags/list?n={PAGE_SIZE}",
+            self.base_url,
+            repository_path()
+        );
+
+        let mut tags = Vec::new();
+        for _ in 0..MAX_PAGES {
+            let response = self
+                .http
+                .get(&url)
+                .send()
+                .await
+                .context("registry tags request")?;
+            let status = response.status();
+            if !status.is_success() {
+                return Err(anyhow!("registry answered {status} listing tags"));
+            }
+
+            let link = response
+                .headers()
+                .get(LINK)
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_owned);
+            let page: TagsPage = response.json().await.context("registry tags body")?;
+            tags.extend(page.tags.unwrap_or_default());
+
+            match next_page_url(link.as_deref(), &self.base_url) {
+                Some(next) => url = next,
+                None => return Ok(tags),
+            }
+        }
+
+        tracing::warn!(
+            pages = MAX_PAGES,
+            "registry tag listing hit the page cap; the rest is dropped"
+        );
+        Ok(tags)
+    }
+}
+
+/// The tags-list body of the OCI distribution spec; `tags` is null for an
+/// empty repository on some registries.
+#[derive(Debug, serde::Deserialize)]
+struct TagsPage {
+    tags: Option<Vec<String>>,
+}
+
+/// The repository path within the registry: [`IMAGE_REPOSITORY`] minus its
+/// registry-host segment.
+fn repository_path() -> &'static str {
+    IMAGE_REPOSITORY
+        .split_once('/')
+        .map_or(IMAGE_REPOSITORY, |(_host, path)| path)
+}
+
+/// The follow-up URL out of an OCI `Link` header (`<url>; rel="next"`),
+/// resolved against the registry base when the URL is host-relative.
+fn next_page_url(link: Option<&str>, base_url: &str) -> Option<String> {
+    let target = link?
+        .split(',')
+        .find(|part| part.contains("rel=\"next\""))?
+        .trim();
+    let url = target.strip_prefix('<')?.split_once('>')?.0;
+    if url.starts_with('/') {
+        Some(format!("{base_url}{url}"))
+    } else {
+        Some(url.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_repository_path_drops_the_registry_host() {
+        assert_eq!(repository_path(), "constructorfabric/insight-frontend");
+    }
+
+    #[test]
+    fn pagination_follows_only_a_rel_next_link() {
+        let base = "https://registry.example.com";
+        for (case, link, expected) in [
+            ("no header", None, None),
+            ("no next rel", Some("</v2/x>; rel=\"prev\""), None),
+            (
+                "relative next",
+                Some("</v2/app/tags/list?last=preview-a&n=1000>; rel=\"next\""),
+                Some(
+                    "https://registry.example.com/v2/app/tags/list?last=preview-a&n=1000"
+                        .to_owned(),
+                ),
+            ),
+            (
+                "absolute next",
+                Some("<https://other.example.com/v2/app/tags/list?last=b>; rel=\"next\""),
+                Some("https://other.example.com/v2/app/tags/list?last=b".to_owned()),
+            ),
+            (
+                "next among several",
+                Some("</v2/x>; rel=\"prev\", </v2/y>; rel=\"next\""),
+                Some("https://registry.example.com/v2/y".to_owned()),
+            ),
+            ("malformed target", Some("v2/y; rel=\"next\""), None),
+        ] {
+            assert_eq!(next_page_url(link, base), expected, "for: {case}");
+        }
+    }
+}

--- a/src/frontend/src/api/previews-client.test.ts
+++ b/src/frontend/src/api/previews-client.test.ts
@@ -8,6 +8,7 @@ import {
   createExperiment,
   deleteExperiment,
   listExperiments,
+  listImages,
   PreviewsApiError,
 } from "./previews-client";
 
@@ -15,7 +16,7 @@ const mockFetch = fetchWithAuth as unknown as ReturnType<typeof vi.fn>;
 
 function response(
   body: unknown,
-  init?: { ok?: boolean; status?: number },
+  init?: { ok?: boolean; status?: number }
 ): Response {
   return {
     ok: init?.ok ?? true,
@@ -37,10 +38,11 @@ beforeEach(() => {
 });
 
 describe("listExperiments", () => {
-  it("unwraps the experiments list", async () => {
-    mockFetch.mockResolvedValueOnce(response({ experiments: [EXPERIMENT] }));
+  it("serves the list with its count and cap", async () => {
+    const listed = { experiments: [EXPERIMENT], liveCount: 1, cap: 10 };
+    mockFetch.mockResolvedValueOnce(response(listed));
 
-    await expect(listExperiments()).resolves.toEqual([EXPERIMENT]);
+    await expect(listExperiments()).resolves.toEqual(listed);
     expect(mockFetch).toHaveBeenCalledWith("/api/previews/v1/experiments");
   });
 
@@ -52,10 +54,34 @@ describe("listExperiments", () => {
 
   it("raises the refusal with its status", async () => {
     mockFetch.mockResolvedValueOnce(
-      response({ detail: "unauthenticated" }, { ok: false, status: 401 }),
+      response({ detail: "unauthenticated" }, { ok: false, status: 401 })
     );
 
     await expect(listExperiments()).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+describe("listImages", () => {
+  it("serves the tags with the configured flag", async () => {
+    const listed = { configured: true, tags: ["preview-my-branch"] };
+    mockFetch.mockResolvedValueOnce(response(listed));
+
+    await expect(listImages()).resolves.toEqual(listed);
+    expect(mockFetch).toHaveBeenCalledWith("/api/previews/v1/images");
+  });
+
+  it("raises a malformed answer rather than inventing tags", async () => {
+    mockFetch.mockResolvedValueOnce(response({ configured: true }));
+
+    await expect(listImages()).rejects.toBeInstanceOf(PreviewsApiError);
+  });
+
+  it("raises the refusal with its status", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ detail: "unavailable" }, { ok: false, status: 503 })
+    );
+
+    await expect(listImages()).rejects.toMatchObject({ status: 503 });
   });
 });
 
@@ -75,13 +101,16 @@ describe("createExperiment", () => {
   it("raises the server's refusal — the 403 is the boundary, not the UI", async () => {
     mockFetch.mockResolvedValueOnce(
       response(
-        { detail: "managing experiments requires the previews-admin or admin role" },
-        { ok: false, status: 403 },
-      ),
+        {
+          detail:
+            "managing experiments requires the previews-admin or admin role",
+        },
+        { ok: false, status: 403 }
+      )
     );
 
     await expect(
-      createExperiment({ name: "x", tag: "preview-x" }),
+      createExperiment({ name: "x", tag: "preview-x" })
     ).rejects.toMatchObject({ status: 403 });
   });
 });
@@ -94,17 +123,17 @@ describe("deleteExperiment", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       "/api/previews/v1/experiments/my-experiment",
-      { method: "DELETE" },
+      { method: "DELETE" }
     );
   });
 
   it("raises a refusal rather than reporting a delete that never happened", async () => {
     mockFetch.mockResolvedValueOnce(
-      response({ detail: "experiment not found" }, { ok: false, status: 404 }),
+      response({ detail: "experiment not found" }, { ok: false, status: 404 })
     );
 
     await expect(deleteExperiment("gone")).rejects.toBeInstanceOf(
-      PreviewsApiError,
+      PreviewsApiError
     );
   });
 });

--- a/src/frontend/src/api/previews-client.ts
+++ b/src/frontend/src/api/previews-client.ts
@@ -25,6 +25,17 @@ export interface Experiment {
 
 export interface ExperimentListResponse {
   experiments: Experiment[];
+  /** How many experiments count against the cap (expired ones do not). */
+  liveCount: number;
+  /** The server's live-experiment cap; a create at the cap is refused. */
+  cap: number;
+}
+
+/** The registry tags the create form can offer. */
+export interface ImageListResponse {
+  /** False when the server holds no registry credential; `tags` is empty. */
+  configured: boolean;
+  tags: string[];
 }
 
 export interface CreateExperimentRequest {
@@ -32,6 +43,8 @@ export interface CreateExperimentRequest {
   name: string;
   /** FE image tag — the server validates (`preview-…` or a CI build tag). */
   tag: string;
+  /** Days until expiry — the server defaults and caps it when omitted. */
+  ttlDays?: number;
 }
 
 export class PreviewsApiError extends Error {
@@ -51,8 +64,8 @@ async function failure(res: Response): Promise<PreviewsApiError> {
   return new PreviewsApiError(res.status, body);
 }
 
-/** Every live experiment; authenticated-only. */
-export async function listExperiments(): Promise<Experiment[]> {
+/** Every live experiment plus the count/cap; authenticated-only. */
+export async function listExperiments(): Promise<ExperimentListResponse> {
   const res = await fetchWithAuth(`${BASE}/experiments`);
   if (!res.ok) throw await failure(res);
   let listed: ExperimentListResponse;
@@ -64,12 +77,28 @@ export async function listExperiments(): Promise<Experiment[]> {
   if (!Array.isArray(listed.experiments)) {
     throw new PreviewsApiError(res.status, { error: "malformed_experiments" });
   }
-  return listed.experiments;
+  return listed;
+}
+
+/** The registry's `preview-…` tags; authenticated-only. */
+export async function listImages(): Promise<ImageListResponse> {
+  const res = await fetchWithAuth(`${BASE}/images`);
+  if (!res.ok) throw await failure(res);
+  let listed: ImageListResponse;
+  try {
+    listed = (await res.json()) as ImageListResponse;
+  } catch {
+    throw new PreviewsApiError(res.status, { error: "invalid_json" });
+  }
+  if (!Array.isArray(listed.tags)) {
+    throw new PreviewsApiError(res.status, { error: "malformed_tags" });
+  }
+  return listed;
 }
 
 /** Create an experiment (name + tag). Requires previews-admin or admin. */
 export async function createExperiment(
-  req: CreateExperimentRequest,
+  req: CreateExperimentRequest
 ): Promise<Experiment> {
   const res = await fetchWithAuth(`${BASE}/experiments`, {
     method: "POST",
@@ -88,7 +117,7 @@ export async function createExperiment(
 export async function deleteExperiment(name: string): Promise<void> {
   const res = await fetchWithAuth(
     `${BASE}/experiments/${encodeURIComponent(name)}`,
-    { method: "DELETE" },
+    { method: "DELETE" }
   );
   if (!res.ok) throw await failure(res);
 }

--- a/src/frontend/src/api/previews-client.ts
+++ b/src/frontend/src/api/previews-client.ts
@@ -25,15 +25,13 @@ export interface Experiment {
 
 export interface ExperimentListResponse {
   experiments: Experiment[];
-  /** How many experiments count against the cap (expired ones do not). */
+  /** Experiments counting against the cap; expired ones do not. */
   liveCount: number;
-  /** The server's live-experiment cap; a create at the cap is refused. */
   cap: number;
 }
 
-/** The registry tags the create form can offer. */
 export interface ImageListResponse {
-  /** False when the server holds no registry credential; `tags` is empty. */
+  /** False when tag listing is disabled server-side; `tags` is empty. */
   configured: boolean;
   tags: string[];
 }
@@ -43,7 +41,7 @@ export interface CreateExperimentRequest {
   name: string;
   /** FE image tag — the server validates (`preview-…` or a CI build tag). */
   tag: string;
-  /** Days until expiry — the server defaults and caps it when omitted. */
+  /** Days until expiry; server default when omitted. */
   ttlDays?: number;
 }
 

--- a/src/frontend/src/queries/previews.test.tsx
+++ b/src/frontend/src/queries/previews.test.tsx
@@ -20,10 +20,12 @@ import {
   useCreateExperiment,
   useDeleteExperiment,
   useExperiments,
+  useImages,
   usePreviewsGate,
 } from "./previews";
 
 const listExperiments = vi.mocked(previewsClient.listExperiments);
+const listImages = vi.mocked(previewsClient.listImages);
 const createExperiment = vi.mocked(previewsClient.createExperiment);
 const deleteExperiment = vi.mocked(previewsClient.deleteExperiment);
 
@@ -101,13 +103,14 @@ describe("usePreviewsGate", () => {
 });
 
 describe("useExperiments", () => {
-  it("serves the listing", async () => {
-    listExperiments.mockResolvedValueOnce([EXPERIMENT]);
+  it("serves the listing with its count and cap", async () => {
+    const listed = { experiments: [EXPERIMENT], liveCount: 1, cap: 10 };
+    listExperiments.mockResolvedValueOnce(listed);
 
     const { result } = renderHook(() => useExperiments(), harness());
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
-    expect(result.current.data).toEqual([EXPERIMENT]);
+    expect(result.current.data).toEqual(listed);
   });
 
   it("never asks without a session", async () => {
@@ -120,9 +123,43 @@ describe("useExperiments", () => {
   });
 });
 
+describe("useImages", () => {
+  it("serves the registry tags", async () => {
+    const listed = { configured: true, tags: ["preview-my-branch"] };
+    listImages.mockResolvedValueOnce(listed);
+
+    const { result } = renderHook(() => useImages(), harness());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.data).toEqual(listed);
+  });
+
+  it("surfaces a listing failure without retrying — the form falls back", async () => {
+    listImages.mockRejectedValueOnce(new Error("Previews API 503"));
+
+    const { result } = renderHook(() => useImages(), harness());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(listImages).toHaveBeenCalledTimes(1);
+  });
+
+  it("never asks without a session", async () => {
+    auth.session = null;
+
+    renderHook(() => useImages(), harness());
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(listImages).not.toHaveBeenCalled();
+  });
+});
+
 describe("mutations", () => {
   it("create invalidates the listing so the console reconciles", async () => {
-    listExperiments.mockResolvedValue([EXPERIMENT]);
+    listExperiments.mockResolvedValue({
+      experiments: [EXPERIMENT],
+      liveCount: 1,
+      cap: 10,
+    });
     createExperiment.mockResolvedValueOnce(EXPERIMENT);
     const h = harness();
     const invalidate = vi.spyOn(h.queryClient, "invalidateQueries");

--- a/src/frontend/src/queries/previews.ts
+++ b/src/frontend/src/queries/previews.ts
@@ -16,8 +16,11 @@ import {
   createExperiment,
   deleteExperiment,
   listExperiments,
+  listImages,
   type CreateExperimentRequest,
   type Experiment,
+  type ExperimentListResponse,
+  type ImageListResponse,
 } from "@/api/previews-client";
 import { useAuth } from "@/auth/use-auth";
 import { sessionAuthorizationScope } from "@/auth/session-scope";
@@ -33,7 +36,7 @@ const EXPERIMENTS_STALE_TIME = 30 * 1000;
 export function canManagePreviews(session: Session | null): boolean {
   if (!session?.experimentsEnabled) return false;
   return session.roles.some((role) =>
-    (PREVIEWS_MANAGE_ROLES as readonly string[]).includes(role),
+    (PREVIEWS_MANAGE_ROLES as readonly string[]).includes(role)
   );
 }
 
@@ -42,7 +45,7 @@ export function usePreviewsGate(): boolean {
   return canManagePreviews(session);
 }
 
-export function useExperiments(): UseQueryResult<Experiment[]> {
+export function useExperiments(): UseQueryResult<ExperimentListResponse> {
   const { session } = useAuth();
   const sessionScope = sessionAuthorizationScope(session);
   return useQuery({
@@ -50,6 +53,21 @@ export function useExperiments(): UseQueryResult<Experiment[]> {
     queryKey: ["previews", "experiments", sessionScope],
     queryFn: listExperiments,
     staleTime: EXPERIMENTS_STALE_TIME,
+    enabled: sessionScope != null,
+  });
+}
+
+/** The registry's tags barely move; a listing failure is not worth retrying. */
+const IMAGES_STALE_TIME = 5 * 60 * 1000;
+
+export function useImages(): UseQueryResult<ImageListResponse> {
+  const { session } = useAuth();
+  const sessionScope = sessionAuthorizationScope(session);
+  return useQuery({
+    queryKey: ["previews", "images", sessionScope],
+    queryFn: listImages,
+    staleTime: IMAGES_STALE_TIME,
+    retry: false,
     enabled: sessionScope != null,
   });
 }

--- a/src/frontend/src/screens/previews.test.tsx
+++ b/src/frontend/src/screens/previews.test.tsx
@@ -9,8 +9,14 @@ const hooks = vi.hoisted(() => ({
   experiments: {
     isPending: false,
     isError: false,
-    data: [] as Experiment[],
+    data: { experiments: [] as Experiment[], liveCount: 0, cap: 10 },
     refetch: vi.fn(),
+  },
+  images: {
+    isPending: false,
+    isError: false,
+    data: { configured: false, tags: [] as string[] } as
+      { configured: boolean; tags: string[] } | undefined,
   },
   create: {
     isPending: false,
@@ -29,6 +35,7 @@ const hooks = vi.hoisted(() => ({
 vi.mock("@/queries/previews", () => ({
   usePreviewsGate: () => gate.allowed,
   useExperiments: () => hooks.experiments,
+  useImages: () => hooks.images,
   useCreateExperiment: () => hooks.create,
   useDeleteExperiment: () => hooks.remove,
 }));
@@ -46,9 +53,11 @@ const EXPERIMENT: Experiment = {
 beforeEach(() => {
   vi.clearAllMocks();
   gate.allowed = true;
-  hooks.experiments.data = [];
+  hooks.experiments.data = { experiments: [], liveCount: 0, cap: 10 };
   hooks.experiments.isPending = false;
   hooks.experiments.isError = false;
+  hooks.images.data = { configured: false, tags: [] };
+  hooks.images.isError = false;
 });
 
 describe("PreviewsBody", () => {
@@ -58,37 +67,55 @@ describe("PreviewsBody", () => {
     render(<PreviewsBody />);
 
     expect(screen.getByRole("alert")).toHaveTextContent(
-      "Previews are not available",
+      "Previews are not available"
     );
     expect(
-      screen.queryByRole("form", { name: "Create a preview experiment" }),
+      screen.queryByRole("form", { name: "Create a preview experiment" })
     ).not.toBeInTheDocument();
   });
 
   it("renders the listing with an open link to the served URL", () => {
-    hooks.experiments.data = [EXPERIMENT];
+    hooks.experiments.data = {
+      experiments: [EXPERIMENT],
+      liveCount: 1,
+      cap: 10,
+    };
 
     render(<PreviewsBody />);
 
     expect(screen.getByText("my-experiment")).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Open experiment my-experiment" }),
+      screen.getByRole("link", { name: "Open experiment my-experiment" })
     ).toHaveAttribute("href", EXPERIMENT.url);
   });
 
+  it("shows the live count against the cap", () => {
+    hooks.experiments.data = {
+      experiments: [EXPERIMENT],
+      liveCount: 1,
+      cap: 5,
+    };
+
+    render(<PreviewsBody />);
+
+    expect(screen.getByText("1 of 5 experiments")).toBeInTheDocument();
+  });
+
   it("delete asks for confirmation before mutating", () => {
-    hooks.experiments.data = [EXPERIMENT];
+    hooks.experiments.data = {
+      experiments: [EXPERIMENT],
+      liveCount: 1,
+      cap: 10,
+    };
 
     render(<PreviewsBody />);
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
 
     expect(hooks.remove.mutate).not.toHaveBeenCalled();
-    fireEvent.click(
-      screen.getAllByRole("button", { name: "Delete" }).at(-1)!,
-    );
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete" }).at(-1)!);
     expect(hooks.remove.mutate).toHaveBeenCalledWith(
       "my-experiment",
-      expect.anything(),
+      expect.anything()
     );
   });
 
@@ -111,7 +138,56 @@ describe("PreviewsBody", () => {
     fireEvent.click(submit);
     expect(hooks.create.mutate).toHaveBeenCalledWith(
       { name: "my-experiment", tag: "preview-my-branch" },
-      expect.anything(),
+      expect.anything()
     );
+  });
+
+  it("a filled TTL rides the create request; empty means the server default", () => {
+    render(<PreviewsBody />);
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "my-experiment" },
+    });
+    fireEvent.change(screen.getByLabelText("Image tag"), {
+      target: { value: "preview-my-branch" },
+    });
+    fireEvent.change(screen.getByLabelText("TTL days"), {
+      target: { value: "3" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Create/ }));
+
+    expect(hooks.create.mutate).toHaveBeenCalledWith(
+      { name: "my-experiment", tag: "preview-my-branch", ttlDays: 3 },
+      expect.anything()
+    );
+  });
+
+  it("suggests registry tags only when the listing is configured and non-empty", () => {
+    hooks.images.data = {
+      configured: true,
+      tags: ["preview-alpha", "preview-beta"],
+    };
+
+    const { unmount } = render(<PreviewsBody />);
+    expect(screen.getByLabelText("Image tag")).toHaveAttribute(
+      "list",
+      "previews-tag-options"
+    );
+    unmount();
+
+    hooks.images.data = { configured: false, tags: [] };
+    render(<PreviewsBody />);
+    expect(screen.getByLabelText("Image tag")).not.toHaveAttribute("list");
+  });
+
+  it("keeps free-text tag entry when the tag listing errors", () => {
+    hooks.images.data = undefined;
+    hooks.images.isError = true;
+
+    render(<PreviewsBody />);
+
+    const tagInput = screen.getByLabelText("Image tag");
+    expect(tagInput).not.toHaveAttribute("list");
+    expect(tagInput).toBeEnabled();
   });
 });

--- a/src/frontend/src/screens/previews.tsx
+++ b/src/frontend/src/screens/previews.tsx
@@ -26,6 +26,7 @@ import {
   useCreateExperiment,
   useDeleteExperiment,
   useExperiments,
+  useImages,
   usePreviewsGate,
 } from "@/queries/previews";
 
@@ -51,8 +52,8 @@ export function PreviewsBody() {
         <div className="rounded-lg border p-6 text-center">
           <p className="text-sm font-semibold">Previews are not available</p>
           <p className="mt-2 text-sm text-muted-foreground">
-            Managing preview experiments needs the previews-admin or admin
-            role, on a stand with experiments enabled.
+            Managing preview experiments needs the previews-admin or admin role,
+            on a stand with experiments enabled.
           </p>
         </div>
       </div>
@@ -66,8 +67,8 @@ export function PreviewsBody() {
             Preview experiments
           </h2>
           <p className="text-sm text-muted-foreground">
-            Each experiment serves one frontend build under /exp/&lt;name&gt;
-            on the preview host, against this stand&apos;s data.
+            Each experiment serves one frontend build under /exp/&lt;name&gt; on
+            the preview host, against this stand&apos;s data.
           </p>
         </section>
         <CreateExperimentForm />
@@ -90,19 +91,32 @@ function errorMessage(error: unknown): string {
 function CreateExperimentForm() {
   const [name, setName] = useState("");
   const [tag, setTag] = useState("");
+  const [ttlDays, setTtlDays] = useState("");
   const create = useCreateExperiment();
+  const images = useImages();
+  // Free text stays available either way; the registry only adds suggestions.
+  const suggestedTags =
+    images.data?.configured && images.data.tags.length > 0
+      ? images.data.tags
+      : null;
 
   const submit = (event: React.FormEvent) => {
     event.preventDefault();
     if (!name.trim() || !tag.trim() || create.isPending) return;
+    const ttl = Number.parseInt(ttlDays, 10);
     create.mutate(
-      { name: name.trim(), tag: tag.trim() },
+      {
+        name: name.trim(),
+        tag: tag.trim(),
+        ...(Number.isFinite(ttl) && ttl > 0 ? { ttlDays: ttl } : {}),
+      },
       {
         onSuccess: () => {
           setName("");
           setTag("");
+          setTtlDays("");
         },
-      },
+      }
     );
   };
 
@@ -112,7 +126,7 @@ function CreateExperimentForm() {
       className="flex flex-col gap-3 rounded-lg border bg-card p-4"
       aria-label="Create a preview experiment"
     >
-      <div className="grid gap-3 sm:grid-cols-[1fr_1fr_auto] sm:items-end">
+      <div className="grid gap-3 sm:grid-cols-[1fr_1fr_auto_auto] sm:items-end">
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="previews-name">Name</Label>
           <Input
@@ -131,6 +145,27 @@ function CreateExperimentForm() {
             onChange={(event) => setTag(event.target.value)}
             placeholder="preview-my-branch"
             autoComplete="off"
+            list={suggestedTags ? "previews-tag-options" : undefined}
+          />
+          {suggestedTags ? (
+            <datalist id="previews-tag-options">
+              {suggestedTags.map((option) => (
+                <option key={option} value={option} />
+              ))}
+            </datalist>
+          ) : null}
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="previews-ttl">TTL days</Label>
+          <Input
+            id="previews-ttl"
+            type="number"
+            min={1}
+            className="w-24"
+            value={ttlDays}
+            onChange={(event) => setTtlDays(event.target.value)}
+            placeholder="default"
+            autoComplete="off"
           />
         </div>
         <Button
@@ -142,8 +177,12 @@ function CreateExperimentForm() {
         </Button>
       </div>
       <p className="text-xs text-muted-foreground">
-        The server validates both: the name is a DNS label (at most 55
-        characters), the tag a preview- or CI build tag.
+        The server validates everything: the name is a DNS label (at most 55
+        characters), the tag a preview- or CI build tag, the TTL within the
+        server&apos;s maximum.
+        {suggestedTags
+          ? " The tag field suggests the registry's preview- tags."
+          : null}
       </p>
       {create.isError ? (
         <Alert variant="destructive">
@@ -184,77 +223,90 @@ function ExperimentList() {
       </Alert>
     );
   }
-  if (experiments.data.length === 0) {
+  const { experiments: rows, liveCount, cap } = experiments.data;
+  const countLine = (
+    <p className="text-sm text-muted-foreground">
+      {liveCount} of {cap} experiments
+    </p>
+  );
+
+  if (rows.length === 0) {
     return (
-      <p className="rounded-lg border p-6 text-center text-sm text-muted-foreground">
-        No experiments are running.
-      </p>
+      <div className="flex flex-col gap-2">
+        {countLine}
+        <p className="rounded-lg border p-6 text-center text-sm text-muted-foreground">
+          No experiments are running.
+        </p>
+      </div>
     );
   }
 
   return (
-    <div className="overflow-x-auto rounded-lg border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Tag</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Expires</TableHead>
-            <TableHead className="text-right">Actions</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {experiments.data.map((experiment) => (
-            <TableRow key={experiment.name}>
-              <TableCell className="font-mono text-xs">
-                {experiment.name}
-              </TableCell>
-              <TableCell className="font-mono text-xs">
-                {experiment.tag}
-              </TableCell>
-              <TableCell className="text-muted-foreground">
-                {experiment.status}
-              </TableCell>
-              <TableCell className="text-muted-foreground">
-                {experiment.expiresAt
-                  ? new Date(experiment.expiresAt).toLocaleString()
-                  : "—"}
-              </TableCell>
-              <TableCell className="text-right">
-                <div className="flex justify-end gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    render={
-                      // Cross-origin (the preview host), so a plain anchor.
-                      <a
-                        href={experiment.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        aria-label={`Open experiment ${experiment.name}`}
-                      />
-                    }
-                  >
-                    <ExternalLink />
-                    Open
-                  </Button>
-                  <Button
-                    variant="destructive"
-                    size="sm"
-                    onClick={() => {
-                      remove.reset();
-                      setDeleting(experiment);
-                    }}
-                  >
-                    Delete
-                  </Button>
-                </div>
-              </TableCell>
+    <div className="flex flex-col gap-2">
+      {countLine}
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Tag</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Expires</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {rows.map((experiment) => (
+              <TableRow key={experiment.name}>
+                <TableCell className="font-mono text-xs">
+                  {experiment.name}
+                </TableCell>
+                <TableCell className="font-mono text-xs">
+                  {experiment.tag}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {experiment.status}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {experiment.expiresAt
+                    ? new Date(experiment.expiresAt).toLocaleString()
+                    : "—"}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      render={
+                        // Cross-origin (the preview host), so a plain anchor.
+                        <a
+                          href={experiment.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          aria-label={`Open experiment ${experiment.name}`}
+                        />
+                      }
+                    >
+                      <ExternalLink />
+                      Open
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => {
+                        remove.reset();
+                        setDeleting(experiment);
+                      }}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
       <ConfirmDialog
         open={deleting != null}
         onOpenChange={(open) => {

--- a/tests/stand/api/schemas/previews.py
+++ b/tests/stand/api/schemas/previews.py
@@ -47,8 +47,8 @@ class ImageListResponse(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    configured: bool = Field(..., description='False when the service holds no registry read credential; `tags` is\nthen empty and the create form keeps free-text entry.')
-    tags: list[str] = Field(..., description='The `preview-…` tags of the fixed FE image repository, deduped and\nsorted.')
+    configured: bool = Field(..., description='False when tag listing is disabled server-side; `tags` is then empty.')
+    tags: list[str] = Field(..., description="The repository's `preview-…` tags, deduped and sorted.")
 
 
 class Problem(BaseModel):
@@ -90,6 +90,6 @@ class ExperimentListResponse(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    cap: int = Field(..., description='The configured live-experiment cap; a create at the cap is refused.', ge=0)
+    cap: int = Field(..., ge=0)
     experiments: list[ExperimentResponse]
-    liveCount: int = Field(..., description='How many experiments count against the cap (expired ones do not).', ge=0)
+    liveCount: int = Field(..., description='Experiments counting against the cap; expired ones do not.', ge=0)

--- a/tests/stand/api/schemas/previews.py
+++ b/tests/stand/api/schemas/previews.py
@@ -40,6 +40,17 @@ class ExperimentStatus(StrEnum):
     expired = 'expired'
 
 
+class ImageListResponse(BaseModel):
+    """
+    Body of `GET /v1/images`.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    configured: bool = Field(..., description='False when the service holds no registry read credential; `tags` is\nthen empty and the create form keeps free-text entry.')
+    tags: list[str] = Field(..., description='The `preview-…` tags of the fixed FE image repository, deduped and\nsorted.')
+
+
 class Problem(BaseModel):
     """
     RFC 9457 problem+json. `context` varies by error category.
@@ -79,4 +90,6 @@ class ExperimentListResponse(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
+    cap: int = Field(..., description='The configured live-experiment cap; a create at the cap is refused.', ge=0)
     experiments: list[ExperimentResponse]
+    liveCount: int = Field(..., description='How many experiments count against the cap (expired ones do not).', ge=0)


### PR DESCRIPTION
**Why:** Phase 4 of #1981 (the first two Scope boxes of #2375) — the create form needed real tags to offer and the console gave no view of the cap or expiry.

**What changed:** New authenticated `GET /api/previews/v1/images` lists the repository's `preview-*` tags via the OCI tags-list API — anonymously by default (401 → challenge → anonymous pull token), with `registry_token` as a Secret-backed override for a private repository and `registry_url: ""` as the explicit off switch (`configured: false`); the experiment list now carries `liveCount`/`cap`; the FE shows "N of M experiments", suggests registry tags on the tag field (free text stays the fallback when listing is disabled or errors), and takes an optional TTL-days value.

**Verified:** cargo fmt/clippy/test for previews, the OpenAPI doc and generated stand schemas pass their check gates, helm contract tests pass, pnpm typecheck + lint + vitest green.