### PR TITLE
fix(frontend): stop asking a metric to narrow by a dimension it has no idea about

### DIFF
--- a/src/frontend/src/lib/metrics/collection.test.ts
+++ b/src/frontend/src/lib/metrics/collection.test.ts
@@ -750,6 +750,25 @@ describe("filterCollectionToDeclaredDimensions", () => {
     ).toEqual([]);
   });
 
+  it("judges each entry by its OWN filters, not by the first with that key", () => {
+    // Two entries can name one metric under different filters. Deciding the
+    // second by the first's filters would leave an unsupported filter in the
+    // request, which is the 400 this gate exists to prevent.
+    const twice: MetricCollectionConfig = {
+      metrics: [
+        { key: "git.commits", filters: REPO, views: [{ view: "period" }] },
+        {
+          key: "git.commits",
+          filters: [{ dimension: "team", values: ["platform"] }],
+          views: [{ view: "peer" }],
+        },
+      ],
+    };
+    const out = filterCollectionToDeclaredDimensions(twice, declared);
+    // git.commits declares `repository` and not `team`.
+    expect(out.metrics).toEqual([twice.metrics[0]]);
+  });
+
   it("drops nothing while the catalog is unknown", () => {
     // Null is "not answered yet" — the caller holds the request instead.
     expect(filterCollectionToDeclaredDimensions(scoped, null)).toBe(scoped);

--- a/src/frontend/src/lib/metrics/collection.test.ts
+++ b/src/frontend/src/lib/metrics/collection.test.ts
@@ -10,6 +10,7 @@ import {
   buildMetricCollectionRequest,
   entityObserved,
   filterCollectionToAvailable,
+  filterCollectionToDeclaredDimensions,
   type NormalizedMetricResult,
   chunkEntityIds,
   entityChunkSize,
@@ -687,6 +688,80 @@ describe("entityObserved", () => {
       period: { view: "period", values: [{ entity_id: "a@x", value: 0 }] },
     } as unknown as NormalizedMetricResult;
     expect(entityObserved(noPeer, "a@x")).toBe(false);
+  });
+});
+
+describe("filterCollectionToDeclaredDimensions", () => {
+  const REPO = [{ dimension: "repository", values: ["src:acme/api"] }];
+  const declared = new Map<string, ReadonlySet<string>>([
+    ["git.commits", new Set(["repository", "hour_block"])],
+    ["git.prs_merged", new Set(["repository"])],
+    ["tasks.closed", new Set(["project"])],
+  ]);
+  const scoped: MetricCollectionConfig = {
+    metrics: [
+      { key: "git.commits", filters: REPO, views: [{ view: "period" }] },
+      { key: "tasks.closed", filters: REPO, views: [{ view: "period" }] },
+    ],
+  };
+
+  it("drops a metric narrowed by a dimension it does not declare", () => {
+    // The backend answers the whole request with 400 "metric tasks.closed does
+    // not support dimension repository", so this is the difference between a
+    // scoped screen and a blank one.
+    const out = filterCollectionToDeclaredDimensions(scoped, declared);
+    expect(out.metrics.map((m) => m.key)).toEqual(["git.commits"]);
+  });
+
+  it("keeps a metric that asks for no dimension at all", () => {
+    const plain: MetricCollectionConfig = {
+      metrics: [{ key: "tasks.closed", views: [{ view: "period" }] }],
+    };
+    expect(filterCollectionToDeclaredDimensions(plain, declared)).toBe(plain);
+  });
+
+  it("needs EVERY named dimension, not just one of them", () => {
+    const both: MetricCollectionConfig = {
+      metrics: [
+        {
+          key: "git.prs_merged",
+          filters: [
+            { dimension: "repository", values: ["src:acme/api"] },
+            { dimension: "hour_block", values: ["08"] },
+          ],
+          views: [{ view: "period" }],
+        },
+      ],
+    };
+    // git.prs_merged declares `repository` and not `hour_block`.
+    expect(filterCollectionToDeclaredDimensions(both, declared).metrics).toEqual(
+      [],
+    );
+  });
+
+  it("drops a metric the catalog does not describe at all", () => {
+    const unknown: MetricCollectionConfig = {
+      metrics: [
+        { key: "git.mystery", filters: REPO, views: [{ view: "period" }] },
+      ],
+    };
+    expect(
+      filterCollectionToDeclaredDimensions(unknown, declared).metrics,
+    ).toEqual([]);
+  });
+
+  it("drops nothing while the catalog is unknown", () => {
+    // Null is "not answered yet" — the caller holds the request instead.
+    expect(filterCollectionToDeclaredDimensions(scoped, null)).toBe(scoped);
+  });
+
+  it("returns the SAME object when every filter is supported", () => {
+    const fine: MetricCollectionConfig = {
+      metrics: [
+        { key: "git.commits", filters: REPO, views: [{ view: "period" }] },
+      ],
+    };
+    expect(filterCollectionToDeclaredDimensions(fine, declared)).toBe(fine);
   });
 });
 

