### PR TITLE
feat(semantic): materialize measures on a schedule and serve reads from the cache

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -3845,9 +3845,11 @@
         "type": "string"
       },
       "ServedFrom": {
-        "description": "Where the rows behind this answer came from.",
+        "description": "Where the rows behind this answer came from. `mixed` is one answer some of\nwhose reads were cached and some computed.",
         "enum": [
-          "computed"
+          "cache",
+          "computed",
+          "mixed"
         ],
         "type": "string"
       },

--- a/src/backend/services/analytics/config/insight.yaml
+++ b/src/backend/services/analytics/config/insight.yaml
@@ -141,6 +141,11 @@ gears:
       identity_url: ""
       visibility_policy: "org_chart"
       redis_url: ""
+      # Answer from the semantic layer's materialized measures where the
+      # refresher's coverage allows it. TRUE is the adopted default; set to
+      # false to make every question compile over its dataset again.
+      measure_cache:
+        read_enabled: true
       metric_catalog:
         tenant_metrics_enabled: false
         # Per-tenant observation filter on metric reads. Off until the ingest

--- a/src/backend/services/analytics/src/api/query/values.rs
+++ b/src/backend/services/analytics/src/api/query/values.rs
@@ -32,6 +32,7 @@ pub async fn query_values(
         catalog,
         &state.ch,
         &state.db,
+        state.config.measure_cache.read_enabled,
         ctx.subject_tenant_id(),
         batch,
     )

