### PR TITLE
fix(jira-enrich): size the last_state prefetch by backlog, not by history

### DIFF
--- a/charts/insight/templates/ingestion/tt-enrich-jira-run.yaml
+++ b/charts/insight/templates/ingestion/tt-enrich-jira-run.yaml
@@ -52,10 +52,5 @@ spec:
           - {{ `"--clickhouse-user={{inputs.parameters.clickhouse_user}}"` }}
           - {{ `"--batch-size={{inputs.parameters.batch_size}}"` }}
         resources:
-          requests:
-            cpu: "500m"
-            memory: "1Gi"
-          limits:
-            cpu: "2"
-            memory: "2Gi"
+          {{- toYaml (required "ingestion.jiraEnrich.resources is required" .Values.ingestion.jiraEnrich.resources) | nindent 10 }}
 {{- end }}

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -212,6 +212,21 @@ ingestion:
   airbyteSync:
     pollIntervalSeconds: 30
     idleThresholdSeconds: 1800 # 30 min without any byte/record/state movement → fail
+  # jira-enrich (templates/ingestion/tt-enrich-jira-run.yaml). Phase 1 of the
+  # binary holds the whole reference set in memory — field metadata, every
+  # issue snapshot, and the last known value of each field it must diff
+  # against — before the first row is written, so its peak scales with the
+  # size of the Jira corpus rather than with the run's backlog. An instance
+  # whose journal has outgrown the default OOM-kills in that phase, having
+  # written nothing; raise the limit here rather than editing the template.
+  jiraEnrich:
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "2Gi"
+      limits:
+        cpu: "2"
+        memory: "8Gi"
   # Data-quality checks: a CronWorkflow runs the dbt check catalog (the
   # `data_quality` selector — tests tagged data_quality, not every dbt test) on
   # a schedule, independent of the per-connector pipeline. See

--- a/src/ingestion/connectors/task-tracking/jira/enrich/src/io/reader.rs
+++ b/src/ingestion/connectors/task-tracking/jira/enrich/src/io/reader.rs
@@ -292,6 +292,43 @@ pub struct ChangelogRow {
     pub value_to_string: Option<String>,
 }
 
