### PR TITLE
test(gitlab): name the non-default branch walk in tests of its own

### DIFF
--- a/src/ingestion/connectors/git/gitlab/tests/test_file_changes_stream.py
+++ b/src/ingestion/connectors/git/gitlab/tests/test_file_changes_stream.py
@@ -155,6 +155,21 @@ class TestDiffTasks:
         # the default ref contributes nothing, the branch still has to be walked
         assert seen == [({"project_id": 1, "ref": "H1..H2"}, frozenset({404}))]
 
+    def test_a_branch_the_stream_has_not_seen_is_walked_from_the_default_head(self):
+        parent = FakeParent([({"mode": "instance"}, [self._project()])])
+        stream = _stream(
+            parent=parent,
+            branches=FakeBranches({1: [
+                {"name": "main", "commit_sha": "H1"},
+                {"name": "feat", "commit_sha": "H2"},
+            ]}),
+        )
+        stream.state = {"projects": {"1": {"default_head": "H1", "branches": {}}}}
+        seen = self._capture(stream, ["sha1"])
+        tasks = list(stream._diff_tasks(_HeadFrontier(stream)))
+        assert seen == [({"project_id": 1, "ref": "H1..H2"}, frozenset({404}))]
+        assert tasks == [{"project_id": 1, "sha": "sha1", "ref_key": (1, "feat")}]
+
     def test_branch_at_the_default_head_is_skipped(self):
         parent = FakeParent([({"mode": "instance"}, [self._project()])])
         stream = _stream(
@@ -185,6 +200,24 @@ class TestDiffTasks:
         seen = self._capture(stream)
         assert list(stream._diff_tasks(_HeadFrontier(stream))) == []
         assert seen == []
+
+    def test_a_branch_whose_head_moved_since_the_last_sync_is_walked_again(self):
+        parent = FakeParent([({"mode": "instance"}, [self._project()])])
+        stream = _stream(
+            parent=parent,
+            branches=FakeBranches({1: [
+                {"name": "main", "commit_sha": "H1"},
+                {"name": "feat", "commit_sha": "H3"},
+            ]}),
+        )
+        stream.state = {
+            "projects": {"1": {"default_head": "H1", "branches": {"feat": "H2"}}}
+        }
+        seen = self._capture(stream, ["sha1"])
+        tasks = list(stream._diff_tasks(_HeadFrontier(stream)))
+        # anchored on the current default head, not on the branch's stored head
+        assert seen == [({"project_id": 1, "ref": "H1..H3"}, frozenset({404}))]
+        assert tasks == [{"project_id": 1, "sha": "sha1", "ref_key": (1, "feat")}]
 
     def test_deleted_branch_is_pruned_from_state(self):
         parent = FakeParent([({"mode": "instance"}, [self._project()])])


### PR DESCRIPTION
Follow-up to #2904, from the verification of #2464.

**Why.** The GitLab file-change stream walks branches other than the default one — the property #2464 turns on — and no test is named for it. It is asserted in passing inside `test_unchanged_default_head_skips_only_the_default_walk`, whose name is about the skip, so a reader auditing coverage does not find it.

**What changed.** Two tests in `test_file_changes_stream.py`, each named for what it proves: a branch the stream has not seen is walked from the current default head, and a branch whose head moved since the last sync is walked again from that same head. No production code changes.

**The second case had no coverage at all, not merely a misleading name.** Anchoring the range on the branch's stored head instead of the current default head — `stored_branches.get(name) or default_head` — passes every one of the 200 tests on `main`. That mutation is a real regression: a commit already diffed under the previous range would be re-diffed, and a branch rebased onto a newer default head would lose the commits between the two heads.

**Verified.** `202 passed` (200 on `main` plus these two). Both mutations checked: removing the non-default walk fails three tests including both new ones; re-anchoring the range fails only the new moved-head test, which is the gap this closes. `ruff check` clean on the touched file — `ruff format` is not applied to it on `main` either, so the existing hand-alignment is left as is.