--- a/src/backend/services/analytics/src/config.rs
+++ b/src/backend/services/analytics/src/config.rs
@@ -78,6 +78,10 @@ pub struct GearConfig {
     /// Metric read configuration.
     pub metric_catalog: MetricCatalogConfig,
 
+    /// Whether reads may answer from the semantic layer's materialized
+    /// measures.
+    pub measure_cache: MeasureCacheConfig,
+
     /// Usage-monitoring configuration.
     pub usage: UsageConfig,
 
@@ -100,6 +104,7 @@ impl Default for GearConfig {
             visibility_policy: VisibilityPolicy::default(),
             redis_url: String::new(),
             metric_catalog: MetricCatalogConfig::default(),
+            measure_cache: MeasureCacheConfig::default(),
             usage: UsageConfig::default(),
             ai_assist: AiAssistConfig::default(),
             external_sources: Vec::new(),
@@ -125,6 +130,24 @@ pub struct MetricCatalogConfig {
     ///
     /// Env: `APP__gears__analytics__config__metric_catalog__enforce_tenant_scope`.
     pub enforce_tenant_scope: bool,
+}
+
+/// Whether a read may answer from the semantic layer's materialized measures.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct MeasureCacheConfig {
+    /// Off means every question compiles over its dataset, whatever the
+    /// refresher has built. The materialized tier is the adopted default, so
+    /// this is the kill switch rather than the opt-in.
+    ///
+    /// Env: `APP__gears__analytics__config__measure_cache__read_enabled`.
+    pub read_enabled: bool,
+}
+
+impl Default for MeasureCacheConfig {
+    fn default() -> Self {
+        Self { read_enabled: true }
+    }
 }
 
 /// Whether this instance records how the product is used.

--- a/src/backend/services/analytics/src/domain/compiler/cache_build.rs
+++ b/src/backend/services/analytics/src/domain/compiler/cache_build.rs
@@ -1,0 +1,579 @@
+//! Renders one measure's cache build: the `INSERT ... SELECT` that materializes
+//! its rows at the finest grain every read over it can re-aggregate from.
+//!
+//! SAFETY: catalog-validated field names and expressions are written into the
+//! statement; keys, versions, dates and filter values are all bound.
+
+use std::fmt::Write;
+
+use chrono::NaiveDate;
+
+use crate::domain::definitions::definition::{
+    Aggregation, Computation, MeasureDefinition, MetricDefinition,
+};
+use crate::domain::field_catalog::model::{CatalogDataset, FieldRole};
+
+use super::dimensions::{dimension_label_expr, dimension_value_expr};
+use super::error::CompileError;
+use super::request::Bucket;
+use super::sql::{
+    CompiledMeasureQuery, QueryParam, TimeBucket, aggregate_expr, from_clause, render_filter,
+    subject_operand, value_operand,
+};
+
+pub const CACHE_RELATION: &str = "insight.semantic_measure_cache";
+pub const STAGING_RELATION: &str = "insight.semantic_measure_cache_staging";
+
+/// INVARIANT: the served relation and its staging twin share this column order;
+/// `INSERT ... SELECT` matches by position.
+const CACHE_COLUMNS: &str = "(tenant_id, measure_key, definition_version, kind, metric_date, \
+     entity, dimensions, value, subject, built_at)";
+
+const DIMENSIONS_TYPE: &str = "Array(Tuple(key String, value String, label Nullable(String)))";
+
+/// The row shape a measure's cached work takes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheRowKind {
+    /// One row per tenant, entity, day and dimension tuple.
+    Aggregate,
+    /// One row per source event, so a distribution over the values stays exact.
+    Event,
+    /// One row per counted subject, so a distinct count over any span of days
+    /// counts each subject once.
+    Subject,
+}
+
+impl CacheRowKind {
+    pub fn as_db(self) -> &'static str {
+        match self {
+            Self::Aggregate => "aggregate",
+            Self::Event => "event",
+            Self::Subject => "subject",
+        }
+    }
+
+    /// The shape a stored spelling names; `None` for one this release does not
+    /// write, which no read may guess a fold for.
+    pub fn from_db(stored: &str) -> Option<Self> {
+        match stored {
+            "aggregate" => Some(Self::Aggregate),
+            "event" => Some(Self::Event),
+            "subject" => Some(Self::Subject),
+            _ => None,
+        }
+    }
+}
+
+/// What a build is asked to materialize: one measure at one version over one
+/// span of days.
+#[derive(Debug, Clone, Copy)]
+pub struct CacheBuild<'a> {
+    pub measure: &'a MeasureDefinition,
+    pub definition_version: u32,
+    pub kind: CacheRowKind,
+    pub from: NaiveDate,
+    pub to: NaiveDate,
+}
+
+/// The finest reusable form: rows are kept whenever folding them away would
+/// cost an answer, and folded otherwise.
+pub fn row_kind(measure: &MeasureDefinition, metrics: &[MetricDefinition]) -> CacheRowKind {
+    if read_as_distribution(measure, metrics) {
+        return CacheRowKind::Event;
+    }
+
+    match measure.aggregation {
+        // INVARIANT: an average carries no count to re-weight with, so a
+        // day-folded average cannot re-fold across a wider window.
+        Aggregation::Avg => CacheRowKind::Event,
+        Aggregation::CountDistinct => CacheRowKind::Subject,
+        Aggregation::Count | Aggregation::Sum | Aggregation::Min | Aggregation::Max => {
+            CacheRowKind::Aggregate
+        }
+    }
+}
+
+/// A distribution is taken over per-row values, so a measure any metric reads
+/// that way keeps its rows whatever its own fold is.
+fn read_as_distribution(measure: &MeasureDefinition, metrics: &[MetricDefinition]) -> bool {
+    metrics.iter().any(|metric| match &metric.computation {
+        Computation::Percentile { measure: read, .. } | Computation::Stddev { measure: read } => {
+            *read == measure.key
+        }
+        Computation::Direct { .. } | Computation::Ratio { .. } | Computation::Derived { .. } => {
+            false
+        }
+    })
+}
+
+/// The build always lands in staging; the refresher swaps it into the served
+/// relation one partition at a time.
+pub fn compile_cache_build(
+    dataset: &CatalogDataset,
+    build: &CacheBuild<'_>,
+) -> Result<CompiledMeasureQuery, CompileError> {
+    let measure = build.measure;
+    let tenant_field = dataset
+        .fields_with_role(FieldRole::Tenant)
+        .next()
+        .ok_or_else(|| CompileError::NoTenantField {
+            dataset: dataset.key.clone(),
+        })?;
+
+    let mut params = vec![
+        QueryParam::Text(measure.key.clone()),
+        QueryParam::UInt(u64::from(build.definition_version)),
+    ];
+    let dimensions = dimensions_expr(measure, &mut params);
+    let value = value_expr(build)?;
+    let subject = subject_expr(build)?;
+
+    let metric_date = TimeBucket::over_event_time(dataset, &measure.event_time, Bucket::Day);
+    // SAFETY: the tenant's `assumeNotNull` is sound under the guard below, and
+    // a row naming no tenant is reachable by no request.
+    let mut predicates = vec![
+        format!("{} IS NOT NULL", tenant_field.name),
+        format!("{} >= toDate(?)", metric_date.expr()),
+        format!("{} <= toDate(?)", metric_date.expr()),
+    ];
+    params.push(QueryParam::Text(build.from.to_string()));
+    params.push(QueryParam::Text(build.to.to_string()));
+    metric_date.exclude_timeless(&mut predicates);
+    if let Some(filter) = &measure.filter {
+        predicates.push(render_filter(measure, filter, &mut params)?);
+    }
+
+    let mut sql = format!("INSERT INTO {STAGING_RELATION} {CACHE_COLUMNS}\n");
+    sql.push_str("SELECT\n");
+    let _ = writeln!(
+        sql,
+        "    assumeNotNull({}) AS cache_tenant,",
+        tenant_field.name
+    );
+    let _ = writeln!(sql, "    ? AS cache_measure_key,");
+    let _ = writeln!(sql, "    ? AS cache_definition_version,");
+    let _ = writeln!(sql, "    '{}' AS cache_kind,", build.kind.as_db());
+    let _ = writeln!(sql, "    {} AS cache_metric_date,", metric_date.expr());
+    let _ = writeln!(sql, "    {} AS cache_entity,", measure.entity);
+    let _ = writeln!(sql, "    {dimensions} AS cache_dimensions,");
+    let _ = writeln!(sql, "    {value} AS cache_value,");
+    let _ = writeln!(sql, "    {subject} AS cache_subject,");
+    let _ = writeln!(sql, "    now64(3) AS cache_built_at");
+    let _ = writeln!(sql, "FROM {}", from_clause(dataset));
+    let _ = write!(sql, "WHERE {}", predicates.join("\n  AND "));
+    if let Some(group_by) = group_columns(build.kind) {
+        let _ = write!(sql, "\nGROUP BY {group_by}");
+    }
+
+    Ok(CompiledMeasureQuery { sql, params })
+}
+
+/// A pre-folded row is one per group; an event row is the source row itself.
+fn group_columns(kind: CacheRowKind) -> Option<&'static str> {
+    match kind {
+        CacheRowKind::Aggregate => {
+            Some("cache_tenant, cache_metric_date, cache_entity, cache_dimensions")
+        }
+        CacheRowKind::Subject => {
+            Some("cache_tenant, cache_metric_date, cache_entity, cache_dimensions, cache_subject")
+        }
+        CacheRowKind::Event => None,
+    }
+}
+
+fn value_expr(build: &CacheBuild<'_>) -> Result<String, CompileError> {
+    match build.kind {
+        CacheRowKind::Aggregate => Ok(format!("toFloat64({})", aggregate_expr(build.measure)?)),
+        CacheRowKind::Event => Ok(format!("toFloat64({})", value_operand(build.measure)?)),
+        // A subject row is a presence, and the count of them is the answer.
+        CacheRowKind::Subject => Ok("toFloat64(1)".to_owned()),
+    }
+}
+
+fn subject_expr(build: &CacheBuild<'_>) -> Result<String, CompileError> {
+    match build.kind {
+        CacheRowKind::Aggregate | CacheRowKind::Event => {
+            Ok("CAST(NULL AS Nullable(String))".to_owned())
+        }
+        CacheRowKind::Subject => Ok(format!("toString({})", subject_operand(build.measure)?)),
+    }
+}
+
+/// Every declared dimension travels with the row, under the same value and
+/// label expressions a live read groups by, so a cached answer and a live one
+/// agree on what a group is.
+fn dimensions_expr(measure: &MeasureDefinition, params: &mut Vec<QueryParam>) -> String {
+    let mut tuples = Vec::with_capacity(measure.dimensions.len());
+    for binding in &measure.dimensions {
+        params.push(QueryParam::Text(binding.key.clone()));
+        tuples.push(format!(
+            "tuple(?, {}, {})",
+            dimension_value_expr(binding),
+            dimension_label_expr(binding)
+        ));
+    }
+
+    format!("CAST([{}], '{DIMENSIONS_TYPE}')", tuples.join(", "))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::compiler::test_catalog::dataset;
+    use crate::domain::definitions::definition::{
+        DimensionBinding, Direction, Format, MetricDefinition,
+    };
+    use crate::domain::definitions::filter::{
+        FilterLeaf, FilterOp, FilterTree, FilterValue, Scalar,
+    };
+    use crate::domain::field_catalog::model::EntityType;
+
+    fn measure() -> MeasureDefinition {
+        MeasureDefinition {
+            key: "prs_merged".to_owned(),
+            dataset: "git_pull_requests".to_owned(),
+            description: None,
+            filter: serde_yaml::from_str("{ field: state, op: eq, value: merged }").ok(),
+            aggregation: Aggregation::Count,
+            value_expr: None,
+            subject_expr: None,
+            event_time: "closed_on".to_owned(),
+            entity: "author_email".to_owned(),
+            dimensions: vec![
+                DimensionBinding {
+                    key: "repository".to_owned(),
+                    value_field: "repo_slug".to_owned(),
+                    label_field: None,
+                },
+                DimensionBinding {
+                    key: "source".to_owned(),
+                    value_field: "data_source".to_owned(),
+                    label_field: Some("data_source_label".to_owned()),
+                },
+            ],
+        }
+    }
+
+    fn build(measure: &MeasureDefinition, kind: CacheRowKind) -> CacheBuild<'_> {
+        CacheBuild {
+            measure,
+            definition_version: 7,
+            kind,
+            from: NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
+            to: NaiveDate::from_ymd_opt(2026, 2, 4).expect("valid date"),
+        }
+    }
+
+    fn compile(measure: &MeasureDefinition, kind: CacheRowKind) -> CompiledMeasureQuery {
+        compile_cache_build(&dataset(&measure.dataset), &build(measure, kind)).expect("compiles")
+    }
+
+    fn text(value: &str) -> QueryParam {
+        QueryParam::Text(value.to_owned())
+    }
+
+    fn lines(expected: &[&str]) -> String {
+        expected.join("\n")
+    }
+
+    fn metric(key: &str, computation: Computation) -> MetricDefinition {
+        MetricDefinition {
+            key: key.to_owned(),
+            computation,
+            transform: None,
+            format: Format::Decimal,
+            direction: Direction::HigherIsBetter,
+            entity_type: EntityType::Person,
+            cohort_key: None,
+            label: None,
+            description: None,
+        }
+    }
+
+    #[test]
+    fn an_aggregate_build_folds_one_row_per_entity_day_and_dimension_tuple() {
+        let compiled = compile(&measure(), CacheRowKind::Aggregate);
+
+        assert_eq!(
+            compiled.sql,
+            lines(&[
+                "INSERT INTO insight.semantic_measure_cache_staging (tenant_id, measure_key, definition_version, kind, metric_date, entity, dimensions, value, subject, built_at)",
+                "SELECT",
+                "    assumeNotNull(tenant_id) AS cache_tenant,",
+                "    ? AS cache_measure_key,",
+                "    ? AS cache_definition_version,",
+                "    'aggregate' AS cache_kind,",
+                "    toDate(assumeNotNull(closed_on)) AS cache_metric_date,",
+                "    author_email AS cache_entity,",
+                "    CAST([tuple(?, coalesce(toString(repo_slug), '__unknown__'), coalesce(toString(repo_slug), 'Unknown')), tuple(?, coalesce(toString(data_source), '__unknown__'), coalesce(toString(data_source_label), 'Unknown'))], 'Array(Tuple(key String, value String, label Nullable(String)))') AS cache_dimensions,",
+                "    toFloat64(count()) AS cache_value,",
+                "    CAST(NULL AS Nullable(String)) AS cache_subject,",
+                "    now64(3) AS cache_built_at",
+                "FROM silver.class_git_pull_requests FINAL",
+                "WHERE tenant_id IS NOT NULL",
+                "  AND toDate(assumeNotNull(closed_on)) >= toDate(?)",
+                "  AND toDate(assumeNotNull(closed_on)) <= toDate(?)",
+                "  AND isNotNull(closed_on)",
+                "  AND state = ?",
+                "GROUP BY cache_tenant, cache_metric_date, cache_entity, cache_dimensions",
+            ])
+        );
+        assert_eq!(
+            compiled.params,
+            vec![
+                text("prs_merged"),
+                QueryParam::UInt(7),
+                text("repository"),
+                text("source"),
+                text("2026-01-01"),
+                text("2026-02-04"),
+                text("merged"),
+            ]
+        );
+    }
+
+    #[test]
+    fn an_event_build_keeps_one_row_per_source_row() {
+        let mut measure = measure();
+        measure.aggregation = Aggregation::Avg;
+        measure.value_expr = Some("lines_added".to_owned());
+
+        let compiled = compile(&measure, CacheRowKind::Event);
+
+        assert!(compiled.sql.contains("    'event' AS cache_kind,"));
+        assert!(
+            compiled
+                .sql
+                .contains("    toFloat64(lines_added) AS cache_value,")
+        );
+        assert!(
+            !compiled.sql.contains("GROUP BY"),
+            "a per-event row is not folded: {}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn a_subject_build_keeps_one_row_per_counted_subject() {
+        let mut measure = measure();
+        measure.aggregation = Aggregation::CountDistinct;
+        measure.subject_expr = Some("pull_request_id".to_owned());
+
+        let compiled = compile(&measure, CacheRowKind::Subject);
+
+        assert!(compiled.sql.contains("    'subject' AS cache_kind,"));
+        assert!(compiled.sql.contains("    toFloat64(1) AS cache_value,"));
+        assert!(
+            compiled
+                .sql
+                .contains("    toString(pull_request_id) AS cache_subject,")
+        );
+        assert!(compiled.sql.contains(
+            "GROUP BY cache_tenant, cache_metric_date, cache_entity, cache_dimensions, cache_subject"
+        ));
+    }
+
+    #[test]
+    fn a_collapsing_dataset_is_read_final_and_a_direct_one_is_not() {
+        let mut measure = measure();
+        measure.filter = None;
+        assert!(
+            compile(&measure, CacheRowKind::Aggregate)
+                .sql
+                .contains("FROM silver.class_git_pull_requests FINAL\n")
+        );
+
+        measure.dataset = "git_commits".to_owned();
+        measure.event_time = "committed_on".to_owned();
+        measure.dimensions = vec![DimensionBinding {
+            key: "repository".to_owned(),
+            value_field: "repo_slug".to_owned(),
+            label_field: None,
+        }];
+
+        let compiled = compile(&measure, CacheRowKind::Aggregate);
+
+        assert!(compiled.sql.contains("FROM silver.class_git_commits\n"));
+        assert!(!compiled.sql.contains("FINAL"));
+    }
+
+    #[test]
+    fn an_event_time_no_row_leaves_empty_is_dated_without_a_timeless_guard() {
+        let mut measure = measure();
+        measure.filter = None;
+        measure.dataset = "git_commits".to_owned();
+        measure.event_time = "committed_on".to_owned();
+        measure.dimensions = vec![DimensionBinding {
+            key: "repository".to_owned(),
+            value_field: "repo_slug".to_owned(),
+            label_field: None,
+        }];
+
+        let compiled = compile(&measure, CacheRowKind::Aggregate);
+
+        assert!(
+            compiled
+                .sql
+                .contains("    toDate(committed_on) AS cache_metric_date,"),
+            "{}",
+            compiled.sql
+        );
+        assert!(
+            !compiled.sql.contains("isNotNull"),
+            "no row is guarded away: {}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn a_build_scopes_every_tenant_and_narrows_none() {
+        let compiled = compile(&measure(), CacheRowKind::Aggregate);
+
+        assert!(
+            !compiled.sql.contains("tenant_id = ?"),
+            "the cache is all-tenant: {}",
+            compiled.sql
+        );
+        assert!(
+            compiled
+                .sql
+                .contains("assumeNotNull(tenant_id) AS cache_tenant")
+        );
+    }
+
+    #[test]
+    fn no_authored_value_reaches_the_statement_text() {
+        let injection = "'; DROP TABLE x; --";
+        let mut measure = measure();
+        measure.key = injection.to_owned();
+        measure.dimensions[0].key = injection.to_owned();
+        measure.filter = Some(FilterTree::Leaf(FilterLeaf {
+            field: "state".to_owned(),
+            op: FilterOp::Eq,
+            value: Some(FilterValue::Scalar(Scalar::String(injection.to_owned()))),
+        }));
+
+        let compiled = compile(&measure, CacheRowKind::Aggregate);
+
+        assert!(!compiled.sql.contains("DROP TABLE"), "{}", compiled.sql);
+        assert_eq!(
+            compiled
+                .params
+                .iter()
+                .filter(|param| **param == text(injection))
+                .count(),
+            3
+        );
+    }
+
+    #[test]
+    fn every_placeholder_has_exactly_one_bound_parameter() {
+        for kind in [
+            CacheRowKind::Aggregate,
+            CacheRowKind::Event,
+            CacheRowKind::Subject,
+        ] {
+            let mut measure = measure();
+            measure.aggregation = Aggregation::CountDistinct;
+            measure.subject_expr = Some("pull_request_id".to_owned());
+            measure.value_expr = None;
+            if kind == CacheRowKind::Event {
+                measure.aggregation = Aggregation::Sum;
+                measure.value_expr = Some("lines_added".to_owned());
+                measure.subject_expr = None;
+            }
+
+            let compiled = compile(&measure, kind);
+
+            assert_eq!(
+                compiled.sql.matches('?').count(),
+                compiled.params.len(),
+                "{kind:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_fold_missing_its_operand_is_rejected_rather_than_rendered() {
+        let mut measure = measure();
+        measure.aggregation = Aggregation::Sum;
+
+        assert_eq!(
+            compile_cache_build(
+                &dataset(&measure.dataset),
+                &build(&measure, CacheRowKind::Aggregate)
+            )
+            .expect_err("expected a compile error"),
+            CompileError::MissingOperand {
+                measure: "prs_merged".to_owned(),
+                aggregation: "sum",
+                operand: "value",
+            }
+        );
+    }
+
+    #[test]
+    fn a_measure_a_distribution_reads_is_kept_per_event() {
+        let mut measure = measure();
+        measure.aggregation = Aggregation::Sum;
+        measure.value_expr = Some("lines_added".to_owned());
+
+        for computation in [
+            Computation::Percentile {
+                measure: measure.key.clone(),
+                quantile: 0.5,
+            },
+            Computation::Stddev {
+                measure: measure.key.clone(),
+            },
+        ] {
+            let metrics = vec![metric("git.pr_size", computation)];
+
+            assert_eq!(row_kind(&measure, &metrics), CacheRowKind::Event);
+        }
+    }
+
+    #[test]
+    fn an_average_keeps_its_rows_even_when_no_distribution_reads_it() {
+        let mut averaged = measure();
+        averaged.aggregation = Aggregation::Avg;
+        averaged.value_expr = Some("lines_added".to_owned());
+
+        let metrics = vec![metric(
+            "git.pr_size",
+            Computation::Direct {
+                measure: averaged.key.clone(),
+            },
+        )];
+
+        assert_eq!(row_kind(&averaged, &metrics), CacheRowKind::Event);
+    }
+
+    #[test]
+    fn a_fold_a_wider_window_can_re_fold_is_kept_at_that_fold() {
+        let counted = measure();
+        let mut distinct = measure();
+        distinct.aggregation = Aggregation::CountDistinct;
+        distinct.subject_expr = Some("pull_request_id".to_owned());
+
+        let metrics = vec![
+            metric(
+                "git.prs_merged",
+                Computation::Direct {
+                    measure: counted.key.clone(),
+                },
+            ),
+            metric(
+                "git.pr_size",
+                Computation::Percentile {
+                    measure: "another_measure".to_owned(),
+                    quantile: 0.5,
+                },
+            ),
+        ];
+
+        assert_eq!(row_kind(&counted, &metrics), CacheRowKind::Aggregate);
+        assert_eq!(row_kind(&distinct, &metrics), CacheRowKind::Subject);
+    }
+}

--- a/src/backend/services/analytics/src/domain/compiler/cache_read.rs
+++ b/src/backend/services/analytics/src/domain/compiler/cache_read.rs
@@ -1,0 +1,1124 @@
+//! Renders a metric read over the measures already materialized: the same
+//! result-row shape a dataset read produces, re-folded from cached rows.
+//!
+//! INVARIANT: a cached row is already past its measure's filter, so the fold
+//! that re-reads it applies no filter of its own — only the request's.
+
+use std::collections::BTreeMap;
+
+use crate::domain::definitions::definition::{Aggregation, MeasureDefinition, MetricDefinition};
+
+use super::cache_build::{CACHE_RELATION, CacheRowKind};
+use super::combined_split;
+use super::dimensions::{
+    CACHED_DATE, CACHED_KEYS, CACHED_VALUES, DimensionSource,
+    combined_split_dimension_select_group, dimension_select_group,
+};
+use super::error::CompileError;
+use super::fold::{Fold, FoldKind, ScopedRead, bounded_query};
+use super::metric::subject_total_sql;
+use super::pool::{Pool, joined_entity, only_cte, scan_clause};
+use super::request::{EntityScope, MetricQuery, ViewKind};
+use super::sql::{
+    CompiledMeasureQuery, EmptyFold, QueryParam, ReadScope, TimeBucket, aggregate_function,
+    dimension_binding, placeholders,
+};
+use super::subject_series;
+use super::subject_split::subject_split_sql;
+
+/// The column a cached row keys its entity by, standing where a dataset read
+/// writes the measure's entity field.
+const CACHED_ENTITY: &str = "entity";
+const CACHED_VALUE: &str = "value";
+const CACHED_SUBJECT: &str = "subject";
+
+/// Why a cached read is not the shape a request asks for. Stated once so the
+/// planner and the compiler refuse in the same words.
+const CAPPED_RULE: &str =
+    "a capped split ranks its groups over the dataset, and the cache serves no ranked read";
+const DISTRIBUTION_RULE: &str = "the cache serves the value views, not the distribution ones";
+
+/// What the cache holds for one input measure of a metric.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CachedInput {
+    pub kind: CacheRowKind,
+    pub definition_version: u32,
+}
+
+/// Whether the cache can answer a view at all, before anything is compiled.
+#[must_use]
+pub fn view_is_cacheable(view: &ViewKind) -> bool {
+    match view {
+        ViewKind::SubjectTotal | ViewKind::SubjectSplit(_) => true,
+        ViewKind::SubjectSeries(view) => view.group_limit.is_none(),
+        ViewKind::CombinedSplit(view) => view.group_limit.is_none(),
+        ViewKind::Bins(_) | ViewKind::Quantiles(_) | ViewKind::Comparison(_) => false,
+    }
+}
+
+/// INVARIANT: every input measure of the metric must appear in `cached`; a
+/// metric one input is uncached for is read from the dataset whole.
+pub fn compile_cached_metric_query(
+    metric: &MetricDefinition,
+    measures: &BTreeMap<String, MeasureDefinition>,
+    cached: &BTreeMap<String, CachedInput>,
+    query: &MetricQuery,
+) -> Result<CompiledMeasureQuery, CompileError> {
+    let fold = Fold::resolve(metric, measures)?;
+    let pool = Pool::of_scope(&query.entity_scope);
+    let source = DimensionSource::Cached(fold.grain);
+    let read = cached_read(
+        &fold,
+        metric,
+        cached,
+        &ReadScope::of_metric(query),
+        pool.as_ref(),
+    )?;
+
+    let unsupported = |view: &'static str, reason: &'static str| CompileError::UnsupportedView {
+        metric: metric.key.clone(),
+        view,
+        reason,
+    };
+
+    match &query.view {
+        ViewKind::SubjectTotal => {
+            let inner = subject_total_sql(&read);
+            Ok(bounded_query(
+                metric.transform.as_ref(),
+                read.params,
+                query.row_limit,
+                inner,
+            ))
+        }
+        ViewKind::SubjectSplit(view) => {
+            if view.dimensions.is_empty() {
+                return Err(CompileError::EmptySelection {
+                    selection: "the subject-split dimensions".to_owned(),
+                });
+            }
+            let (select, group) = dimension_select_group(&source, &view.dimensions)?;
+            let inner = subject_split_sql(&read, &select, &group);
+            Ok(bounded_query(
+                metric.transform.as_ref(),
+                read.params,
+                query.row_limit,
+                inner,
+            ))
+        }
+        ViewKind::SubjectSeries(view) => {
+            if view.group_limit.is_some() {
+                return Err(unsupported("subject_series", CAPPED_RULE));
+            }
+            let (select, group) = dimension_select_group(&source, &view.dimensions)?;
+            let bucket = TimeBucket::over_column(CACHED_DATE, query.bucket);
+            let inner = subject_series::uncapped_sql(&read, bucket.expr(), (&select, &group));
+            Ok(bounded_query(
+                metric.transform.as_ref(),
+                read.params,
+                query.row_limit,
+                inner,
+            ))
+        }
+        ViewKind::CombinedSplit(view) => {
+            if view.group_limit.is_some() {
+                return Err(unsupported("combined_split", CAPPED_RULE));
+            }
+            if view.dimensions.is_empty() {
+                return Err(CompileError::EmptySelection {
+                    selection: "the combined-split dimensions".to_owned(),
+                });
+            }
+            let (select, group) = combined_split_dimension_select_group(&source, &view.dimensions)?;
+            let inner = combined_split::uncapped_sql(&read, &select, &group);
+            Ok(bounded_query(
+                metric.transform.as_ref(),
+                read.params,
+                query.row_limit,
+                inner,
+            ))
+        }
+        ViewKind::Bins(_) => Err(unsupported("bins", DISTRIBUTION_RULE)),
+        ViewKind::Quantiles(_) => Err(unsupported("quantiles", DISTRIBUTION_RULE)),
+        ViewKind::Comparison(_) => Err(unsupported("peer", DISTRIBUTION_RULE)),
+    }
+}
+
+// INVARIANT: placeholders bind by position, so parameters are pushed in the
+// order the statement writes them: pool head, fold values, scope predicates —
+// the order a dataset read binds in, because the same renderers write both.
+fn cached_read(
+    fold: &Fold<'_>,
+    metric: &MetricDefinition,
+    cached: &BTreeMap<String, CachedInput>,
+    scope: &ReadScope<'_>,
+    pool: Option<&Pool<'_>>,
+) -> Result<ScopedRead, CompileError> {
+    let mut params = Vec::new();
+    let head = only_cte(pool, &mut params)?;
+    let value = cached_value_expr(fold, metric, cached, &mut params)?;
+    let predicates = cached_predicates(fold, cached, scope, &mut params)?;
+
+    Ok(ScopedRead {
+        head,
+        scan: scan_clause(CACHE_RELATION.to_owned(), pool, CACHED_ENTITY, ""),
+        entity: joined_entity(pool, CACHED_ENTITY).to_owned(),
+        value,
+        predicates,
+        // INVARIANT: a cached row is a matched row, so every group the scan
+        // admits is one an input matched.
+        matched_group: None,
+        params,
+    })
+}
+
+/// Which of the scan's rows one fold reads.
+enum FoldRows<'a> {
+    /// Every row the scan admits, for a metric with one input.
+    All,
+    /// One input's rows, with what an empty fold reports.
+    OfMeasure {
+        condition: &'a str,
+        empty: EmptyFold,
+    },
+}
+
+fn cached_value_expr(
+    fold: &Fold<'_>,
+    metric: &MetricDefinition,
+    cached: &BTreeMap<String, CachedInput>,
+    params: &mut Vec<QueryParam>,
+) -> Result<String, CompileError> {
+    let value = match fold.kind() {
+        FoldKind::Aggregate(measure) => {
+            cached_fold(measure, kind_of(cached, measure)?, &FoldRows::All)?
+        }
+        FoldKind::Ratio {
+            numerator,
+            denominator,
+        } => {
+            // INVARIANT: a zero denominator is an undefined ratio; a numerator
+            // re-folds to what the live read reports empty — zero for counts.
+            let numerator = one_input(cached, numerator, EmptyFold::Null, params)?;
+            let denominator = one_input(cached, denominator, EmptyFold::Zero, params)?;
+            format!("{numerator} / nullIf({denominator}, 0)")
+        }
+        FoldKind::Quantile { measure, quantile } => {
+            // INVARIANT: a quantile of pre-folded aggregates is not that
+            // quantile, so only per-event rows can answer one.
+            per_event(measure, kind_of(cached, measure)?)?;
+            format!("quantileExact({quantile})({CACHED_VALUE})")
+        }
+        FoldKind::Deviation { measure } => {
+            per_event(measure, kind_of(cached, measure)?)?;
+            format!("stddevSampIfOrNull({CACHED_VALUE}, {CACHED_VALUE} IS NOT NULL)")
+        }
+        FoldKind::Derived { inputs, expr } => {
+            // INVARIANT: an input re-folds to what the live read reports for
+            // an unmatched group — zero for counts, NULL for the rest.
+            let mut folded = Vec::with_capacity(expr.references.len());
+            for alias in &expr.references {
+                let (_, measure) =
+                    inputs
+                        .iter()
+                        .find(|(name, _)| name == alias)
+                        .ok_or_else(|| CompileError::UnknownDerivedInput {
+                            metric: metric.key.clone(),
+                            alias: alias.clone(),
+                        })?;
+                folded.push(one_input(cached, measure, EmptyFold::Null, params)?);
+            }
+
+            expr.render(&folded)
+                .map_err(|source| CompileError::MalformedExpr {
+                    metric: metric.key.clone(),
+                    source,
+                })?
+        }
+    };
+
+    Ok(format!("toFloat64({value})"))
+}
+
+/// One input of a composed metric, folded over the rows that name it, so both
+/// halves are read from a single scan of the relation they share.
+fn one_input(
+    cached: &BTreeMap<String, CachedInput>,
+    measure: &MeasureDefinition,
+    empty: EmptyFold,
+    params: &mut Vec<QueryParam>,
+) -> Result<String, CompileError> {
+    let kind = kind_of(cached, measure)?;
+    params.push(QueryParam::Text(measure.key.clone()));
+
+    cached_fold(
+        measure,
+        kind,
+        &FoldRows::OfMeasure {
+            condition: "measure_key = ?",
+            empty,
+        },
+    )
+}
+
+fn cached_fold(
+    measure: &MeasureDefinition,
+    kind: CacheRowKind,
+    rows: &FoldRows<'_>,
+) -> Result<String, CompileError> {
+    let (function, operand) = cached_function(measure, kind)?;
+
+    match rows {
+        FoldRows::All => Ok(match operand {
+            None => format!("{function}()"),
+            Some(column) => format!("{function}({column})"),
+        }),
+        FoldRows::OfMeasure { condition, empty } => {
+            let combinators = match live_empty_fold(measure.aggregation, *empty) {
+                EmptyFold::Zero => "If",
+                EmptyFold::Null => "IfOrNull",
+            };
+            Ok(match operand {
+                None => format!("{function}{combinators}({condition})"),
+                Some(column) => format!("{function}{combinators}({column}, {condition})"),
+            })
+        }
+    }
+}
+
+/// What the live read reports for a group none of the measure's rows fall in,
+/// which the re-fold reports too. A live `count` or `uniqExact` reports zero
+/// there even under `-OrNull`, while the `sum` its cached days re-fold through
+/// reports NULL.
+fn live_empty_fold(aggregation: Aggregation, requested: EmptyFold) -> EmptyFold {
+    match aggregation {
+        Aggregation::Count | Aggregation::CountDistinct => EmptyFold::Zero,
+        Aggregation::Sum | Aggregation::Avg | Aggregation::Min | Aggregation::Max => requested,
+    }
+}
+
+/// The re-fold a cached row supports, as the function and the column it reads.
+/// A row shape that cannot answer the measure's own fold is refused rather than
+/// folded into a number the dataset would not agree with.
+fn cached_function(
+    measure: &MeasureDefinition,
+    kind: CacheRowKind,
+) -> Result<(&'static str, Option<&'static str>), CompileError> {
+    let aggregation = measure.aggregation;
+    let re_fold = match kind {
+        // A pre-folded day re-folds under the same fold, except a count: the
+        // build wrote per-day counts, so summing them counts each row once.
+        CacheRowKind::Aggregate => match aggregation {
+            Aggregation::Count | Aggregation::Sum => Some(("sum", Some(CACHED_VALUE))),
+            Aggregation::Min | Aggregation::Max => {
+                Some((aggregate_function(aggregation), Some(CACHED_VALUE)))
+            }
+            Aggregation::Avg | Aggregation::CountDistinct => None,
+        },
+        // A per-event row is the source row, so every fold reads it directly —
+        // but a per-event build kept no subject to count distinctly.
+        CacheRowKind::Event => match aggregation {
+            Aggregation::Count => Some(("count", None)),
+            Aggregation::Sum | Aggregation::Avg | Aggregation::Min | Aggregation::Max => {
+                Some((aggregate_function(aggregation), Some(CACHED_VALUE)))
+            }
+            Aggregation::CountDistinct => None,
+        },
+        CacheRowKind::Subject => match aggregation {
+            Aggregation::CountDistinct => {
+                Some((aggregate_function(aggregation), Some(CACHED_SUBJECT)))
+            }
+            Aggregation::Count
+            | Aggregation::Sum
+            | Aggregation::Avg
+            | Aggregation::Min
+            | Aggregation::Max => None,
+        },
+    };
+
+    re_fold.ok_or_else(|| CompileError::CachedFoldMismatch {
+        measure: measure.key.clone(),
+        aggregation: aggregation.as_db(),
+        kind: kind.as_db(),
+    })
+}
+
+fn per_event(measure: &MeasureDefinition, kind: CacheRowKind) -> Result<(), CompileError> {
+    match kind {
+        CacheRowKind::Event => Ok(()),
+        CacheRowKind::Aggregate | CacheRowKind::Subject => Err(CompileError::CachedFoldMismatch {
+            measure: measure.key.clone(),
+            aggregation: measure.aggregation.as_db(),
+            kind: kind.as_db(),
+        }),
+    }
+}
+
+fn kind_of(
+    cached: &BTreeMap<String, CachedInput>,
+    measure: &MeasureDefinition,
+) -> Result<CacheRowKind, CompileError> {
+    cached
+        .get(&measure.key)
+        .map(|input| input.kind)
+        .ok_or_else(|| CompileError::MeasureNotCached {
+            measure: measure.key.clone(),
+        })
+}
+
+/// The `WHERE` predicates of a cached read, in binding order.
+fn cached_predicates(
+    fold: &Fold<'_>,
+    cached: &BTreeMap<String, CachedInput>,
+    scope: &ReadScope<'_>,
+    params: &mut Vec<QueryParam>,
+) -> Result<Vec<String>, CompileError> {
+    // INVARIANT: tenancy leads every read, bound from the request's resolved
+    // tenant and never written into the SQL.
+    let mut predicates = vec!["tenant_id = ?".to_owned()];
+    params.push(QueryParam::Text(scope.tenant_id.to_owned()));
+
+    let mut inputs: Vec<(&str, CachedInput)> = Vec::new();
+    for (_, measure) in fold.inputs() {
+        let input = *cached
+            .get(&measure.key)
+            .ok_or_else(|| CompileError::MeasureNotCached {
+                measure: measure.key.clone(),
+            })?;
+        if !inputs.iter().any(|(key, _)| *key == measure.key) {
+            inputs.push((&measure.key, input));
+        }
+    }
+    predicates.push(format!(
+        "(measure_key, definition_version) IN ({})",
+        vec!["(?, ?)"; inputs.len()].join(", ")
+    ));
+    for (key, input) in &inputs {
+        params.push(QueryParam::Text((*key).to_owned()));
+        params.push(QueryParam::UInt(u64::from(input.definition_version)));
+    }
+
+    // INVARIANT: a people-scoped read is narrowed by the join its `Pool`
+    // declares rather than by a predicate, so no arm adds one here.
+    match scope.entity_scope {
+        EntityScope::Tenant | EntityScope::People(_) => {}
+        EntityScope::Identities(identities) => {
+            if identities.is_empty() {
+                return Err(CompileError::EmptySelection {
+                    selection: "the entity scope".to_owned(),
+                });
+            }
+            predicates.push(format!(
+                "{CACHED_ENTITY} IN ({})",
+                placeholders(identities.len())
+            ));
+            params.extend(identities.iter().cloned().map(QueryParam::Text));
+        }
+    }
+
+    predicates.push(format!("{CACHED_DATE} >= toDate(?)"));
+    params.push(QueryParam::Text(scope.from.to_string()));
+    predicates.push(format!("{CACHED_DATE} <= toDate(?)"));
+    params.push(QueryParam::Text(scope.to.to_string()));
+
+    for filter in scope.dimension_filters {
+        // SAFETY: the key is written into the statement only after the grain
+        // measure resolved it, so what lands here is an authored key.
+        dimension_binding(fold.grain, &filter.key)?;
+        if filter.values.is_empty() {
+            return Err(CompileError::EmptySelection {
+                selection: format!("dimension filter `{}`", filter.key),
+            });
+        }
+        let index = format!("indexOf({CACHED_KEYS}, '{}')", filter.key);
+        predicates.push(format!(
+            "{index} > 0 AND {CACHED_VALUES}[{index}] IN ({})",
+            placeholders(filter.values.len())
+        ));
+        params.extend(filter.values.iter().cloned().map(QueryParam::Text));
+    }
+
+    Ok(predicates)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::compiler::fixtures::{
+        bins_view, derived, direct, labelled_measure, lines, measure, measures, metric, people,
+        people_params, percent_of_total, percentile, plain_subject_series, query, ratio,
+        sized_measure, stddev, text,
+    };
+    use crate::domain::compiler::request::{
+        Bucket, CombinedSplitView, DimensionFilter, EntityScope, GroupLimit, RankedDimension,
+        RankedGroup, SubjectSeriesView, SubjectSplitView,
+    };
+    use crate::domain::definitions::definition::{Aggregation, MeasureDefinition};
+
+    const VERSION: u32 = 7;
+
+    fn cached(defined: &[MeasureDefinition], kind: CacheRowKind) -> BTreeMap<String, CachedInput> {
+        defined
+            .iter()
+            .map(|measure| {
+                (
+                    measure.key.clone(),
+                    CachedInput {
+                        kind,
+                        definition_version: VERSION,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn compile(
+        metric: &MetricDefinition,
+        defined: &[MeasureDefinition],
+        kind: CacheRowKind,
+        request: &MetricQuery,
+    ) -> CompiledMeasureQuery {
+        compile_cached_metric_query(metric, &measures(defined), &cached(defined, kind), request)
+            .expect("compiles")
+    }
+
+    fn compile_err(
+        metric: &MetricDefinition,
+        defined: &[MeasureDefinition],
+        kind: CacheRowKind,
+        request: &MetricQuery,
+    ) -> CompileError {
+        compile_cached_metric_query(metric, &measures(defined), &cached(defined, kind), request)
+            .expect_err("expected a compile error")
+    }
+
+    fn weekly_series() -> ViewKind {
+        ViewKind::SubjectSeries(SubjectSeriesView {
+            dimensions: Vec::new(),
+            group_limit: None,
+        })
+    }
+
+    fn summed(key: &str) -> MeasureDefinition {
+        MeasureDefinition {
+            aggregation: Aggregation::Sum,
+            value_expr: Some("lines_added".to_owned()),
+            ..measure(key, Some("{ field: state, op: eq, value: merged }"))
+        }
+    }
+
+    fn distinct(key: &str) -> MeasureDefinition {
+        MeasureDefinition {
+            aggregation: Aggregation::CountDistinct,
+            subject_expr: Some("pull_request_id".to_owned()),
+            ..measure(key, None)
+        }
+    }
+
+    #[test]
+    fn a_summed_measure_re_folds_its_cached_days_over_a_weekly_series_of_the_people_asked_about() {
+        let lines_merged = summed("lines_merged");
+        let mut request = query(weekly_series());
+        request.bucket = Bucket::Week;
+        request.entity_scope = people();
+
+        let compiled = compile(
+            &metric(direct("lines_merged")),
+            &[lines_merged],
+            CacheRowKind::Aggregate,
+            &request,
+        );
+
+        assert_eq!(
+            compiled.sql,
+            lines(&[
+                "WITH pool AS (",
+                "    SELECT",
+                "        member.1 AS person_ref,",
+                "        member.2 AS identity",
+                "    FROM (SELECT arrayJoin([(?, ?), (?, ?), (?, ?)]) AS member)",
+                ")",
+                "SELECT",
+                "    pool.person_ref AS entity_id,",
+                "    toString(toStartOfWeek(toDate(metric_date), 1)) AS bucket_start,",
+                "    toFloat64(sum(value)) AS value,",
+                "    toUInt8(grouping(toStartOfWeek(toDate(metric_date), 1))) AS is_total,",
+                "    CAST(NULL AS Nullable(UInt32)) AS rank,",
+                "    toUInt8(0) AS remainder,",
+                "    CAST(NULL AS Nullable(String)) AS group_label",
+                "FROM insight.semantic_measure_cache",
+                "INNER JOIN pool ON pool.identity = entity",
+                "WHERE tenant_id = ?",
+                "  AND (measure_key, definition_version) IN ((?, ?))",
+                "  AND metric_date >= toDate(?)",
+                "  AND metric_date <= toDate(?)",
+                "GROUP BY GROUPING SETS ((entity_id, toStartOfWeek(toDate(metric_date), 1)), (entity_id))",
+                "ORDER BY entity_id, is_total, bucket_start",
+                "LIMIT ?",
+            ])
+        );
+        assert_eq!(
+            compiled.params,
+            [
+                people_params(),
+                vec![
+                    text("acme-tenant"),
+                    text("lines_merged"),
+                    QueryParam::UInt(u64::from(VERSION)),
+                    text("2026-01-01"),
+                    text("2026-01-31"),
+                    QueryParam::UInt(10_001),
+                ]
+            ]
+            .concat()
+        );
+    }
+
+    #[test]
+    fn the_measures_own_filter_is_never_re_applied_because_the_build_already_applied_it() {
+        let compiled = compile(
+            &metric(direct("lines_merged")),
+            &[summed("lines_merged")],
+            CacheRowKind::Aggregate,
+            &query(ViewKind::SubjectTotal),
+        );
+
+        assert!(!compiled.sql.contains("state"), "{}", compiled.sql);
+        assert!(!compiled.params.contains(&text("merged")));
+    }
+
+    #[test]
+    fn each_row_kind_re_folds_through_the_column_its_build_wrote() {
+        let cases = [
+            (
+                metric(direct("prs_merged")),
+                measure("prs_merged", None),
+                CacheRowKind::Aggregate,
+                "toFloat64(sum(value)) AS value",
+            ),
+            (
+                metric(direct("prs_counted")),
+                distinct("prs_counted"),
+                CacheRowKind::Subject,
+                "toFloat64(uniqExact(subject)) AS value",
+            ),
+            (
+                metric(percentile("pr_size", 0.5)),
+                sized_measure("pr_size"),
+                CacheRowKind::Event,
+                "toFloat64(quantileExact(0.5)(value)) AS value",
+            ),
+            (
+                metric(stddev("pr_size")),
+                sized_measure("pr_size"),
+                CacheRowKind::Event,
+                "toFloat64(stddevSampIfOrNull(value, value IS NOT NULL)) AS value",
+            ),
+        ];
+
+        for (metric, defined, kind, expected) in cases {
+            let compiled = compile(&metric, &[defined], kind, &query(ViewKind::SubjectTotal));
+
+            assert!(compiled.sql.contains(expected), "{}", compiled.sql);
+        }
+    }
+
+    #[test]
+    fn an_averaged_measure_reads_its_kept_rows_rather_than_averaging_averages() {
+        let averaged = MeasureDefinition {
+            aggregation: Aggregation::Avg,
+            ..sized_measure("pr_size")
+        };
+
+        let compiled = compile(
+            &metric(direct("pr_size")),
+            &[averaged],
+            CacheRowKind::Event,
+            &query(ViewKind::SubjectTotal),
+        );
+
+        assert!(
+            compiled.sql.contains("toFloat64(avg(value)) AS value"),
+            "{}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn a_ratio_folds_both_inputs_in_one_scan_of_the_relation_they_share() {
+        let merged = measure(
+            "prs_merged",
+            Some("{ field: state, op: eq, value: merged }"),
+        );
+        let closed = measure(
+            "prs_closed",
+            Some("{ field: state, op: in, value: [merged, closed] }"),
+        );
+
+        let compiled = compile(
+            &metric(ratio("prs_merged", "prs_closed")),
+            &[merged, closed],
+            CacheRowKind::Aggregate,
+            &query(ViewKind::SubjectTotal),
+        );
+
+        assert!(
+            compiled.sql.contains(
+                "toFloat64(sumIf(value, measure_key = ?) / nullIf(sumIf(value, measure_key = ?), 0)) AS value"
+            ),
+            "{}",
+            compiled.sql
+        );
+        assert!(
+            compiled
+                .sql
+                .contains("(measure_key, definition_version) IN ((?, ?), (?, ?))"),
+            "{}",
+            compiled.sql
+        );
+        assert_eq!(
+            compiled.params,
+            vec![
+                text("prs_merged"),
+                text("prs_closed"),
+                text("acme-tenant"),
+                text("prs_merged"),
+                QueryParam::UInt(u64::from(VERSION)),
+                text("prs_closed"),
+                QueryParam::UInt(u64::from(VERSION)),
+                text("2026-01-01"),
+                text("2026-01-31"),
+                QueryParam::UInt(10_001),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_derived_metric_folds_every_input_under_its_expression() {
+        let merged = measure(
+            "prs_merged",
+            Some("{ field: state, op: eq, value: merged }"),
+        );
+        let opened = measure("prs_opened", None);
+        let metric = metric(derived(
+            &[("merged", "prs_merged"), ("opened", "prs_opened")],
+            "(opened - merged) / opened",
+        ));
+
+        let compiled = compile(
+            &metric,
+            &[merged, opened],
+            CacheRowKind::Aggregate,
+            &query(ViewKind::SubjectTotal),
+        );
+
+        assert!(
+            compiled.sql.contains(
+                "toFloat64(((sumIf(value, measure_key = ?)) - (sumIf(value, measure_key = ?))) / (sumIf(value, measure_key = ?))) AS value"
+            ),
+            "{}",
+            compiled.sql
+        );
+        assert_eq!(compiled.sql.matches('?').count(), compiled.params.len());
+    }
+
+    #[test]
+    fn a_counting_input_re_folds_without_or_null_because_the_live_count_reports_zero() {
+        let cases = [
+            (
+                CacheRowKind::Aggregate,
+                measure("prs_merged", None),
+                measure("prs_closed", None),
+                "toFloat64(sumIf(value, measure_key = ?) / nullIf(sumIf(value, measure_key = ?), 0)) AS value",
+            ),
+            (
+                CacheRowKind::Event,
+                measure("prs_merged", None),
+                measure("prs_closed", None),
+                "toFloat64(countIf(measure_key = ?) / nullIf(countIf(measure_key = ?), 0)) AS value",
+            ),
+            (
+                CacheRowKind::Subject,
+                distinct("prs_counted"),
+                distinct("prs_reviewed"),
+                "toFloat64(uniqExactIf(subject, measure_key = ?) / nullIf(uniqExactIf(subject, measure_key = ?), 0)) AS value",
+            ),
+        ];
+
+        for (kind, numerator, denominator, expected) in cases {
+            let computation = ratio(&numerator.key, &denominator.key);
+            let compiled = compile(
+                &metric(computation),
+                &[numerator, denominator],
+                kind,
+                &query(ViewKind::SubjectTotal),
+            );
+
+            assert!(
+                compiled.sql.contains(expected),
+                "{kind:?}: {}",
+                compiled.sql
+            );
+        }
+    }
+
+    #[test]
+    fn a_fold_reporting_nothing_over_no_rows_keeps_or_null_on_a_ratio_input() {
+        let averaged = |key: &str| MeasureDefinition {
+            aggregation: Aggregation::Avg,
+            ..sized_measure(key)
+        };
+        let smallest = |key: &str| MeasureDefinition {
+            aggregation: Aggregation::Min,
+            ..sized_measure(key)
+        };
+        let cases = [
+            (
+                CacheRowKind::Aggregate,
+                summed("lines_merged"),
+                summed("lines_opened"),
+                "sumIfOrNull(value, measure_key = ?)",
+            ),
+            (
+                CacheRowKind::Aggregate,
+                smallest("smallest_merged"),
+                smallest("smallest_opened"),
+                "minIfOrNull(value, measure_key = ?)",
+            ),
+            (
+                CacheRowKind::Event,
+                averaged("merged_size"),
+                averaged("opened_size"),
+                "avgIfOrNull(value, measure_key = ?)",
+            ),
+        ];
+
+        for (kind, numerator, denominator, expected) in cases {
+            let computation = ratio(&numerator.key, &denominator.key);
+            let compiled = compile(
+                &metric(computation),
+                &[numerator, denominator],
+                kind,
+                &query(ViewKind::SubjectTotal),
+            );
+
+            assert!(
+                compiled.sql.contains(expected),
+                "{kind:?}: {}",
+                compiled.sql
+            );
+        }
+    }
+
+    #[test]
+    fn a_split_reads_each_dimension_out_of_the_tuples_the_row_carries() {
+        let compiled = compile(
+            &metric(direct("prs_merged")),
+            &[labelled_measure("prs_merged")],
+            CacheRowKind::Aggregate,
+            &query(ViewKind::SubjectSplit(SubjectSplitView {
+                dimensions: vec!["repository".to_owned(), "source".to_owned()],
+            })),
+        );
+
+        assert_eq!(
+            compiled.sql,
+            lines(&[
+                "SELECT",
+                "    entity AS entity_id,",
+                "    if(indexOf(dimensions.1, 'repository') = 0, '__unknown__', coalesce(dimensions.2[indexOf(dimensions.1, 'repository')], '__unknown__')) AS dim_0_value,",
+                "    if(indexOf(dimensions.1, 'repository') = 0, 'Unknown', coalesce(dimensions.3[indexOf(dimensions.1, 'repository')], 'Unknown')) AS dim_0_label,",
+                "    if(indexOf(dimensions.1, 'source') = 0, '__unknown__', coalesce(dimensions.2[indexOf(dimensions.1, 'source')], '__unknown__')) AS dim_1_value,",
+                "    if(indexOf(dimensions.1, 'source') = 0, 'Unknown', coalesce(dimensions.3[indexOf(dimensions.1, 'source')], 'Unknown')) AS dim_1_label,",
+                "    toFloat64(sum(value)) AS value",
+                "FROM insight.semantic_measure_cache",
+                "WHERE tenant_id = ?",
+                "  AND (measure_key, definition_version) IN ((?, ?))",
+                "  AND metric_date >= toDate(?)",
+                "  AND metric_date <= toDate(?)",
+                "GROUP BY entity_id, dim_0_value, dim_0_label, dim_1_value, dim_1_label",
+                "ORDER BY entity_id",
+                "LIMIT ?",
+            ])
+        );
+    }
+
+    #[test]
+    fn a_combined_split_picks_each_groups_label_from_its_latest_cached_day() {
+        let compiled = compile(
+            &metric(direct("prs_merged")),
+            &[labelled_measure("prs_merged")],
+            CacheRowKind::Aggregate,
+            &query(ViewKind::CombinedSplit(CombinedSplitView {
+                dimensions: vec!["repository".to_owned()],
+                group_limit: None,
+            })),
+        );
+
+        assert!(
+            compiled.sql.contains(
+                "argMax(if(indexOf(dimensions.1, 'repository') = 0, 'Unknown', coalesce(dimensions.3[indexOf(dimensions.1, 'repository')], 'Unknown')), tuple(metric_date, if(indexOf(dimensions.1, 'repository') = 0, 'Unknown', coalesce(dimensions.3[indexOf(dimensions.1, 'repository')], 'Unknown')))) AS dim_0_label,"
+            ),
+            "{}",
+            compiled.sql
+        );
+        assert!(
+            compiled
+                .sql
+                .contains("uniqExact(entity) AS contributing_entity_count,")
+        );
+    }
+
+    #[test]
+    fn a_narrowing_reaches_the_cached_row_through_the_dimension_it_names() {
+        let mut request = query(ViewKind::SubjectTotal);
+        request.dimension_filters = vec![DimensionFilter {
+            key: "repository".to_owned(),
+            values: vec!["example/app".to_owned(), "example/lib".to_owned()],
+        }];
+
+        let compiled = compile(
+            &metric(direct("prs_merged")),
+            &[labelled_measure("prs_merged")],
+            CacheRowKind::Aggregate,
+            &request,
+        );
+
+        assert!(
+            compiled.sql.contains(
+                "  AND indexOf(dimensions.1, 'repository') > 0 AND dimensions.2[indexOf(dimensions.1, 'repository')] IN (?, ?)"
+            ),
+            "{}",
+            compiled.sql
+        );
+        assert!(compiled.params.contains(&text("example/app")));
+        assert!(compiled.params.contains(&text("example/lib")));
+    }
+
+    #[test]
+    fn an_identity_scope_narrows_the_cached_entity_column_by_predicate() {
+        let mut request = query(ViewKind::SubjectTotal);
+        request.entity_scope = EntityScope::Identities(vec!["dev@example.com".to_owned()]);
+
+        let compiled = compile(
+            &metric(direct("prs_merged")),
+            &[measure("prs_merged", None)],
+            CacheRowKind::Aggregate,
+            &request,
+        );
+
+        assert!(
+            compiled.sql.contains("  AND entity IN (?)"),
+            "{}",
+            compiled.sql
+        );
+        assert!(!compiled.sql.contains("pool"));
+    }
+
+    #[test]
+    fn a_transform_projects_over_the_re_folded_value_exactly_as_a_dataset_read_does() {
+        let mut metric = metric(direct("prs_merged"));
+        metric.transform = Some(percent_of_total());
+
+        let compiled = compile(
+            &metric,
+            &[measure("prs_merged", None)],
+            CacheRowKind::Aggregate,
+            &query(ViewKind::SubjectTotal),
+        );
+
+        assert!(compiled.sql.starts_with(&lines(&[
+            "SELECT",
+            "    * EXCEPT (value),",
+            "    if((100.0 * (value)) IS NULL, NULL, least(100.0, greatest(0.0, 100.0 * (value)))) AS value",
+            "FROM (",
+        ])));
+    }
+
+    #[test]
+    fn a_row_shape_that_cannot_answer_the_measures_fold_is_refused_rather_than_re_folded() {
+        let cases = [
+            (distinct("prs_counted"), CacheRowKind::Aggregate),
+            (distinct("prs_counted"), CacheRowKind::Event),
+            (measure("prs_merged", None), CacheRowKind::Subject),
+            (
+                MeasureDefinition {
+                    aggregation: Aggregation::Avg,
+                    ..sized_measure("pr_size")
+                },
+                CacheRowKind::Aggregate,
+            ),
+        ];
+
+        for (defined, kind) in cases {
+            let key = defined.key.clone();
+            let error = compile_err(
+                &metric(direct(&key)),
+                &[defined],
+                kind,
+                &query(ViewKind::SubjectTotal),
+            );
+
+            assert!(
+                matches!(error, CompileError::CachedFoldMismatch { .. }),
+                "{key} as {kind:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_distribution_over_pre_folded_rows_is_refused_rather_than_taken() {
+        for kind in [CacheRowKind::Aggregate, CacheRowKind::Subject] {
+            let error = compile_err(
+                &metric(percentile("pr_size", 0.5)),
+                &[sized_measure("pr_size")],
+                kind,
+                &query(ViewKind::SubjectTotal),
+            );
+
+            assert!(
+                matches!(error, CompileError::CachedFoldMismatch { .. }),
+                "{kind:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_measure_the_gate_did_not_decide_cacheable_names_no_cached_read() {
+        let error = compile_cached_metric_query(
+            &metric(direct("prs_merged")),
+            &measures(&[measure("prs_merged", None)]),
+            &BTreeMap::new(),
+            &query(ViewKind::SubjectTotal),
+        )
+        .expect_err("an undecided measure names no cached read");
+
+        assert_eq!(
+            error,
+            CompileError::MeasureNotCached {
+                measure: "prs_merged".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn only_the_value_views_without_a_ranked_cap_are_served_from_the_cache() {
+        let capped = Some(GroupLimit {
+            groups: vec![RankedGroup {
+                rank: 1,
+                dimensions: vec![RankedDimension {
+                    value: "example/app".to_owned(),
+                    label: None,
+                }],
+            }],
+            include_remainder: true,
+        });
+        let cases = [
+            (ViewKind::SubjectTotal, true),
+            (plain_subject_series(), true),
+            (
+                ViewKind::SubjectSplit(SubjectSplitView {
+                    dimensions: vec!["repository".to_owned()],
+                }),
+                true,
+            ),
+            (
+                ViewKind::CombinedSplit(CombinedSplitView {
+                    dimensions: vec!["repository".to_owned()],
+                    group_limit: None,
+                }),
+                true,
+            ),
+            (
+                ViewKind::SubjectSeries(SubjectSeriesView {
+                    dimensions: vec!["repository".to_owned()],
+                    group_limit: capped.clone(),
+                }),
+                false,
+            ),
+            (
+                ViewKind::CombinedSplit(CombinedSplitView {
+                    dimensions: vec!["repository".to_owned()],
+                    group_limit: capped,
+                }),
+                false,
+            ),
+            (bins_view(10), false),
+        ];
+
+        for (view, expected) in cases {
+            let name = view.name();
+            assert_eq!(view_is_cacheable(&view), expected, "{name}");
+
+            if !expected {
+                let error = compile_err(
+                    &metric(direct("prs_merged")),
+                    &[labelled_measure("prs_merged")],
+                    CacheRowKind::Aggregate,
+                    &query(view),
+                );
+                assert!(
+                    matches!(error, CompileError::UnsupportedView { .. }),
+                    "{name}: {error}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn every_placeholder_has_exactly_one_bound_parameter() {
+        let merged = measure(
+            "prs_merged",
+            Some("{ field: state, op: eq, value: merged }"),
+        );
+        let closed = measure(
+            "prs_closed",
+            Some("{ field: state, op: in, value: [merged, closed] }"),
+        );
+        let mut request = query(plain_subject_series());
+        request.bucket = Bucket::Month;
+        request.entity_scope = people();
+        request.dimension_filters = vec![DimensionFilter {
+            key: "repository".to_owned(),
+            values: vec!["example/app".to_owned()],
+        }];
+
+        let compiled = compile(
+            &metric(ratio("prs_merged", "prs_closed")),
+            &[merged, closed],
+            CacheRowKind::Aggregate,
+            &request,
+        );
+
+        assert_eq!(compiled.sql.matches('?').count(), compiled.params.len());
+    }
+
+    #[test]
+    fn no_caller_supplied_value_reaches_the_statement_text() {
+        let injection = "'; DROP TABLE x; --";
+        let mut request = query(ViewKind::SubjectTotal);
+        request.entity_scope = EntityScope::Identities(vec![injection.to_owned()]);
+        request.dimension_filters = vec![DimensionFilter {
+            key: "repository".to_owned(),
+            values: vec![injection.to_owned()],
+        }];
+
+        let compiled = compile(
+            &metric(direct("prs_merged")),
+            &[labelled_measure("prs_merged")],
+            CacheRowKind::Aggregate,
+            &request,
+        );
+
+        assert!(!compiled.sql.contains("DROP TABLE"), "{}", compiled.sql);
+        assert_eq!(
+            compiled
+                .params
+                .iter()
+                .filter(|param| **param == text(injection))
+                .count(),
+            2
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/compiler/mod.rs
+++ b/src/backend/services/analytics/src/domain/compiler/mod.rs
@@ -7,6 +7,8 @@
 #![allow(dead_code)]
 
 mod bins;
+pub mod cache_build;
+pub mod cache_read;
 mod combined_split;
 pub mod comparison;
 pub(crate) mod dimensions;

--- a/src/backend/services/analytics/src/domain/definitions/seeds.rs
+++ b/src/backend/services/analytics/src/domain/definitions/seeds.rs
@@ -14,6 +14,7 @@ use crate::domain::field_catalog::{
     self,
     model::{FieldCatalog, ReadDiscipline as CatalogReadDiscipline},
 };
+use crate::domain::measure_cache::seed_cache_policies;
 
 const ACTOR: &str = "product-seed";
 
@@ -119,6 +120,17 @@ pub async fn reconcile_product_definitions(db: &DatabaseConnection) -> Result<()
     for metric in &definitions.metrics {
         reconcile_metric(&txn, metric, Origin::Product, ACTOR).await?;
     }
+    // INVARIANT: caching is policy, not semantics — this seeds a default beside
+    // the definitions and never touches a definition version.
+    seed_cache_policies(
+        &txn,
+        definitions
+            .measures
+            .iter()
+            .map(|measure| measure.key.as_str()),
+    )
+    .await
+    .map_err(StoreError::from)?;
     txn.commit().await.map_err(StoreError::from)?;
     Ok(())
 }

--- a/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
+++ b/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
@@ -2082,6 +2082,102 @@
         "type": "String"
       },
       {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "definition_version",
+        "type": "UInt32"
+      },
+      {
+        "name": "kind",
+        "type": "Enum8('aggregate' = 1, 'event' = 2, 'subject' = 3)"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "entity",
+        "type": "String"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      },
+      {
+        "name": "value",
+        "type": "Float64"
+      },
+      {
+        "name": "subject",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "built_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "semantic_measure_cache",
+    "sorting_key": "tenant_id, measure_key, entity, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "definition_version",
+        "type": "UInt32"
+      },
+      {
+        "name": "kind",
+        "type": "Enum8('aggregate' = 1, 'event' = 2, 'subject' = 3)"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "entity",
+        "type": "String"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      },
+      {
+        "name": "value",
+        "type": "Float64"
+      },
+      {
+        "name": "subject",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "built_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "semantic_measure_cache_staging",
+    "sorting_key": "tenant_id, measure_key, entity, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
         "name": "insight_source_id",
         "type": "String"
       },

--- a/src/backend/services/analytics/src/domain/measure_cache/error.rs
+++ b/src/backend/services/analytics/src/domain/measure_cache/error.rs
@@ -1,0 +1,17 @@
+use crate::domain::compiler::error::CompileError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CacheRefreshError {
+    #[error("the policy store is unreadable: {0}")]
+    PolicyStore(#[from] sea_orm::DbErr),
+    #[error("measure `{measure}` does not compile into a cache build: {source}")]
+    Uncompilable {
+        measure: String,
+        #[source]
+        source: CompileError,
+    },
+    #[error("measure `{measure}` reads dataset `{dataset}`, which the catalog does not carry")]
+    UncataloguedDataset { measure: String, dataset: String },
+    #[error("the warehouse refused the build for measure `{measure}`")]
+    BuildRefused { measure: String },
+}

--- a/src/backend/services/analytics/src/domain/measure_cache/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/measure_cache/live_tests.rs
@@ -1,0 +1,224 @@
+//! Live MariaDB tests for the cache policy and coverage store. `#[ignore]`d and
+//! skipped when `INTEGRATION_TESTS_MARIADB_URL` is unset; CI runs them with
+//! `--include-ignored` against a migrated MariaDB.
+
+use chrono::NaiveDate;
+use sea_orm::{ConnectOptions, ConnectionTrait, Database, DatabaseConnection, Statement, Value};
+
+use super::policy::{
+    CoverageWrite, coverage_row_kind, enabled_policies, record_coverage, seed_cache_policies,
+};
+use crate::domain::compiler::cache_build::CacheRowKind;
+use crate::domain::definitions::seeds::{product_definitions, reconcile_product_definitions};
+
+const ENV_VAR: &str = "INTEGRATION_TESTS_MARIADB_URL";
+
+async fn connect_or_skip() -> Option<DatabaseConnection> {
+    let Ok(url) = std::env::var(ENV_VAR) else {
+        eprintln!("skipping: {ENV_VAR} not set");
+        return None;
+    };
+    let mut opts = ConnectOptions::new(url);
+    opts.max_connections(2).sqlx_logging(false);
+    match Database::connect(opts).await {
+        Ok(db) => Some(db),
+        Err(e) => {
+            eprintln!("skipping: cannot connect to {ENV_VAR}: {e}");
+            None
+        }
+    }
+}
+
+async fn cleanup(db: &DatabaseConnection, key: &str) {
+    for table in ["semantic_cache_policies", "semantic_cache_coverage"] {
+        let _ = db
+            .execute_raw(Statement::from_sql_and_values(
+                db.get_database_backend(),
+                format!("DELETE FROM {table} WHERE measure_key = ?"),
+                [Value::from(key)],
+            ))
+            .await;
+    }
+}
+
+async fn scalar(db: &DatabaseConnection, sql: &str, key: &str) -> String {
+    let row = db
+        .query_one_raw(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            sql,
+            [Value::from(key)],
+        ))
+        .await
+        .expect("query runs")
+        .expect("row exists");
+    row.try_get::<String>("", "answer").expect("column reads")
+}
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(year, month, day).expect("valid date")
+}
+
+#[tokio::test]
+#[ignore = "requires INTEGRATION_TESTS_MARIADB_URL"]
+async fn seeding_a_policy_twice_leaves_what_an_operator_set() {
+    let Some(db) = connect_or_skip().await else {
+        return;
+    };
+    let key = "live_cache_policy_seed";
+    cleanup(&db, key).await;
+
+    seed_cache_policies(&db, [key]).await.expect("first seed");
+    db.execute_raw(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        "UPDATE semantic_cache_policies SET enabled = FALSE, hot_window_days = 7 \
+         WHERE measure_key = ?",
+        [Value::from(key)],
+    ))
+    .await
+    .expect("an operator narrows the policy");
+
+    seed_cache_policies(&db, [key]).await.expect("second seed");
+
+    let settings = scalar(
+        &db,
+        "SELECT CONCAT(enabled, ':', hot_window_days) AS answer \
+         FROM semantic_cache_policies WHERE measure_key = ?",
+        key,
+    )
+    .await;
+
+    assert_eq!(settings, "0:7", "a reseed must not overwrite the policy");
+    cleanup(&db, key).await;
+}
+
+#[tokio::test]
+#[ignore = "requires INTEGRATION_TESTS_MARIADB_URL"]
+async fn coverage_widens_with_every_successful_build_and_never_narrows() {
+    let Some(db) = connect_or_skip().await else {
+        return;
+    };
+    let key = "live_cache_coverage";
+    cleanup(&db, key).await;
+
+    record_coverage(
+        &db,
+        key,
+        1,
+        CacheRowKind::Aggregate,
+        date(2026, 2, 1),
+        date(2026, 3, 8),
+        CoverageWrite::Widen,
+    )
+    .await
+    .expect("first build lands");
+    record_coverage(
+        &db,
+        key,
+        1,
+        CacheRowKind::Aggregate,
+        date(2026, 2, 5),
+        date(2026, 3, 12),
+        CoverageWrite::Widen,
+    )
+    .await
+    .expect("second build lands");
+
+    let covered = scalar(
+        &db,
+        "SELECT CONCAT(covered_from, '..', covered_to, ' ', row_kind) AS answer \
+         FROM semantic_cache_coverage WHERE measure_key = ?",
+        key,
+    )
+    .await;
+
+    assert_eq!(covered, "2026-02-01..2026-03-12 aggregate");
+    cleanup(&db, key).await;
+}
+
+#[tokio::test]
+#[ignore = "requires INTEGRATION_TESTS_MARIADB_URL"]
+async fn a_rebuild_at_a_new_row_shape_replaces_the_window_the_old_shape_covered() {
+    let Some(db) = connect_or_skip().await else {
+        return;
+    };
+    let key = "live_cache_reshaped";
+    cleanup(&db, key).await;
+
+    record_coverage(
+        &db,
+        key,
+        1,
+        CacheRowKind::Aggregate,
+        date(2026, 1, 1),
+        date(2026, 3, 8),
+        CoverageWrite::Widen,
+    )
+    .await
+    .expect("the first shape lands");
+
+    assert_eq!(
+        coverage_row_kind(&db, key, 1)
+            .await
+            .expect("coverage reads"),
+        Some(CacheRowKind::Aggregate)
+    );
+
+    record_coverage(
+        &db,
+        key,
+        1,
+        CacheRowKind::Event,
+        date(2026, 3, 1),
+        date(2026, 3, 12),
+        CoverageWrite::Replace,
+    )
+    .await
+    .expect("the rebuild lands");
+
+    let covered = scalar(
+        &db,
+        "SELECT CONCAT(covered_from, '..', covered_to, ' ', row_kind) AS answer \
+         FROM semantic_cache_coverage WHERE measure_key = ?",
+        key,
+    )
+    .await;
+
+    assert_eq!(
+        covered, "2026-03-01..2026-03-12 event",
+        "a reshaped rebuild claims only what it built"
+    );
+    cleanup(&db, key).await;
+}
+
+#[tokio::test]
+#[ignore = "requires INTEGRATION_TESTS_MARIADB_URL"]
+async fn every_shipped_measure_reconciles_with_a_policy_and_no_second_pass_churns_it() {
+    let Some(db) = connect_or_skip().await else {
+        return;
+    };
+
+    reconcile_product_definitions(&db)
+        .await
+        .expect("first reconcile");
+    let after_first = enabled_policies(&db).await.expect("policies read");
+
+    reconcile_product_definitions(&db)
+        .await
+        .expect("second reconcile");
+    let after_second = enabled_policies(&db).await.expect("policies read");
+
+    let shipped = product_definitions().expect("definitions are valid");
+    for measure in &shipped.measures {
+        assert!(
+            after_first
+                .iter()
+                .any(|policy| policy.measure_key == measure.key),
+            "measure `{}` has no cache policy",
+            measure.key
+        );
+    }
+    assert_eq!(
+        after_first, after_second,
+        "a second reconcile churns policy"
+    );
+}

--- a/src/backend/services/analytics/src/domain/measure_cache/lock.rs
+++ b/src/backend/services/analytics/src/domain/measure_cache/lock.rs
@@ -1,0 +1,151 @@
+//! The per-measure advisory lock. Every replica runs the refresh loop and they
+//! share one staging relation, so two of them building the same measure would
+//! swap in each other's rows on top of their own.
+//!
+//! INVARIANT: `GET_LOCK` is session-scoped, so this owns a pool pinned to one
+//! connection — a shared pool would scatter acquire and release across sessions.
+
+use std::time::Duration;
+
+use sea_orm::{
+    ConnectOptions, ConnectionTrait, Database, DatabaseConnection, DbBackend, DbErr, Statement,
+    Value,
+};
+
+/// sqlx's own idle and lifetime defaults would reap the pinned connection
+/// between an acquire and its release, handing the release a session that never
+/// held the lock.
+const SESSION_LIFETIME: Duration = Duration::from_hours(24);
+
+/// INVARIANT: MariaDB caps a lock name at 192 characters, which this prefix
+/// plus a `VARCHAR(128)` measure key cannot reach.
+const NAME_PREFIX: &str = "semantic-cache-";
+
+/// What one acquisition attempt answered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockOutcome {
+    /// This session owns the measure until it releases.
+    Held,
+    /// Another session is building this measure right now.
+    HeldElsewhere,
+    /// The lock could not be asked for, which is not the same as being refused.
+    Unknown,
+}
+
+pub struct LockSession {
+    db: DatabaseConnection,
+}
+
+impl LockSession {
+    /// # Errors
+    ///
+    /// Returns an error if the pinned session cannot be opened.
+    pub async fn connect(database_url: &str) -> Result<Self, DbErr> {
+        let mut opts = ConnectOptions::new(database_url.to_owned());
+        opts.max_connections(1)
+            .min_connections(1)
+            .idle_timeout(SESSION_LIFETIME)
+            .max_lifetime(SESSION_LIFETIME)
+            .test_before_acquire(false)
+            .sqlx_logging(false);
+
+        Ok(Self {
+            db: Database::connect(opts).await?,
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn disconnected() -> Self {
+        Self {
+            db: DatabaseConnection::default(),
+        }
+    }
+
+    /// Never waits: a measure another replica already owns is that replica's
+    /// tick to spend, not this one's to queue behind.
+    pub async fn acquire(&self, measure_key: &str) -> LockOutcome {
+        // CAST so the column type is deterministic — the lock builtins are typed
+        // per expression and an uncast result decodes differently per server.
+        let answered = self
+            .db
+            .query_one_raw(Statement::from_sql_and_values(
+                DbBackend::MySql,
+                "SELECT CAST(GET_LOCK(?, 0) AS SIGNED)",
+                [Value::from(lock_name(measure_key))],
+            ))
+            .await;
+
+        match answered {
+            Ok(Some(row)) => outcome(row.try_get_by_index::<Option<i64>>(0).ok().flatten()),
+            Ok(None) => LockOutcome::Unknown,
+            Err(error) => {
+                tracing::warn!(%error, measure = %measure_key, "the measure cache lock is unavailable");
+                LockOutcome::Unknown
+            }
+        }
+    }
+
+    /// A release that does not land is not a lost build: the lock dies with the
+    /// session, and the next tick asks again.
+    pub async fn release(&self, measure_key: &str) {
+        if let Err(error) = self
+            .db
+            .execute_raw(Statement::from_sql_and_values(
+                DbBackend::MySql,
+                "SELECT RELEASE_LOCK(?)",
+                [Value::from(lock_name(measure_key))],
+            ))
+            .await
+        {
+            tracing::warn!(%error, measure = %measure_key, "the measure cache lock was not released");
+        }
+    }
+}
+
+fn lock_name(measure_key: &str) -> String {
+    format!("{NAME_PREFIX}{measure_key}")
+}
+
+/// `GET_LOCK` answers 1 when this session took the lock and 0 when the wait
+/// expired because another session holds it; anything else says nothing.
+fn outcome(answer: Option<i64>) -> LockOutcome {
+    match answer {
+        Some(1) => LockOutcome::Held,
+        Some(0) => LockOutcome::HeldElsewhere,
+        Some(_) | None => LockOutcome::Unknown,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_lock_stands_for_one_measure() {
+        assert_eq!(lock_name("commits"), "semantic-cache-commits");
+        assert_ne!(lock_name("commits"), lock_name("default_commits"));
+    }
+
+    #[test]
+    fn the_longest_measure_key_the_store_admits_still_names_a_lock_mariadb_accepts() {
+        let longest = "m".repeat(128);
+
+        assert!(lock_name(&longest).len() <= 192);
+    }
+
+    #[test]
+    fn a_refused_lock_is_told_apart_from_a_lock_that_could_not_be_asked_for() {
+        assert_eq!(outcome(Some(1)), LockOutcome::Held);
+        assert_eq!(outcome(Some(0)), LockOutcome::HeldElsewhere);
+        assert_eq!(outcome(None), LockOutcome::Unknown);
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_session_owns_nothing_rather_than_assuming_it_does() {
+        let session = LockSession::disconnected();
+
+        assert_eq!(session.acquire("commits").await, LockOutcome::Unknown);
+        session.release("commits").await;
+    }
+}

--- a/src/backend/services/analytics/src/domain/measure_cache/mod.rs
+++ b/src/backend/services/analytics/src/domain/measure_cache/mod.rs
@@ -1,0 +1,554 @@
+//! Scheduled materialization of the semantic layer's measures. A read never
+//! triggers a build; a tick builds each due measure's hot window into staging
+//! and swaps it in one partition at a time. A build that fails leaves the
+//! previous coverage and the previously served partitions exactly as they were.
+
+mod error;
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod live_tests;
+mod lock;
+mod plan;
+mod policy;
+pub mod read_gate;
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod warehouse_live_tests;
+
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use clickhouse::Row;
+use sea_orm::DatabaseConnection;
+use serde::Deserialize;
+
+use crate::domain::compiler::cache_build::{
+    CacheBuild, CacheRowKind, compile_cache_build, row_kind,
+};
+use crate::domain::compiler::sql::{CompiledMeasureQuery, QueryParam};
+use crate::domain::definitions::definition::MeasureDefinition;
+use crate::domain::definitions::seeds::product_definitions;
+use crate::domain::field_catalog::model::FieldCatalog;
+use crate::domain::field_catalog::product_catalog;
+
+use lock::{LockOutcome, LockSession};
+use plan::HotWindow;
+use policy::CoverageWrite;
+
+pub use error::CacheRefreshError;
+pub use policy::seed_cache_policies;
+pub use read_gate::{CacheDecision, ReadGate};
+
+/// How often the loop looks for due measures. Each measure's own cadence comes
+/// from its policy, so this only bounds how late a due measure starts.
+const TICK: Duration = Duration::from_mins(1);
+
+/// A build is background work over a whole dataset: it gets room to finish and
+/// a thread budget that cannot starve the serving pool. No read-bytes ceiling —
+/// scanning the dataset is the job, and a cap sized for a small install would
+/// fail the build on a large one instead of bounding it.
+const BUILD_TIMEOUT_SECS: u64 = 600;
+const BUILD_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const BUILD_THREADS: u32 = 2;
+
+#[derive(Debug, Row, Deserialize)]
+struct CachePartition {
+    version: u32,
+    month: u32,
+}
+
+/// A shipped measure and the row shape its own metrics decide, resolved once so
+/// no build has to guess one for the other.
+struct CachedMeasure {
+    definition: MeasureDefinition,
+    kind: CacheRowKind,
+}
+
+/// Materializes measures on a schedule. One measure at a time per tick, so a
+/// build never competes with the next one for the warehouse.
+pub struct MeasureCacheRefresher {
+    db: DatabaseConnection,
+    locks: LockSession,
+    ch: insight_clickhouse::Client,
+    catalog: &'static FieldCatalog,
+    measures: BTreeMap<String, CachedMeasure>,
+    attempted: BTreeMap<String, Instant>,
+}
+
+impl MeasureCacheRefresher {
+    /// # Errors
+    ///
+    /// Returns an error if the compiled-in product definitions do not load —
+    /// an authoring failure rather than a runtime one — or if the pinned lock
+    /// session cannot be opened.
+    pub async fn new(
+        db: DatabaseConnection,
+        ch: insight_clickhouse::Client,
+        database_url: &str,
+    ) -> anyhow::Result<Self> {
+        let definitions = product_definitions()?;
+        let catalog = product_catalog().map_err(|error| anyhow::anyhow!("{error}"))?;
+        let locks = LockSession::connect(database_url).await?;
+
+        let measures = definitions
+            .measures
+            .iter()
+            .map(|measure| {
+                let kind = row_kind(measure, &definitions.metrics);
+                (
+                    measure.key.clone(),
+                    CachedMeasure {
+                        definition: measure.clone(),
+                        kind,
+                    },
+                )
+            })
+            .collect();
+
+        Ok(Self {
+            db,
+            locks,
+            ch,
+            catalog,
+            measures,
+            attempted: BTreeMap::new(),
+        })
+    }
+
+    /// Periodic sweep. Never returns; run it on a spawned task.
+    pub async fn run(mut self) {
+        let mut ticks = tokio::time::interval(TICK);
+        ticks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticks.tick().await;
+            self.refresh_due().await;
+        }
+    }
+
+    async fn refresh_due(&mut self) {
+        let policies = match policy::enabled_policies(&self.db).await {
+            Ok(policies) => policies,
+            Err(error) => {
+                tracing::warn!(%error, "measure cache policies are unreadable; nothing refreshed");
+                return;
+            }
+        };
+        let versions = match policy::current_versions(&self.db).await {
+            Ok(versions) => versions,
+            Err(error) => {
+                tracing::warn!(%error, "measure definition versions are unreadable; nothing refreshed");
+                return;
+            }
+        };
+
+        let today = Utc::now().date_naive();
+        for policy in policies {
+            let due = Duration::from_secs(u64::from(policy.refresh_interval_minutes) * 60);
+            if self
+                .attempted
+                .get(&policy.measure_key)
+                .is_some_and(|last| last.elapsed() < due)
+            {
+                continue;
+            }
+            let Some(&version) = versions.get(&policy.measure_key) else {
+                continue;
+            };
+            match self.locks.acquire(&policy.measure_key).await {
+                LockOutcome::Held => {}
+                LockOutcome::HeldElsewhere => {
+                    tracing::debug!(
+                        measure = %policy.measure_key,
+                        "another replica is building this measure; skipping the tick"
+                    );
+                    continue;
+                }
+                LockOutcome::Unknown => continue,
+            }
+
+            self.attempted
+                .insert(policy.measure_key.clone(), Instant::now());
+            let window = plan::hot_window(today, policy.hot_window_days);
+
+            let outcome = self.refresh(&policy.measure_key, version, window).await;
+            self.locks.release(&policy.measure_key).await;
+
+            if let Err(error) = outcome {
+                tracing::error!(
+                    %error,
+                    measure = %policy.measure_key,
+                    definition_version = version,
+                    "measure cache refresh failed; the previous coverage keeps serving"
+                );
+            }
+        }
+    }
+
+    async fn refresh(
+        &self,
+        measure_key: &str,
+        version: u32,
+        window: HotWindow,
+    ) -> Result<(), CacheRefreshError> {
+        let Some(cached) = self.measures.get(measure_key) else {
+            return Ok(());
+        };
+        let measure = &cached.definition;
+        let dataset = self.catalog.dataset(&measure.dataset).ok_or_else(|| {
+            CacheRefreshError::UncataloguedDataset {
+                measure: measure.key.clone(),
+                dataset: measure.dataset.clone(),
+            }
+        })?;
+
+        let build = CacheBuild {
+            measure,
+            definition_version: version,
+            kind: cached.kind,
+            from: window.from,
+            to: window.to,
+        };
+        let compiled = compile_cache_build(dataset, &build).map_err(|source| {
+            CacheRefreshError::Uncompilable {
+                measure: measure.key.clone(),
+                source,
+            }
+        })?;
+        let months = plan::months(window);
+
+        self.clear_staging(measure_key, version, &months).await?;
+        self.execute(measure_key, &compiled).await?;
+
+        // INVARIANT: a shape change at one version cannot be healed by widening
+        // coverage — a settled month would keep rows of the old shape under a
+        // window claiming the new one. The drop follows the staged build, so a
+        // build the warehouse refuses drops nothing.
+        let write = if self.reshaped(measure_key, version, cached.kind).await? {
+            self.drop_version(measure_key, version).await?;
+            CoverageWrite::Replace
+        } else {
+            CoverageWrite::Widen
+        };
+
+        for month in &months {
+            self.alter_partition(measure_key, &plan::swap_partition_sql(), version, *month)
+                .await?;
+        }
+        self.clear_staging(measure_key, version, &months).await?;
+
+        policy::record_coverage(
+            &self.db,
+            measure_key,
+            version,
+            cached.kind,
+            window.from,
+            window.to,
+            write,
+        )
+        .await?;
+        self.drop_superseded(measure_key, version).await;
+        Ok(())
+    }
+
+    /// Whether what the coverage attests was built at a different row shape
+    /// than the one this release folds the measure into.
+    async fn reshaped(
+        &self,
+        measure_key: &str,
+        version: u32,
+        kind: CacheRowKind,
+    ) -> Result<bool, CacheRefreshError> {
+        let attested = policy::coverage_row_kind(&self.db, measure_key, version).await?;
+        Ok(attested.is_some_and(|attested| attested != kind))
+    }
+
+    /// Every partition one version occupies, dropped before its rebuild so the
+    /// months this run does not touch cannot keep the shape it is replacing.
+    async fn drop_version(&self, measure_key: &str, version: u32) -> Result<(), CacheRefreshError> {
+        let occupied = self
+            .bounded(&plan::version_partitions_sql())
+            .bind(measure_key)
+            .bind(version)
+            .fetch_all::<CachePartition>()
+            .await
+            .map_err(|error| {
+                tracing::error!(%error, measure = %measure_key, version, "the partitions of a reshaped measure are unreadable");
+                CacheRefreshError::BuildRefused {
+                    measure: measure_key.to_owned(),
+                }
+            })?;
+
+        let sql = plan::drop_cache_partition_sql();
+        for partition in occupied {
+            self.alter_partition(measure_key, &sql, partition.version, partition.month)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn clear_staging(
+        &self,
+        measure_key: &str,
+        version: u32,
+        months: &[u32],
+    ) -> Result<(), CacheRefreshError> {
+        let sql = plan::clear_staging_partition_sql();
+        for month in months {
+            self.alter_partition(measure_key, &sql, version, *month)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Reclamation, not correctness: a superseded version's rows are dropped
+    /// after the current version has landed, and a drop that does not happen is
+    /// disk this run failed to release, never an answer this run got wrong.
+    async fn drop_superseded(&self, measure_key: &str, version: u32) {
+        let stale = self
+            .bounded(&plan::superseded_partitions_sql())
+            .bind(measure_key)
+            .bind(version)
+            .fetch_all::<CachePartition>()
+            .await;
+        let stale = match stale {
+            Ok(stale) => stale,
+            Err(error) => {
+                tracing::warn!(%error, measure = %measure_key, "superseded cache partitions are unreadable");
+                return;
+            }
+        };
+
+        let sql = plan::drop_cache_partition_sql();
+        for partition in stale {
+            if let Err(error) = self
+                .alter_partition(measure_key, &sql, partition.version, partition.month)
+                .await
+            {
+                tracing::warn!(%error, measure = %measure_key, "a superseded cache partition was not dropped");
+            }
+        }
+    }
+
+    async fn alter_partition(
+        &self,
+        measure_key: &str,
+        sql: &str,
+        version: u32,
+        month: u32,
+    ) -> Result<(), CacheRefreshError> {
+        self.bounded(sql)
+            .bind(measure_key)
+            .bind(version)
+            .bind(month)
+            .execute()
+            .await
+            .map_err(|error| {
+                tracing::error!(%error, measure = %measure_key, version, month, sql, "cache partition statement failed");
+                CacheRefreshError::BuildRefused {
+                    measure: measure_key.to_owned(),
+                }
+            })
+    }
+
+    async fn execute(
+        &self,
+        measure_key: &str,
+        compiled: &CompiledMeasureQuery,
+    ) -> Result<(), CacheRefreshError> {
+        let mut request = self.bounded(&compiled.sql);
+        for param in &compiled.params {
+            request = match param {
+                QueryParam::Text(value) => request.bind(value.as_str()),
+                QueryParam::Int(value) => request.bind(*value),
+                QueryParam::UInt(value) => request.bind(*value),
+                QueryParam::Float(value) => request.bind(*value),
+                QueryParam::Bool(value) => request.bind(*value),
+            };
+        }
+
+        request.execute().await.map_err(|error| {
+            tracing::error!(%error, measure = %measure_key, sql = %compiled.sql, "measure cache build failed");
+            CacheRefreshError::BuildRefused {
+                measure: measure_key.to_owned(),
+            }
+        })
+    }
+
+    fn bounded(&self, sql: &str) -> clickhouse::query::Query {
+        self.ch
+            .query(sql)
+            .with_setting("max_execution_time", BUILD_TIMEOUT_SECS.to_string())
+            .with_setting("max_memory_usage", BUILD_MEMORY_BYTES.to_string())
+            .with_setting("max_threads", BUILD_THREADS.to_string())
+            .with_setting("log_comment", "semantic-measure-cache-refresh")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use chrono::NaiveDate;
+
+    use super::*;
+    use crate::domain::definitions::definition::Computation;
+
+    /// Points at a closed port: a statement that reached the network would fail.
+    fn offline_clickhouse() -> insight_clickhouse::Client {
+        insight_clickhouse::Client::new(insight_clickhouse::Config {
+            url: "http://127.0.0.1:1".to_owned(),
+            database: "insight".to_owned(),
+            user: None,
+            password: None,
+            query_timeout: None,
+            query_max_threads: None,
+            query_max_memory_bytes: None,
+        })
+    }
+
+    fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(year, month, day).expect("valid date")
+    }
+
+    fn offline_shipped_refresher() -> MeasureCacheRefresher {
+        let definitions = product_definitions().expect("definitions are valid");
+
+        offline_refresher(
+            definitions
+                .measures
+                .iter()
+                .map(|measure| {
+                    let kind = row_kind(measure, &definitions.metrics);
+                    (
+                        measure.key.clone(),
+                        CachedMeasure {
+                            definition: measure.clone(),
+                            kind,
+                        },
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    fn offline_refresher(measures: BTreeMap<String, CachedMeasure>) -> MeasureCacheRefresher {
+        MeasureCacheRefresher {
+            db: DatabaseConnection::default(),
+            locks: LockSession::disconnected(),
+            ch: offline_clickhouse(),
+            catalog: product_catalog().expect("catalog loads"),
+            measures,
+            attempted: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn every_shipped_measure_is_given_the_row_shape_its_metrics_can_be_answered_from() {
+        let definitions = product_definitions().expect("definitions are valid");
+
+        for metric in &definitions.metrics {
+            let read = match &metric.computation {
+                Computation::Percentile { measure, .. } | Computation::Stddev { measure } => {
+                    measure
+                }
+                Computation::Direct { .. }
+                | Computation::Ratio { .. }
+                | Computation::Derived { .. } => continue,
+            };
+            let measure = definitions
+                .measures
+                .iter()
+                .find(|candidate| &candidate.key == read)
+                .expect("a shipped metric reads a shipped measure");
+
+            assert_eq!(
+                row_kind(measure, &definitions.metrics),
+                CacheRowKind::Event,
+                "metric `{}` takes a distribution over `{}`",
+                metric.key,
+                measure.key
+            );
+        }
+    }
+
+    #[test]
+    fn every_shipped_average_keeps_its_rows_because_an_average_cannot_re_fold() {
+        use crate::domain::definitions::definition::Aggregation;
+
+        let definitions = product_definitions().expect("definitions are valid");
+
+        for measure in &definitions.measures {
+            if measure.aggregation != Aggregation::Avg {
+                continue;
+            }
+            assert_eq!(
+                row_kind(measure, &definitions.metrics),
+                CacheRowKind::Event,
+                "measure `{}`",
+                measure.key
+            );
+        }
+    }
+
+    #[test]
+    fn every_shipped_measure_compiles_a_build_over_its_hot_window() {
+        let definitions = product_definitions().expect("definitions are valid");
+        let catalog = product_catalog().expect("catalog loads");
+        let window = plan::hot_window(date(2026, 3, 10), 35);
+
+        for measure in &definitions.measures {
+            let dataset = catalog
+                .dataset(&measure.dataset)
+                .expect("a shipped measure reads a catalogued dataset");
+            let build = CacheBuild {
+                measure,
+                definition_version: 1,
+                kind: row_kind(measure, &definitions.metrics),
+                from: window.from,
+                to: window.to,
+            };
+
+            let compiled = compile_cache_build(dataset, &build)
+                .unwrap_or_else(|error| panic!("measure `{}`: {error}", measure.key));
+
+            assert_eq!(
+                compiled.sql.matches('?').count(),
+                compiled.params.len(),
+                "measure `{}`",
+                measure.key
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_measure_this_release_does_not_ship_is_skipped_rather_than_failed() {
+        let refresher = offline_refresher(BTreeMap::new());
+
+        let outcome = refresher
+            .refresh(
+                "retired_measure",
+                1,
+                plan::hot_window(date(2026, 3, 10), 35),
+            )
+            .await;
+
+        assert!(outcome.is_ok());
+    }
+
+    /// The offline store cannot be reached at all, so a `BuildRefused` proves
+    /// the run stopped at the warehouse before the reshape read, the partition
+    /// drop and the coverage write.
+    #[tokio::test]
+    async fn a_build_the_warehouse_refuses_drops_nothing_and_writes_no_coverage() {
+        let refresher = offline_shipped_refresher();
+
+        let outcome = refresher
+            .refresh("commits", 1, plan::hot_window(date(2026, 3, 10), 35))
+            .await;
+
+        assert!(matches!(
+            outcome.expect_err("a closed port cannot take a build"),
+            CacheRefreshError::BuildRefused { measure } if measure == "commits"
+        ));
+    }
+}

--- a/src/backend/services/analytics/src/domain/measure_cache/plan.rs
+++ b/src/backend/services/analytics/src/domain/measure_cache/plan.rs
@@ -1,0 +1,162 @@
+//! What one refresh tick covers and the statements it issues.
+//!
+//! Partitions are `(measure, definition version, month)`, so every statement
+//! here names a partition by that triple and touches nothing else.
+
+use chrono::{Datelike, NaiveDate, TimeDelta};
+
+use crate::domain::compiler::cache_build::{CACHE_RELATION, STAGING_RELATION};
+
+/// The span a refresh rebuilds. Days that fall out of it keep the rows an
+/// earlier run left, which is what makes a settled period cheap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HotWindow {
+    pub from: NaiveDate,
+    pub to: NaiveDate,
+}
+
+pub fn hot_window(today: NaiveDate, hot_window_days: u32) -> HotWindow {
+    let from = today
+        .checked_sub_signed(TimeDelta::days(i64::from(hot_window_days)))
+        .unwrap_or(NaiveDate::MIN);
+
+    HotWindow { from, to: today }
+}
+
+/// The partition months the window spans, as `toYYYYMM` reads them.
+pub fn months(window: HotWindow) -> Vec<u32> {
+    let last = (window.to.year(), window.to.month());
+    let (mut year, mut month) = (window.from.year(), window.from.month());
+
+    let mut months = Vec::new();
+    while (year, month) <= last {
+        months.push(year_month(year, month));
+        if month == 12 {
+            year += 1;
+            month = 1;
+        } else {
+            month += 1;
+        }
+    }
+
+    months
+}
+
+fn year_month(year: i32, month: u32) -> u32 {
+    year.unsigned_abs() * 100 + month
+}
+
+/// Clears the slot a build is about to fill, so a crashed run's leftovers can
+/// never be swapped in as if they were this run's work.
+pub fn clear_staging_partition_sql() -> String {
+    format!("ALTER TABLE {STAGING_RELATION} DROP PARTITION (?, ?, ?)")
+}
+
+/// The swap: one month of one measure at one version, replaced whole. A reader
+/// sees either the previous partition or the new one, never a half-built mix.
+pub fn swap_partition_sql() -> String {
+    format!("ALTER TABLE {CACHE_RELATION} REPLACE PARTITION (?, ?, ?) FROM {STAGING_RELATION}")
+}
+
+pub fn drop_cache_partition_sql() -> String {
+    format!("ALTER TABLE {CACHE_RELATION} DROP PARTITION (?, ?, ?)")
+}
+
+/// The partitions a superseded definition still occupies. Read after the
+/// current version has landed, so a failed build never drops what still serves.
+pub fn superseded_partitions_sql() -> String {
+    format!(
+        "SELECT DISTINCT definition_version AS version, toYYYYMM(metric_date) AS month \
+         FROM {CACHE_RELATION} WHERE measure_key = ? AND definition_version < ?"
+    )
+}
+
+/// The partitions one version currently occupies, for a rebuild that cannot
+/// leave a settled month holding rows of the shape it is replacing.
+pub fn version_partitions_sql() -> String {
+    format!(
+        "SELECT DISTINCT definition_version AS version, toYYYYMM(metric_date) AS month \
+         FROM {CACHE_RELATION} WHERE measure_key = ? AND definition_version = ?"
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(year, month, day).expect("valid date")
+    }
+
+    #[test]
+    fn the_hot_window_ends_today_and_reaches_back_the_policy_days() {
+        let window = hot_window(date(2026, 3, 10), 35);
+
+        assert_eq!(window.to, date(2026, 3, 10));
+        assert_eq!(window.from, date(2026, 2, 3));
+    }
+
+    #[test]
+    fn a_window_covers_every_month_it_touches() {
+        let cases = [
+            (hot_window(date(2026, 3, 10), 35), vec![202_602, 202_603]),
+            (hot_window(date(2026, 3, 10), 1), vec![202_603]),
+            (
+                hot_window(date(2026, 1, 15), 60),
+                vec![202_511, 202_512, 202_601],
+            ),
+        ];
+
+        for (window, expected) in cases {
+            assert_eq!(months(window), expected, "window {window:?}");
+        }
+    }
+
+    #[test]
+    fn a_window_whose_end_precedes_its_start_covers_nothing() {
+        let inverted = HotWindow {
+            from: date(2026, 5, 1),
+            to: date(2026, 4, 1),
+        };
+
+        assert!(months(inverted).is_empty());
+    }
+
+    #[test]
+    fn every_statement_names_one_partition_by_measure_version_and_month() {
+        for sql in [
+            clear_staging_partition_sql(),
+            swap_partition_sql(),
+            drop_cache_partition_sql(),
+        ] {
+            assert!(sql.contains("PARTITION (?, ?, ?)"), "{sql}");
+            assert_eq!(sql.matches('?').count(), 3, "{sql}");
+        }
+    }
+
+    #[test]
+    fn the_swap_moves_a_partition_from_staging_into_the_served_relation() {
+        assert_eq!(
+            swap_partition_sql(),
+            "ALTER TABLE insight.semantic_measure_cache REPLACE PARTITION (?, ?, ?) \
+             FROM insight.semantic_measure_cache_staging"
+        );
+    }
+
+    #[test]
+    fn the_superseded_read_asks_only_about_versions_below_the_current_one() {
+        let sql = superseded_partitions_sql();
+
+        assert!(sql.contains("definition_version < ?"), "{sql}");
+        assert_eq!(sql.matches('?').count(), 2, "{sql}");
+    }
+
+    #[test]
+    fn the_rebuild_read_asks_only_about_the_version_it_is_replacing() {
+        let sql = version_partitions_sql();
+
+        assert!(sql.contains("definition_version = ?"), "{sql}");
+        assert_eq!(sql.matches('?').count(), 2, "{sql}");
+    }
+}

--- a/src/backend/services/analytics/src/domain/measure_cache/policy.rs
+++ b/src/backend/services/analytics/src/domain/measure_cache/policy.rs
@@ -1,0 +1,208 @@
+//! The policy and coverage store. Policy says whether and how often a measure
+//! is materialized; coverage says which dates the cache can answer from.
+
+use std::collections::BTreeMap;
+
+use chrono::NaiveDate;
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, DatabaseConnection, DbErr, EntityTrait, QueryFilter, Statement,
+    Value,
+};
+use uuid::Uuid;
+
+use crate::domain::compiler::cache_build::CacheRowKind;
+use crate::infra::db::entities::{semantic_cache_policies, semantic_measures};
+
+/// How one measure is materialized.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CachePolicy {
+    pub measure_key: String,
+    pub hot_window_days: u32,
+    pub refresh_interval_minutes: u32,
+}
+
+pub async fn enabled_policies(db: &DatabaseConnection) -> Result<Vec<CachePolicy>, DbErr> {
+    let rows = semantic_cache_policies::Entity::find()
+        .filter(semantic_cache_policies::Column::Enabled.eq(true))
+        .all(db)
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| CachePolicy {
+            measure_key: row.measure_key,
+            hot_window_days: row.hot_window_days.unsigned_abs(),
+            refresh_interval_minutes: row.refresh_interval_minutes.unsigned_abs(),
+        })
+        .collect())
+}
+
+/// The version each product measure currently stands at. A build always writes
+/// at the version the store holds, never at the one a previous run wrote.
+pub async fn current_versions(db: &DatabaseConnection) -> Result<BTreeMap<String, u32>, DbErr> {
+    let rows = semantic_measures::Entity::find()
+        .filter(semantic_measures::Column::TenantId.is_null())
+        .filter(semantic_measures::Column::IsEnabled.eq(true))
+        .all(db)
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| (row.measure_key, row.definition_version.unsigned_abs()))
+        .collect())
+}
+
+/// What a landed build leaves the coverage row claiming.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverageWrite {
+    /// The window widens to cover this run plus what earlier runs left behind.
+    Widen,
+    /// Only this run's window is claimed: what earlier runs left was a
+    /// different row shape and has been dropped.
+    Replace,
+}
+
+/// The row shape the coverage of one measure at one version was built at, or
+/// `None` when nothing has been built for that pair.
+pub async fn coverage_row_kind(
+    db: &DatabaseConnection,
+    measure_key: &str,
+    definition_version: u32,
+) -> Result<Option<CacheRowKind>, DbErr> {
+    let rows = db
+        .query_all_raw(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "SELECT row_kind AS row_kind FROM semantic_cache_coverage \
+             WHERE measure_key = ? AND definition_version = ?",
+            [
+                Value::from(measure_key),
+                Value::from(i64::from(definition_version)),
+            ],
+        ))
+        .await?;
+
+    rows.first()
+        .map(|row| row.try_get::<String>("", "row_kind"))
+        .transpose()
+        .map(|kind| kind.as_deref().and_then(CacheRowKind::from_db))
+}
+
+/// Written by the refresher alone, after a build lands, and always carrying the
+/// row shape that build wrote.
+pub async fn record_coverage(
+    db: &DatabaseConnection,
+    measure_key: &str,
+    definition_version: u32,
+    kind: CacheRowKind,
+    from: NaiveDate,
+    to: NaiveDate,
+    write: CoverageWrite,
+) -> Result<(), DbErr> {
+    db.execute_raw(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        coverage_upsert_sql(write),
+        [
+            Value::Bytes(Some(Uuid::now_v7().as_bytes().to_vec())),
+            Value::from(measure_key),
+            Value::from(i64::from(definition_version)),
+            Value::from(kind.as_db()),
+            Value::from(from.to_string()),
+            Value::from(to.to_string()),
+        ],
+    ))
+    .await?;
+    Ok(())
+}
+
+// INVARIANT: `row_kind` is rewritten by both forms, so a coverage row never
+// states a shape other than the one the last landed build wrote.
+fn coverage_upsert_sql(write: CoverageWrite) -> &'static str {
+    match write {
+        CoverageWrite::Widen => {
+            "INSERT INTO semantic_cache_coverage \
+                (id, measure_key, definition_version, row_kind, covered_from, covered_to) \
+             VALUES (?, ?, ?, ?, ?, ?) \
+             ON DUPLICATE KEY UPDATE \
+                row_kind = VALUES(row_kind), \
+                covered_from = LEAST(covered_from, VALUES(covered_from)), \
+                covered_to = GREATEST(covered_to, VALUES(covered_to)), \
+                refreshed_at = CURRENT_TIMESTAMP(3)"
+        }
+        CoverageWrite::Replace => {
+            "INSERT INTO semantic_cache_coverage \
+                (id, measure_key, definition_version, row_kind, covered_from, covered_to) \
+             VALUES (?, ?, ?, ?, ?, ?) \
+             ON DUPLICATE KEY UPDATE \
+                row_kind = VALUES(row_kind), \
+                covered_from = VALUES(covered_from), \
+                covered_to = VALUES(covered_to), \
+                refreshed_at = CURRENT_TIMESTAMP(3)"
+        }
+    }
+}
+
+/// INVARIANT: seeding writes the default once and never overwrites it — the
+/// enablement and cadence an operator set are theirs, and no column here can
+/// move a definition version.
+pub async fn seed_cache_policies<C: ConnectionTrait>(
+    conn: &C,
+    measure_keys: impl IntoIterator<Item = &str>,
+) -> Result<(), DbErr> {
+    for measure_key in measure_keys {
+        conn.execute_raw(Statement::from_sql_and_values(
+            conn.get_database_backend(),
+            "INSERT INTO semantic_cache_policies (id, measure_key, enabled) VALUES (?, ?, TRUE) \
+             ON DUPLICATE KEY UPDATE measure_key = measure_key",
+            [
+                Value::Bytes(Some(Uuid::now_v7().as_bytes().to_vec())),
+                Value::from(measure_key),
+            ],
+        ))
+        .await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_widened_window_keeps_what_earlier_runs_left_and_a_replaced_one_does_not() {
+        let widen = coverage_upsert_sql(CoverageWrite::Widen);
+        let replace = coverage_upsert_sql(CoverageWrite::Replace);
+
+        assert!(
+            widen.contains("LEAST(covered_from, VALUES(covered_from))"),
+            "{widen}"
+        );
+        assert!(
+            widen.contains("GREATEST(covered_to, VALUES(covered_to))"),
+            "{widen}"
+        );
+        assert!(!replace.contains("LEAST("), "{replace}");
+        assert!(!replace.contains("GREATEST("), "{replace}");
+        assert!(
+            replace.contains("covered_from = VALUES(covered_from)"),
+            "{replace}"
+        );
+        assert!(
+            replace.contains("covered_to = VALUES(covered_to)"),
+            "{replace}"
+        );
+    }
+
+    #[test]
+    fn every_coverage_write_states_the_row_shape_the_build_wrote() {
+        for write in [CoverageWrite::Widen, CoverageWrite::Replace] {
+            let sql = coverage_upsert_sql(write);
+
+            assert!(
+                sql.contains("row_kind = VALUES(row_kind)"),
+                "{write:?}: {sql}"
+            );
+            assert_eq!(sql.matches('?').count(), 6, "{write:?}: {sql}");
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/measure_cache/read_gate.rs
+++ b/src/backend/services/analytics/src/domain/measure_cache/read_gate.rs
@@ -1,0 +1,431 @@
+//! Whether a read may answer from a measure's materialized rows. One store read
+//! carries policy, coverage and the versions the definitions stand at; the
+//! decision itself is per measure and per window, and anything degraded reads
+//! the dataset instead.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::NaiveDate;
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbErr, Statement, Value};
+
+use crate::domain::compiler::cache_build::CacheRowKind;
+
+/// Why one measure is read from its dataset rather than from the cache. Logged
+/// at debug; the answer states only that it was computed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LiveReason {
+    /// The read side is switched off for this deployment.
+    ReadDisabled,
+    /// The store carries no enabled definition of the measure.
+    Undefined,
+    /// No policy row, or one an operator disabled.
+    PolicyOff,
+    /// The store cannot be read, so nothing about the cache is known.
+    StoreUnreadable,
+    /// Nothing has been built for the measure at any version.
+    NoCoverage,
+    /// What was built stands at an older definition than the store holds.
+    VersionStale,
+    /// The window reaches outside the days the cache covers.
+    RangeUncovered,
+    /// What was built is a different row shape than the one this release folds
+    /// the measure into, so re-folding it would answer a different question.
+    KindChanged,
+}
+
+/// What one measure's read was decided to be.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheDecision {
+    Cached { definition_version: u32 },
+    Live { reason: LiveReason },
+}
+
+/// One measure's policy and coverage as the store holds them, before a window
+/// decides anything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoverageRow {
+    pub measure_key: String,
+    pub current_version: u32,
+    pub enabled: bool,
+    /// A version something was built at, absent when nothing was.
+    pub cached_version: Option<u32>,
+    /// The row shape that build wrote; absent for a spelling this release does
+    /// not know, which is a shape no read may guess a fold for.
+    pub cached_kind: Option<CacheRowKind>,
+    pub covered_from: Option<NaiveDate>,
+    pub covered_to: Option<NaiveDate>,
+}
+
+/// The store's answer for the measures one request names, read once and asked
+/// per window afterwards.
+#[derive(Debug)]
+pub struct ReadGate {
+    rows: Vec<CoverageRow>,
+    /// What every measure decides to when the read side is off or unreadable.
+    refused: Option<LiveReason>,
+}
+
+const COVERAGE_SQL: &str = "SELECT \
+        m.measure_key AS measure_key, \
+        m.definition_version AS current_version, \
+        CAST(COALESCE(p.enabled, FALSE) AS SIGNED) AS enabled, \
+        c.definition_version AS cached_version, \
+        c.row_kind AS cached_kind, \
+        c.covered_from AS covered_from, \
+        c.covered_to AS covered_to \
+     FROM semantic_measures m \
+     LEFT JOIN semantic_cache_policies p ON p.measure_key = m.measure_key \
+     LEFT JOIN semantic_cache_coverage c ON c.measure_key = m.measure_key \
+     WHERE m.tenant_id IS NULL AND m.is_enabled = TRUE AND m.measure_key IN (";
+
+impl ReadGate {
+    /// INVARIANT: a store that cannot be read degrades to the dataset rather
+    /// than refusing the request — slower is never wrong.
+    pub async fn read(
+        db: &DatabaseConnection,
+        read_enabled: bool,
+        measure_keys: &BTreeSet<String>,
+    ) -> Self {
+        if !read_enabled {
+            return Self::refusing(LiveReason::ReadDisabled);
+        }
+        if measure_keys.is_empty() {
+            return Self {
+                rows: Vec::new(),
+                refused: None,
+            };
+        }
+
+        match coverage(db, measure_keys).await {
+            Ok(rows) => Self {
+                rows,
+                refused: None,
+            },
+            Err(error) => {
+                tracing::warn!(%error, "the measure cache policy store is unreadable; every read compiles over its dataset");
+                Self::refusing(LiveReason::StoreUnreadable)
+            }
+        }
+    }
+
+    /// Every measure decided live, for a caller that pins the dataset read.
+    #[cfg(test)]
+    #[must_use]
+    pub fn all_live() -> Self {
+        Self::refusing(LiveReason::ReadDisabled)
+    }
+
+    /// The gate over rows a caller already holds, rather than over a store.
+    #[cfg(test)]
+    #[must_use]
+    pub fn over(rows: Vec<CoverageRow>) -> Self {
+        Self {
+            rows,
+            refused: None,
+        }
+    }
+
+    fn refusing(reason: LiveReason) -> Self {
+        Self {
+            rows: Vec::new(),
+            refused: Some(reason),
+        }
+    }
+
+    /// The decision for each named measure over one window. `expected` states
+    /// the row shape this release folds each measure into, which the coverage
+    /// must attest before its rows can answer.
+    #[must_use]
+    pub fn decide(
+        &self,
+        expected: &BTreeMap<String, CacheRowKind>,
+        from: NaiveDate,
+        to: NaiveDate,
+    ) -> BTreeMap<String, CacheDecision> {
+        expected
+            .iter()
+            .map(|(key, kind)| {
+                let decision = match self.refused {
+                    Some(reason) => CacheDecision::Live { reason },
+                    None => decide_one(&self.rows, key, *kind, from, to),
+                };
+                if let CacheDecision::Live { reason } = decision {
+                    tracing::debug!(measure = %key, ?reason, "a measure is read from its dataset");
+                }
+                (key.clone(), decision)
+            })
+            .collect()
+    }
+}
+
+/// INVARIANT: the coverage rows of one measure are one per version, so the
+/// current version's row is the only one that can answer.
+fn decide_one(
+    rows: &[CoverageRow],
+    measure_key: &str,
+    expected: CacheRowKind,
+    from: NaiveDate,
+    to: NaiveDate,
+) -> CacheDecision {
+    let mut named = rows.iter().filter(|row| row.measure_key == measure_key);
+    let Some(first) = named.next() else {
+        return CacheDecision::Live {
+            reason: LiveReason::Undefined,
+        };
+    };
+    if !first.enabled {
+        return CacheDecision::Live {
+            reason: LiveReason::PolicyOff,
+        };
+    }
+
+    let version = first.current_version;
+    let mut any_coverage = false;
+    for row in std::iter::once(first).chain(named) {
+        let (Some(cached), Some(covered_from), Some(covered_to)) =
+            (row.cached_version, row.covered_from, row.covered_to)
+        else {
+            continue;
+        };
+        any_coverage = true;
+        if cached != version {
+            continue;
+        }
+        if row.cached_kind != Some(expected) {
+            return CacheDecision::Live {
+                reason: LiveReason::KindChanged,
+            };
+        }
+        if covered_from > from || covered_to < to {
+            return CacheDecision::Live {
+                reason: LiveReason::RangeUncovered,
+            };
+        }
+        return CacheDecision::Cached {
+            definition_version: version,
+        };
+    }
+
+    CacheDecision::Live {
+        reason: if any_coverage {
+            LiveReason::VersionStale
+        } else {
+            LiveReason::NoCoverage
+        },
+    }
+}
+
+async fn coverage(
+    db: &DatabaseConnection,
+    measure_keys: &BTreeSet<String>,
+) -> Result<Vec<CoverageRow>, DbErr> {
+    let placeholders = vec!["?"; measure_keys.len()].join(", ");
+    let sql = format!("{COVERAGE_SQL}{placeholders})");
+    let values: Vec<Value> = measure_keys.iter().map(Value::from).collect();
+
+    let rows = db
+        .query_all_raw(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            sql,
+            values,
+        ))
+        .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(CoverageRow {
+                measure_key: row.try_get("", "measure_key")?,
+                current_version: row.try_get::<i32>("", "current_version")?.unsigned_abs(),
+                enabled: row.try_get::<i64>("", "enabled")? != 0,
+                cached_version: row
+                    .try_get::<Option<i32>>("", "cached_version")?
+                    .map(i32::unsigned_abs),
+                cached_kind: row
+                    .try_get::<Option<String>>("", "cached_kind")?
+                    .as_deref()
+                    .and_then(CacheRowKind::from_db),
+                covered_from: row.try_get("", "covered_from")?,
+                covered_to: row.try_get("", "covered_to")?,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(year, month, day).expect("valid date")
+    }
+
+    fn covered(cached_version: u32, from: (i32, u32, u32), to: (i32, u32, u32)) -> CoverageRow {
+        CoverageRow {
+            measure_key: "commits".to_owned(),
+            current_version: 4,
+            enabled: true,
+            cached_version: Some(cached_version),
+            cached_kind: Some(CacheRowKind::Aggregate),
+            covered_from: Some(date(from.0, from.1, from.2)),
+            covered_to: Some(date(to.0, to.1, to.2)),
+        }
+    }
+
+    /// The shape this release folds `commits` into, which its coverage must
+    /// attest.
+    fn expected() -> BTreeMap<String, CacheRowKind> {
+        BTreeMap::from([("commits".to_owned(), CacheRowKind::Aggregate)])
+    }
+
+    fn keys() -> BTreeSet<String> {
+        BTreeSet::from(["commits".to_owned()])
+    }
+
+    fn decide(rows: Vec<CoverageRow>) -> CacheDecision {
+        let gate = ReadGate::over(rows);
+        gate.decide(&expected(), date(2026, 3, 1), date(2026, 3, 31))["commits"]
+    }
+
+    #[test]
+    fn a_measure_covered_at_its_current_version_over_the_whole_window_reads_the_cache() {
+        assert_eq!(
+            decide(vec![covered(4, (2026, 1, 1), (2026, 4, 30))]),
+            CacheDecision::Cached {
+                definition_version: 4
+            }
+        );
+    }
+
+    #[test]
+    fn a_window_matching_the_covered_span_exactly_still_reads_the_cache() {
+        assert_eq!(
+            decide(vec![covered(4, (2026, 3, 1), (2026, 3, 31))]),
+            CacheDecision::Cached {
+                definition_version: 4
+            }
+        );
+    }
+
+    #[test]
+    fn every_degraded_state_reads_the_dataset_and_names_why() {
+        let cases = [
+            (Vec::new(), LiveReason::Undefined),
+            (
+                vec![CoverageRow {
+                    enabled: false,
+                    ..covered(4, (2026, 1, 1), (2026, 4, 30))
+                }],
+                LiveReason::PolicyOff,
+            ),
+            (
+                vec![CoverageRow {
+                    cached_version: None,
+                    cached_kind: None,
+                    covered_from: None,
+                    covered_to: None,
+                    ..covered(4, (2026, 1, 1), (2026, 4, 30))
+                }],
+                LiveReason::NoCoverage,
+            ),
+            (
+                vec![CoverageRow {
+                    cached_kind: Some(CacheRowKind::Event),
+                    ..covered(4, (2026, 1, 1), (2026, 4, 30))
+                }],
+                LiveReason::KindChanged,
+            ),
+            (
+                vec![CoverageRow {
+                    cached_kind: None,
+                    ..covered(4, (2026, 1, 1), (2026, 4, 30))
+                }],
+                LiveReason::KindChanged,
+            ),
+            (
+                vec![covered(3, (2026, 1, 1), (2026, 4, 30))],
+                LiveReason::VersionStale,
+            ),
+            (
+                vec![covered(4, (2026, 3, 5), (2026, 4, 30))],
+                LiveReason::RangeUncovered,
+            ),
+            (
+                vec![covered(4, (2026, 1, 1), (2026, 3, 20))],
+                LiveReason::RangeUncovered,
+            ),
+        ];
+
+        for (rows, reason) in cases {
+            assert_eq!(decide(rows), CacheDecision::Live { reason }, "{reason:?}");
+        }
+    }
+
+    #[test]
+    fn a_measure_covered_at_one_version_among_several_reads_the_one_the_store_stands_at() {
+        assert_eq!(
+            decide(vec![
+                covered(3, (2026, 1, 1), (2026, 4, 30)),
+                covered(4, (2026, 2, 1), (2026, 4, 30)),
+            ]),
+            CacheDecision::Cached {
+                definition_version: 4
+            }
+        );
+    }
+
+    #[test]
+    fn a_measure_the_read_did_not_ask_about_is_absent_from_the_decision() {
+        let gate = ReadGate::over(vec![covered(4, (2026, 1, 1), (2026, 4, 30))]);
+
+        let decided = gate.decide(
+            &BTreeMap::from([("prs_merged".to_owned(), CacheRowKind::Aggregate)]),
+            date(2026, 3, 1),
+            date(2026, 3, 31),
+        );
+
+        assert_eq!(
+            decided,
+            BTreeMap::from([(
+                "prs_merged".to_owned(),
+                CacheDecision::Live {
+                    reason: LiveReason::Undefined
+                }
+            )])
+        );
+    }
+
+    #[tokio::test]
+    async fn the_kill_switch_decides_every_measure_live_without_asking_the_store() {
+        let gate = ReadGate::read(&DatabaseConnection::default(), false, &keys()).await;
+
+        assert_eq!(
+            gate.decide(&expected(), date(2026, 3, 1), date(2026, 3, 31))["commits"],
+            CacheDecision::Live {
+                reason: LiveReason::ReadDisabled
+            }
+        );
+    }
+
+    #[test]
+    fn a_store_that_cannot_answer_leaves_every_measure_live() {
+        let gate = ReadGate::refusing(LiveReason::StoreUnreadable);
+
+        assert_eq!(
+            gate.decide(&expected(), date(2026, 3, 1), date(2026, 3, 31))["commits"],
+            CacheDecision::Live {
+                reason: LiveReason::StoreUnreadable
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn a_request_naming_no_measure_asks_the_store_nothing() {
+        let gate = ReadGate::read(&DatabaseConnection::default(), true, &BTreeSet::new()).await;
+
+        assert!(
+            gate.decide(&BTreeMap::new(), date(2026, 3, 1), date(2026, 3, 31))
+                .is_empty()
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/measure_cache/warehouse_live_tests.rs
+++ b/src/backend/services/analytics/src/domain/measure_cache/warehouse_live_tests.rs
@@ -1,0 +1,693 @@
+//! Live ClickHouse test for the cache write path: the migration's own DDL, the
+//! compiled build for each row kind, and the partition swap, all executed for
+//! real in a scratch database that the test drops when it is done.
+//!
+//! `#[ignore]`d and skips silently when `INTEGRATION_TESTS_CLICKHOUSE_URL` is
+//! unset; optional auth via `INTEGRATION_TESTS_CLICKHOUSE_USER` /
+//! `INTEGRATION_TESTS_CLICKHOUSE_PASSWORD`.
+
+use chrono::NaiveDate;
+use clickhouse::Row;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use std::collections::BTreeMap;
+
+use super::plan;
+use crate::domain::compiler::cache_build::{CacheBuild, CacheRowKind, compile_cache_build};
+use crate::domain::compiler::cache_read::{CachedInput, compile_cached_metric_query};
+use crate::domain::compiler::metric::compile_metric_query;
+use crate::domain::compiler::request::{Bucket, EntityScope, MetricQuery, ViewKind};
+use crate::domain::compiler::sql::{CompiledMeasureQuery, QueryParam};
+use crate::domain::definitions::definition::{
+    Aggregation, Computation, DimensionBinding, Direction, Format, MeasureDefinition,
+    MetricDefinition,
+};
+use crate::domain::field_catalog::model::{
+    CatalogDataset, CatalogField, EntityType, FieldCatalog, FieldRole, FieldType, ReadDiscipline,
+};
+
+const URL_VAR: &str = "INTEGRATION_TESTS_CLICKHOUSE_URL";
+
+/// The relations the migration writes are named for the app database; a scratch
+/// run rewrites that one prefix and changes nothing else.
+const SHIPPED_DATABASE: &str = "insight.";
+
+const MIGRATION: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../ingestion/scripts/migrations/20260828000000_semantic-measure-cache.sql"
+);
+
+const WINDOW_FROM: (i32, u32, u32) = (2026, 3, 1);
+const WINDOW_TO: (i32, u32, u32) = (2026, 4, 30);
+const REBUILD_FROM: (i32, u32, u32) = (2026, 4, 1);
+const VERSION: u32 = 4;
+
+#[derive(Debug, Row, Deserialize)]
+struct Counted {
+    rows: u64,
+}
+
+#[derive(Debug, Row, Deserialize)]
+struct Summed {
+    total: f64,
+}
+
+/// One read the reconciliation pins: the metric to compute, the measure the
+/// cache answers it from, and what the fixture rows say the answer is.
+struct Reconciled {
+    measure_key: &'static str,
+    computation: Computation,
+    expected: &'static [(&'static str, f64)],
+}
+
+/// One partition of the served relation, as the version read names it.
+#[derive(Debug, Row, Deserialize)]
+struct Partition {
+    version: u32,
+    month: u32,
+}
+
+/// One entity's answer, as every value view keys it.
+#[derive(Debug, Row, Deserialize, PartialEq)]
+struct EntityValue {
+    entity_id: String,
+    value: f64,
+}
+
+// Empty counts as unset: the CI matrix passes '' to entries without a
+// provisioned ClickHouse, and set-but-empty must skip exactly like absent.
+fn client_or_skip() -> Option<insight_clickhouse::Client> {
+    let url = std::env::var(URL_VAR).unwrap_or_default();
+    if url.is_empty() {
+        eprintln!("skipping: {URL_VAR} not set");
+        return None;
+    }
+    let mut config = insight_clickhouse::Config::new(url, "default");
+    if let (Ok(user), Ok(password)) = (
+        std::env::var("INTEGRATION_TESTS_CLICKHOUSE_USER"),
+        std::env::var("INTEGRATION_TESTS_CLICKHOUSE_PASSWORD"),
+    ) && !user.is_empty()
+    {
+        config = config.with_auth(user, password);
+    }
+    Some(insight_clickhouse::Client::new(config))
+}
+
+fn scoped(sql: &str, database: &str) -> String {
+    sql.replace(SHIPPED_DATABASE, &format!("{database}."))
+}
+
+async fn run(ch: &insight_clickhouse::Client, sql: &str) -> Result<(), clickhouse::error::Error> {
+    ch.query(sql).execute().await
+}
+
+async fn bind_and_run(
+    ch: &insight_clickhouse::Client,
+    compiled: &CompiledMeasureQuery,
+    database: &str,
+) -> Result<(), clickhouse::error::Error> {
+    let mut request = ch.query(&scoped(&compiled.sql, database));
+    for param in &compiled.params {
+        request = match param {
+            QueryParam::Text(value) => request.bind(value.as_str()),
+            QueryParam::Int(value) => request.bind(*value),
+            QueryParam::UInt(value) => request.bind(*value),
+            QueryParam::Float(value) => request.bind(*value),
+            QueryParam::Bool(value) => request.bind(*value),
+        };
+    }
+    request.execute().await
+}
+
+async fn count(
+    ch: &insight_clickhouse::Client,
+    sql: &str,
+) -> Result<u64, clickhouse::error::Error> {
+    ch.query(sql)
+        .fetch_one::<Counted>()
+        .await
+        .map(|row| row.rows)
+}
+
+/// Six rows in two months: a repeated ticket on one day so a subject build
+/// deduplicates, three rows on one day so an aggregate build folds, and one row
+/// with no tenant that no build may keep.
+async fn create_source(
+    ch: &insight_clickhouse::Client,
+    database: &str,
+) -> Result<(), clickhouse::error::Error> {
+    run(
+        ch,
+        &format!(
+            "CREATE TABLE {database}.work_items (
+                 tenant_id Nullable(String),
+                 actor String,
+                 happened_at DateTime,
+                 amount Int64,
+                 ticket String,
+                 repo String,
+                 repo_label String
+             ) ENGINE = MergeTree ORDER BY (actor, happened_at)"
+        ),
+    )
+    .await?;
+    run(
+        ch,
+        &format!(
+            "INSERT INTO {database}.work_items VALUES
+                 ('acme', 'alice@example.com', '2026-03-02 09:00:00', 10, 'T-1', 'r1', 'Repo One'),
+                 ('acme', 'alice@example.com', '2026-03-02 10:00:00', 20, 'T-1', 'r1', 'Repo One'),
+                 ('acme', 'alice@example.com', '2026-03-02 11:00:00', 30, 'T-2', 'r1', 'Repo One'),
+                 ('acme', 'bob@example.com',   '2026-03-05 09:00:00', 40, 'T-3', 'r2', 'Repo Two'),
+                 (NULL,   'carol@example.com', '2026-03-06 09:00:00', 50, 'T-4', 'r1', 'Repo One'),
+                 ('acme', 'alice@example.com', '2026-04-01 09:00:00', 60, 'T-5', 'r1', 'Repo One')"
+        ),
+    )
+    .await
+}
+
+fn dataset(database: &str) -> CatalogDataset {
+    let field = |name: &str, raw: &str, role: Option<FieldRole>| CatalogField {
+        name: name.to_owned(),
+        field_type: FieldType::parse(raw),
+        role,
+        display: Vec::new(),
+        label_field: None,
+    };
+
+    CatalogDataset {
+        key: "work_items".to_owned(),
+        database: database.to_owned(),
+        relation: "work_items".to_owned(),
+        entity_type: EntityType::Person,
+        read_discipline: ReadDiscipline::Direct,
+        sorting_key: vec!["actor".to_owned(), "happened_at".to_owned()],
+        row_identity: vec!["ticket".to_owned()],
+        fields: vec![
+            field("tenant_id", "Nullable(String)", Some(FieldRole::Tenant)),
+            field("actor", "String", Some(FieldRole::Entity)),
+            field("happened_at", "DateTime", Some(FieldRole::EventTime)),
+            field("amount", "Int64", Some(FieldRole::Measurable)),
+            field("ticket", "String", Some(FieldRole::Dimension)),
+            field("repo", "String", Some(FieldRole::Dimension)),
+            field("repo_label", "String", None),
+        ],
+    }
+}
+
+fn measure(key: &str, aggregation: Aggregation) -> MeasureDefinition {
+    MeasureDefinition {
+        key: key.to_owned(),
+        dataset: "work_items".to_owned(),
+        description: None,
+        filter: None,
+        aggregation,
+        value_expr: matches!(aggregation, Aggregation::Sum | Aggregation::Avg)
+            .then(|| "amount".to_owned()),
+        subject_expr: (aggregation == Aggregation::CountDistinct).then(|| "ticket".to_owned()),
+        event_time: "happened_at".to_owned(),
+        entity: "actor".to_owned(),
+        dimensions: vec![DimensionBinding {
+            key: "repository".to_owned(),
+            value_field: "repo".to_owned(),
+            label_field: Some("repo_label".to_owned()),
+        }],
+    }
+}
+
+fn window_date(parts: (i32, u32, u32)) -> NaiveDate {
+    NaiveDate::from_ymd_opt(parts.0, parts.1, parts.2).expect("valid date")
+}
+
+/// One measure's build over the whole fixture span.
+async fn build_and_swap(
+    ch: &insight_clickhouse::Client,
+    database: &str,
+    measure: &MeasureDefinition,
+    kind: CacheRowKind,
+) -> Result<(), clickhouse::error::Error> {
+    build_window(
+        ch,
+        database,
+        measure,
+        kind,
+        plan::HotWindow {
+            from: window_date(WINDOW_FROM),
+            to: window_date(WINDOW_TO),
+        },
+    )
+    .await
+}
+
+/// One measure's build, staged and swapped exactly as a refresh tick does it,
+/// over the window that tick covers.
+async fn build_window(
+    ch: &insight_clickhouse::Client,
+    database: &str,
+    measure: &MeasureDefinition,
+    kind: CacheRowKind,
+    window: plan::HotWindow,
+) -> Result<(), clickhouse::error::Error> {
+    let compiled = compile_cache_build(
+        &dataset(database),
+        &CacheBuild {
+            measure,
+            definition_version: VERSION,
+            kind,
+            from: window.from,
+            to: window.to,
+        },
+    )
+    .expect("a synthetic measure over a synthetic dataset compiles");
+    let months = plan::months(window);
+
+    for month in &months {
+        partition(
+            ch,
+            database,
+            &plan::clear_staging_partition_sql(),
+            *month,
+            measure,
+        )
+        .await?;
+    }
+    bind_and_run(ch, &compiled, database).await?;
+    for month in &months {
+        partition(ch, database, &plan::swap_partition_sql(), *month, measure).await?;
+    }
+    for month in &months {
+        partition(
+            ch,
+            database,
+            &plan::clear_staging_partition_sql(),
+            *month,
+            measure,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn partition(
+    ch: &insight_clickhouse::Client,
+    database: &str,
+    sql: &str,
+    month: u32,
+    measure: &MeasureDefinition,
+) -> Result<(), clickhouse::error::Error> {
+    ch.query(&scoped(sql, database))
+        .bind(measure.key.as_str())
+        .bind(VERSION)
+        .bind(month)
+        .execute()
+        .await
+}
+
+#[tokio::test]
+#[ignore = "requires live ClickHouse; set INTEGRATION_TESTS_CLICKHOUSE_URL to enable"]
+async fn a_build_of_each_row_kind_lands_through_the_shipped_ddl_and_replaces_on_a_rerun()
+-> anyhow::Result<()> {
+    let Some(ch) = client_or_skip() else {
+        return Ok(());
+    };
+    let database = format!("semantic_cache_live_{}", Uuid::now_v7().simple());
+
+    let outcome = exercise(&ch, &database).await;
+
+    let _ = run(&ch, &format!("DROP DATABASE IF EXISTS {database}")).await;
+    outcome
+}
+
+async fn exercise(ch: &insight_clickhouse::Client, database: &str) -> anyhow::Result<()> {
+    run(ch, &format!("CREATE DATABASE {database}")).await?;
+    let migration = std::fs::read_to_string(MIGRATION)?;
+    for statement in migration.split(';') {
+        if statement.trim().is_empty() {
+            continue;
+        }
+        run(ch, &scoped(statement, database)).await?;
+    }
+    create_source(ch, database).await?;
+
+    let cases = [
+        (
+            measure("folded", Aggregation::Count),
+            CacheRowKind::Aggregate,
+            3_u64,
+        ),
+        (measure("kept", Aggregation::Sum), CacheRowKind::Event, 5),
+        (
+            measure("counted", Aggregation::CountDistinct),
+            CacheRowKind::Subject,
+            4,
+        ),
+    ];
+
+    for (measure, kind, expected) in &cases {
+        build_and_swap(ch, database, measure, *kind).await?;
+
+        let landed = count(
+            ch,
+            &format!(
+                "SELECT count() AS rows FROM {database}.semantic_measure_cache \
+                 WHERE measure_key = '{}'",
+                measure.key
+            ),
+        )
+        .await?;
+        anyhow::ensure!(
+            landed == *expected,
+            "{kind:?} landed {landed} rows, expected {expected}"
+        );
+
+        build_and_swap(ch, database, measure, *kind).await?;
+
+        let after_rerun = count(
+            ch,
+            &format!(
+                "SELECT count() AS rows FROM {database}.semantic_measure_cache \
+                 WHERE measure_key = '{}'",
+                measure.key
+            ),
+        )
+        .await?;
+        anyhow::ensure!(
+            after_rerun == *expected,
+            "{kind:?} appended on the second run: {after_rerun} rows"
+        );
+    }
+
+    let staging_left = count(
+        ch,
+        &format!("SELECT count() AS rows FROM {database}.semantic_measure_cache_staging"),
+    )
+    .await?;
+    anyhow::ensure!(staging_left == 0, "staging kept {staging_left} rows");
+
+    let untenanted = count(
+        ch,
+        &format!(
+            "SELECT count() AS rows FROM {database}.semantic_measure_cache \
+             WHERE entity = 'carol@example.com'"
+        ),
+    )
+    .await?;
+    anyhow::ensure!(untenanted == 0, "a row naming no tenant was cached");
+
+    let unlabelled = count(
+        ch,
+        &format!(
+            "SELECT count() AS rows FROM {database}.semantic_measure_cache \
+             WHERE dimensions[1].1 != 'repository' OR dimensions[1].3 IS NULL"
+        ),
+    )
+    .await?;
+    anyhow::ensure!(unlabelled == 0, "a dimension tuple lost its key or label");
+
+    let summed: f64 = ch
+        .query(&format!(
+            "SELECT sum(value) AS total FROM {database}.semantic_measure_cache \
+             WHERE measure_key = 'kept'"
+        ))
+        .fetch_one::<Summed>()
+        .await?
+        .total;
+    anyhow::ensure!(
+        (summed - 160.0).abs() < f64::EPSILON,
+        "kept rows summed to {summed}, expected 160"
+    );
+
+    reconcile(ch, database, &cases).await?;
+    heal_a_reshaped_measure(ch, database).await
+}
+
+/// A measure whose row shape changed at the same version: the refresher drops
+/// the partitions the old shape occupies before it swaps the new build in, so
+/// no month is left holding rows of a shape the coverage no longer attests.
+async fn heal_a_reshaped_measure(
+    ch: &insight_clickhouse::Client,
+    database: &str,
+) -> anyhow::Result<()> {
+    let reshaped = measure("reshaped", Aggregation::Sum);
+    build_and_swap(ch, database, &reshaped, CacheRowKind::Aggregate).await?;
+
+    let folded = count(
+        ch,
+        &format!(
+            "SELECT count() AS rows FROM {database}.semantic_measure_cache \
+             WHERE measure_key = 'reshaped'"
+        ),
+    )
+    .await?;
+    anyhow::ensure!(folded == 3, "the folded build landed {folded} rows");
+
+    // The rebuild's hot window reaches back only into April, so March is a
+    // settled month the swap alone would leave holding the replaced shape.
+    drop_version(ch, database, &reshaped).await?;
+    let dropped = count(
+        ch,
+        &format!(
+            "SELECT count() AS rows FROM {database}.semantic_measure_cache \
+             WHERE measure_key = 'reshaped'"
+        ),
+    )
+    .await?;
+    anyhow::ensure!(dropped == 0, "the old shape left {dropped} rows behind");
+
+    build_window(
+        ch,
+        database,
+        &reshaped,
+        CacheRowKind::Event,
+        plan::HotWindow {
+            from: window_date(REBUILD_FROM),
+            to: window_date(WINDOW_TO),
+        },
+    )
+    .await?;
+
+    let mixed = count(
+        ch,
+        &format!(
+            "SELECT count() AS rows FROM {database}.semantic_measure_cache \
+             WHERE measure_key = 'reshaped' AND kind != 'event'"
+        ),
+    )
+    .await?;
+    anyhow::ensure!(mixed == 0, "{mixed} rows of the replaced shape survived");
+
+    let median = entity_values(
+        ch,
+        &compile_cached_metric_query(
+            &metric(
+                "reconciliation",
+                Computation::Percentile {
+                    measure: "reshaped".to_owned(),
+                    quantile: 0.5,
+                },
+            ),
+            &BTreeMap::from([(reshaped.key.clone(), reshaped.clone())]),
+            &BTreeMap::from([(
+                reshaped.key.clone(),
+                CachedInput {
+                    kind: CacheRowKind::Event,
+                    definition_version: VERSION,
+                },
+            )]),
+            &window_query(),
+        )?,
+        database,
+    )
+    .await?;
+
+    anyhow::ensure!(
+        median
+            == vec![EntityValue {
+                entity_id: "alice@example.com".to_owned(),
+                value: 60.0,
+            }],
+        "the rebuilt shape answered {median:?}"
+    );
+    Ok(())
+}
+
+/// The partitions one version occupies, dropped exactly as a reshaped refresh
+/// drops them.
+async fn drop_version(
+    ch: &insight_clickhouse::Client,
+    database: &str,
+    measure: &MeasureDefinition,
+) -> Result<(), clickhouse::error::Error> {
+    let occupied = ch
+        .query(&scoped(&plan::version_partitions_sql(), database))
+        .bind(measure.key.as_str())
+        .bind(VERSION)
+        .fetch_all::<Partition>()
+        .await?;
+
+    let sql = plan::drop_cache_partition_sql();
+    for found in occupied {
+        ch.query(&scoped(&sql, database))
+            .bind(measure.key.as_str())
+            .bind(found.version)
+            .bind(found.month)
+            .execute()
+            .await?;
+    }
+    Ok(())
+}
+
+fn catalog(database: &str) -> FieldCatalog {
+    FieldCatalog {
+        datasets: vec![dataset(database)],
+    }
+}
+
+fn metric(key: &str, computation: Computation) -> MetricDefinition {
+    MetricDefinition {
+        key: key.to_owned(),
+        computation,
+        transform: None,
+        format: Format::Decimal,
+        direction: Direction::HigherIsBetter,
+        entity_type: EntityType::Person,
+        cohort_key: None,
+        label: None,
+        description: None,
+    }
+}
+
+fn window_query() -> MetricQuery {
+    MetricQuery {
+        tenant_id: "acme".to_owned(),
+        entity_scope: EntityScope::Tenant,
+        from: window_date(WINDOW_FROM),
+        to: window_date(WINDOW_TO),
+        bucket: Bucket::Day,
+        dimension_filters: Vec::new(),
+        view: ViewKind::SubjectTotal,
+        row_limit: 10_000,
+    }
+}
+
+async fn entity_values(
+    ch: &insight_clickhouse::Client,
+    compiled: &CompiledMeasureQuery,
+    database: &str,
+) -> Result<Vec<EntityValue>, clickhouse::error::Error> {
+    let mut request = ch.query(&scoped(&compiled.sql, database));
+    for param in &compiled.params {
+        request = match param {
+            QueryParam::Text(value) => request.bind(value.as_str()),
+            QueryParam::Int(value) => request.bind(*value),
+            QueryParam::UInt(value) => request.bind(*value),
+            QueryParam::Float(value) => request.bind(*value),
+            QueryParam::Bool(value) => request.bind(*value),
+        };
+    }
+
+    let mut rows = request.fetch_all::<EntityValue>().await?;
+    rows.sort_by(|left, right| left.entity_id.cmp(&right.entity_id));
+    Ok(rows)
+}
+
+/// The reconciliation in miniature: for each row kind, what the cached read
+/// answers, what the dataset read answers, and what the fixture rows say — all
+/// three must agree.
+async fn reconcile(
+    ch: &insight_clickhouse::Client,
+    database: &str,
+    cases: &[(MeasureDefinition, CacheRowKind, u64)],
+) -> anyhow::Result<()> {
+    // alice authored three rows in March and one in April; bob one in March;
+    // the row naming no tenant belongs to no answer.
+    let expectations = [
+        Reconciled {
+            measure_key: "folded",
+            computation: Computation::Direct {
+                measure: "folded".to_owned(),
+            },
+            expected: &[("alice@example.com", 4.0), ("bob@example.com", 1.0)],
+        },
+        Reconciled {
+            measure_key: "kept",
+            computation: Computation::Direct {
+                measure: "kept".to_owned(),
+            },
+            expected: &[("alice@example.com", 120.0), ("bob@example.com", 40.0)],
+        },
+        Reconciled {
+            measure_key: "counted",
+            computation: Computation::Direct {
+                measure: "counted".to_owned(),
+            },
+            expected: &[("alice@example.com", 3.0), ("bob@example.com", 1.0)],
+        },
+        Reconciled {
+            measure_key: "kept",
+            computation: Computation::Percentile {
+                measure: "kept".to_owned(),
+                quantile: 0.5,
+            },
+            expected: &[("alice@example.com", 30.0), ("bob@example.com", 40.0)],
+        },
+    ];
+
+    let measures: BTreeMap<String, MeasureDefinition> = cases
+        .iter()
+        .map(|(measure, _, _)| (measure.key.clone(), measure.clone()))
+        .collect();
+    let kinds: BTreeMap<String, CacheRowKind> = cases
+        .iter()
+        .map(|(measure, kind, _)| (measure.key.clone(), *kind))
+        .collect();
+
+    for Reconciled {
+        measure_key,
+        computation,
+        expected,
+    } in expectations
+    {
+        let metric = metric("reconciliation", computation);
+        let query = window_query();
+        let cached = BTreeMap::from([(
+            measure_key.to_owned(),
+            CachedInput {
+                kind: kinds[measure_key],
+                definition_version: VERSION,
+            },
+        )]);
+
+        let from_cache = entity_values(
+            ch,
+            &compile_cached_metric_query(&metric, &measures, &cached, &query)?,
+            database,
+        )
+        .await?;
+        let from_dataset = entity_values(
+            ch,
+            &compile_metric_query(&catalog(database), &metric, &measures, &query)?,
+            database,
+        )
+        .await?;
+        let hand_computed: Vec<EntityValue> = expected
+            .iter()
+            .map(|(entity_id, value)| EntityValue {
+                entity_id: (*entity_id).to_owned(),
+                value: *value,
+            })
+            .collect();
+
+        anyhow::ensure!(
+            from_cache == hand_computed,
+            "{measure_key}: the cache answered {from_cache:?}, the fixture rows say {hand_computed:?}"
+        );
+        anyhow::ensure!(
+            from_dataset == hand_computed,
+            "{measure_key}: the dataset answered {from_dataset:?}, the fixture rows say {hand_computed:?}"
+        );
+    }
+
+    Ok(())
+}

--- a/src/backend/services/analytics/src/domain/metric_query/catalog.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/catalog.rs
@@ -6,6 +6,8 @@
 use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
+use crate::domain::compiler::cache_build::{CacheRowKind, row_kind};
+use crate::domain::compiler::cache_read::{CachedInput, compile_cached_metric_query};
 use crate::domain::compiler::drilldown::{
     CompiledDrilldown, DrilldownPageShape, compile_drilldown, drilldown_input_roles,
     drilldown_page_shapes, drilldown_reported_columns,
@@ -26,6 +28,9 @@ pub struct MetricCatalog {
     catalog: &'static FieldCatalog,
     measures: BTreeMap<String, MeasureDefinition>,
     metrics: BTreeMap<String, MetricDefinition>,
+    /// The row shape each measure's cached work takes, decided once from the
+    /// metrics that read it, so a cached read folds what the build wrote.
+    row_kinds: BTreeMap<String, CacheRowKind>,
 }
 
 impl std::fmt::Debug for MetricCatalog {
@@ -34,6 +39,7 @@ impl std::fmt::Debug for MetricCatalog {
             .field("datasets", &self.catalog.datasets.len())
             .field("measures", &self.measures.len())
             .field("metrics", &self.metrics.len())
+            .field("row_kinds", &self.row_kinds.len())
             .finish()
     }
 }
@@ -49,6 +55,11 @@ impl MetricCatalog {
         let catalog = product_catalog().map_err(|error| SeedError::Catalog(error.to_string()))?;
         let definitions = product_definitions()?;
 
+        let row_kinds = definitions
+            .measures
+            .iter()
+            .map(|measure| (measure.key.clone(), row_kind(measure, &definitions.metrics)))
+            .collect();
         let loaded = Self {
             catalog,
             measures: definitions
@@ -61,6 +72,7 @@ impl MetricCatalog {
                 .into_iter()
                 .map(|metric| (metric.key.clone(), metric))
                 .collect(),
+            row_kinds,
         };
 
         tracing::info!(
@@ -129,6 +141,23 @@ impl MetricCatalog {
         query: &MetricQuery,
     ) -> Result<CompiledMeasureQuery, CompileError> {
         compile_metric_query(self.catalog, metric, &self.measures, query)
+    }
+
+    /// The same read over the measures already materialized. `cached` names
+    /// every input of the metric, or the read has no business being here.
+    pub(super) fn compile_cached(
+        &self,
+        metric: &MetricDefinition,
+        cached: &BTreeMap<String, CachedInput>,
+        query: &MetricQuery,
+    ) -> Result<CompiledMeasureQuery, CompileError> {
+        compile_cached_metric_query(metric, &self.measures, cached, query)
+    }
+
+    /// The row shape a measure's cached work takes; absent for a measure this
+    /// release does not ship.
+    pub(super) fn row_kind(&self, measure_key: &str) -> Option<CacheRowKind> {
+        self.row_kinds.get(measure_key).copied()
     }
 
     /// One page per input of the metric's computation: the rows its value was

--- a/src/backend/services/analytics/src/domain/metric_query/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/dto.rs
@@ -39,9 +39,30 @@ pub enum Executor {
     Semantic,
 }
 
-/// Where the rows behind this answer came from.
+/// Where the rows behind this answer came from. `mixed` is one answer some of
+/// whose reads were cached and some computed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ServedFrom {
+    Cache,
     Computed,
+    Mixed,
+}
+
+impl ServedFrom {
+    /// What a set of reads together were served from.
+    pub(super) fn of(reads: impl IntoIterator<Item = bool>) -> Self {
+        let mut cached = 0_usize;
+        let mut total = 0_usize;
+        for read in reads {
+            total += 1;
+            cached += usize::from(read);
+        }
+
+        match (cached, total) {
+            (0, _) => Self::Computed,
+            (cached, total) if cached == total => Self::Cache,
+            _ => Self::Mixed,
+        }
+    }
 }

--- a/src/backend/services/analytics/src/domain/metric_query/provenance.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/provenance.rs
@@ -61,11 +61,11 @@ mod tests {
         let versions = BTreeMap::from([("git.commits".to_owned(), 3)]);
 
         assert_eq!(
-            provenance(&versions, "git.commits", ServedFrom::Computed),
+            provenance(&versions, "git.commits", ServedFrom::Cache),
             Provenance {
                 executor: Executor::Semantic,
                 definition_version: Some(3),
-                served_from: ServedFrom::Computed,
+                served_from: ServedFrom::Cache,
             }
         );
     }
@@ -76,5 +76,20 @@ mod tests {
 
         assert_eq!(provenance.definition_version, None);
         assert_eq!(provenance.executor, Executor::Semantic);
+    }
+
+    #[test]
+    fn an_answer_states_cache_only_when_every_read_behind_it_was_cached() {
+        let cases = [
+            (vec![true, true], ServedFrom::Cache),
+            (vec![true, false], ServedFrom::Mixed),
+            (vec![false, false], ServedFrom::Computed),
+            (vec![false], ServedFrom::Computed),
+            (vec![true], ServedFrom::Cache),
+        ];
+
+        for (reads, expected) in cases {
+            assert_eq!(ServedFrom::of(reads.clone()), expected, "{reads:?}");
+        }
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_query/values/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/dto.rs
@@ -288,7 +288,11 @@ mod tests {
 
     #[test]
     fn an_answer_states_on_the_wire_where_the_rows_behind_it_came_from() {
-        let cases = [(ServedFrom::Computed, "computed")];
+        let cases = [
+            (ServedFrom::Cache, "cache"),
+            (ServedFrom::Computed, "computed"),
+            (ServedFrom::Mixed, "mixed"),
+        ];
 
         for (served_from, spelling) in cases {
             let provenance = Provenance {

--- a/src/backend/services/analytics/src/domain/metric_query/values/plan.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/plan.rs
@@ -8,15 +8,20 @@ use std::collections::{BTreeMap, BTreeSet};
 use chrono::NaiveDate;
 use uuid::Uuid;
 
+use crate::domain::compiler::cache_build::CacheRowKind;
+use crate::domain::compiler::cache_read::{CachedInput, view_is_cacheable};
 use crate::domain::compiler::request::{
     Bucket, CombinedSplitView, DimensionFilter, EntityScope, GroupLimit, GroupRankingQuery,
     MetricQuery, RankedGroup, ResolvedPerson, SubjectSeriesView, SubjectSplitView, ViewKind,
 };
 use crate::domain::compiler::sql::CompiledMeasureQuery;
+use crate::domain::definitions::definition::MetricDefinition;
 use crate::domain::field_catalog::model::EntityType;
 use crate::domain::identity_binding::{IdentitySet, resolve_all_identities, resolve_identities};
+use crate::domain::measure_cache::{CacheDecision, ReadGate};
 
 use super::super::catalog::MetricCatalog;
+use super::super::dto::ServedFrom;
 use super::super::error::QueryError;
 use super::super::question::{query_row_limit, row_limit};
 use super::dto::Grain;
@@ -28,14 +33,27 @@ use super::validation::{
 #[derive(Debug, PartialEq)]
 pub(super) enum PlannedQuery {
     /// The statements one question runs: its own, and the compared window's
-    /// when it asked for one.
+    /// when it asked for one, with where between them the rows came from.
     Read {
         current: CompiledMeasureQuery,
         compared: Option<CompiledMeasureQuery>,
+        served_from: ServedFrom,
     },
     /// The mapping knows no identity for anyone this question asks about, so
     /// no row can carry a value for them and it is answered empty.
     NoIdentities,
+}
+
+impl PlannedQuery {
+    /// Where the rows behind this question's answer came from. INVARIANT: a
+    /// question that runs no statement took no row from the cache, which is
+    /// what an empty set of reads reports.
+    pub(super) fn served_from(&self) -> ServedFrom {
+        match self {
+            Self::Read { served_from, .. } => *served_from,
+            Self::NoIdentities => ServedFrom::of(std::iter::empty()),
+        }
+    }
 }
 
 /// The window one compiled read covers.
@@ -71,11 +89,14 @@ struct RankingKey {
 pub(super) async fn plan(
     catalog: &MetricCatalog,
     clickhouse: &insight_clickhouse::Client,
+    db: &sea_orm::DatabaseConnection,
+    cache_reads_enabled: bool,
     tenant_id: Uuid,
     batch: &ValidatedBatch,
 ) -> Result<Vec<PlannedQuery>, QueryError> {
     let identities = identities(clickhouse, tenant_id, batch).await?;
     let tenant = tenant_pool(clickhouse, tenant_id, batch).await?;
+    let gate = ReadGate::read(db, cache_reads_enabled, &input_measures(catalog, batch)).await;
 
     let mut rankings: BTreeMap<RankingKey, Vec<RankedGroup>> = BTreeMap::new();
     let mut compiled = Vec::with_capacity(batch.queries.len());
@@ -94,12 +115,21 @@ pub(super) async fn plan(
 
         // INVARIANT: both reads keep the groups the current window ranked, so
         // a series compares against the same group it reports.
-        let current = compile(catalog, tenant_id, query, &scope, limit.clone(), window)?;
+        let (current, current_cached) = compile(
+            catalog,
+            &gate,
+            tenant_id,
+            query,
+            &scope,
+            limit.clone(),
+            window,
+        )?;
         let compared = query
             .compare
             .map(|compared| {
                 compile(
                     catalog,
+                    &gate,
                     tenant_id,
                     query,
                     &scope,
@@ -108,19 +138,80 @@ pub(super) async fn plan(
                 )
             })
             .transpose()?;
-        compiled.push(PlannedQuery::Read { current, compared });
+
+        let served_from = ServedFrom::of(
+            std::iter::once(current_cached).chain(compared.as_ref().map(|(_, cached)| *cached)),
+        );
+        compiled.push(PlannedQuery::Read {
+            current,
+            compared: compared.map(|(statement, _)| statement),
+            served_from,
+        });
     }
     Ok(compiled)
 }
 
+/// Every measure the request's metrics compose, so one store read decides all
+/// of them.
+fn input_measures(catalog: &MetricCatalog, batch: &ValidatedBatch) -> BTreeSet<String> {
+    batch
+        .queries
+        .iter()
+        .filter_map(|query| catalog.metric(&query.metric_key))
+        .flat_map(|metric| metric.input_measures())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// INVARIANT: a metric reads the cache only when every one of its inputs was
+/// decided cacheable — one statement folds them all, so a metric with one
+/// degraded input is compiled over its dataset whole.
+fn cached_inputs(
+    catalog: &MetricCatalog,
+    gate: &ReadGate,
+    metric: &MetricDefinition,
+    view: &ViewKind,
+    window: Window,
+) -> Option<BTreeMap<String, CachedInput>> {
+    if !view_is_cacheable(view) {
+        return None;
+    }
+
+    // INVARIANT: the shape this release folds a measure into is what the gate
+    // asks the coverage to attest, so a shape change degrades to the dataset.
+    let expected: BTreeMap<String, CacheRowKind> = metric
+        .input_measures()
+        .into_iter()
+        .map(|key| Some((key.to_owned(), catalog.row_kind(key)?)))
+        .collect::<Option<_>>()?;
+    let decided = gate.decide(&expected, window.from, window.to);
+
+    expected
+        .into_iter()
+        .map(|(key, kind)| match decided.get(&key) {
+            Some(CacheDecision::Cached { definition_version }) => Some((
+                key,
+                CachedInput {
+                    kind,
+                    definition_version: *definition_version,
+                },
+            )),
+            Some(CacheDecision::Live { .. }) | None => None,
+        })
+        .collect()
+}
+
+/// The statement one window of one question runs, and whether it reads the
+/// cache.
 fn compile(
     catalog: &MetricCatalog,
+    gate: &ReadGate,
     tenant_id: Uuid,
     query: &ValidatedQuery,
     scope: &EntityScope,
     limit: Option<GroupLimit>,
     window: Window,
-) -> Result<CompiledMeasureQuery, QueryError> {
+) -> Result<(CompiledMeasureQuery, bool), QueryError> {
     // INVARIANT: validation refuses a metric the definitions do not carry, so
     // every planned question names one they do.
     let Some(metric) = catalog.metric(&query.metric_key) else {
@@ -129,20 +220,21 @@ fn compile(
         });
     };
 
-    let compiled = catalog.compile(
-        metric,
-        &MetricQuery {
-            tenant_id: tenant_id.to_string(),
-            entity_scope: scope.clone(),
-            from: window.from,
-            to: window.to,
-            bucket: bucket(query.grain),
-            dimension_filters: query.filters.clone(),
-            view: view(query, limit),
-            row_limit: query_row_limit(),
-        },
-    )?;
-    Ok(compiled)
+    let request = MetricQuery {
+        tenant_id: tenant_id.to_string(),
+        entity_scope: scope.clone(),
+        from: window.from,
+        to: window.to,
+        bucket: bucket(query.grain),
+        dimension_filters: query.filters.clone(),
+        view: view(query, limit),
+        row_limit: query_row_limit(),
+    };
+
+    match cached_inputs(catalog, gate, metric, &request.view, window) {
+        Some(cached) => Ok((catalog.compile_cached(metric, &cached, &request)?, true)),
+        None => Ok((catalog.compile(metric, &request)?, false)),
+    }
 }
 
 /// The compiler's view for one question's shape. A shape that reports no group
@@ -341,6 +433,7 @@ mod tests {
     use super::super::fixtures::validated;
     use super::*;
     use crate::domain::compiler::sql::QueryParam;
+    use crate::domain::measure_cache::read_gate::CoverageRow;
 
     fn person() -> Uuid {
         Uuid::from_u128(1)
@@ -383,16 +476,68 @@ mod tests {
         }
     }
 
+    /// The gate that decides every named measure cacheable over any window a
+    /// question can name, so a test can pin the cached read without a store.
+    fn cached_gate(measure_keys: &[&str]) -> ReadGate {
+        let catalog = product_metric_catalog().expect("loads");
+
+        ReadGate::over(
+            measure_keys
+                .iter()
+                .map(|key| CoverageRow {
+                    measure_key: (*key).to_owned(),
+                    current_version: 1,
+                    enabled: true,
+                    cached_version: Some(1),
+                    cached_kind: catalog.row_kind(key),
+                    covered_from: Some(NaiveDate::MIN),
+                    covered_to: Some(NaiveDate::MAX),
+                })
+                .collect(),
+        )
+    }
+
+    /// The same gate with one measure's coverage attesting a shape this release
+    /// no longer folds it into.
+    fn reshaped_gate(measure_key: &str) -> ReadGate {
+        let catalog = product_metric_catalog().expect("loads");
+        let attested = match catalog.row_kind(measure_key) {
+            Some(CacheRowKind::Event) => CacheRowKind::Aggregate,
+            Some(CacheRowKind::Aggregate | CacheRowKind::Subject) | None => CacheRowKind::Event,
+        };
+
+        ReadGate::over(vec![CoverageRow {
+            measure_key: measure_key.to_owned(),
+            current_version: 1,
+            enabled: true,
+            cached_version: Some(1),
+            cached_kind: Some(attested),
+            covered_from: Some(NaiveDate::MIN),
+            covered_to: Some(NaiveDate::MAX),
+        }])
+    }
+
     fn compiled(query: &ValidatedQuery, scope: &EntityScope) -> CompiledMeasureQuery {
+        compile_with(&ReadGate::all_live(), query, scope, None)
+            .unwrap_or_else(|error| panic!("{:?} compiles: {error}", query.shape))
+            .0
+    }
+
+    fn compile_with(
+        gate: &ReadGate,
+        query: &ValidatedQuery,
+        scope: &EntityScope,
+        limit: Option<GroupLimit>,
+    ) -> Result<(CompiledMeasureQuery, bool), QueryError> {
         compile(
             product_metric_catalog().expect("loads"),
+            gate,
             tenant(),
             query,
             scope,
-            None,
+            limit,
             window(query),
         )
-        .unwrap_or_else(|error| panic!("{:?} compiles: {error}", query.shape))
     }
 
     #[test]
@@ -520,6 +665,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn a_question_that_runs_no_statement_took_no_row_from_the_cache() {
+        assert_eq!(
+            PlannedQuery::NoIdentities.served_from(),
+            ServedFrom::Computed
+        );
+    }
+
+    /// The gate is keyed by measure and the cache's rows by whatever the
+    /// measure's entity column carries, so the two decisions compose: a
+    /// tenant-grain metric reads the cache under tenancy alone, exactly as it
+    /// reads its dataset.
+    #[test]
+    fn a_cached_tenant_grain_metric_reads_the_cache_under_tenancy_alone_and_opens_no_pool() {
+        let query = ValidatedQuery {
+            metric_key: SHIPPED_TENANT_METRIC.to_owned(),
+            ..asking(EntityType::Tenant, ValidatedSubjects::Tenant)
+        };
+        let scope = entity_scope(&query, &BTreeMap::new(), &tenant_people());
+        let inputs = product_metric_catalog()
+            .expect("loads")
+            .metric(SHIPPED_TENANT_METRIC)
+            .expect("the metric is shipped")
+            .input_measures();
+
+        let (compiled, cached) = compile_with(&cached_gate(&inputs), &query, &scope, None)
+            .expect("a tenant-grain question compiles over the cache");
+
+        assert!(cached);
+        assert!(
+            compiled.sql.contains("FROM insight.semantic_measure_cache"),
+            "{}",
+            compiled.sql
+        );
+        assert!(!compiled.sql.contains("pool"), "{}", compiled.sql);
+        assert_eq!(compiled.sql.matches('?').count(), compiled.params.len());
+    }
+
     #[tokio::test]
     async fn a_tenant_grain_question_never_enumerates_the_tenants_people() {
         let batch = ValidatedBatch {
@@ -571,15 +754,8 @@ mod tests {
     fn a_dimension_the_definitions_do_not_declare_does_not_compile() {
         let query = validated(QueryShape::SubjectSplit, Grain::Total, &["not_a_dimension"]);
 
-        let error = compile(
-            product_metric_catalog().expect("loads"),
-            tenant(),
-            &query,
-            &people_scope(),
-            None,
-            window(&query),
-        )
-        .expect_err("an undeclared dimension names no column");
+        let error = compile_with(&ReadGate::all_live(), &query, &people_scope(), None)
+            .expect_err("an undeclared dimension names no column");
 
         assert!(matches!(error, QueryError::Uncompilable(_)), "{error}");
     }
@@ -823,9 +999,8 @@ mod tests {
             }),
         });
 
-        let compiled = compile(
-            product_metric_catalog().expect("loads"),
-            tenant(),
+        let (compiled, _) = compile_with(
+            &ReadGate::all_live(),
             &query,
             &EntityScope::Tenant,
             Some(GroupLimit {
@@ -838,7 +1013,6 @@ mod tests {
                 }],
                 include_remainder: true,
             }),
-            window(&query),
         )
         .expect("a capped rollup compiles once its groups are ranked");
 
@@ -889,6 +1063,143 @@ mod tests {
         assert_eq!(compiled.sql.matches('?').count(), compiled.params.len());
     }
 
+    /// A ratio, so a question whose two inputs are decided differently is
+    /// visible in what the read scans.
+    const RATIO_METRIC: &str = "git.test_change_share";
+
+    #[test]
+    fn a_question_whose_measure_is_cached_scans_the_materialized_relation() {
+        let query = validated(QueryShape::SubjectTotal, Grain::Total, &[]);
+
+        let (compiled, cached) =
+            compile_with(&cached_gate(&["commits"]), &query, &people_scope(), None)
+                .expect("a cached question compiles");
+
+        assert!(cached);
+        assert!(
+            compiled.sql.contains("FROM insight.semantic_measure_cache"),
+            "{}",
+            compiled.sql
+        );
+        assert!(
+            compiled
+                .params
+                .contains(&QueryParam::Text("commits".to_owned())),
+            "the read names the measure it re-folds"
+        );
+    }
+
+    #[test]
+    fn a_measure_whose_coverage_attests_another_row_shape_scans_the_dataset() {
+        let query = validated(QueryShape::SubjectTotal, Grain::Total, &[]);
+
+        let (compiled, cached) =
+            compile_with(&reshaped_gate("commits"), &query, &people_scope(), None)
+                .expect("a reshaped question compiles over its dataset");
+
+        assert!(!cached);
+        assert!(
+            !compiled.sql.contains("semantic_measure_cache"),
+            "{}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn the_same_question_over_a_live_gate_scans_the_dataset_instead() {
+        let query = validated(QueryShape::SubjectTotal, Grain::Total, &[]);
+
+        let (compiled, cached) = compile_with(&ReadGate::all_live(), &query, &people_scope(), None)
+            .expect("a live question compiles");
+
+        assert!(!cached);
+        assert!(
+            !compiled.sql.contains("semantic_measure_cache"),
+            "{}",
+            compiled.sql
+        );
+        assert!(
+            compiled.sql.contains("FROM insight.git_commits"),
+            "{}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn a_ratio_reads_the_cache_only_when_both_of_its_inputs_were_decided_cacheable() {
+        let mut query = validated(QueryShape::SubjectTotal, Grain::Total, &[]);
+        query.metric_key = RATIO_METRIC.to_owned();
+        let cases = [
+            (
+                cached_gate(&["test_lines_added", "test_and_code_lines_added"]),
+                true,
+            ),
+            (cached_gate(&["test_lines_added"]), false),
+            (cached_gate(&["test_and_code_lines_added"]), false),
+            (cached_gate(&[]), false),
+        ];
+
+        for (gate, expected) in cases {
+            let (compiled, cached) = compile_with(&gate, &query, &people_scope(), None)
+                .expect("a ratio question compiles either way");
+
+            assert_eq!(cached, expected, "{}", compiled.sql);
+            assert_eq!(
+                compiled.sql.contains("semantic_measure_cache"),
+                expected,
+                "{}",
+                compiled.sql
+            );
+        }
+    }
+
+    #[test]
+    fn a_capped_split_reads_its_dataset_however_the_gate_decided_its_measure() {
+        let mut query = validated(QueryShape::CombinedSplit, Grain::Total, &["repository"]);
+        query.split = Some(ValidatedSplit {
+            dimensions: vec!["repository".to_owned()],
+            limit: Some(super::super::validation::ValidatedSplitLimit {
+                top: 2,
+                rank_by: SHIPPED_METRIC.to_owned(),
+                remainder: true,
+            }),
+        });
+
+        let (compiled, cached) = compile_with(
+            &cached_gate(&["commits"]),
+            &query,
+            &EntityScope::Tenant,
+            Some(GroupLimit {
+                groups: vec![RankedGroup {
+                    rank: 1,
+                    dimensions: vec![crate::domain::compiler::request::RankedDimension {
+                        value: "example/app".to_owned(),
+                        label: None,
+                    }],
+                }],
+                include_remainder: true,
+            }),
+        )
+        .expect("a capped rollup compiles");
+
+        assert!(!cached);
+        assert!(!compiled.sql.contains("semantic_measure_cache"));
+    }
+
+    #[test]
+    fn an_answer_states_mixed_when_its_two_windows_were_not_served_the_same_way() {
+        let cases = [
+            (vec![true, true], ServedFrom::Cache),
+            (vec![true, false], ServedFrom::Mixed),
+            (vec![false, true], ServedFrom::Mixed),
+            (vec![false, false], ServedFrom::Computed),
+        ];
+
+        for (reads, expected) in cases {
+            assert_eq!(ServedFrom::of(reads.clone()), expected, "{reads:?}");
+        }
+    }
+
     #[test]
     fn a_compared_question_compiles_the_same_read_over_the_shifted_window() {
         let mut query = validated(QueryShape::SubjectTotal, Grain::Total, &[]);
@@ -900,13 +1211,15 @@ mod tests {
         let current = compiled(&query, &people_scope());
         let compared = compile(
             product_metric_catalog().expect("loads"),
+            &ReadGate::all_live(),
             tenant(),
             &query,
             &people_scope(),
             None,
             query.compare.expect("the question compares").into(),
         )
-        .expect("the compared window compiles");
+        .expect("the compared window compiles")
+        .0;
 
         assert_eq!(
             compared.sql, current.sql,

--- a/src/backend/services/analytics/src/domain/metric_query/values/service.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/service.rs
@@ -9,7 +9,6 @@ use uuid::Uuid;
 use serde::de::DeserializeOwned;
 
 use super::super::catalog::MetricCatalog;
-use super::super::dto::ServedFrom;
 use super::super::error::QueryError;
 use super::super::execute::fetch;
 use super::super::provenance::{metric_versions, provenance};
@@ -29,10 +28,19 @@ pub async fn answer(
     catalog: &MetricCatalog,
     clickhouse: &insight_clickhouse::Client,
     db: &DatabaseConnection,
+    cache_reads_enabled: bool,
     tenant_id: Uuid,
     batch: ValidatedBatch,
 ) -> Result<ValuesResponse, QueryError> {
-    let compiled = plan(catalog, clickhouse, tenant_id, &batch).await?;
+    let compiled = plan(
+        catalog,
+        clickhouse,
+        db,
+        cache_reads_enabled,
+        tenant_id,
+        &batch,
+    )
+    .await?;
 
     let keys: Vec<String> = batch
         .queries
@@ -47,10 +55,11 @@ pub async fn answer(
     let results = batch
         .queries
         .iter()
+        .zip(&compiled)
         .zip(bodies?)
-        .map(|(query, result)| QueryResult {
+        .map(|((query, planned), result)| QueryResult {
             metric: query.metric_key.clone(),
-            provenance: provenance(&versions, &query.metric_key, ServedFrom::Computed),
+            provenance: provenance(&versions, &query.metric_key, planned.served_from()),
             result,
         })
         .collect();
@@ -120,7 +129,10 @@ async fn read_both<T>(
 where
     T: DeserializeOwned,
 {
-    let PlannedQuery::Read { current, compared } = planned else {
+    let PlannedQuery::Read {
+        current, compared, ..
+    } = planned
+    else {
         return Ok((Vec::new(), None));
     };
 
@@ -147,6 +159,7 @@ fn shape_name(shape: QueryShape) -> &'static str {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use crate::domain::compiler::sql::CompiledMeasureQuery;
+    use crate::domain::metric_query::dto::ServedFrom;
 
     use super::super::super::fixtures::offline_clickhouse;
     use super::super::dto::Grain;
@@ -174,6 +187,7 @@ mod tests {
                 params: Vec::new(),
             },
             compared: None,
+            served_from: ServedFrom::Computed,
         }
     }
 

--- a/src/backend/services/analytics/src/domain/mod.rs
+++ b/src/backend/services/analytics/src/domain/mod.rs
@@ -7,6 +7,7 @@ pub mod definitions;
 pub mod external_links;
 pub mod field_catalog;
 pub mod identity_binding;
+pub mod measure_cache;
 pub(crate) mod metric_access;
 pub mod metric_crud;
 pub mod metric_definitions;

--- a/src/backend/services/analytics/src/gear.rs
+++ b/src/backend/services/analytics/src/gear.rs
@@ -21,8 +21,8 @@ use crate::config::GearConfig;
 use crate::domain::external_links::ExternalSourceRegistry;
 use crate::{api, infra};
 
-/// Analytics API gear. Capabilities: `rest` only (the background validator and
-/// contract-version passes are `tokio::spawn`ed in `init`; no
+/// Analytics API gear. Capabilities: `rest` only (the background validator,
+/// contract-version and measure-cache passes are `tokio::spawn`ed in `init`; no
 /// `stateful`/`RunnableCapability`).
 // Config key is the gear name `analytics`; env overrides are
 // `APP__gears__analytics__config__*`.
@@ -89,6 +89,15 @@ impl Gear for AnalyticsApiGear {
                 ch.clone(),
             );
 
+        // Its own pinned session: the per-measure advisory lock that keeps two
+        // replicas out of one staging relation is session-scoped.
+        let measure_cache_refresher = crate::domain::measure_cache::MeasureCacheRefresher::new(
+            db.clone(),
+            ch.clone(),
+            &cfg.database_url,
+        )
+        .await?;
+
         let contract_ch = ch.clone();
 
         let anthropic = infra::anthropic::AnthropicClient::new(
@@ -121,6 +130,9 @@ impl Gear for AnalyticsApiGear {
         // dbt-created after boot on a fresh deploy, and the registry has no
         // write path that would re-trigger probing.
         tokio::spawn(metric_definition_validator.run());
+        // Scheduled, never triggered by a read: a request answers from the
+        // coverage the last successful build left, and waits for nothing.
+        tokio::spawn(measure_cache_refresher.run());
 
         Ok(())
     }

--- a/src/backend/services/analytics/src/infra/db/entities.rs
+++ b/src/backend/services/analytics/src/infra/db/entities.rs
@@ -247,3 +247,31 @@ pub mod semantic_definition_revisions {
 
     impl ActiveModelBehavior for ActiveModel {}
 }
+
+#[allow(dead_code)] // seeding writes through a statement; the entity types the read side
+pub mod semantic_cache_policies {
+    //! `semantic_cache_policies` entity — whether and how often a measure's work
+    //! is materialized.
+    //!
+    //! INVARIANT: caching is policy, not semantics — nothing on this row may
+    //! move a `definition_version`.
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "semantic_cache_policies")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub measure_key: String,
+        pub enabled: bool,
+        pub hot_window_days: i32,
+        pub refresh_interval_minutes: i32,
+        pub created_at: ChronoDateTimeUtc,
+        pub updated_at: ChronoDateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}

--- a/src/backend/services/analytics/src/migration/m20260828_000001_semantic_cache.rs
+++ b/src/backend/services/analytics/src/migration/m20260828_000001_semantic_cache.rs
@@ -1,0 +1,115 @@
+//! Caching policy and coverage for the semantic layer's measures.
+//!
+//! Policy is not semantics: it says whether and how often a measure's work is
+//! materialized, never what the measure means, so nothing here may move a
+//! `definition_version`. Coverage is written by the refresher alone, after a
+//! build lands, and states the dates the cache can be answered from.
+
+use sea_orm_migration::prelude::*;
+
+pub const REQUIRED_POLICY_CHECKS: &[&str] = &[
+    "chk_semantic_cache_policies_measure_key_shape",
+    "chk_semantic_cache_policies_hot_window_positive",
+    "chk_semantic_cache_policies_refresh_interval_positive",
+];
+
+pub const REQUIRED_COVERAGE_CHECKS: &[&str] = &[
+    "chk_semantic_cache_coverage_measure_key_shape",
+    "chk_semantic_cache_coverage_definition_version_positive",
+    "chk_semantic_cache_coverage_window_ordered",
+];
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        for statement in SCHEMA_STATEMENTS {
+            conn.execute_unprepared(statement).await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Err(DbErr::Custom("we have only forward migrations".to_owned()))
+    }
+}
+
+const SCHEMA_STATEMENTS: &[&str] = &[
+    "CREATE TABLE IF NOT EXISTS semantic_cache_policies (
+        id BINARY(16) NOT NULL PRIMARY KEY,
+        measure_key VARCHAR(128) NOT NULL,
+        enabled BOOLEAN NOT NULL DEFAULT TRUE,
+        hot_window_days INT NOT NULL DEFAULT 35,
+        refresh_interval_minutes INT NOT NULL DEFAULT 60,
+        created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+        updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+        UNIQUE KEY uq_semantic_cache_policies_measure (measure_key),
+        CONSTRAINT chk_semantic_cache_policies_measure_key_shape CHECK (measure_key REGEXP BINARY '^[a-z][a-z0-9_]*$'),
+        CONSTRAINT chk_semantic_cache_policies_hot_window_positive CHECK (hot_window_days >= 1),
+        CONSTRAINT chk_semantic_cache_policies_refresh_interval_positive CHECK (refresh_interval_minutes >= 1)
+    )",
+    // One row per measure and version: a version change starts its own coverage
+    // rather than inheriting the dates the previous definition's rows covered.
+    "CREATE TABLE IF NOT EXISTS semantic_cache_coverage (
+        id BINARY(16) NOT NULL PRIMARY KEY,
+        measure_key VARCHAR(128) NOT NULL,
+        definition_version INT NOT NULL,
+        covered_from DATE NOT NULL,
+        covered_to DATE NOT NULL,
+        refreshed_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+        UNIQUE KEY uq_semantic_cache_coverage_measure_version (measure_key, definition_version),
+        CONSTRAINT chk_semantic_cache_coverage_measure_key_shape CHECK (measure_key REGEXP BINARY '^[a-z][a-z0-9_]*$'),
+        CONSTRAINT chk_semantic_cache_coverage_definition_version_positive CHECK (definition_version >= 1),
+        CONSTRAINT chk_semantic_cache_coverage_window_ordered CHECK (covered_to >= covered_from)
+    )",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_required_check_appears_in_schema() {
+        let all_sql = SCHEMA_STATEMENTS.join("\n");
+        for check in REQUIRED_POLICY_CHECKS
+            .iter()
+            .chain(REQUIRED_COVERAGE_CHECKS)
+        {
+            assert!(all_sql.contains(check), "missing CHECK {check}");
+        }
+    }
+
+    #[test]
+    fn a_measure_is_cached_under_one_policy_and_one_coverage_row_per_version() {
+        let all_sql = SCHEMA_STATEMENTS.join("\n");
+        assert!(all_sql.contains("UNIQUE KEY uq_semantic_cache_policies_measure (measure_key)"));
+        assert!(all_sql.contains(
+            "UNIQUE KEY uq_semantic_cache_coverage_measure_version (measure_key, definition_version)"
+        ));
+    }
+
+    #[test]
+    fn policy_carries_no_column_that_could_state_what_a_measure_means() {
+        let policy = SCHEMA_STATEMENTS
+            .iter()
+            .find(|statement| statement.contains("semantic_cache_policies"))
+            .unwrap_or_else(|| panic!("no CREATE for semantic_cache_policies"));
+
+        for semantic in [
+            "definition_version",
+            "aggregation",
+            "filter",
+            "value_expr",
+            "subject_expr",
+            "dimensions",
+        ] {
+            assert!(
+                !policy.contains(semantic),
+                "policy must not carry `{semantic}` — caching is not semantics"
+            );
+        }
+    }
+}

--- a/src/backend/services/analytics/src/migration/m20260828_000002_semantic_cache_row_kind.rs
+++ b/src/backend/services/analytics/src/migration/m20260828_000002_semantic_cache_row_kind.rs
@@ -1,0 +1,72 @@
+//! The row shape a coverage window was built at.
+//!
+//! A measure's row kind is decided by its own fold and by whether any metric
+//! reads it as a distribution, so a release can change it without moving the
+//! measure's `definition_version`. Coverage that cannot state the shape it
+//! attests cannot keep a read from folding two shapes into one number.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        for statement in SCHEMA_STATEMENTS {
+            conn.execute_unprepared(statement).await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Err(DbErr::Custom("we have only forward migrations".to_owned()))
+    }
+}
+
+// INVARIANT: the column takes no default, so every coverage row states the
+// shape it was built at. Rows written before it existed cannot, and a refresh
+// re-earns them rather than a backfill inventing a shape they may not have.
+const SCHEMA_STATEMENTS: &[&str] = &[
+    "DELETE FROM semantic_cache_coverage",
+    "ALTER TABLE semantic_cache_coverage
+        ADD COLUMN row_kind ENUM('aggregate', 'event', 'subject') NOT NULL
+        AFTER definition_version",
+];
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_column_admits_exactly_the_three_row_shapes_a_build_writes() {
+        let all_sql = SCHEMA_STATEMENTS.join("\n");
+
+        assert!(
+            all_sql.contains("ENUM('aggregate', 'event', 'subject')"),
+            "{all_sql}"
+        );
+        assert!(all_sql.contains("NOT NULL"), "{all_sql}");
+        assert!(
+            !all_sql.contains("DEFAULT"),
+            "a default would let a coverage row claim a shape it was not built at: {all_sql}"
+        );
+    }
+
+    #[test]
+    fn coverage_written_before_the_column_existed_is_cleared_rather_than_backfilled() {
+        assert_eq!(SCHEMA_STATEMENTS[0], "DELETE FROM semantic_cache_coverage");
+    }
+
+    #[tokio::test]
+    async fn the_migration_is_forward_only() {
+        let error = Migration
+            .down(&SchemaManager::new(&sea_orm::DatabaseConnection::default()))
+            .await
+            .expect_err("a down migration is refused");
+
+        assert!(matches!(error, DbErr::Custom(_)), "{error}");
+    }
+}

--- a/src/backend/services/analytics/src/migration/mod.rs
+++ b/src/backend/services/analytics/src/migration/mod.rs
@@ -67,6 +67,8 @@ mod m20260823_000001_ratio_denominator_aggregation;
 mod m20260824_000001_metric_percentile_stddev_computation;
 mod m20260825_000001_metric_evidence_presentation;
 mod m20260826_000001_semantic_dataset_version;
+mod m20260828_000001_semantic_cache;
+mod m20260828_000002_semantic_cache_row_kind;
 pub(crate) use m20260822_000001_feedback::feedback_schema;
 pub(crate) use m20260822_000002_ai_assist::ai_assist_schema;
 
@@ -145,6 +147,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20260824_000001_metric_percentile_stddev_computation::Migration),
             Box::new(m20260825_000001_metric_evidence_presentation::Migration),
             Box::new(m20260826_000001_semantic_dataset_version::Migration),
+            Box::new(m20260828_000001_semantic_cache::Migration),
+            Box::new(m20260828_000002_semantic_cache_row_kind::Migration),
         ]
     }
 }
@@ -210,6 +214,14 @@ pub const REQUIRED_CHECKS_BY_TABLE: &[(&str, &[&str])] = &[
     (
         "semantic_definition_revisions",
         m20260805_000001_semantic_definition_core::REQUIRED_REVISION_CHECKS,
+    ),
+    (
+        "semantic_cache_policies",
+        m20260828_000001_semantic_cache::REQUIRED_POLICY_CHECKS,
+    ),
+    (
+        "semantic_cache_coverage",
+        m20260828_000001_semantic_cache::REQUIRED_COVERAGE_CHECKS,
     ),
 ];
 
@@ -290,6 +302,14 @@ mod tests {
             (
                 "semantic_definition_revisions",
                 m20260805_000001_semantic_definition_core::REQUIRED_REVISION_CHECKS,
+            ),
+            (
+                "semantic_cache_policies",
+                m20260828_000001_semantic_cache::REQUIRED_POLICY_CHECKS,
+            ),
+            (
+                "semantic_cache_coverage",
+                m20260828_000001_semantic_cache::REQUIRED_COVERAGE_CHECKS,
             ),
         ];
 

--- a/src/ingestion/scripts/bootstrap-db/presentation-role.sql
+++ b/src/ingestion/scripts/bootstrap-db/presentation-role.sql
@@ -1,8 +1,10 @@
 -- presentation_ro: read-only-by-construction role for the presentation query
--- path (#1963). Contract = SELECT only; `presentation` = SELECT/INSERT/CREATE;
--- `product_usage` = SELECT/INSERT only, `ingestion_history` = SELECT only,
--- both with DDL owned by a migration;
--- no DROP/ALTER/TRUNCATE anywhere. Idempotent. Needs an admin with
+-- path (#1963). Contract = SELECT only, apart from the semantic measure cache
+-- relations the query path materializes itself; `presentation` =
+-- SELECT/INSERT/CREATE; `product_usage` = SELECT/INSERT only,
+-- `ingestion_history` = SELECT only, both with DDL owned by a migration;
+-- no DROP/TRUNCATE anywhere, and no ALTER outside those two named tables.
+-- Idempotent. Needs an admin with
 -- access_management (compose/e2e/bitnami already have it; see README.md).
 -- Spec: docs/domain/presentation-layer/specs.
 -- The grant-less `presentation` user that carries this role is created by
@@ -31,3 +33,14 @@ GRANT SELECT, INSERT ON product_usage.* TO presentation_ro;
 -- the database exists on a fresh install (apply-ch-migrations.sh provisions the
 -- role first); ClickHouse grants by name, so that ordering is fine.
 GRANT SELECT ON ingestion_history.* TO presentation_ro;
+
+-- Semantic measure cache: the only relations in `insight` this role may write.
+-- The refresher stages a build, swaps it in one partition at a time and clears
+-- the slot around it, so it needs INSERT plus ALTER DELETE on both — ClickHouse
+-- checks DROP PARTITION as ALTER DELETE, and REPLACE PARTITION as INSERT +
+-- ALTER DELETE on the target with SELECT on the source. Table-scoped, so the
+-- database stays read-only everywhere else. Their DDL comes from
+-- migrations/20260828000000_semantic-measure-cache.sql; ClickHouse grants by
+-- name, so the role may be provisioned before the tables exist.
+GRANT INSERT, ALTER DELETE ON insight.semantic_measure_cache TO presentation_ro;
+GRANT INSERT, ALTER DELETE ON insight.semantic_measure_cache_staging TO presentation_ro;

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -731,6 +731,50 @@ ORDER BY (tenant_id, entity_id, metric_date)
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS insight.semantic_measure_cache
+(
+    `tenant_id` String,
+    `measure_key` String,
+    `definition_version` UInt32,
+    `kind` Enum8('aggregate' = 1, 'event' = 2, 'subject' = 3),
+    `metric_date` Date,
+    `entity` String,
+    `dimensions` Array(Tuple(
+        key String,
+        value String,
+        label Nullable(String))),
+    `value` Float64,
+    `subject` Nullable(String),
+    `built_at` DateTime64(3)
+)
+ENGINE = MergeTree
+PARTITION BY (measure_key, definition_version, toYYYYMM(metric_date))
+ORDER BY (tenant_id, measure_key, entity, metric_date)
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.semantic_measure_cache_staging
+(
+    `tenant_id` String,
+    `measure_key` String,
+    `definition_version` UInt32,
+    `kind` Enum8('aggregate' = 1, 'event' = 2, 'subject' = 3),
+    `metric_date` Date,
+    `entity` String,
+    `dimensions` Array(Tuple(
+        key String,
+        value String,
+        label Nullable(String))),
+    `value` Float64,
+    `subject` Nullable(String),
+    `built_at` DateTime64(3)
+)
+ENGINE = MergeTree
+PARTITION BY (measure_key, definition_version, toYYYYMM(metric_date))
+ORDER BY (tenant_id, measure_key, entity, metric_date)
+SETTINGS index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS insight.task_close_events
 (
     `tenant_id` String,

--- a/src/ingestion/scripts/migrations/20260828000000_semantic-measure-cache.sql
+++ b/src/ingestion/scripts/migrations/20260828000000_semantic-measure-cache.sql
@@ -1,0 +1,49 @@
+-- Materialized work behind the semantic layer's measures: each measure's rows
+-- at the finest grain a request can re-aggregate from, every tenant in one
+-- relation so authoring a measure never issues DDL.
+--
+-- `kind` names the row shape: `aggregate` is one row per tenant x entity x day
+-- x dimension tuple, `event` is one row per source event (a distribution over
+-- pre-folded values is not that distribution), `subject` is one row per counted
+-- subject (so a distinct count over any window stays exact).
+--
+-- The partition key is the invalidation unit: refreshing a hot window replaces
+-- (measure, version, month) partitions, and a superseded definition's rows drop
+-- by partition rather than by mutation.
+--
+-- The staging twin carries one build. It must keep the same columns, partition
+-- key and sorting key as the served relation, or `REPLACE PARTITION` refuses.
+
+CREATE TABLE IF NOT EXISTS insight.semantic_measure_cache
+(
+    tenant_id          String,
+    measure_key        String,
+    definition_version UInt32,
+    kind               Enum8('aggregate' = 1, 'event' = 2, 'subject' = 3),
+    metric_date        Date,
+    entity             String,
+    dimensions         Array(Tuple(key String, value String, label Nullable(String))),
+    value              Float64,
+    subject            Nullable(String),
+    built_at           DateTime64(3)
+)
+ENGINE = MergeTree
+PARTITION BY (measure_key, definition_version, toYYYYMM(metric_date))
+ORDER BY (tenant_id, measure_key, entity, metric_date);
+
+CREATE TABLE IF NOT EXISTS insight.semantic_measure_cache_staging
+(
+    tenant_id          String,
+    measure_key        String,
+    definition_version UInt32,
+    kind               Enum8('aggregate' = 1, 'event' = 2, 'subject' = 3),
+    metric_date        Date,
+    entity             String,
+    dimensions         Array(Tuple(key String, value String, label Nullable(String))),
+    value              Float64,
+    subject            Nullable(String),
+    built_at           DateTime64(3)
+)
+ENGINE = MergeTree
+PARTITION BY (measure_key, definition_version, toYYYYMM(metric_date))
+ORDER BY (tenant_id, measure_key, entity, metric_date);

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -1221,9 +1221,12 @@ class Scope(StrEnum):
 
 class ServedFrom(StrEnum):
     """
-    Where the rows behind this answer came from.
+    Where the rows behind this answer came from. `mixed` is one answer some of
+    whose reads were cached and some computed.
     """
+    cache = 'cache'
     computed = 'computed'
+    mixed = 'mixed'
 
 
 class SnapshotScope(StrEnum):


### PR DESCRIPTION
**DEFERRED — do not merge until the four review findings below are fixed.**

**Why.** Every `/v1/query` read compiles and scans gold live; hot dashboards recompute identical answers per request.

**What changed.** A scheduled measure cache: hot-window materialization per measure into a ClickHouse relation, a MariaDB-backed read gate deciding cache vs live per question, cached re-folds pinned to agree with live reads (counts and distinct counts re-fold to zero, matched-group and bucket rules render identically), `served_from` reporting cache/mixed/computed on the wire.

## Known defects to fix before merge

1. **Critical — refresh deletes cached history while coverage claims it.** Month partitions + rolling 35-day `REPLACE PARTITION` truncate the window's first month every run; `covered_from` only widens. Gated reads answer from a fraction of the claimed window.
2. **Major — `value Float64` is not Nullable**: a NULL fold stores as 0.0; live reads answer null, cached reads 0, for sum measures over all-NULL windows.
3. **Major — `__unknown__` dimension filters diverge**: the cache matches the stored coalesced sentinel; the live read filters the raw column and matches nothing.
4. **Major — no ClickHouse-side sanity check against MariaDB coverage**: an emptied cache relation serves zeros labeled `served_from: cache` instead of falling back live.

Minor follow-ups from the same review: no TTL/eviction for retired measures, per-replica refresh cadence, refresher failure at boot fails the whole gear.

**Verified.** `cargo test -p analytics --bin analytics`: 1216 passed, 0 failed at this tip; clippy `-D warnings`, fmt, OpenAPI + stand-schema drift clean; `dbt parse` clean. Cache/live agreement holds in rendered-SQL tests; the defects above are behavioral, reachable only with the cache enabled.