+#[derive(Row, Deserialize, Debug)]
+struct IssueKeyRow {
+    id_readable: String,
+}
+
+/// Issues the cursor below will actually stream — i.e. those carrying at least one event
+/// past their high-water mark.
+///
+/// INVARIANT: the predicate here must stay identical to `open_events_cursor`'s. It scopes
+/// `fetch_last_state_for`, and an issue the cursor streams but this misses would be diffed
+/// against an absent last state and re-emit values it already has.
+pub async fn issues_with_new_events(
+    cfg: &ChConfig,
+    insight_source_id: &str,
+) -> Result<Vec<String>, IoError> {
+    let client = cfg.client();
+    let rows: Vec<IssueKeyRow> = client
+        .query(
+            "SELECT DISTINCT e.id_readable AS id_readable \
+             FROM staging.jira_changelog_items e \
+             LEFT JOIN ( \
+                 SELECT id_readable, max(event_at) AS hwm \
+                 FROM staging.jira__task_field_history \
+                 WHERE data_source = 'jira' AND insight_source_id = ? \
+                 GROUP BY id_readable \
+             ) c ON e.id_readable = c.id_readable \
+             WHERE e.insight_source_id = ? \
+               AND (c.hwm IS NULL OR e.created_at > c.hwm)",
+        )
+        .bind(insight_source_id)
+        .bind(insight_source_id)
+        .fetch_all()
+        .await?;
+
+    Ok(rows.into_iter().map(|r| r.id_readable).collect())
+}
+
 /// Open a streaming cursor over new events — ordered by `(id_readable, event_at)` so callers
 /// can group into per-issue chunks without buffering everything in memory.
 pub fn open_events_cursor(

--- a/src/ingestion/connectors/task-tracking/jira/enrich/src/main.rs
+++ b/src/ingestion/connectors/task-tracking/jira/enrich/src/main.rs
@@ -137,13 +137,20 @@ async fn run(args: Args) -> Result<()> {
     let snapshots = reader::fetch_all_snapshots(&cfg, &args.insight_source_id).await?;
     tracing::info!(snapshots = snapshots.len(), "loaded all issue snapshots");
 
-    let known_issues: Vec<String> = hwms.keys().cloned().collect();
-    let last_state = if known_issues.is_empty() {
+    // Scoped to the issues the cursor will stream, not every issue in the journal: this map
+    // holds one entry per (issue, field) and is the largest thing phase 1 builds, so keying it
+    // off the whole corpus makes a run's memory grow with history rather than with its backlog.
+    let pending_issues = reader::issues_with_new_events(&cfg, &args.insight_source_id).await?;
+    let last_state = if pending_issues.is_empty() {
         HashMap::new()
     } else {
-        reader::fetch_last_state_for(&cfg, &args.insight_source_id, &known_issues).await?
+        reader::fetch_last_state_for(&cfg, &args.insight_source_id, &pending_issues).await?
     };
-    tracing::info!(last_state_issues = last_state.len(), "loaded last state");
+    tracing::info!(
+        pending_issues = pending_issues.len(),
+        last_state_issues = last_state.len(),
+        "loaded last state"
+    );
 
     let meta: Arc<HashMap<String, FieldMeta>> = Arc::new(meta);
     let snapshots: Arc<HashMap<String, IssueSnapshot>> = Arc::new(snapshots);
@@ -318,7 +325,11 @@ async fn run(args: Args) -> Result<()> {
             if touched_issues.contains(issue_key) {
                 continue;
             }
-            if last_state.contains_key(issue_key) {
+            // `hwms`, not `last_state`: the latter now covers only issues with new events,
+            // while this needs every issue already in the journal. The synthetic event id is
+            // deterministic, so a miss here re-emits rows the RMT collapses rather than
+            // corrupting anything — but it re-derives every untouched issue on every run.
+            if hwms.contains_key(issue_key) {
                 continue;
             }
             let rows = crate::core::process_issue(&meta, snapshot, &[], None);


### PR DESCRIPTION
**Why.** `jira-enrich` can be OOM-killed in its phase-1 prefetch — before it writes a single row — on an installation whose field-history journal has grown large. A restart repeats the same work and dies at the same point, so the journal stops advancing and no amount of re-running moves it.

**What changed.** `last_state` was built from `hwms.keys()` — every issue the journal has ever recorded — although it is only ever read for issues the cursor streams. It holds one entry per (issue, field), so its cost tracked total history rather than the run's backlog. `issues_with_new_events` reuses the cursor's own predicate to name exactly the streamed set, and the prefetch is keyed off that.

**Category C's known-issue test moves from `last_state` to `hwms`.** It meant "already in the journal", which `last_state` is no longer. Both sets come from one `GROUP BY id_readable` over the same table, so the tested set is unchanged.

**Enrich resources become `ingestion.jiraEnrich.resources`, with a raised default limit.** They were literals in the template, so an installation that outgrew them had no supported lever — only editing the rendered WorkflowTemplate, which the next `helm upgrade` reverts. `required` keeps the block from being dropped silently.

**Out of scope.** A changelog item whose field the binary does not map is never written, so its issue's high-water mark never advances and the issue re-enters the streamed set on every run. Pre-existing, and the new query mirrors the cursor deliberately — an issue it missed would be diffed against an absent last state.

**Verified.** `cargo check --features io --all-targets`, `cargo test --features io` (52 pass), `cargo fmt --check`. `helm template` renders the resources block and fails with `ingestion.jiraEnrich.resources is required` once it is removed. Not run: the binary end-to-end against a populated journal — that needs a full pipeline, so it is left to CI and the stand.