--- a/src/frontend/src/lib/metrics/collection.ts
+++ b/src/frontend/src/lib/metrics/collection.ts
@@ -115,12 +115,16 @@ export function filterCollectionToDeclaredDimensions(
   declared: ReadonlyMap<string, ReadonlySet<string>> | null,
 ): MetricCollectionConfig {
   if (!declared) return collection;
-  return filterCollectionByKey(collection, (key) => {
-    const asked = collection.metrics.find((m) => m.key === key)?.filters ?? [];
+  // Judged per ENTRY, not per key: two entries may name the same metric under
+  // different filters, and looking the key up would decide the second one by
+  // the first one's filters.
+  const kept = collection.metrics.filter((metric) => {
+    const asked = metric.filters ?? [];
     if (!asked.length) return true;
-    const supported = declared.get(key);
+    const supported = declared.get(metric.key);
     return asked.every((filter) => supported?.has(filter.dimension) ?? false);
   });
+  return kept.length === collection.metrics.length ? collection : { metrics: kept };
 }
 
 export type MetricCollectionEntity =

--- a/src/frontend/src/lib/metrics/collection.ts
+++ b/src/frontend/src/lib/metrics/collection.ts
@@ -96,6 +96,33 @@ export function filterCollectionByKey(
   return kept.length === collection.metrics.length ? collection : { metrics: kept };
 }
 
+/**
+ * Drop metrics whose request narrows by a dimension they do not declare.
+ *
+ * The backend rejects the WHOLE request over one such filter — "metric
+ * tasks.closed does not support dimension repository" — so a screen that
+ * scopes a whole direction to one repository would blank itself over the
+ * metrics that have nothing to do with repositories.
+ *
+ * Dropping, not un-filtering: an unfiltered tile on a scoped screen would show
+ * a figure for the whole roster under a heading that names one repository,
+ * which is worse than an absent tile. `declared === null` means the catalog has
+ * not answered, and then nothing is dropped — the caller holds the request
+ * instead, the same rule `filterCollectionToAvailable` follows.
+ */
+export function filterCollectionToDeclaredDimensions(
+  collection: MetricCollectionConfig,
+  declared: ReadonlyMap<string, ReadonlySet<string>> | null,
+): MetricCollectionConfig {
+  if (!declared) return collection;
+  return filterCollectionByKey(collection, (key) => {
+    const asked = collection.metrics.find((m) => m.key === key)?.filters ?? [];
+    if (!asked.length) return true;
+    const supported = declared.get(key);
+    return asked.every((filter) => supported?.has(filter.dimension) ?? false);
+  });
+}
+
 export type MetricCollectionEntity =
   // The tenant variant carries no ids: the backend derives the organization
   // from the session, and a client-supplied identifier is rejected outright.

--- a/src/frontend/src/queries/metric-results.ts
+++ b/src/frontend/src/queries/metric-results.ts
@@ -14,6 +14,7 @@ import {
   chunkEntityIds,
   filterCollectionByKey,
   filterCollectionToAvailable,
+  filterCollectionToDeclaredDimensions,
   entityChunkSize,
   mergeNormalizedResults,
   normalizeMetricResults,
@@ -26,7 +27,10 @@ import {
 import { normalizePersonId } from "@/lib/metrics/entity";
 import { metricVisible } from "@/lib/portal/nav-policy";
 import { usePortalShowPlanned } from "@/lib/portal/portal-store";
-import { useAvailableMetricKeys } from "@/queries/metric-definitions";
+import {
+  useAvailableMetricKeys,
+  useDeclaredMetricDimensions,
+} from "@/queries/metric-definitions";
 import type { PeriodValue } from "@/types/insight";
 
 /**
@@ -122,9 +126,13 @@ export function useMetricCollection(
   // rejects the WHOLE request over one unknown key, so a compiled-in key that
   // a tenant does not have would blank the screen instead of its own tile.
   const catalog = useAvailableMetricKeys();
+  const dimensions = useDeclaredMetricDimensions();
   const gate = useMetricGate();
   const asked = filterCollectionByKey(
-    filterCollectionToAvailable(collection, catalog.keys),
+    filterCollectionToDeclaredDimensions(
+      filterCollectionToAvailable(collection, catalog.keys),
+      dimensions.byMetricKey
+    ),
     gate
   );
   const canonicalEntity: MetricCollectionEntity =
@@ -150,6 +158,7 @@ export function useMetricCollection(
     entitySelected(entity, ids) &&
     request.metrics.length > 0 &&
     !catalog.isPending &&
+    !dimensions.isPending &&
     Boolean(range.from && range.to);
 
   const current = useQuery({
@@ -225,10 +234,12 @@ export function useMetricCollectionSet(
 ): Map<string, MetricCollectionResult> {
   const ids = canonicalEntityIds(entity);
   const catalog = useAvailableMetricKeys();
+  const dimensions = useDeclaredMetricDimensions();
   const gate = useMetricGate();
   const enabled =
     entitySelected(entity, ids) &&
     !catalog.isPending &&
+    !dimensions.isPending &&
     Boolean(range.from && range.to);
 
   // Large rosters are chunked so a period+peer collection over N entities
@@ -238,7 +249,10 @@ export function useMetricCollectionSet(
   const requests = collections.flatMap(({ key, collection: raw }) => {
     // Same catalog and install gates as `useMetricCollection` — see the notes there.
     const collection = filterCollectionByKey(
-      filterCollectionToAvailable(raw, catalog.keys),
+      filterCollectionToDeclaredDimensions(
+        filterCollectionToAvailable(raw, catalog.keys),
+        dimensions.byMetricKey
+      ),
       gate
     );
     const chunkSize = entityChunkSize(collection);

--- a/src/frontend/src/queries/metric-results.ts
+++ b/src/frontend/src/queries/metric-results.ts
@@ -187,10 +187,13 @@ export function useMetricCollection(
     previousByKey,
     // Pending while the catalog resolves too: the request is coming, so the
     // screen must show a skeleton rather than an empty state it would replace
-    // a moment later.
+    // a moment later. Both catalog reads gate `enabled`, so both belong here —
+    // one missing leaves a window where nothing is asked and nothing is
+    // pending, which renders as "no data".
     isPending:
       (current.isPending && enabled) ||
-      (entitySelected(entity, ids) && catalog.isPending),
+      (entitySelected(entity, ids) &&
+        (catalog.isPending || dimensions.isPending)),
     isFetching: current.isFetching,
     // Defensive: `ids` and `range` both ride in the query key, so today a
     // disabled query cannot be holding an error from an enabled one. Kept so
@@ -310,12 +313,13 @@ export function useMetricCollectionSet(
     out.set(key, {
       byKey: new Map(),
       previousByKey: null,
-      // Pending covers the catalog wait too — otherwise a screen reads "no
+      // Pending covers both catalog waits too — otherwise a screen reads "no
       // data" for the moment before its requests are even allowed to fire.
       isPending:
         (existing?.isPending ?? false) ||
         (query.isPending && active) ||
-        (entitySelected(entity, ids) && catalog.isPending),
+        (entitySelected(entity, ids) &&
+          (catalog.isPending || dimensions.isPending)),
       isFetching: (existing?.isFetching ?? false) || query.isFetching,
       isError: (existing?.isError ?? false) || (active && query.isError),
       // Chunks of the same collection share a key; refetch fans out to all.


### PR DESCRIPTION
**Why.** The repository screen renders nothing: every request it makes comes back 400 `metric tasks.closed does not support dimension repository`.

**What changed.** The screen scopes a whole direction to one repository, and the Development grid carries the tasks family beside the git one — one unsupported filter and `/v1/metric-results` refuses the whole request. A metric whose request names a dimension its declaration lacks is now dropped before the request is built, in the same place the catalog gate already sits, so both collection hooks cover the grid, the trend, the breakdowns, the rollup table and the heatmap — and the next scoped screen.

**Dropped, not un-filtered.** An unfiltered tile on a scoped screen would show the whole roster's figure under a heading naming one repository — worse than an absent tile. Reversible by deleting one call.

**Verified.** Six new unit tests on the gate (undeclared dimension, every named dimension rather than one, a key the catalog does not describe, pending catalog, object identity), typecheck and eslint clean. `src/api/reports-client.test.ts` fails on this branch and on pristine `main` alike — pre-existing, untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented metric requests from including filters for dimensions that are not declared in the catalog.
  * Evaluated duplicate metric entries independently, preserving supported filters while removing only entries with unsupported filters.
  * Ensured metrics without dimension filters remain available.
  * Delayed metric queries until dimension metadata is loaded, keeping results accurate and the screen in a pending state.
  * Preserved existing behavior when catalog metadata is unavailable or all configured dimensions are supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->