### PR TITLE
fix(test-stand): grant ci-deployer RBAC in insight-previews, redeploy previews

### DIFF
--- a/.github/workflows/deploy-test-stand.yml
+++ b/.github/workflows/deploy-test-stand.yml
@@ -487,6 +487,19 @@ jobs:
           echo "lines above."
           exit 1
 
+      # Chromium and its system libraries, resolved by the locked test
+      # environment so every runner drives the same build. Its own step: a
+      # failed install is an infrastructure problem, not a red suite.
+      #
+      # INVARIANT: this runs BEFORE the smoke gate. `stand_smoke` selects
+      # browser journeys as well as API cases, so a smoke-only run needs the
+      # browser too — move this below the gate and a `deploy+seed+smoke` run
+      # can never pass.
+      - name: 'Install the browser the journeys drive'
+        if: steps.stages.outputs.run_smoke == 'true' || steps.stages.outputs.run_suite == 'true'
+        timeout-minutes: 10
+        run: uv run --project tests --frozen playwright install --with-deps chromium
+
       - name: 'Stage 4/5 — smoke the stand through its public URL'
         id: smoke
         if: steps.stages.outputs.run_smoke == 'true'
@@ -506,14 +519,6 @@ jobs:
           uv run --project tests --frozen \
             pytest tests/stand -m stand_smoke --stand-manifest "$INSIGHT_STAND_MANIFEST" \
             2>&1 | python3 "$REDACT"
-
-      # Chromium and its system libraries, resolved by the locked test
-      # environment so every runner drives the same build. Its own step: a
-      # failed install is an infrastructure problem, not a red suite.
-      - name: 'Stage 5/5 — install the browser the journeys drive'
-        if: steps.stages.outputs.run_suite == 'true'
-        timeout-minutes: 10
-        run: uv run --project tests --frozen playwright install --with-deps chromium
 
       # Every API contract and every browser journey, against the stand this run
       # just deployed and seeded — the smoke gate above says a persona can sign

--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -985,6 +985,8 @@ verify-ci-credential: vpn-up kube-ctx
 		|| { echo "$(C_RED)ERROR$(C_RST): no kubeconfig at $(CI_DEPLOYER_OUT) — run 'make provision-ci ENV=$(ENV)' first"; exit 1; }
 	@test -n "$(AIRBYTE_NAMESPACE)" \
 		|| { echo "$(C_RED)ERROR$(C_RST): airbyte.namespace is empty in $(VALUES) — nothing to verify the airbyte supplement against"; exit 1; }
