### PR TITLE
fix(frontend): stack metric card headers where a line cannot hold both

### DIFF
--- a/src/frontend/docs/testing/storybook-component-tests.md
+++ b/src/frontend/docs/testing/storybook-component-tests.md
@@ -50,7 +50,8 @@ cyber-insight-front/
 ├─ src/test/storybook/
 │   ├─ test-router.ts          # createTestingRouter() — memory-history TanStack Router
 │   ├─ with-providers.tsx      # QueryClient + router + theme + i18n decorator
-│   └─ theme-decorators.ts     # addon-themes adapted to light/dark
+│   ├─ theme-decorators.ts     # addon-themes adapted to light/dark
+│   └─ layout.ts               # geometry assertions + the card widths stories measure at
 ├─ vitest.config.ts            # test.projects = [unit (jsdom), storybook (browser)]
 ├─ public/mockServiceWorker.js # already present (msw workerDirectory: public)
 └─ src/components/widgets/dashboard/kpi-tile.stories.tsx  # PoC story + play tests

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.stories.tsx
@@ -1,0 +1,162 @@
+/**
+ * Browser component tests for the header of `<MetricActivity>` — the metric's
+ * name on one side, its total and the two comparisons on the other.
+ *
+ * The rest of the section (the event list, the day strip) is covered by the
+ * jsdom tests in `metric-activity.test.tsx`; what needs a real browser is the
+ * header's geometry, which no text query can see. The fixture declares no
+ * granularity on purpose: that leaves the detail query disabled, so the
+ * section renders its header and nothing that fetches.
+ *
+ * See docs/testing/storybook-component-tests.md.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import { MetricActivity } from "@/components/widgets/metric-views/metric-activity";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+import { CARD_PX_AT_390, CARD_PX_WIDE } from "@/test/storybook/layout";
+
+const ENTITY_ID = "019e27bc-dec0-7626-81a9-c5524662a6a9";
+const METRIC_KEY = "git.prs_merged";
+
+/**
+ * A long name against a long pair of comparisons — the shape that has no room
+ * for both on one line, and the only shape this test is about.
+ */
+function result(value: number, withPeer: boolean): MetricResult {
+  return {
+    metric_key: METRIC_KEY,
+    label: "Pull requests merged",
+    description: "Authored pull requests merged",
+    unit: "PRs",
+    format: "integer",
+    computation: "sum",
+    direction: "higher_is_better",
+    views: [
+      { view: "period", values: [{ entity_id: ENTITY_ID, value }] },
+      ...(withPeer
+        ? [
+            {
+              view: "peer",
+              values: [
+                {
+                  entity_id: ENTITY_ID,
+                  target_value: value,
+                  p25: 1,
+                  median: 3,
+                  p75: 7,
+                },
+              ],
+            },
+          ]
+        : []),
+    ],
+    selection: {
+      metric_key: METRIC_KEY,
+      entity: { type: "person", ids: [ENTITY_ID] },
+      period: { from: "2026-08-24", to: "2026-08-30" },
+      filters: [],
+    },
+  } as unknown as MetricResult;
+}
+
+function normalized(value: number, withPeer: boolean) {
+  return normalizeMetricResults([result(value, withPeer)]).get(METRIC_KEY)!;
+}
+
+const meta: Meta<typeof MetricActivity> = {
+  title: "Widgets/MetricViews/MetricActivity",
+  component: MetricActivity,
+  args: {
+    metric: normalized(11, true),
+    previous: normalized(14, false),
+    entityId: ENTITY_ID,
+    periodNoun: "week",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof MetricActivity>;
+
+/** Demo story for the Storybook UI (untagged — not a test). */
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
+ * Where a line fits both, the name and the figures share it.
+ *
+ * The narrow case below only proves something if the wide case is still one
+ * line — a header that always stacks would pass it and be a different bug.
+ */
+export const TestWideHeaderStaysOnOneLine: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const name = canvas.getByText("Pull requests merged");
+    const total = canvas.getByText("11 PRs");
+
+    // They share a line — asserted as overlapping vertical bands rather than
+    // equal tops, which an inline box and a block box never have.
+    const nameBox = name.getBoundingClientRect();
+    const totalBox = total.getBoundingClientRect();
+
+    await expect(totalBox.top).toBeLessThan(nameBox.bottom);
+    await expect(nameBox.top).toBeLessThan(totalBox.bottom);
+  },
+};
+
+/**
+ * Too narrow for both, the header stacks and the name keeps the whole line.
+ *
+ * Unfixed, the name column collapsed and the name wrapped into a stack of
+ * single words beside the figures — unreadable, while every `getByText` still
+ * passed. Only geometry can see it.
+ */
+export const TestNarrowHeaderStacksInsteadOfOverlapping: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    // The column, not the text in it: the name renders as an inline span, which
+    // keeps its own width by overflowing a column collapsed to nothing.
+    const name = canvas.getByText("Pull requests merged");
+    const column = name.closest("div")!;
+    const columnBox = column.getBoundingClientRect();
+    const rowBox = column.parentElement!.getBoundingClientRect();
+    const totalBox = canvas.getByText("11 PRs").getBoundingClientRect();
+
+    await expect(
+      totalBox.top,
+      `the figures share the name's line (name ends ${columnBox.bottom}, figures start ${totalBox.top})`
+    ).toBeGreaterThanOrEqual(columnBox.bottom);
+
+    // Stacking is only worth the line it costs if the name got that line: a
+    // column narrow enough to break the name into single words satisfies the
+    // assertion above just as well.
+    await expect(
+      columnBox.width,
+      `the name column is ${columnBox.width}px of a ${rowBox.width}px row`
+    ).toBeGreaterThan(rowBox.width / 2);
+  },
+};

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -91,8 +91,11 @@ export function MetricActivity({
 
   return (
     <section className="flex flex-col gap-2 border-t py-4 first:border-t-0">
-      <header className="flex items-baseline justify-between gap-4">
-        <div className="min-w-0">
+      <header className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+        {/* INVARIANT: a fixed basis, because a flex line breaks on content
+            size — with none, the untruncated description decides the width at
+            which the figures drop to their own line. */}
+        <div className="min-w-0 flex-[1_1_16rem]">
           <MetricName metric={metric} className="text-sm font-medium" />
           {help?.description ? (
             <p className="truncate text-xs text-muted-foreground">
@@ -100,7 +103,7 @@ export function MetricActivity({
             </p>
           ) : null}
         </div>
-        <div className="shrink-0 text-right">
+        <div className="ms-auto shrink-0 text-right">
           <div className="text-sm tabular-nums">{total}</div>
           {/* Both readings, stated and neither judged. The reader's own last
               period comes first because it is the one they can act on; the

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
@@ -34,6 +34,10 @@ import {
   metricResultsHandler,
   RANGE,
 } from "@/components/widgets/metric-views/metric-timeseries.story-fixtures";
+import {
+  CARD_PX_AT_390,
+  expectNothingOverlaps,
+} from "@/test/storybook/layout";
 
 const TOP_REPOSITORIES = {
   default: "repository",
@@ -609,5 +613,49 @@ export const TestXlsxExport: Story = {
       "Commits: 10 · Lines added: 98"
     );
     await expect(sheet?.views[0]).toMatchObject({ xSplit: 1, ySplit: 2 });
+  },
+};
+
+/**
+ * On a card too narrow for both, the header stacks instead of overlapping.
+ *
+ * The failure this pins is invisible to a text query: with the toolbar holding
+ * its width and the title column free to collapse, the title was laid out
+ * under the buttons — every `getByText` still passed while the card could not
+ * be identified on screen. So this reads the boxes the browser produced.
+ */
+export const TestNarrowHeaderStacksInsteadOfOverlapping: Story = {
+  tags: ["test"],
+  args: { groupBy: TOP_REPOSITORIES, defaultPresentation: "table" },
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const title = await canvas.findByRole("heading", {
+      name: /By repository/,
+    });
+    // The header row only — the table below it scrolls sideways by design, and
+    // its cells are buttons that leave the card's box on purpose.
+    const header = title.closest('[data-slot="card"] > *');
+    await expect(header, "the card renders a header row").not.toBeNull();
+    const controls = Array.from(header!.querySelectorAll("button"));
+
+    await expect(controls.length, "the header has controls to clear").toBeGreaterThan(0);
+    expectNothingOverlaps(title, controls, (element) =>
+      element.getAttribute("aria-label") ?? element.textContent ?? "a control"
+    );
+
+    // Clearing the controls by shrinking the title to nothing would satisfy
+    // the check above; the title has to still be readable.
+    const label = title.querySelector("span");
+    await expect(label, "the title renders its truncating span").not.toBeNull();
+    await expect(
+      label!.scrollWidth,
+      `the title is clipped (${label!.scrollWidth}px of text in ${label!.clientWidth}px)`
+    ).toBeLessThanOrEqual(label!.clientWidth);
   },
 };

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.tsx
@@ -503,11 +503,14 @@ export function MetricTimeseriesView({
         data.isFetching && "opacity-60"
       )}
     >
-      <div className="flex items-center justify-between gap-2 border-b p-2">
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2 border-b p-2">
+        {/* INVARIANT: a fixed basis, because a flex line breaks on content
+            size — with none, the untruncated title decides the width at which
+            the controls drop to their own line. */}
+        <div className="flex min-w-0 flex-[1_1_8rem] flex-wrap items-center gap-2">
           {selectedMetric ? (
             shouldCombineMetrics ? (
-              <h3 className="px-2 text-sm font-semibold">
+              <h3 className="min-w-0 truncate px-2 text-sm font-semibold">
                 {model.metrics.map((metric) => metric.label).join(" & ")}
               </h3>
             ) : model.metrics.length > 1 && presentation === "chart" ? (
@@ -520,7 +523,7 @@ export function MetricTimeseriesView({
                 <SelectTrigger
                   size="sm"
                   aria-label="Metric"
-                  className="border-transparent bg-transparent ps-2 pe-2 font-semibold shadow-none hover:bg-muted/50 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/40 data-popup-open:bg-muted/50 dark:bg-transparent dark:hover:bg-muted/50"
+                  className="min-w-0 max-w-full border-transparent bg-transparent ps-2 pe-2 font-semibold shadow-none hover:bg-muted/50 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/40 data-popup-open:bg-muted/50 dark:bg-transparent dark:hover:bg-muted/50 [&>span]:truncate"
                 >
                   <SelectValue>{selectedMetric.label}</SelectValue>
                 </SelectTrigger>
@@ -540,20 +543,22 @@ export function MetricTimeseriesView({
               // columns. The count is load-bearing: such a table is usually
               // wider than the screen, and the grand total below covers groups
               // the reader cannot see.
-              <h3 className="px-2 text-sm font-semibold">
-                {breakdownHeading([selectedGroupBy])}
-                <span className="ps-1.5 font-normal text-muted-foreground">
+              <h3 className="flex min-w-0 items-baseline px-2 text-sm font-semibold">
+                <span className="truncate">
+                  {breakdownHeading([selectedGroupBy])}
+                </span>
+                <span className="shrink-0 ps-1.5 font-normal text-muted-foreground">
                   · {model.columns.length}
                 </span>
               </h3>
             ) : model.metrics.length === 1 ? (
-              <h3 className="px-2 text-sm font-semibold">
+              <h3 className="min-w-0 truncate px-2 text-sm font-semibold">
                 {selectedMetric.label}
               </h3>
             ) : null
           ) : null}
         </div>
-        <div className="flex shrink-0 items-center justify-end gap-2">
+        <div className="ms-auto flex min-w-0 flex-wrap items-center justify-end gap-2">
           {dimensionOptions.length > 1 || filterModels.length > 0 ? (
             <DimensionControls
               dimensions={dimensionOptions}

--- a/src/frontend/src/components/widgets/metric-views/section-metric-index.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/section-metric-index.stories.tsx
@@ -1,0 +1,179 @@
+/**
+ * Browser component tests for the geometry of `<SectionMetricIndex>` — the
+ * "Also measured here" list, one metric per row: name, value, the pool's
+ * middle, and the mark on the shared axis.
+ *
+ * What order the rows come in and which of them are dropped is covered by the
+ * jsdom tests in `section-metric-index.test.tsx`. What needs a real browser is
+ * the row: the readings hold a fixed width, so a name sharing their line has
+ * whatever is left — which on a phone is nothing, and a name truncated to
+ * nothing leaves a column of numbers belonging to no metric.
+ *
+ * See docs/testing/storybook-component-tests.md.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import { SectionMetricIndex } from "@/components/widgets/metric-views/section-metric-index";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+import {
+  CARD_PX_AT_390,
+  CARD_PX_WIDE,
+  expectHorizontallyContained,
+} from "@/test/storybook/layout";
+
+const ENTITY_ID = "019e27bc-dec0-7626-81a9-c5524662a6a9";
+
+/** The row's name, long enough that a collapsed column is unmistakable. */
+const LONG_NAME = "Merges without approval rate";
+
+function metric(
+  key: string,
+  label: string,
+  value: number,
+  unit: string | null,
+  median: number
+): MetricResult {
+  return {
+    metric_key: key,
+    label,
+    unit,
+    format: "integer",
+    computation: "sum",
+    direction: "higher_is_better",
+    views: [
+      { view: "period", values: [{ entity_id: ENTITY_ID, value }] },
+      {
+        view: "peer",
+        values: [
+          {
+            entity_id: ENTITY_ID,
+            target_value: value,
+            p25: 1,
+            median,
+            p75: 100000,
+          },
+        ],
+      },
+    ],
+  } as unknown as MetricResult;
+}
+
+const RESULTS = [
+  metric("git.long", LONG_NAME, 325, null, 731),
+  metric("git.short", "Merge rate", 12408, "lines", 9),
+];
+
+const meta: Meta<typeof SectionMetricIndex> = {
+  title: "Widgets/MetricViews/SectionMetricIndex",
+  component: SectionMetricIndex,
+  args: {
+    collection: { metrics: RESULTS.map((r) => ({ key: r.metric_key, views: [] })) },
+    byKey: normalizeMetricResults(RESULTS),
+    entityId: ENTITY_ID,
+    shown: new Set<string>(),
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SectionMetricIndex>;
+
+/** Demo story for the Storybook UI (untagged — not a test). */
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** Where a line fits both, the name and its readings share it. */
+export const TestWideRowStaysOnOneLine: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas, canvasElement }) => {
+    const name = canvas.getByText(LONG_NAME).getBoundingClientRect();
+    const value = canvas.getByText("325").getBoundingClientRect();
+
+    await expect(value.top, "the readings dropped to their own line").toBeLessThan(
+      name.bottom
+    );
+    await expect(name.top).toBeLessThan(value.bottom);
+
+    // The container query is what puts the readings back into fixed columns;
+    // without it the rows still render, just unaligned, so nothing else here
+    // would notice it failing to compile.
+    const readings = canvasElement.querySelectorAll("dd");
+    // The value and the median; the third child is the peer mark's own fixed
+    // 112px svg, which no breakpoint touches.
+    const columns = Array.from(readings).map((dd) =>
+      Array.from(dd.children)
+        .slice(0, 2)
+        .map((span) => Math.round(span.getBoundingClientRect().width))
+    );
+    await expect(
+      columns,
+      `the value and median columns are not the fixed 128/112 (${JSON.stringify(columns)})`
+    ).toEqual([
+      [128, 112],
+      [128, 112],
+    ]);
+  },
+};
+
+/**
+ * Too narrow for both, the row stacks and the name keeps its whole width.
+ *
+ * The failure this pins reads as data with no labels: the readings held their
+ * fixed columns, the name column collapsed to zero, and `truncate` cut the
+ * name away entirely — leaving numbers belonging to no metric.
+ */
+export const TestNarrowRowKeepsTheMetricName: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas, canvasElement }) => {
+    // The column, not the text inside it: the name renders as an inline span,
+    // which keeps its full width by overflowing a column collapsed to zero.
+    const column = canvas.getByText(LONG_NAME).closest("dt")!;
+    const value = canvas.getByText("325");
+    const columnBox = column.getBoundingClientRect();
+
+    const list = canvasElement.querySelector("dl");
+    await expect(list, "the index renders its list").not.toBeNull();
+    const row = column.parentElement!.getBoundingClientRect();
+
+    // The readings having wrapped away, the name owns the row's whole width.
+    await expect(
+      columnBox.width,
+      `the name column is ${columnBox.width}px of a ${row.width}px row`
+    ).toBeGreaterThan(row.width / 2);
+    await expect(
+      value.getBoundingClientRect().top,
+      "the readings share the name's line"
+    ).toBeGreaterThanOrEqual(columnBox.bottom);
+
+    // The readings are 368px of fixed columns at full width; hanging outside
+    // the list drops the peer marks off the card.
+    expectHorizontallyContained(
+      list!,
+      Array.from(list!.querySelectorAll("dd")),
+      () => "a row's readings"
+    );
+  },
+};

--- a/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
+++ b/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
@@ -81,7 +81,10 @@ export function SectionMetricIndex({
           break at each row's padding and read as a dotted column; the whole
           point is an unbroken line for the ordinary readings to disappear
           into. */}
-      <dl className="relative pt-2">
+      {/* A container query, not a viewport one: this list is as narrow as
+          whatever holds it, which on a wide screen can still be a drilldown
+          pane. */}
+      <dl className="@container relative pt-2">
         <span
           aria-hidden
           className="pointer-events-none absolute inset-y-2 w-px bg-foreground/20"
@@ -90,17 +93,20 @@ export function SectionMetricIndex({
         {rest.map((metric) => (
           <div
             key={metric.metric_key}
-            className="flex items-center justify-between gap-4 border-b border-dashed py-1 last:border-b-0"
+            className="flex flex-wrap items-center gap-x-4 gap-y-0.5 border-b border-dashed py-1 last:border-b-0"
           >
-            <dt className={cn("min-w-0 flex-1 truncate", TEXT_NAME)}>
+            <dt className={cn("min-w-0 truncate", TEXT_NAME)}>
               <MetricName metric={metric} />
             </dt>
             {/* Layout only. Putting the label role on the container greyed
                 the person's own value along with its median, so the subject of
                 the row and the context around it read the same — which is the
                 distinction this scale exists to make. */}
-            <dd className="flex shrink-0 items-baseline gap-2 tabular-nums">
-              <span className={cn("w-32 text-right", TEXT_BODY)}>
+            {/* INVARIANT: 26rem is the readings' own 368px (128 + 112 + the
+                mark's 112, plus two gaps) with a name floor on top — the fixed
+                columns come back only where they fit. */}
+            <dd className="ms-auto flex min-w-0 flex-wrap items-baseline justify-end gap-2 tabular-nums">
+              <span className={cn("w-auto text-right @min-[26rem]:w-32", TEXT_BODY)}>
                 {formatMetricValue(
                   forEntity(metric, entityId).value,
                   metric.format,
@@ -111,7 +117,7 @@ export function SectionMetricIndex({
                   anything. Uncoloured: a list of thirty numbers lit up by
                   quartile is a scoreboard, and the reader did not ask to be
                   scored on every one of them. */}
-              <span className={cn("w-28 text-right", TEXT_LABEL)}>
+              <span className={cn("w-auto text-right @min-[26rem]:w-28", TEXT_LABEL)}>
                 {metricComparisons(metric, null, entityId).median ?? ""}
               </span>
               {/* And how far off that middle, on the axis every row shares.

--- a/src/frontend/src/test/storybook/layout.ts
+++ b/src/frontend/src/test/storybook/layout.ts
@@ -1,0 +1,78 @@
+/**
+ * Geometry assertions for stories that run in a real browser.
+ *
+ * A header whose title is painted under its own buttons still passes every
+ * query-by-text assertion — the text is in the DOM, it is just unreadable. So
+ * these read the boxes the browser actually laid out. They are meaningless in
+ * jsdom, which gives every element a zero rect.
+ */
+
+/** Two boxes share at least one pixel. Touching edges do not count. */
+function boxesOverlap(a: DOMRect, b: DOMRect): boolean {
+  return (
+    a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom
+  );
+}
+
+/**
+ * Nothing in `elements` is drawn over `subject`.
+ *
+ * The message names the offender and both boxes, because a bare "expected
+ * false" says nothing about which control landed on the title.
+ */
+export function expectNothingOverlaps(
+  subject: Element,
+  elements: readonly Element[],
+  describe: (element: Element) => string
+): void {
+  const box = subject.getBoundingClientRect();
+  for (const element of elements) {
+    const other = element.getBoundingClientRect();
+    if (!boxesOverlap(box, other)) continue;
+    throw new Error(
+      `${describe(element)} is drawn over the subject: ` +
+        `subject x ${box.left}–${box.right} y ${box.top}–${box.bottom}, ` +
+        `other x ${other.left}–${other.right} y ${other.top}–${other.bottom}`
+    );
+  }
+}
+
+/**
+ * Every element is laid out within `container`'s left and right edges.
+ *
+ * The inline axis only: a card clips what runs past its side, and a list that
+ * scrolls sideways is meant to exceed its box downward.
+ */
+export function expectHorizontallyContained(
+  container: Element,
+  elements: readonly Element[],
+  describe: (element: Element) => string
+): void {
+  const SLACK_PX = 1;
+  const box = container.getBoundingClientRect();
+  for (const element of elements) {
+    const other = element.getBoundingClientRect();
+    if (
+      other.left >= box.left - SLACK_PX &&
+      other.right <= box.right + SLACK_PX
+    ) {
+      continue;
+    }
+    throw new Error(
+      `${describe(element)} spills outside its container: ` +
+        `container x ${box.left}–${box.right}, ` +
+        `other x ${other.left}–${other.right}`
+    );
+  }
+}
+
+/**
+ * Card widths the narrow/wide stories measure at.
+ *
+ * A phone is 390px of viewport; a card in the single-column stack loses the
+ * page's own padding, which is what a component actually gets.
+ */
+export const CARD_PX_AT_390 = 296;
+
+/** A card in a full-width section on a desktop viewport. */
+export const CARD_PX_WIDE = 900;


### PR DESCRIPTION
On a narrow screen a metric card's title was laid out under its own toolbar buttons: the controls held their width, the title column collapsed, and the two claimed the same pixels. Three headers in the person section carried the same shape and are fixed the same way — the row wraps, so the fixed side drops to its own line. Closes #2782.

Two changes go slightly beyond the issue text, which only describes card titles: the same collapse truncated the metric name to zero width in "Also measured here", and `MetricActivity` now lets a long name wrap instead of truncating — `MetricName` puts only the description in `sr-only`, so a clipped name was unrecoverable.

**Where:** `src/frontend/src/components/widgets/metric-views/` — `metric-timeseries-view`, `metric-activity`, `section-metric-index`.

**Verify:** the geometry is asserted in a real browser; each new story was checked against the unfixed components first.

```
cd src/frontend && pnpm install --frozen-lockfile
pnpm test && pnpm test:storybook:ci
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metric activity and timeseries headers so content wraps cleanly on narrow cards without overlapping.
  * Updated metric index rows to adapt responsively, preserving metric names and keeping readings contained.

* **Tests**
  * Added Storybook browser tests covering wide and narrow layouts, wrapping behavior, truncation, spacing, and content containment.
  * Added documentation for responsive layout test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->