+	@test -n "$(NS_PREVIEWS)" \
+		|| { echo "$(C_RED)ERROR$(C_RST): namespaces.previews is empty in $(INVENTORY) — nothing to verify the previews supplement against"; exit 1; }
 	@FAILURES=0; \
 	check() { \
 		WANT=$$1; DESC=$$2; shift 2; \
@@ -1009,6 +1011,11 @@ verify-ci-credential: vpn-up kube-ctx
 	check yes "create Roles in $(AIRBYTE_NAMESPACE)"                         create roles.rbac.authorization.k8s.io -n $(AIRBYTE_NAMESPACE); \
 	check yes "create RoleBindings in $(AIRBYTE_NAMESPACE) (the chart's airbyte-auth-reader)" create rolebindings.rbac.authorization.k8s.io -n $(AIRBYTE_NAMESPACE); \
 	check no  "read pods in $(AIRBYTE_NAMESPACE) (the exception is RBAC-only)" get pods -n $(AIRBYTE_NAMESPACE); \
+	check yes "create Roles in $(NS_PREVIEWS) (the chart's experiments RBAC lands there)" create roles.rbac.authorization.k8s.io -n $(NS_PREVIEWS); \
+	check yes "create RoleBindings in $(NS_PREVIEWS) (same object, the binding half)" create rolebindings.rbac.authorization.k8s.io -n $(NS_PREVIEWS); \
+	check yes "create Deployments in $(NS_PREVIEWS) (escalation prevention: the chart's Role grants it)" create deployments.apps -n $(NS_PREVIEWS); \
+	check yes "create HTTPRoutes in $(NS_PREVIEWS) (escalation prevention: the chart's Role grants it)" create httproutes.gateway.networking.k8s.io -n $(NS_PREVIEWS); \
+	check no  "read pods in $(NS_PREVIEWS) (the exception is RBAC-only)"     get pods -n $(NS_PREVIEWS); \
 	check no  "anything, anywhere (the blanket check)"                       '*' '*' --all-namespaces; \
 	check no  "list namespaces at cluster scope"                            list namespaces --all-namespaces; \
 	check no  "create namespaces (hence the --create-namespace limitation)" create namespaces --all-namespaces; \

--- a/deploy/gitops/environments/test-stand/INFRA.md
+++ b/deploy/gitops/environments/test-stand/INFRA.md
@@ -37,6 +37,7 @@ by hand rather than generated.
 |---|---|---|---|
 | **L-1** | Cluster: nodes, CNI, OpenStack Cinder CSI driver, public DNS record | the cloud platform | assumed; deploy scripts hard-fail without the CSI driver, Insight is gated on DNS |
 | **L0** | Edge + PKI: Envoy Gateway (`GatewayClass`/`Gateway`/`EnvoyProxy`), cert-manager + the two-step `ClusterIssuer` chain, the `cinder` StorageClass | the deployment repository | named in `values.yaml`; never created here |
+| **L0** | The `insight-previews` namespace — where the release binds its experiments RBAC | the deployment repository | named in `inventory.yaml` (`namespaces.previews`); granted over by `ci-deployer-rbac.yaml`, never created here |
 | **L2** | Datastores under their operators (ClickHouse, MariaDB, Redis, Redpanda), plus Airbyte and Argo — each in its own namespace | the deployment repository | addressed by in-cluster Service DNS; never created here |
 | **L2** | Generate-once Secrets + the realm ConfigMap the release consumes by name | the deployment repository | referenced by name; `enabled: false` in `inventory.yaml` |
 | **L3** | **The umbrella release `insight` — every value in `values.yaml`** | **this directory** | **owned; changed by CI on every merge to `main`** |

--- a/deploy/gitops/environments/test-stand/ci-deployer-rbac.yaml
+++ b/deploy/gitops/environments/test-stand/ci-deployer-rbac.yaml
@@ -126,6 +126,51 @@ subjects:
     name: ci-deployer
     namespace: insight
 ---
+# The chart's experiments RBAC lands in `previews.experiments.namespace`, not in
+# `insight`. The namespace is L0: `provision-ci` fails if it does not exist yet.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ci-deployer-previews-rbac
+  namespace: insight-previews
+  labels:
+    app.kubernetes.io/name: ci-deployer
+    app.kubernetes.io/component: ci-credential
+    app.kubernetes.io/managed-by: gitops
+rules:
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: [roles, rolebindings]
+    verbs: [get, list, watch, create, update, patch, delete]
+  # INVARIANT: a rule-for-rule mirror of the chart's `insight-previews-experiments`
+  # Role. Nothing here applies them; escalation prevention needs them to exist.
+  - apiGroups: ["apps"]
+    resources: [deployments]
+    verbs: [create, list, delete]
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [create, list, delete]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: [httproutes]
+    verbs: [create, list, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ci-deployer-previews-rbac
+  namespace: insight-previews
+  labels:
+    app.kubernetes.io/name: ci-deployer
+    app.kubernetes.io/component: ci-credential
+    app.kubernetes.io/managed-by: gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ci-deployer-previews-rbac
+subjects:
+  - kind: ServiceAccount
+    name: ci-deployer
+    namespace: insight
+---
 # Legacy (non-expiring) SA token: a GitHub environment secret is a static string
 # with no refresh path. The token controller fills .data.token after apply.
 apiVersion: v1

--- a/deploy/gitops/environments/test-stand/credentials-runbook.md
+++ b/deploy/gitops/environments/test-stand/credentials-runbook.md
@@ -54,8 +54,11 @@ CA, which invalidates every other certificate on the cluster at once.
    kubectl config current-context
    yq -r '.kubeContext' deploy/gitops/environments/test-stand/inventory.yaml
    ```
-3. The application namespace already exists (`insight` by default). See
-   §7 "First install into an empty namespace" if it does not.
+3. The application namespace already exists (`insight` by default), and so
+   does the experiments namespace (`insight-previews` — `namespaces.previews`
+   in `inventory.yaml`). The manifest grants over the second but never creates
+   it, so `provision-ci` fails on a cluster that lacks it. See §7 "First
+   install into an empty namespace".
 4. `gh` authenticated with admin rights on the repository, for §4.
 
 ---
@@ -74,7 +77,7 @@ kubectl --context "$(yq -r '.kubeContext' deploy/gitops/environments/test-stand/
   apply --dry-run=client -f deploy/gitops/environments/test-stand/ci-deployer-rbac.yaml
 ```
 
-Read the manifest. You are looking for five things:
+Read the manifest. You are looking for six things:
 
 - the binding is a `RoleBinding`, not a `ClusterRoleBinding`;
 - its `roleRef` is `ClusterRole/admin` — a cluster role bound namespace-wide, which
@@ -88,6 +91,15 @@ Read the manifest. You are looking for five things:
   deployment identity over a namespace this repository does not own is
   infrastructure policy, owned by whoever installs Airbyte. `make
   verify-ci-credential` (§3) asserts the grant exists there; it never creates it;
+- the manifest **does** carry `ci-deployer-previews-rbac` in `insight-previews`,
+  and that is not a contradiction of the line above: no third party installs
+  that namespace, it exists only because this release binds RBAC into it, so
+  leaving the grant out of band would leave it unreproducible. The *namespace*
+  is still L0 and stays out of the manifest — `revoke-ci` deletes everything the
+  manifest names, and a revoked credential must not take live experiments with
+  it. Its three workload rules (`deployments`, `services`, `httproutes`) are
+  never exercised: they exist so RBAC escalation prevention permits creating the
+  chart's own Role, and they must stay a rule-for-rule mirror of it;
 - the token `Secret` carries no `data:` block (the token controller fills it).
 
 If your kube-context does not resolve to the inventory's `kubeContext`, the
@@ -153,6 +165,10 @@ make -C deploy/gitops verify-ci-credential ENV=test-stand
 | `update persistentvolumeclaims -n insight` | its chart and version labels change on every bump |
 | `create roles.rbac.authorization.k8s.io -n airbyte` | the chart renders `insight-airbyte-auth-reader` into the Airbyte namespace, not the release one |
 | `create rolebindings.rbac.authorization.k8s.io -n airbyte` | same object, the binding half |
+| `create roles.rbac.authorization.k8s.io -n insight-previews` | the previews subchart renders `insight-previews-experiments` into the experiments namespace |
+| `create rolebindings.rbac.authorization.k8s.io -n insight-previews` | same object, the binding half |
+| `create deployments.apps -n insight-previews` | escalation prevention: the chart's Role grants it, so the credential must hold it to create that Role |
+| `create httproutes.gateway.networking.k8s.io -n insight-previews` | same reason |
 
 **Must be `no`** — this is the containment claim:
 
@@ -160,6 +176,7 @@ make -C deploy/gitops verify-ci-credential ENV=test-stand
 |---|---|
 | `'*' '*' --all-namespaces` | the blanket check |
 | `get pods -n airbyte` | the cross-namespace grant is RBAC-only; it reads one Secret by name and nothing else |
+| `get pods -n insight-previews` | the previews grant is RBAC-only; the experiments themselves are the previews service's business, not CI's |
 | `list namespaces --all-namespaces` | cannot enumerate the cluster |
 | `create namespaces --all-namespaces` | see §7 |
 | `get secrets --all-namespaces` | the datastore namespaces' credentials stay out of reach |

--- a/deploy/gitops/environments/test-stand/inventory.yaml
+++ b/deploy/gitops/environments/test-stand/inventory.yaml
@@ -80,10 +80,14 @@ protected: true
 
 # ─── Namespaces ────────────────────────────────────────────────────────
 namespaces:
-  # The umbrella release namespace. Everything this env touches lives
-  # here, which is also why a namespace-scoped ServiceAccount is enough
-  # for CI to deploy — no cluster-scoped grant is needed or wanted.
+  # The umbrella release namespace. Everything this env touches lives here bar
+  # the previews RBAC below, which is why a namespace-scoped ServiceAccount is
+  # enough for CI to deploy — no cluster-scoped grant is needed or wanted.
   services: insight
+
+  # Where the previews subchart binds its experiments RBAC (#1981).
+  # ci-deployer-rbac.yaml spells this name literally — change both together.
+  previews: insight-previews
 
   # Read the warning before changing this.
   #

--- a/deploy/gitops/environments/test-stand/values.yaml
+++ b/deploy/gitops/environments/test-stand/values.yaml
@@ -433,13 +433,12 @@ gitCliProxy:
   deploy: false
 
 previews:
-  # Off, against the chart default: the subchart emits a Namespace and
-  # Role/RoleBinding in the experiments namespace, and this stand deploys
-  # with the namespace-scoped `ci-deployer` ServiceAccount — the upgrade
-  # dies on `namespaces is forbidden` before anything renders. Turn on only
-  # together with a ci-deployer-rbac.yaml grant for that namespace, when the
-  # stand suite starts exercising previews (#1981).
-  deploy: false
+  # Stays deployed (the chart default): the gateway routes `/api/previews`
+  # unconditionally, and nginx refuses to start on an upstream it cannot resolve.
+  experiments:
+    # Off, against the chart default: the namespace is L0 here. `create
+    # namespaces` takes no resourceNames, so CI must never hold it.
+    manageNamespace: false
 
 frontend: # the web UI (dashboard)
   replicaCount: 1


### PR DESCRIPTION
**Why.** No test-stand deploy has succeeded since Aug 28. Two regressions stack: `namespaces "insight-previews" is forbidden` blocked every upgrade from chart 0.6.22, and once previews was switched off the gateway crashlooped on `host not found in upstream "insight-previews:8085"`. Behind both, the smoke gate needs a browser installed a step after it runs.

**What changed.** Previews deploys again with a `ci-deployer` Role/RoleBinding in `insight-previews`, and `playwright install` moves above the smoke gate.

**The namespace stays L0, outside the release.** `create namespaces` takes no `resourceNames` and `verify-ci-credential` asserts the credential lacks it, so `manageNamespace` is false and the Namespace stays out of the manifest `revoke-ci` deletes.

**The grant's three workload rules are never applied.** Escalation prevention refuses a Role granting what the SA does not hold, so they stay a rule-for-rule mirror of the chart's `insight-previews-experiments` Role.

**The `stand_smoke` markers on the three journeys stay.** A stand whose API answers while the SPA renders an empty shell passes every API test; those journeys close that gap, so the install moved rather than the markers.

**Out of scope.** The gateway route table lists `/api/previews` unconditionally, so previews still cannot be switched off on any stand. Not tracked yet.

**Verified.** Dispatched on this branch ([run 33392195866](https://github.com/constructorfabric/insight/actions/runs/33392195866)): deploy, edge, seed, browser install and the smoke gate all pass — the first clearance since Aug 28. Suite 359 passed, 21 skipped, 13 xfailed; its 110 `test_drilldown.py` failures are #2995 contract skew between branch tests and chart 0.6.30 images, which the after-publish path cannot hit.
