### PR TITLE
feat(semantic): discovery catalog and definition dry-run

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -1,6 +1,17 @@
 {
   "components": {
     "schemas": {
+      "Aggregation": {
+        "enum": [
+          "count",
+          "sum",
+          "avg",
+          "min",
+          "max",
+          "count_distinct"
+        ],
+        "type": "string"
+      },
       "AiConfigResponse": {
         "properties": {
           "admin_only": {
@@ -60,6 +71,36 @@
         ],
         "type": "object"
       },
+      "AllNode": {
+        "additionalProperties": false,
+        "properties": {
+          "all": {
+            "items": {
+              "$ref": "#/components/schemas/FilterTree"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "all"
+        ],
+        "type": "object"
+      },
+      "AnyNode": {
+        "additionalProperties": false,
+        "properties": {
+          "any": {
+            "items": {
+              "$ref": "#/components/schemas/FilterTree"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "any"
+        ],
+        "type": "object"
+      },
       "BreakdownValueDto": {
         "properties": {
           "dimensions": {
@@ -92,6 +133,156 @@
           "month"
         ],
         "type": "string"
+      },
+      "CatalogComputation": {
+        "description": "How the value is computed, named without the measures it is computed from.",
+        "oneOf": [
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "direct"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "ratio"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "percentile"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "stddev"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "derived"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "CatalogDimension": {
+        "properties": {
+          "key": {
+            "description": "What a filter, a split or a display dimension names.",
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ],
+        "type": "object"
+      },
+      "CatalogMetric": {
+        "properties": {
+          "cohort_key": {
+            "description": "The grouping a cohort comparison reads; absent when the metric declares\nnone, and then no cohort comparison is offered.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "computation": {
+            "$ref": "#/components/schemas/CatalogComputation"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "dimensions": {
+            "items": {
+              "$ref": "#/components/schemas/CatalogDimension"
+            },
+            "type": "array"
+          },
+          "direction": {
+            "$ref": "#/components/schemas/Direction"
+          },
+          "entity_type": {
+            "description": "What the metric's values are keyed by, such as `person`.",
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/Format"
+          },
+          "key": {
+            "description": "The key a question names, such as `git.commits`.",
+            "type": "string"
+          },
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "questions": {
+            "$ref": "#/components/schemas/MetricQuestions"
+          }
+        },
+        "required": [
+          "key",
+          "format",
+          "direction",
+          "entity_type",
+          "computation",
+          "dimensions",
+          "questions"
+        ],
+        "type": "object"
       },
       "ColumnKind": {
         "description": "How a column's values read, so a caller renders a page without matching key\nspellings.",
@@ -192,6 +383,21 @@
         ],
         "type": "object"
       },
+      "ComparisonQuestions": {
+        "properties": {
+          "populations": {
+            "description": "Written as a comparison question's `population` field takes them.",
+            "items": {
+              "$ref": "#/components/schemas/Population"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "populations"
+        ],
+        "type": "object"
+      },
       "ComparisonResult": {
         "properties": {
           "metric": {
@@ -244,6 +450,123 @@
           "results"
         ],
         "type": "object"
+      },
+      "Computation": {
+        "description": "A percentile is metric-level because a percentile of pre-aggregated values\nis not a percentile; a standard deviation is metric-level for the same\nreason.",
+        "oneOf": [
+          {
+            "properties": {
+              "measure": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "direct"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "measure",
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "denominator": {
+                "type": "string"
+              },
+              "numerator": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "ratio"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "numerator",
+              "denominator",
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "measure": {
+                "type": "string"
+              },
+              "quantile": {
+                "description": "The quantile to serve, in `(0, 1)`.",
+                "format": "double",
+                "type": "number"
+              },
+              "type": {
+                "enum": [
+                  "percentile"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "measure",
+              "quantile",
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "measure": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "stddev"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "measure",
+              "type"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "Arithmetic over measures the expression names by alias.",
+            "properties": {
+              "expr": {
+                "type": "string"
+              },
+              "inputs": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Alias to measure key. The alias is what `expr` may reference.",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "type": {
+                "enum": [
+                  "derived"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "inputs",
+              "expr",
+              "type"
+            ],
+            "type": "object"
+          }
+        ]
       },
       "ComputationDto": {
         "oneOf": [
@@ -685,6 +1008,28 @@
         ],
         "type": "object"
       },
+      "DimensionBinding": {
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "label_field": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value_field": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "value_field"
+        ],
+        "type": "object"
+      },
       "DimensionFilter": {
         "additionalProperties": false,
         "description": "Keeps only the rows whose dimension holds one of the named values.",
@@ -705,6 +1050,14 @@
           "values"
         ],
         "type": "object"
+      },
+      "Direction": {
+        "enum": [
+          "higher_is_better",
+          "lower_is_better",
+          "neutral"
+        ],
+        "type": "string"
       },
       "DistributionQuery": {
         "additionalProperties": false,
@@ -751,6 +1104,18 @@
           "metric",
           "subjects",
           "time"
+        ],
+        "type": "object"
+      },
+      "DistributionQuestions": {
+        "properties": {
+          "admitted": {
+            "description": "Whether the metric's computation is taken over per-row values, which is\nwhat having a distribution means.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "admitted"
         ],
         "type": "object"
       },
@@ -953,11 +1318,90 @@
         ],
         "type": "object"
       },
+      "FilterLeaf": {
+        "additionalProperties": false,
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "op": {
+            "$ref": "#/components/schemas/FilterOp"
+          },
+          "value": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/FilterValue"
+              }
+            ]
+          }
+        },
+        "required": [
+          "field",
+          "op"
+        ],
+        "type": "object"
+      },
+      "FilterOp": {
+        "enum": [
+          "eq",
+          "neq",
+          "gt",
+          "gte",
+          "lt",
+          "lte",
+          "in",
+          "not_in",
+          "is_null",
+          "not_null"
+        ],
+        "type": "string"
+      },
+      "FilterTree": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AllNode"
+          },
+          {
+            "$ref": "#/components/schemas/AnyNode"
+          },
+          {
+            "$ref": "#/components/schemas/NotNode"
+          },
+          {
+            "$ref": "#/components/schemas/FilterLeaf"
+          }
+        ]
+      },
+      "FilterValue": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Scalar"
+          },
+          {
+            "items": {
+              "$ref": "#/components/schemas/Scalar"
+            },
+            "type": "array"
+          }
+        ]
+      },
       "Fold": {
         "description": "Whether each subject keeps its own value or the subjects fold into one.",
         "enum": [
           "per_subject",
           "combined"
+        ],
+        "type": "string"
+      },
+      "Format": {
+        "enum": [
+          "integer",
+          "decimal",
+          "currency",
+          "percent"
         ],
         "type": "string"
       },
@@ -1264,6 +1708,85 @@
         ],
         "type": "object"
       },
+      "MeasureDefinition": {
+        "additionalProperties": false,
+        "properties": {
+          "aggregation": {
+            "$ref": "#/components/schemas/Aggregation"
+          },
+          "dataset": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "dimensions": {
+            "items": {
+              "$ref": "#/components/schemas/DimensionBinding"
+            },
+            "type": "array"
+          },
+          "entity": {
+            "type": "string"
+          },
+          "event_time": {
+            "type": "string"
+          },
+          "filter": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/FilterTree"
+              }
+            ]
+          },
+          "key": {
+            "type": "string"
+          },
+          "subject_expr": {
+            "description": "What `count_distinct` counts one of.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value_expr": {
+            "description": "The operand for the numeric folds; absent for `count`/`count_distinct`.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "dataset",
+          "aggregation",
+          "event_time",
+          "entity"
+        ],
+        "type": "object"
+      },
+      "MetricCatalogResponse": {
+        "properties": {
+          "metrics": {
+            "description": "Every metric the definitions carry, in key order.",
+            "items": {
+              "$ref": "#/components/schemas/CatalogMetric"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "metrics"
+        ],
+        "type": "object"
+      },
       "MetricComputation": {
         "enum": [
           "sum",
@@ -1274,6 +1797,62 @@
           "distinct_count"
         ],
         "type": "string"
+      },
+      "MetricDefinition": {
+        "additionalProperties": false,
+        "properties": {
+          "cohort_key": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "computation": {
+            "$ref": "#/components/schemas/Computation"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "direction": {
+            "$ref": "#/components/schemas/Direction"
+          },
+          "entity_type": {
+            "type": "string"
+          },
+          "format": {
+            "$ref": "#/components/schemas/Format"
+          },
+          "key": {
+            "type": "string"
+          },
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "transform": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Transform"
+              }
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "computation",
+          "format",
+          "direction",
+          "entity_type"
+        ],
+        "type": "object"
       },
       "MetricDefinitionListResponse": {
         "description": "Response body for `GET /v1/metric-definitions`. Metrics are sorted by\n`metric_key` ascending so the payload is byte-stable for caching and\ndiff tooling.",
@@ -1839,6 +2418,29 @@
           "custom"
         ],
         "type": "string"
+      },
+      "MetricQuestions": {
+        "properties": {
+          "comparisons": {
+            "$ref": "#/components/schemas/ComparisonQuestions"
+          },
+          "distributions": {
+            "$ref": "#/components/schemas/DistributionQuestions"
+          },
+          "rows": {
+            "$ref": "#/components/schemas/RowsQuestions"
+          },
+          "values": {
+            "$ref": "#/components/schemas/ValuesQuestions"
+          }
+        },
+        "required": [
+          "values",
+          "comparisons",
+          "distributions",
+          "rows"
+        ],
+        "type": "object"
       },
       "MetricRequest": {
         "properties": {
@@ -2536,6 +3138,18 @@
           }
         ]
       },
+      "NotNode": {
+        "additionalProperties": false,
+        "properties": {
+          "not": {
+            "$ref": "#/components/schemas/FilterTree"
+          }
+        },
+        "required": [
+          "not"
+        ],
+        "type": "object"
+      },
       "PeerValueDto": {
         "properties": {
           "entity_id": {
@@ -2967,6 +3581,21 @@
         ],
         "type": "object"
       },
+      "RowsQuestions": {
+        "properties": {
+          "inputs": {
+            "description": "The parts of the computation a page of rows may be asked for.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "inputs"
+        ],
+        "type": "object"
+      },
       "RowsRequest": {
         "additionalProperties": false,
         "properties": {
@@ -3183,6 +3812,20 @@
           "name"
         ],
         "type": "object"
+      },
+      "Scalar": {
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "format": "double",
+            "type": "number"
+          },
+          {
+            "type": "string"
+          }
+        ]
       },
       "SchemaStatus": {
         "enum": [
@@ -3598,6 +4241,41 @@
         ],
         "type": "object"
       },
+      "Transform": {
+        "additionalProperties": false,
+        "description": "Post-aggregation shaping: `clamp(min, max, multiplier * value + offset)`.\nAbsent fields are the identity.",
+        "properties": {
+          "clamp_max": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "clamp_min": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "multiplier": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "offset": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "UpdateContextRequest": {
         "properties": {
           "body": {
@@ -3848,6 +4526,83 @@
         ],
         "type": "object"
       },
+      "ValidateDefinitionsRequest": {
+        "additionalProperties": false,
+        "description": "Definitions to judge, in the shape the authored YAML parses into.",
+        "properties": {
+          "measures": {
+            "items": {
+              "$ref": "#/components/schemas/MeasureDefinition"
+            },
+            "type": "array"
+          },
+          "metrics": {
+            "items": {
+              "$ref": "#/components/schemas/MetricDefinition"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ValidateDefinitionsResponse": {
+        "properties": {
+          "errors": {
+            "description": "Every offender, not the first one.",
+            "items": {
+              "$ref": "#/components/schemas/ValidationFailure"
+            },
+            "type": "array"
+          },
+          "valid": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "valid",
+          "errors"
+        ],
+        "type": "object"
+      },
+      "ValidationErrorKind": {
+        "description": "Which rule was broken, as a discriminant a machine can branch on.",
+        "enum": [
+          "key_shape",
+          "metric_key_shape",
+          "duplicate_key",
+          "dataset_not_found",
+          "field_not_found",
+          "role_mismatch",
+          "filter",
+          "expression",
+          "operand",
+          "measure_not_found",
+          "quantile_out_of_range",
+          "mixed_datasets",
+          "distribution_without_value",
+          "no_derived_inputs",
+          "metric_expression",
+          "unknown_derived_input",
+          "unused_derived_input",
+          "dimension_bindings_disagree"
+        ],
+        "type": "string"
+      },
+      "ValidationFailure": {
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/ValidationErrorKind"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "message"
+        ],
+        "type": "object"
+      },
       "ValueTransform": {
         "additionalProperties": false,
         "description": "Affine + clamp shaping for a computed metric value:\n`y = clamp(clamp_min, clamp_max, multiplier * x + offset)`.\nAbsent fields are identity (multiplier 1, offset 0, no bound).",
@@ -3936,6 +4691,40 @@
           "subjects",
           "time",
           "fold"
+        ],
+        "type": "object"
+      },
+      "ValuesQuestions": {
+        "properties": {
+          "compare": {
+            "description": "The earlier windows the same question may be set beside.",
+            "items": {
+              "$ref": "#/components/schemas/CompareOffset"
+            },
+            "type": "array"
+          },
+          "folds": {
+            "items": {
+              "$ref": "#/components/schemas/Fold"
+            },
+            "type": "array"
+          },
+          "grains": {
+            "items": {
+              "$ref": "#/components/schemas/Grain"
+            },
+            "type": "array"
+          },
+          "split": {
+            "description": "Whether the metric declares a dimension to break its value out by.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "grains",
+          "folds",
+          "compare",
+          "split"
         ],
         "type": "object"
       },
@@ -5123,6 +5912,49 @@
         "summary": "Replace this tenant's system prompt"
       }
     },
+    "/v1/catalog/metrics": {
+      "get": {
+        "operationId": "analytics_api.catalog.metrics",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricCatalogResponse"
+                }
+              }
+            },
+            "description": "The metrics a question may name"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Every metric and the questions it admits"
+      }
+    },
     "/v1/connector-health": {
       "get": {
         "operationId": "analytics_api.connector_health.summary",
@@ -5318,6 +6150,80 @@
           }
         ],
         "summary": "Recent syncs of one connector, newest first"
+      }
+    },
+    "/v1/definitions/validate": {
+      "post": {
+        "operationId": "analytics_api.definitions.validate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ValidateDefinitionsRequest"
+              }
+            }
+          },
+          "description": "Measures and metrics to judge",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidateDefinitionsResponse"
+                }
+              }
+            },
+            "description": "Whether the definitions are valid, and every rule they break"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "415": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unsupported Media Type"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Judge definitions without keeping them"
       }
     },
     "/v1/feedback": {

--- a/src/backend/services/analytics/src/api/catalog.rs
+++ b/src/backend/services/analytics/src/api/catalog.rs
@@ -1,0 +1,4 @@
+//! What the semantic definitions can be asked, as a client reads it before
+//! asking anything.
+
+pub(crate) mod metrics;

--- a/src/backend/services/analytics/src/api/catalog/metrics.rs
+++ b/src/backend/services/analytics/src/api/catalog/metrics.rs
@@ -1,0 +1,22 @@
+use axum::Json;
+use toolkit_canonical_errors::CanonicalError;
+
+use crate::domain::metric_query::capability::{MetricCatalogResponse, describe};
+use crate::domain::metric_query::product_metric_catalog;
+
+// SAFETY: the answer is a projection of definitions compiled into the binary,
+// so this handler takes neither a security context nor a backend — there is no
+// tenant value it could disclose.
+pub async fn list_metric_catalog() -> Result<Json<MetricCatalogResponse>, CanonicalError> {
+    let catalog = product_metric_catalog().map_err(|error| {
+        tracing::error!(%error, "the shipped definitions did not load");
+        CanonicalError::internal("metric definitions unavailable").create()
+    })?;
+
+    let response = describe(catalog).map_err(|error| {
+        tracing::error!(%error, "a shipped metric did not resolve its inputs");
+        CanonicalError::internal("metric definitions unavailable").create()
+    })?;
+
+    Ok(Json(response))
+}

--- a/src/backend/services/analytics/src/api/definitions.rs
+++ b/src/backend/services/analytics/src/api/definitions.rs
@@ -1,0 +1,3 @@
+//! Judging definitions a caller wrote, without keeping them.
+
+pub(crate) mod validate;

--- a/src/backend/services/analytics/src/api/definitions/validate.rs
+++ b/src/backend/services/analytics/src/api/definitions/validate.rs
@@ -1,0 +1,20 @@
+use axum::Json;
+use toolkit_canonical_errors::CanonicalError;
+
+use crate::domain::definitions::dry_run::{
+    ValidateDefinitionsRequest, ValidateDefinitionsResponse, dry_run,
+};
+
+// SAFETY: the outcome is the payload, so a set that breaks every rule is a 200
+// carrying the breakages; and the handler holds no store, so nothing submitted
+// can be kept.
+pub async fn validate_definitions(
+    Json(req): Json<ValidateDefinitionsRequest>,
+) -> Result<Json<ValidateDefinitionsResponse>, CanonicalError> {
+    let response = dry_run(req).map_err(|error| {
+        tracing::error!(%error, "the shipped definitions did not load");
+        CanonicalError::internal("metric definitions unavailable").create()
+    })?;
+
+    Ok(Json(response))
+}

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -1,7 +1,9 @@
 //! HTTP API layer — routes and handlers.
 
 pub(crate) mod ai;
+pub(crate) mod catalog;
 mod connector_health;
+pub(crate) mod definitions;
 pub(crate) mod error;
 mod feedback;
 mod metric_definitions;
@@ -559,6 +561,47 @@ pub(crate) fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) ->
         .error_415(openapi)
         .error_500(openapi)
         .handler(query::rows::query_rows)
+        .register(router, openapi);
+
+    // Discovery over the same definitions the question surface answers from:
+    // what exists, and which question each metric admits. Tenant-invariant, so
+    // the handler reads no context and the answer carries no dimension value.
+    router = OperationBuilder::get("/v1/catalog/metrics")
+        .operation_id("analytics_api.catalog.metrics")
+        .summary("Every metric and the questions it admits")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<crate::domain::metric_query::capability::MetricCatalogResponse>(
+            openapi,
+            StatusCode::OK,
+            "The metrics a question may name",
+        )
+        .error_401(openapi)
+        .error_500(openapi)
+        .handler(catalog::metrics::list_metric_catalog)
+        .register(router, openapi);
+
+    // The authoring dry run: definitions are judged beside the shipped ones and
+    // discarded. The outcome is the 200 body, never a refusal status.
+    router = OperationBuilder::post("/v1/definitions/validate")
+        .operation_id("analytics_api.definitions.validate")
+        .summary("Judge definitions without keeping them")
+        .authenticated()
+        .no_license_required()
+        .json_request::<crate::domain::definitions::dry_run::ValidateDefinitionsRequest>(
+            openapi,
+            "Measures and metrics to judge",
+        )
+        .json_response_with_schema::<crate::domain::definitions::dry_run::ValidateDefinitionsResponse>(
+            openapi,
+            StatusCode::OK,
+            "Whether the definitions are valid, and every rule they break",
+        )
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_415(openapi)
+        .error_500(openapi)
+        .handler(definitions::validate::validate_definitions)
         .register(router, openapi);
 
     // Saved-query CRUD + run (#1965) — the presentation-layer "Data Analytics"

--- a/src/backend/services/analytics/src/api/openapi_tests.rs
+++ b/src/backend/services/analytics/src/api/openapi_tests.rs
@@ -33,8 +33,10 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
         "/v1/ai/credentials",
         "/v1/ai/explain",
         "/v1/ai/settings",
+        "/v1/catalog/metrics",
         "/v1/connector-health",
         "/v1/connector-health/{connector}/syncs",
+        "/v1/definitions/validate",
         "/v1/feedback",
         "/v1/metric-definitions",
         "/v1/metric-drilldown",
@@ -59,7 +61,7 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
     }
     assert_eq!(
         paths.len(),
-        27,
+        29,
         "the contract must carry exactly the surviving paths, got {:?}",
         paths.keys().collect::<Vec<_>>()
     );

--- a/src/backend/services/analytics/src/domain/definitions/definition.rs
+++ b/src/backend/services/analytics/src/domain/definitions/definition.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use super::filter::FilterTree;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Aggregation {
     Count,
@@ -25,7 +25,7 @@ pub enum Origin {
     Custom,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct DimensionBinding {
     pub key: String,
@@ -35,7 +35,7 @@ pub struct DimensionBinding {
 }
 
 /// How a relation must be read for its rows to be the deduplicated truth.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ReadDiscipline {
     /// Collapse duplicates at read time.
@@ -57,7 +57,7 @@ pub struct DatasetDefinition {
     pub retention_horizon: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct MeasureDefinition {
     pub key: String,
@@ -82,7 +82,7 @@ pub struct MeasureDefinition {
 /// A percentile is metric-level because a percentile of pre-aggregated values
 /// is not a percentile; a standard deviation is metric-level for the same
 /// reason.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Computation {
     Direct {
@@ -110,7 +110,7 @@ pub enum Computation {
 
 /// Post-aggregation shaping: `clamp(min, max, multiplier * value + offset)`.
 /// Absent fields are the identity.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Transform {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -123,7 +123,7 @@ pub struct Transform {
     pub clamp_max: Option<f64>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Format {
     Integer,
@@ -132,7 +132,7 @@ pub enum Format {
     Percent,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Direction {
     HigherIsBetter,
@@ -140,7 +140,7 @@ pub enum Direction {
     Neutral,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct MetricDefinition {
     pub key: String,

--- a/src/backend/services/analytics/src/domain/definitions/dry_run.rs
+++ b/src/backend/services/analytics/src/domain/definitions/dry_run.rs
@@ -1,0 +1,124 @@
+//! Validating submitted definitions beside the shipped ones without keeping
+//! them. INVARIANT: nothing here reaches a store — the outcome IS the answer,
+//! so a set that validates is not thereby installed.
+
+use serde::{Deserialize, Serialize};
+
+use super::definition::{MeasureDefinition, MetricDefinition};
+use super::seeds::{SeedError, product_definitions};
+use super::validate::{ValidationError, validate_definitions};
+use crate::domain::field_catalog;
+
+/// Definitions to judge, in the shape the authored YAML parses into.
+#[derive(Debug, Default, Deserialize, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ValidateDefinitionsRequest {
+    #[serde(default)]
+    pub measures: Vec<MeasureDefinition>,
+    #[serde(default)]
+    pub metrics: Vec<MetricDefinition>,
+}
+
+#[derive(Debug, PartialEq, Serialize, utoipa::ToSchema)]
+pub struct ValidateDefinitionsResponse {
+    pub valid: bool,
+    /// Every offender, not the first one.
+    pub errors: Vec<ValidationFailure>,
+}
+
+#[derive(Debug, PartialEq, Serialize, utoipa::ToSchema)]
+pub struct ValidationFailure {
+    pub kind: ValidationErrorKind,
+    pub message: String,
+}
+
+/// Which rule was broken, as a discriminant a machine can branch on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationErrorKind {
+    KeyShape,
+    MetricKeyShape,
+    DuplicateKey,
+    DatasetNotFound,
+    FieldNotFound,
+    RoleMismatch,
+    Filter,
+    Expression,
+    Operand,
+    MeasureNotFound,
+    QuantileOutOfRange,
+    MixedDatasets,
+    DistributionWithoutValue,
+    NoDerivedInputs,
+    MetricExpression,
+    UnknownDerivedInput,
+    UnusedDerivedInput,
+    DimensionBindingsDisagree,
+}
+
+/// INVARIANT: the submitted definitions are judged as part of one set with the
+/// shipped ones, so a submitted metric may read a shipped measure, a submitted
+/// measure may be read by a shipped metric, and a key already taken collides.
+pub fn dry_run(
+    request: ValidateDefinitionsRequest,
+) -> Result<ValidateDefinitionsResponse, SeedError> {
+    let catalog =
+        field_catalog::product_catalog().map_err(|error| SeedError::Catalog(error.to_string()))?;
+    let shipped = product_definitions()?;
+
+    let mut measures = shipped.measures;
+    measures.extend(request.measures);
+    let mut metrics = shipped.metrics;
+    metrics.extend(request.metrics);
+
+    let errors = match validate_definitions(catalog, &measures, &metrics) {
+        Ok(()) => Vec::new(),
+        Err(errors) => errors.iter().map(failure).collect(),
+    };
+
+    Ok(ValidateDefinitionsResponse {
+        valid: errors.is_empty(),
+        errors,
+    })
+}
+
+fn failure(error: &ValidationError) -> ValidationFailure {
+    ValidationFailure {
+        kind: kind_of(error),
+        message: error.to_string(),
+    }
+}
+
+const fn kind_of(error: &ValidationError) -> ValidationErrorKind {
+    match error {
+        ValidationError::KeyShape(_) => ValidationErrorKind::KeyShape,
+        ValidationError::MetricKeyShape(_) => ValidationErrorKind::MetricKeyShape,
+        ValidationError::DuplicateKey(_) => ValidationErrorKind::DuplicateKey,
+        ValidationError::DatasetNotFound { .. } => ValidationErrorKind::DatasetNotFound,
+        ValidationError::FieldNotFound { .. } => ValidationErrorKind::FieldNotFound,
+        ValidationError::RoleMismatch { .. } => ValidationErrorKind::RoleMismatch,
+        ValidationError::Filter { .. } => ValidationErrorKind::Filter,
+        ValidationError::Expression { .. } => ValidationErrorKind::Expression,
+        ValidationError::Operand { .. } => ValidationErrorKind::Operand,
+        ValidationError::MeasureNotFound { .. } => ValidationErrorKind::MeasureNotFound,
+        ValidationError::QuantileOutOfRange { .. } => ValidationErrorKind::QuantileOutOfRange,
+        ValidationError::MixedDatasets { .. } => ValidationErrorKind::MixedDatasets,
+        ValidationError::DistributionWithoutValue { .. } => {
+            ValidationErrorKind::DistributionWithoutValue
+        }
+        ValidationError::NoDerivedInputs { .. } => ValidationErrorKind::NoDerivedInputs,
+        ValidationError::MetricExpression { .. } => ValidationErrorKind::MetricExpression,
+        ValidationError::UnknownDerivedInput { .. } => ValidationErrorKind::UnknownDerivedInput,
+        ValidationError::UnusedDerivedInput { .. } => ValidationErrorKind::UnusedDerivedInput,
+        ValidationError::DimensionBindingsDisagree { .. } => {
+            ValidationErrorKind::DimensionBindingsDisagree
+        }
+    }
+}
+
+impl toolkit::api::api_dto::RequestApiDto for ValidateDefinitionsRequest {}
+impl toolkit::api::api_dto::ResponseApiDto for ValidateDefinitionsResponse {}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests;

--- a/src/backend/services/analytics/src/domain/definitions/dry_run/tests.rs
+++ b/src/backend/services/analytics/src/domain/definitions/dry_run/tests.rs
@@ -1,0 +1,248 @@
+use serde_json::{Value, json};
+
+use super::*;
+
+fn probe_measure() -> Value {
+    json!({
+        "key": "probe_lines_touched",
+        "dataset": "git_commits",
+        "description": "Lines added plus removed, over the commits a person authored.",
+        "aggregation": "sum",
+        "value_expr": "lines_added + lines_removed",
+        "event_time": "authored_at",
+        "entity": "author_email",
+        "dimensions": [
+            { "key": "repository", "value_field": "repository", "label_field": "repository_label" },
+        ],
+    })
+}
+
+fn probe_metric(measure: &str) -> Value {
+    json!({
+        "key": "probe.lines_touched",
+        "computation": { "type": "direct", "measure": measure },
+        "format": "integer",
+        "direction": "neutral",
+        "entity_type": "person",
+        "label": "Lines touched",
+    })
+}
+
+fn judged(body: Value) -> ValidateDefinitionsResponse {
+    let request: ValidateDefinitionsRequest =
+        serde_json::from_value(body).expect("the wire shape parses");
+    dry_run(request).expect("the shipped definitions load")
+}
+
+fn kinds(response: &ValidateDefinitionsResponse) -> Vec<ValidationErrorKind> {
+    response.errors.iter().map(|error| error.kind).collect()
+}
+
+#[test]
+fn the_request_is_the_shape_the_authored_definitions_are_written_in() {
+    let response = judged(json!({
+        "measures": [probe_measure()],
+        "metrics": [probe_metric("probe_lines_touched")],
+    }));
+
+    assert_eq!(
+        response,
+        ValidateDefinitionsResponse {
+            valid: true,
+            errors: Vec::new(),
+        }
+    );
+}
+
+#[test]
+fn a_request_naming_nothing_judges_the_shipped_definitions_alone() {
+    assert!(judged(json!({})).valid);
+}
+
+#[test]
+fn a_submitted_metric_reads_a_shipped_measure() {
+    assert!(judged(json!({ "metrics": [probe_metric("commits")] })).valid);
+}
+
+#[test]
+fn a_submitted_measure_is_read_by_a_submitted_metric_in_the_same_request() {
+    let response = judged(json!({
+        "measures": [probe_measure()],
+        "metrics": [probe_metric("probe_lines_touched")],
+    }));
+
+    assert!(response.valid, "{:?}", response.errors);
+}
+
+#[test]
+fn a_metric_reading_a_measure_no_side_of_the_union_defines_is_refused() {
+    let response = judged(json!({ "metrics": [probe_metric("no_such_measure")] }));
+
+    assert!(!response.valid);
+    assert_eq!(kinds(&response), [ValidationErrorKind::MeasureNotFound]);
+}
+
+#[test]
+fn a_submitted_key_a_shipped_definition_already_holds_collides() {
+    let mut measure = probe_measure();
+    measure["key"] = json!("commits");
+
+    let response = judged(json!({ "measures": [measure] }));
+
+    assert!(!response.valid);
+    assert!(kinds(&response).contains(&ValidationErrorKind::DuplicateKey));
+    assert!(
+        response
+            .errors
+            .iter()
+            .any(|error| error.message.contains("commits")),
+        "{:?}",
+        response.errors
+    );
+}
+
+fn assert_each_kind_is_reported(cases: &[(ValidationErrorKind, Value)]) {
+    for (kind, body) in cases {
+        let response = judged(body.clone());
+
+        assert!(!response.valid, "should refuse: {kind:?}");
+        assert!(
+            kinds(&response).contains(kind),
+            "should report {kind:?}, reported {:?}",
+            response.errors
+        );
+    }
+}
+
+#[test]
+fn every_rule_a_measure_can_break_is_reported_under_its_own_discriminant() {
+    let cases: [(ValidationErrorKind, Value); 9] = [
+        (
+            ValidationErrorKind::KeyShape,
+            json!({ "measures": [with(probe_measure(), "key", json!("Not A Key"))] }),
+        ),
+        (
+            ValidationErrorKind::DuplicateKey,
+            json!({ "measures": [with(probe_measure(), "key", json!("commits"))] }),
+        ),
+        (
+            ValidationErrorKind::DatasetNotFound,
+            json!({ "measures": [with(probe_measure(), "dataset", json!("no_such_dataset"))] }),
+        ),
+        (
+            ValidationErrorKind::FieldNotFound,
+            json!({ "measures": [with(probe_measure(), "event_time", json!("no_such_field"))] }),
+        ),
+        (
+            ValidationErrorKind::RoleMismatch,
+            json!({ "measures": [with(probe_measure(), "entity", json!("lines_added"))] }),
+        ),
+        (
+            ValidationErrorKind::Filter,
+            json!({
+                "measures": [with(
+                    probe_measure(),
+                    "filter",
+                    json!({ "field": "Not A Field", "op": "eq", "value": "x" }),
+                )],
+            }),
+        ),
+        (
+            ValidationErrorKind::Expression,
+            json!({ "measures": [with(probe_measure(), "value_expr", json!("lines_added +"))] }),
+        ),
+        (
+            ValidationErrorKind::Operand,
+            json!({ "measures": [with(probe_measure(), "aggregation", json!("count"))] }),
+        ),
+        (
+            ValidationErrorKind::DimensionBindingsDisagree,
+            disagreeing_dimension_bindings(),
+        ),
+    ];
+
+    assert_each_kind_is_reported(&cases);
+}
+
+#[test]
+fn every_rule_a_metric_can_break_is_reported_under_its_own_discriminant() {
+    let cases: [(ValidationErrorKind, Value); 9] = [
+        (
+            ValidationErrorKind::MetricKeyShape,
+            json!({ "metrics": [with(probe_metric("commits"), "key", json!("undotted"))] }),
+        ),
+        (
+            ValidationErrorKind::MeasureNotFound,
+            json!({ "metrics": [probe_metric("no_such_measure")] }),
+        ),
+        (
+            ValidationErrorKind::QuantileOutOfRange,
+            computed(json!({
+                "type": "percentile", "measure": "commit_change_size", "quantile": 1.5,
+            })),
+        ),
+        (
+            ValidationErrorKind::MixedDatasets,
+            computed(json!({
+                "type": "ratio", "numerator": "commits", "denominator": "prs_created",
+            })),
+        ),
+        (
+            ValidationErrorKind::DistributionWithoutValue,
+            computed(json!({ "type": "percentile", "measure": "commits", "quantile": 0.5 })),
+        ),
+        (
+            ValidationErrorKind::NoDerivedInputs,
+            computed(json!({ "type": "derived", "inputs": {}, "expr": "1" })),
+        ),
+        (
+            ValidationErrorKind::MetricExpression,
+            computed(json!({ "type": "derived", "inputs": { "a": "commits" }, "expr": "a +" })),
+        ),
+        (
+            ValidationErrorKind::UnknownDerivedInput,
+            computed(json!({ "type": "derived", "inputs": { "a": "commits" }, "expr": "a + b" })),
+        ),
+        (
+            ValidationErrorKind::UnusedDerivedInput,
+            computed(json!({
+                "type": "derived",
+                "inputs": { "a": "commits", "b": "active_commit_days" },
+                "expr": "a",
+            })),
+        ),
+    ];
+
+    assert_each_kind_is_reported(&cases);
+}
+
+/// A request carrying one metric, computed the way the case names.
+fn computed(computation: Value) -> Value {
+    json!({ "metrics": [with(probe_metric("commits"), "computation", computation)] })
+}
+
+/// Two measures binding one dimension key to different fields, composed by a
+/// metric that reads both.
+fn disagreeing_dimension_bindings() -> Value {
+    let bound = |key: &str, field: &str| {
+        with(
+            with(probe_measure(), "key", json!(key)),
+            "dimensions",
+            json!([{ "key": "repository", "value_field": field }]),
+        )
+    };
+
+    json!({
+        "measures": [bound("probe_left", "repository"), bound("probe_right", "project")],
+        "metrics": [with(
+            probe_metric("probe_left"),
+            "computation",
+            json!({ "type": "ratio", "numerator": "probe_left", "denominator": "probe_right" }),
+        )],
+    })
+}
+
+fn with(mut definition: Value, field: &str, value: Value) -> Value {
+    definition[field] = value;
+    definition
+}

--- a/src/backend/services/analytics/src/domain/definitions/filter.rs
+++ b/src/backend/services/analytics/src/domain/definitions/filter.rs
@@ -28,7 +28,7 @@ pub enum FilterError {
     ValueNotAllowed,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum FilterOp {
     Eq,
@@ -43,22 +43,23 @@ pub enum FilterOp {
     NotNull,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(untagged)]
 pub enum Scalar {
     Bool(bool),
+    #[schema(value_type = f64)]
     Number(serde_json::Number),
     String(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(untagged)]
 pub enum FilterValue {
     Scalar(Scalar),
     List(Vec<Scalar>),
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct FilterLeaf {
     pub field: String,
@@ -67,25 +68,28 @@ pub struct FilterLeaf {
     pub value: Option<FilterValue>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AllNode {
+    #[schema(no_recursion)]
     pub all: Vec<FilterTree>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AnyNode {
+    #[schema(no_recursion)]
     pub any: Vec<FilterTree>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct NotNode {
+    #[schema(no_recursion)]
     pub not: Box<FilterTree>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(untagged)]
 pub enum FilterTree {
     All(AllNode),

--- a/src/backend/services/analytics/src/domain/definitions/mod.rs
+++ b/src/backend/services/analytics/src/domain/definitions/mod.rs
@@ -3,6 +3,7 @@
 //! compose from, and the store that versions and audits every write.
 
 pub mod definition;
+pub mod dry_run;
 pub mod expr;
 pub mod filter;
 #[cfg(test)]

--- a/src/backend/services/analytics/src/domain/metric_query/capability/describe.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/capability/describe.rs
@@ -1,0 +1,88 @@
+//! The catalogue, derived from the definitions rather than declared beside
+//! them. INVARIANT: every question advertised here is decided by the predicate
+//! that validates the request, so the two cannot disagree.
+
+use crate::domain::compiler::error::CompileError;
+use crate::domain::definitions::definition::{Computation, MetricDefinition};
+
+use super::super::catalog::MetricCatalog;
+use super::super::comparisons::{Population, population};
+use super::super::distributions::distributable;
+use super::super::label::humanized;
+use super::super::values::{offered_compare_offsets, offered_folds, offered_grains};
+use super::dto::{
+    CatalogComputation, CatalogDimension, CatalogMetric, ComparisonQuestions,
+    DistributionQuestions, MetricCatalogResponse, MetricQuestions, RowsQuestions, ValuesQuestions,
+};
+
+/// INVARIANT: these enumerate the populations a comparison may name; a variant
+/// added and not listed here is one no caller is ever told about.
+const POPULATIONS: [Population; 2] = [Population::Tenant {}, Population::Cohort {}];
+
+/// What a client needs to form a valid question about any shipped metric.
+pub fn describe(catalog: &MetricCatalog) -> Result<MetricCatalogResponse, CompileError> {
+    let metrics = catalog
+        .metrics()
+        .map(|metric| describe_metric(catalog, metric))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(MetricCatalogResponse { metrics })
+}
+
+fn describe_metric(
+    catalog: &MetricCatalog,
+    metric: &MetricDefinition,
+) -> Result<CatalogMetric, CompileError> {
+    let dimensions: Vec<CatalogDimension> = catalog
+        .dimension_keys(&metric.key)
+        .into_iter()
+        .map(|key| CatalogDimension {
+            label: humanized(key),
+            key: key.to_owned(),
+        })
+        .collect();
+
+    let splittable = !dimensions.is_empty();
+
+    Ok(CatalogMetric {
+        key: metric.key.clone(),
+        label: metric.label.clone(),
+        description: metric.description.clone(),
+        format: metric.format,
+        direction: metric.direction,
+        entity_type: metric.entity_type.clone(),
+        computation: computation_of(&metric.computation),
+        cohort_key: metric.cohort_key.clone(),
+        dimensions,
+        questions: MetricQuestions {
+            values: ValuesQuestions {
+                grains: offered_grains(splittable),
+                folds: offered_folds(splittable),
+                compare: offered_compare_offsets(),
+                split: splittable,
+            },
+            comparisons: ComparisonQuestions {
+                populations: POPULATIONS
+                    .into_iter()
+                    .filter(|asked| population(metric, *asked).is_ok())
+                    .collect(),
+            },
+            distributions: DistributionQuestions {
+                admitted: distributable(catalog, &metric.key).is_ok(),
+            },
+            rows: RowsQuestions {
+                inputs: catalog.input_roles(metric)?,
+            },
+        },
+    })
+}
+
+const fn computation_of(computation: &Computation) -> CatalogComputation {
+    match computation {
+        Computation::Direct { .. } => CatalogComputation::Direct,
+        Computation::Ratio { .. } => CatalogComputation::Ratio,
+        Computation::Percentile { .. } => CatalogComputation::Percentile,
+        Computation::Stddev { .. } => CatalogComputation::Stddev,
+        Computation::Derived { .. } => CatalogComputation::Derived,
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_query/capability/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/capability/dto.rs
@@ -1,0 +1,96 @@
+//! The wire shape of the catalogue: what a metric is, and what each kind of
+//! question may name for it.
+//!
+//! INVARIANT: keys only — no dimension VALUE, and nothing read from a tenant's
+//! data, ever reaches this document.
+
+use serde::Serialize;
+
+use crate::domain::definitions::definition::{Direction, Format};
+
+use super::super::comparisons::Population;
+use super::super::values::{CompareOffset, Fold, Grain};
+
+#[derive(Debug, PartialEq, Serialize, utoipa::ToSchema)]
+pub struct MetricCatalogResponse {
+    /// Every metric the definitions carry, in key order.
+    pub metrics: Vec<CatalogMetric>,
+}
+
+#[derive(Debug, PartialEq, Serialize, utoipa::ToSchema)]
+pub struct CatalogMetric {
+    /// The key a question names, such as `git.commits`.
+    pub key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub format: Format,
+    pub direction: Direction,
+    /// What the metric's values are keyed by, such as `person`.
+    pub entity_type: String,
+    pub computation: CatalogComputation,
+    /// The grouping a cohort comparison reads; absent when the metric declares
+    /// none, and then no cohort comparison is offered.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cohort_key: Option<String>,
+    pub dimensions: Vec<CatalogDimension>,
+    pub questions: MetricQuestions,
+}
+
+/// How the value is computed, named without the measures it is computed from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CatalogComputation {
+    Direct,
+    Ratio,
+    Percentile,
+    Stddev,
+    Derived,
+}
+
+#[derive(Debug, PartialEq, Serialize, utoipa::ToSchema)]
+pub struct CatalogDimension {
+    /// What a filter, a split or a display dimension names.
+    pub key: String,
+    pub label: String,
+}
+
+#[derive(Debug, PartialEq, Serialize, utoipa::ToSchema)]
+pub struct MetricQuestions {
+    pub values: ValuesQuestions,
+    pub comparisons: ComparisonQuestions,
+    pub distributions: DistributionQuestions,
+    pub rows: RowsQuestions,
+}
+
+#[derive(Debug, PartialEq, Serialize, utoipa::ToSchema)]
+pub struct ValuesQuestions {
+    pub grains: Vec<Grain>,
+    pub folds: Vec<Fold>,
+    /// The earlier windows the same question may be set beside.
+    pub compare: Vec<CompareOffset>,
+    /// Whether the metric declares a dimension to break its value out by.
+    pub split: bool,
+}
+
+#[derive(Debug, PartialEq, Serialize, utoipa::ToSchema)]
+pub struct ComparisonQuestions {
+    /// Written as a comparison question's `population` field takes them.
+    pub populations: Vec<Population>,
+}
+
+#[derive(Debug, PartialEq, Serialize, utoipa::ToSchema)]
+pub struct DistributionQuestions {
+    /// Whether the metric's computation is taken over per-row values, which is
+    /// what having a distribution means.
+    pub admitted: bool,
+}
+
+#[derive(Debug, PartialEq, Serialize, utoipa::ToSchema)]
+pub struct RowsQuestions {
+    /// The parts of the computation a page of rows may be asked for.
+    pub inputs: Vec<String>,
+}
+
+impl toolkit::api::api_dto::ResponseApiDto for MetricCatalogResponse {}

--- a/src/backend/services/analytics/src/domain/metric_query/capability/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/capability/mod.rs
@@ -1,0 +1,16 @@
+//! What the definitions can be asked: every metric, with the questions each
+//! kind of read admits for it. The whole set is compiled into the binary and
+//! answered in one document, so it takes no paging and no narrowing.
+//!
+//! INVARIANT: capability is a projection of the definitions, identical on every
+//! tenant and on an empty one.
+
+mod describe;
+mod dto;
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests;
+
+pub use describe::describe;
+pub use dto::MetricCatalogResponse;

--- a/src/backend/services/analytics/src/domain/metric_query/capability/tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/capability/tests.rs
@@ -1,0 +1,222 @@
+use serde_json::{Value, json};
+
+use super::super::catalog::product_metric_catalog;
+use super::super::comparisons::{Population, population};
+use super::super::distributions::distributable;
+use super::super::fixtures::{SHIPPED_DISTRIBUTION_METRIC, SHIPPED_METRIC};
+use super::describe;
+
+use crate::domain::definitions::definition::{
+    Computation, Direction, Format, MetricDefinition, Transform,
+};
+
+const SHIPPED_RATIO_METRIC: &str = "git.merge_rate";
+
+fn catalogued() -> Value {
+    let catalog = product_metric_catalog().expect("the shipped definitions load");
+    serde_json::to_value(describe(catalog).expect("every shipped metric resolves its inputs"))
+        .expect("the catalogue serializes")
+}
+
+fn entry(key: &str) -> Value {
+    catalogued()["metrics"]
+        .as_array()
+        .expect("the catalogue lists metrics")
+        .iter()
+        .find(|metric| metric["key"] == key)
+        .unwrap_or_else(|| panic!("`{key}` is catalogued"))
+        .clone()
+}
+
+fn without_cohort() -> MetricDefinition {
+    MetricDefinition {
+        key: "probe.uncohorted".to_owned(),
+        computation: Computation::Direct {
+            measure: "commits".to_owned(),
+        },
+        transform: Option::<Transform>::None,
+        format: Format::Integer,
+        direction: Direction::Neutral,
+        entity_type: "person".to_owned(),
+        cohort_key: None,
+        label: None,
+        description: None,
+    }
+}
+
+#[test]
+fn a_direct_metric_is_catalogued_with_every_question_it_admits() {
+    assert_eq!(
+        entry(SHIPPED_METRIC),
+        json!({
+            "key": "git.commits",
+            "label": "Commits",
+            "description": "Commits a person authored across connected git sources, excluding merge commits.",
+            "format": "integer",
+            "direction": "higher_is_better",
+            "entity_type": "person",
+            "computation": { "type": "direct" },
+            "cohort_key": "org_unit",
+            "dimensions": [
+                { "key": "branch_scope", "label": "Branch Scope" },
+                { "key": "repository", "label": "Repository" },
+                { "key": "project", "label": "Project" },
+                { "key": "source", "label": "Source" },
+            ],
+            "questions": {
+                "values": {
+                    "grains": ["total", "day", "week", "month"],
+                    "folds": ["per_subject", "combined"],
+                    "compare": ["previous_period", "month", "quarter", "year"],
+                    "split": true,
+                },
+                "comparisons": {
+                    "populations": [{ "type": "tenant" }, { "type": "cohort" }],
+                },
+                "distributions": { "admitted": false },
+                "rows": { "inputs": ["value"] },
+            },
+        })
+    );
+}
+
+#[test]
+fn a_ratio_metric_names_one_page_of_rows_per_side_of_its_computation() {
+    assert_eq!(
+        entry(SHIPPED_RATIO_METRIC),
+        json!({
+            "key": "git.merge_rate",
+            "label": "PR merge rate",
+            "description": "Of the pull requests created in the period, the share that have merged. Requests opened near the end of the period may not have merged yet, which lowers the rate at period edges.",
+            "format": "percent",
+            "direction": "higher_is_better",
+            "entity_type": "person",
+            "computation": { "type": "ratio" },
+            "cohort_key": "org_unit",
+            "dimensions": [
+                { "key": "branch_scope", "label": "Branch Scope" },
+                { "key": "destination_branch", "label": "Destination Branch" },
+                { "key": "repository", "label": "Repository" },
+                { "key": "project", "label": "Project" },
+                { "key": "source", "label": "Source" },
+            ],
+            "questions": {
+                "values": {
+                    "grains": ["total", "day", "week", "month"],
+                    "folds": ["per_subject", "combined"],
+                    "compare": ["previous_period", "month", "quarter", "year"],
+                    "split": true,
+                },
+                "comparisons": {
+                    "populations": [{ "type": "tenant" }, { "type": "cohort" }],
+                },
+                "distributions": { "admitted": false },
+                "rows": { "inputs": ["numerator", "denominator"] },
+            },
+        })
+    );
+}
+
+#[test]
+fn a_percentile_metric_is_the_kind_that_admits_a_distribution() {
+    assert_eq!(
+        entry(SHIPPED_DISTRIBUTION_METRIC),
+        json!({
+            "key": "git.pr_size",
+            "label": "PR size",
+            "description": "Median diff size of authored pull requests \u{2014} lines added plus removed. Smaller requests are easier to review. Sources that do not report line counts contribute no values.",
+            "format": "integer",
+            "direction": "lower_is_better",
+            "entity_type": "person",
+            "computation": { "type": "percentile" },
+            "cohort_key": "org_unit",
+            "dimensions": [
+                { "key": "branch_scope", "label": "Branch Scope" },
+                { "key": "destination_branch", "label": "Destination Branch" },
+                { "key": "repository", "label": "Repository" },
+                { "key": "project", "label": "Project" },
+                { "key": "source", "label": "Source" },
+            ],
+            "questions": {
+                "values": {
+                    "grains": ["total", "day", "week", "month"],
+                    "folds": ["per_subject", "combined"],
+                    "compare": ["previous_period", "month", "quarter", "year"],
+                    "split": true,
+                },
+                "comparisons": {
+                    "populations": [{ "type": "tenant" }, { "type": "cohort" }],
+                },
+                "distributions": { "admitted": true },
+                "rows": { "inputs": ["value"] },
+            },
+        })
+    );
+}
+
+#[test]
+fn every_shipped_metric_is_catalogued_and_none_discloses_a_dimension_value() {
+    let catalog = product_metric_catalog().expect("the shipped definitions load");
+    let described = catalogued();
+    let metrics = described["metrics"].as_array().expect("metrics");
+
+    assert_eq!(metrics.len(), catalog.metrics().count());
+    for metric in metrics {
+        let dimensions = metric["dimensions"].as_array().expect("dimensions");
+        for dimension in dimensions {
+            let fields: Vec<&String> = dimension
+                .as_object()
+                .expect("a dimension is an object")
+                .keys()
+                .collect();
+            assert_eq!(fields, ["key", "label"], "in {metric:?}");
+        }
+    }
+}
+
+#[test]
+fn a_metric_advertising_a_distribution_is_one_a_distribution_question_is_admitted_for() {
+    let catalog = product_metric_catalog().expect("the shipped definitions load");
+
+    for metric in catalogued()["metrics"].as_array().expect("metrics") {
+        let key = metric["key"].as_str().expect("a key");
+        let advertised = metric["questions"]["distributions"]["admitted"]
+            .as_bool()
+            .expect("a flag");
+
+        assert_eq!(
+            advertised,
+            distributable(catalog, key).is_ok(),
+            "`{key}` advertises {advertised} for a distribution"
+        );
+        assert_eq!(
+            advertised,
+            matches!(
+                metric["computation"]["type"].as_str(),
+                Some("percentile" | "stddev")
+            ),
+            "`{key}` advertises {advertised} for a distribution"
+        );
+    }
+}
+
+#[test]
+fn a_metric_declaring_no_cohort_neither_advertises_one_nor_is_compared_within_one() {
+    let metric = without_cohort();
+
+    assert!(population(&metric, Population::Cohort {}).is_err());
+    assert!(population(&metric, Population::Tenant {}).is_ok());
+}
+
+#[test]
+fn a_metric_declaring_a_cohort_advertises_both_populations() {
+    let catalog = product_metric_catalog().expect("the shipped definitions load");
+    let metric = catalog.metric(SHIPPED_METRIC).expect("a shipped metric");
+
+    assert!(metric.cohort_key.is_some());
+    assert_eq!(
+        entry(SHIPPED_METRIC)["questions"]["comparisons"]["populations"],
+        json!([{ "type": "tenant" }, { "type": "cohort" }])
+    );
+    assert!(population(metric, Population::Cohort {}).is_ok());
+}

--- a/src/backend/services/analytics/src/domain/metric_query/catalog.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/catalog.rs
@@ -77,9 +77,8 @@ impl MetricCatalog {
     }
 
     /// Every metric the definitions carry, in key order.
-    #[cfg(test)]
-    pub(super) fn metric_keys(&self) -> Vec<&str> {
-        self.metrics.keys().map(String::as_str).collect()
+    pub(super) fn metrics(&self) -> impl Iterator<Item = &MetricDefinition> {
+        self.metrics.values()
     }
 
     /// The dimension keys a question may name for a metric. INVARIANT: a

--- a/src/backend/services/analytics/src/domain/metric_query/comparisons/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/comparisons/dto.rs
@@ -32,7 +32,7 @@ pub struct ComparisonQuery {
 /// Who a target is compared against, internally tagged on `type`. `cohort`
 /// takes the metric's own declared cohort; a metric that declares none has no
 /// cohort to compare within.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Population {
     Cohort {},

--- a/src/backend/services/analytics/src/domain/metric_query/comparisons/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/comparisons/mod.rs
@@ -10,6 +10,7 @@ mod pool;
 mod service;
 mod validation;
 
-pub use dto::{ComparisonsRequest, ComparisonsResponse};
+pub use dto::{ComparisonsRequest, ComparisonsResponse, Population};
 pub use service::answer;
+pub(super) use validation::population;
 pub use validation::validate_request;

--- a/src/backend/services/analytics/src/domain/metric_query/comparisons/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/comparisons/validation.rs
@@ -103,7 +103,7 @@ fn validate_query(
 /// INVARIANT: the cohort a comparison reads is the metric's own, never one a
 /// request names, so a caller cannot ask a metric to be compared within a
 /// grouping it was not defined against.
-fn population(
+pub(in crate::domain::metric_query) fn population(
     metric: &MetricDefinition,
     population: Population,
 ) -> Result<ValidatedPopulation, QueryError> {

--- a/src/backend/services/analytics/src/domain/metric_query/distributions/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/distributions/mod.rs
@@ -11,4 +11,5 @@ mod validation;
 
 pub use dto::{DistributionsRequest, DistributionsResponse};
 pub use service::answer;
+pub(super) use validation::distributable;
 pub use validation::validate_request;

--- a/src/backend/services/analytics/src/domain/metric_query/distributions/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/distributions/validation.rs
@@ -99,7 +99,10 @@ fn validate_query(
 /// INVARIANT: the rule is the compiler's own — only a computation taken over
 /// the measure's per-row values has a distribution — so a question refused
 /// here would have been refused there, and one admitted here compiles.
-fn distributable(catalog: &MetricCatalog, metric_key: &str) -> Result<(), QueryError> {
+pub(in crate::domain::metric_query) fn distributable(
+    catalog: &MetricCatalog,
+    metric_key: &str,
+) -> Result<(), QueryError> {
     let Some(metric) = catalog.metric(metric_key) else {
         return Err(QueryError::UnknownMetric {
             metric: metric_key.to_owned(),

--- a/src/backend/services/analytics/src/domain/metric_query/fixtures.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/fixtures.rs
@@ -15,12 +15,9 @@ pub fn shipped_input_roles() -> Vec<(&'static str, Vec<String>)> {
     let catalog = product_metric_catalog().expect("the shipped definitions load");
 
     catalog
-        .metric_keys()
-        .into_iter()
-        .map(|key| {
-            let metric = catalog
-                .metric(key)
-                .expect("the catalog carries what it lists");
+        .metrics()
+        .map(|metric| {
+            let key = metric.key.as_str();
             let roles = catalog
                 .input_roles(metric)
                 .unwrap_or_else(|error| panic!("`{key}` resolves its inputs: {error}"));

--- a/src/backend/services/analytics/src/domain/metric_query/label.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/label.rs
@@ -1,0 +1,36 @@
+//! One rule for turning a key into what a reader sees, shared by every answer
+//! and by the catalogue that advertises what may be asked.
+
+/// The key read as words, each of them capitalized.
+pub(super) fn humanized(key: &str) -> String {
+    key.split('_')
+        .filter(|word| !word.is_empty())
+        .map(|word| {
+            let mut characters = word.chars();
+            match characters.next() {
+                Some(first) => first.to_uppercase().chain(characters).collect::<String>(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_key_reads_as_its_words_capitalized() {
+        for (key, label) in [
+            ("repository", "Repository"),
+            ("observed_at", "Observed At"),
+            ("branch_scope", "Branch Scope"),
+            ("__odd__key__", "Odd Key"),
+            ("", ""),
+        ] {
+            assert_eq!(humanized(key), label, "should read: {key:?}");
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_query/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/mod.rs
@@ -3,10 +3,12 @@
 //! the answer in explicit fields. One directory per kind of question, over the
 //! definitions, refusals, reads and provenance they all share.
 
+pub(crate) mod capability;
 mod catalog;
 pub(crate) mod dto;
 mod error;
 mod execute;
+mod label;
 mod provenance;
 mod question;
 

--- a/src/backend/services/analytics/src/domain/metric_query/rows/columns.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/rows/columns.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 
 use crate::domain::compiler::drilldown::{Contribution, DrilldownColumn, DrilldownColumnKind};
 
+use super::super::label::humanized;
 use super::dto::{ColumnKind, RowColumn};
 
 /// The alias a value is read from, beside the column it is reported as.
@@ -125,21 +126,6 @@ fn value_kind(kind: &DrilldownColumnKind) -> ColumnKind {
         DrilldownColumnKind::ObservedAt => ColumnKind::Timestamp,
         DrilldownColumnKind::Contribution => ColumnKind::Number,
     }
-}
-
-/// One rule for every column: the key read as words, each of them capitalized.
-fn humanized(key: &str) -> String {
-    key.split('_')
-        .filter(|word| !word.is_empty())
-        .map(|word| {
-            let mut characters = word.chars();
-            match characters.next() {
-                Some(first) => first.to_uppercase().chain(characters).collect::<String>(),
-                None => String::new(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
 }
 
 #[cfg(test)]

--- a/src/backend/services/analytics/src/domain/metric_query/values/answerable.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/answerable.rs
@@ -1,0 +1,216 @@
+//! Which read answers a values question, decided from the question's shape
+//! alone. INVARIANT: validation and the catalogue both decide here, so every
+//! combination advertised is one a request may name, and no other is.
+
+use super::super::error::QueryError;
+use super::dto::{CompareOffset, Fold, Grain};
+
+/// INVARIANT: these enumerate their enums; a variant added and not listed here
+/// is a combination no caller is ever told about.
+const GRAINS: [Grain; 4] = [Grain::Total, Grain::Day, Grain::Week, Grain::Month];
+const FOLDS: [Fold; 2] = [Fold::PerSubject, Fold::Combined];
+const SUBJECTS: [SubjectsAsk; 2] = [SubjectsAsk::Persons, SubjectsAsk::Tenant];
+const COMPARE_OFFSETS: [CompareOffset; 4] = [
+    CompareOffset::PreviousPeriod,
+    CompareOffset::Month,
+    CompareOffset::Quarter,
+    CompareOffset::Year,
+];
+
+/// Which read answers one question, decided here and nowhere else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryShape {
+    /// One value per subject over the whole window.
+    SubjectTotal,
+    /// One value per subject per split group, over the whole window.
+    SubjectSplit,
+    /// One value per split group, folded over every subject.
+    CombinedSplit,
+    /// One series per subject and split group, plus the window total.
+    SubjectSeries,
+}
+
+/// How many of a split's groups a question keeps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SplitAsk {
+    None,
+    EveryGroup,
+    TopGroups,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SubjectsAsk {
+    Persons,
+    Tenant,
+}
+
+/// A question stripped to what answerability depends on: no dates, no people,
+/// no dimension names — only the shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Ask {
+    pub grain: Grain,
+    pub fold: Fold,
+    pub split: SplitAsk,
+    pub subjects: SubjectsAsk,
+}
+
+/// Which read answers a question of this shape, or why none does.
+pub(super) fn shape_of(ask: Ask) -> Result<QueryShape, QueryError> {
+    let shape = match (ask.grain, ask.fold, ask.split) {
+        (Grain::Total, Fold::PerSubject, SplitAsk::None) => QueryShape::SubjectTotal,
+        (Grain::Total, Fold::PerSubject, SplitAsk::EveryGroup) => QueryShape::SubjectSplit,
+        (Grain::Total, Fold::PerSubject, SplitAsk::TopGroups) => {
+            return Err(QueryError::Unanswerable {
+                reason: "a per-subject split over the whole window reports every group; \
+                         keeping only the top ones needs a time grain or a combined fold",
+            });
+        }
+        (Grain::Total, Fold::Combined, SplitAsk::EveryGroup | SplitAsk::TopGroups) => {
+            QueryShape::CombinedSplit
+        }
+        (Grain::Total, Fold::Combined, SplitAsk::None) => {
+            return Err(QueryError::Unanswerable {
+                reason: "a combined value is reported per split group, so folding every subject \
+                         together names at least one dimension",
+            });
+        }
+        (Grain::Day | Grain::Week | Grain::Month, Fold::PerSubject, _) => QueryShape::SubjectSeries,
+        (Grain::Day | Grain::Week | Grain::Month, Fold::Combined, _) => {
+            return Err(QueryError::Unanswerable {
+                reason: "a combined value folds the window whole, so it is asked at the total \
+                         grain",
+            });
+        }
+    };
+
+    answerable_for(ask.subjects, shape)
+}
+
+/// INVARIANT: a dataset records rows per observed person and never for the
+/// tenant, so a tenant-wide question must report no subject of its own.
+fn answerable_for(subjects: SubjectsAsk, shape: QueryShape) -> Result<QueryShape, QueryError> {
+    match (subjects, shape) {
+        (SubjectsAsk::Persons, _) | (SubjectsAsk::Tenant, QueryShape::CombinedSplit) => Ok(shape),
+        (
+            SubjectsAsk::Tenant,
+            QueryShape::SubjectTotal | QueryShape::SubjectSplit | QueryShape::SubjectSeries,
+        ) => Err(QueryError::Unanswerable {
+            reason: "no dataset records a row keyed by the tenant, so a tenant-wide question is \
+                     answered with its subjects folded together",
+        }),
+    }
+}
+
+/// Every question shape that is answerable at all for a metric, where
+/// `splittable` says whether the metric declares a dimension to break out by.
+fn answerable(splittable: bool) -> impl Iterator<Item = Ask> {
+    let splits: &'static [SplitAsk] = if splittable {
+        &[SplitAsk::None, SplitAsk::EveryGroup, SplitAsk::TopGroups]
+    } else {
+        &[SplitAsk::None]
+    };
+
+    GRAINS.into_iter().flat_map(move |grain| {
+        FOLDS.into_iter().flat_map(move |fold| {
+            splits.iter().flat_map(move |split| {
+                SUBJECTS.into_iter().map(move |subjects| Ask {
+                    grain,
+                    fold,
+                    split: *split,
+                    subjects,
+                })
+            })
+        })
+    })
+}
+
+/// The grains a metric's values may be asked at.
+pub(in crate::domain::metric_query) fn offered_grains(splittable: bool) -> Vec<Grain> {
+    GRAINS
+        .into_iter()
+        .filter(|grain| {
+            answerable(splittable).any(|ask| ask.grain == *grain && shape_of(ask).is_ok())
+        })
+        .collect()
+}
+
+/// The folds a metric's values may be asked with.
+pub(in crate::domain::metric_query) fn offered_folds(splittable: bool) -> Vec<Fold> {
+    FOLDS
+        .into_iter()
+        .filter(|fold| answerable(splittable).any(|ask| ask.fold == *fold && shape_of(ask).is_ok()))
+        .collect()
+}
+
+/// The earlier windows a values question may be set beside. Every offset is a
+/// property of the window asked, not of the metric.
+pub(in crate::domain::metric_query) fn offered_compare_offsets() -> Vec<CompareOffset> {
+    COMPARE_OFFSETS.to_vec()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn ask(grain: Grain, fold: Fold, split: SplitAsk) -> Ask {
+        Ask {
+            grain,
+            fold,
+            split,
+            subjects: SubjectsAsk::Persons,
+        }
+    }
+
+    #[test]
+    fn a_metric_without_a_dimension_is_asked_per_subject_only() {
+        assert_eq!(offered_folds(false), vec![Fold::PerSubject]);
+        assert_eq!(
+            offered_grains(false),
+            vec![Grain::Total, Grain::Day, Grain::Week, Grain::Month]
+        );
+    }
+
+    #[test]
+    fn a_dimension_is_what_makes_a_combined_fold_answerable() {
+        assert_eq!(offered_folds(true), vec![Fold::PerSubject, Fold::Combined]);
+
+        assert!(shape_of(ask(Grain::Total, Fold::Combined, SplitAsk::None)).is_err());
+        assert_eq!(
+            shape_of(ask(Grain::Total, Fold::Combined, SplitAsk::EveryGroup)).ok(),
+            Some(QueryShape::CombinedSplit)
+        );
+    }
+
+    #[test]
+    fn a_per_subject_split_over_the_whole_window_keeps_every_group() {
+        assert_eq!(
+            shape_of(ask(Grain::Total, Fold::PerSubject, SplitAsk::EveryGroup)).ok(),
+            Some(QueryShape::SubjectSplit)
+        );
+        assert!(shape_of(ask(Grain::Total, Fold::PerSubject, SplitAsk::TopGroups)).is_err());
+    }
+
+    #[test]
+    fn only_a_combined_split_is_answered_for_the_tenant() {
+        for split in [SplitAsk::None, SplitAsk::EveryGroup] {
+            assert!(
+                shape_of(Ask {
+                    subjects: SubjectsAsk::Tenant,
+                    ..ask(Grain::Total, Fold::PerSubject, split)
+                })
+                .is_err(),
+                "should refuse: {split:?}"
+            );
+        }
+
+        assert_eq!(
+            shape_of(Ask {
+                subjects: SubjectsAsk::Tenant,
+                ..ask(Grain::Total, Fold::Combined, SplitAsk::EveryGroup)
+            })
+            .ok(),
+            Some(QueryShape::CombinedSplit)
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_query/values/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/mod.rs
@@ -2,6 +2,7 @@
 //! number per subject, or one series per bucket, optionally broken out by a
 //! dimension and set beside an earlier window's.
 
+mod answerable;
 mod assemble;
 mod dto;
 mod group_cap;
@@ -9,9 +10,11 @@ mod plan;
 mod service;
 mod validation;
 
-pub use dto::{ValuesRequest, ValuesResponse};
+pub use dto::{CompareOffset, Fold, Grain, ValuesRequest, ValuesResponse};
 pub use service::answer;
 pub use validation::{ValidatedBatch, validate_request};
+
+pub(super) use answerable::{offered_compare_offsets, offered_folds, offered_grains};
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]

--- a/src/backend/services/analytics/src/domain/metric_query/values/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_query/values/validation.rs
@@ -14,28 +14,18 @@ use super::super::catalog::MetricCatalog;
 use super::super::dto::Subjects;
 use super::super::error::QueryError;
 use super::super::question::{batch_size, defined_metric, filters, person_ids, window};
+use super::answerable::{Ask, SplitAsk, SubjectsAsk, shape_of};
 use super::dto::{
     Compare, CompareOffset, Fold, Grain, Split, SplitLimit, ValuesQuery, ValuesRequest,
 };
+
+pub use super::answerable::QueryShape;
 
 const MAX_SPLIT_DIMENSIONS: usize = 10;
 const MAX_SPLIT_TOP: u32 = 50;
 
 /// The field a values question names its people in.
 const SUBJECTS_FIELD: &str = "queries.subjects.ids";
-
-/// Which read answers one question, decided here and nowhere else.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum QueryShape {
-    /// One value per subject over the whole window.
-    SubjectTotal,
-    /// One value per subject per split group, over the whole window.
-    SubjectSplit,
-    /// One value per split group, folded over every subject.
-    CombinedSplit,
-    /// One series per subject and split group, plus the window total.
-    SubjectSeries,
-}
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ValidatedSubjects {
@@ -270,60 +260,30 @@ fn validate_limit(
     })
 }
 
-/// Which read answers a question, or why none does.
+/// The question stripped to its shape, so answerability is decided by the one
+/// predicate the catalogue also reads.
 fn shape(
     grain: Grain,
     fold: Fold,
     split: Option<&ValidatedSplit>,
     subjects: &ValidatedSubjects,
 ) -> Result<QueryShape, QueryError> {
-    let shape = match (grain, fold, split) {
-        (Grain::Total, Fold::PerSubject, None) => QueryShape::SubjectTotal,
-        (Grain::Total, Fold::PerSubject, Some(split)) => {
-            if split.limit.is_some() {
-                return Err(QueryError::Unanswerable {
-                    reason: "a per-subject split over the whole window reports every group; \
-                             keeping only the top ones needs a time grain or a combined fold",
-                });
-            }
-            QueryShape::SubjectSplit
-        }
-        (Grain::Total, Fold::Combined, Some(_)) => QueryShape::CombinedSplit,
-        (Grain::Total, Fold::Combined, None) => {
-            return Err(QueryError::Unanswerable {
-                reason: "a combined value is reported per split group, so folding every subject \
-                         together names at least one dimension",
-            });
-        }
-        (Grain::Day | Grain::Week | Grain::Month, Fold::PerSubject, _) => QueryShape::SubjectSeries,
-        (Grain::Day | Grain::Week | Grain::Month, Fold::Combined, _) => {
-            return Err(QueryError::Unanswerable {
-                reason: "a combined value folds the window whole, so it is asked at the total \
-                         grain",
-            });
-        }
+    let split = match split {
+        None => SplitAsk::None,
+        Some(split) if split.limit.is_some() => SplitAsk::TopGroups,
+        Some(_) => SplitAsk::EveryGroup,
+    };
+    let subjects = match subjects {
+        ValidatedSubjects::Persons(_) => SubjectsAsk::Persons,
+        ValidatedSubjects::Tenant => SubjectsAsk::Tenant,
     };
 
-    answerable_for(subjects, shape)
-}
-
-/// INVARIANT: a dataset records rows per observed person and never for the
-/// tenant, so a tenant-wide question must report no subject of its own.
-fn answerable_for(
-    subjects: &ValidatedSubjects,
-    shape: QueryShape,
-) -> Result<QueryShape, QueryError> {
-    match (subjects, shape) {
-        (ValidatedSubjects::Persons(_), _)
-        | (ValidatedSubjects::Tenant, QueryShape::CombinedSplit) => Ok(shape),
-        (
-            ValidatedSubjects::Tenant,
-            QueryShape::SubjectTotal | QueryShape::SubjectSplit | QueryShape::SubjectSeries,
-        ) => Err(QueryError::Unanswerable {
-            reason: "no dataset records a row keyed by the tenant, so a tenant-wide question is \
-                     answered with its subjects folded together",
-        }),
-    }
+    shape_of(Ask {
+        grain,
+        fold,
+        split,
+        subjects,
+    })
 }
 
 #[cfg(test)]

--- a/tests/stand/api/analytics/test_catalog.py
+++ b/tests/stand/api/analytics/test_catalog.py
@@ -1,0 +1,111 @@
+"""`GET /v1/catalog/metrics` — what the semantic definitions can be asked.
+
+    GET /v1/catalog/metrics  200 the metrics, and the questions each admits
+
+The 401 half is in `test_gateway.py`, swept over every operation at once.
+
+No seed and no manifest. The document is a projection of definitions compiled
+into the service, so it is the same on a full stand and an empty one — and the
+only thing worth asserting about it is that it does not contradict itself. Every
+claim below is checked against another field of the SAME response: a metric that
+advertises a distribution must be the kind of computation that has one, a metric
+that advertises a combined fold must declare a dimension to fold into, and a
+metric that advertises a cohort comparison must declare the cohort it reads.
+
+Assertions stay off the metric keys on purpose. Which metrics ship is a product
+decision that moves; that the advertisement is answerable is the contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_stand import ApiClient, analytics_path
+
+from ..schemas.analytics import MetricCatalogResponse
+
+CATALOG_METRICS = analytics_path("/v1/catalog/metrics")
+
+#: The computations taken over a measure's per-row values — the ones that have a
+#: distribution at all.
+_DISTRIBUTABLE = frozenset({"percentile", "stddev"})
+
+#: A ratio is folded from two measures, so a page of rows names which side it
+#: reads; every other shipped computation reads one.
+_INPUTS_PER_COMPUTATION = {"ratio": 2}
+
+TENANT = {"type": "tenant"}
+COHORT = {"type": "cohort"}
+
+
+@pytest.mark.reliability
+def test_catalog_metrics_answers_the_shape_its_contract_declares(api: ApiClient) -> None:
+    """Every metric parses against the published document, and the keys are distinct."""
+    response = api.get(CATALOG_METRICS)
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+
+    catalogued = response.parse(MetricCatalogResponse)
+    assert catalogued.metrics, "the catalogue advertised no metric at all"
+
+    keys = [metric.key for metric in catalogued.metrics]
+    assert len(keys) == len(set(keys)), f"a metric key is catalogued twice: {keys}"
+    assert keys == sorted(keys), f"the catalogue is not in key order: {keys}"
+
+
+@pytest.mark.reliability
+def test_every_question_a_metric_advertises_agrees_with_the_rest_of_its_entry(
+    api: ApiClient,
+) -> None:
+    """The advertisement is internally consistent, judged from the response alone."""
+    response = api.get(CATALOG_METRICS)
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+    response.parse(MetricCatalogResponse)
+
+    for metric in response.json()["metrics"]:
+        key = metric["key"]
+        computation = metric["computation"]["type"]
+        splittable = bool(metric["dimensions"])
+        questions = metric["questions"]
+
+        assert questions["distributions"]["admitted"] == (computation in _DISTRIBUTABLE), (
+            f"`{key}` is a {computation} and advertises "
+            f"{questions['distributions']['admitted']} for a distribution"
+        )
+
+        values = questions["values"]
+        assert values["grains"] == ["total", "day", "week", "month"], (
+            f"`{key}` advertises grains {values['grains']}"
+        )
+        assert values["split"] == splittable, (
+            f"`{key}` advertises split={values['split']} with {len(metric['dimensions'])} "
+            f"dimensions"
+        )
+        assert "per_subject" in values["folds"], f"`{key}` advertises folds {values['folds']}"
+        assert ("combined" in values["folds"]) == splittable, (
+            f"`{key}` advertises a combined fold with nothing to fold into: {values['folds']}"
+        )
+        assert values["compare"], f"`{key}` advertises no comparable window"
+
+        populations = questions["comparisons"]["populations"]
+        assert TENANT in populations, f"`{key}` advertises populations {populations}"
+        assert (COHORT in populations) == ("cohort_key" in metric), (
+            f"`{key}` advertises {populations} while its cohort_key is {metric.get('cohort_key')!r}"
+        )
+
+        inputs = questions["rows"]["inputs"]
+        assert len(inputs) == _INPUTS_PER_COMPUTATION.get(computation, 1), (
+            f"`{key}` is a {computation} and names {inputs} as the pages behind it"
+        )
+        assert len(inputs) == len(set(inputs)), f"`{key}` names one page twice: {inputs}"
+
+
+@pytest.mark.security
+def test_catalog_metrics_discloses_no_value_of_any_dimension(api: ApiClient) -> None:
+    """A dimension is advertised by key and label only — never by what it holds."""
+    response = api.get(CATALOG_METRICS)
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+
+    for metric in response.json()["metrics"]:
+        for dimension in metric["dimensions"]:
+            assert sorted(dimension) == ["key", "label"], (
+                f"`{metric['key']}` advertises a dimension carrying more than its name: {dimension}"
+            )

--- a/tests/stand/api/analytics/test_definitions_validate.py
+++ b/tests/stand/api/analytics/test_definitions_validate.py
@@ -1,0 +1,113 @@
+"""`POST /v1/definitions/validate` — judging definitions without keeping them.
+
+    POST /v1/definitions/validate  200 valid · 200 invalid, with every offender
+
+The 401 half is in `test_gateway.py` and the 415 half in
+`test_request_contracts.py`, both swept over every operation at once.
+
+Two things make this endpoint worth a deployed case rather than a unit test. It
+answers 200 for a set that breaks every rule — the outcome is the payload, so a
+proxy or handler turning a refusal into a status code would be a real regression.
+And it writes nothing: the probe definitions below are submitted under keys no
+seed uses, and the case that follows asks the catalogue whether either of them
+became a metric.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_stand import ApiClient, analytics_path
+from insight_stand.api import JsonValue
+
+from ..schemas.analytics import MetricCatalogResponse, ValidateDefinitionsResponse
+
+VALIDATE_DEFINITIONS = analytics_path("/v1/definitions/validate")
+CATALOG_METRICS = analytics_path("/v1/catalog/metrics")
+
+#: A key no shipped definition holds, so a collision would be this request's.
+PROBE_MEASURE = "stand_probe_lines_touched"
+PROBE_METRIC = "stand_probe.lines_touched"
+
+#: Reads a dataset and fields the shipped catalog carries, which is what makes
+#: the pair valid without seeding anything.
+_VALID_MEASURE: dict[str, JsonValue] = {
+    "key": PROBE_MEASURE,
+    "dataset": "git_commits",
+    "aggregation": "sum",
+    "value_expr": "lines_added + lines_removed",
+    "event_time": "authored_at",
+    "entity": "author_email",
+    "dimensions": [{"key": "repository", "value_field": "repository"}],
+}
+
+_VALID_METRIC: dict[str, JsonValue] = {
+    "key": PROBE_METRIC,
+    "computation": {"type": "direct", "measure": PROBE_MEASURE},
+    "format": "integer",
+    "direction": "neutral",
+    "entity_type": "person",
+}
+
+#: Two rules broken at once, in the two halves of the request, so the answer has
+#: to accumulate rather than stop at the first offender: the measure reads a
+#: dataset the catalog does not have, and the metric reads a measure nothing
+#: defines.
+_BROKEN_MEASURE: dict[str, JsonValue] = {**_VALID_MEASURE, "dataset": "no_such_dataset"}
+_BROKEN_METRIC: dict[str, JsonValue] = {
+    **_VALID_METRIC,
+    "computation": {"type": "direct", "measure": "no_such_measure"},
+}
+
+
+@pytest.mark.reliability
+def test_a_valid_pair_is_judged_valid_against_the_shipped_definitions(api: ApiClient) -> None:
+    """A measure and the metric reading it validate as one set with what ships."""
+    response = api.post(
+        VALIDATE_DEFINITIONS,
+        json_body={"measures": [_VALID_MEASURE], "metrics": [_VALID_METRIC]},
+    )
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+
+    judged = response.parse(ValidateDefinitionsResponse)
+    assert judged.valid, f"a valid pair was refused: {judged.errors}"
+    assert judged.errors == []
+
+
+@pytest.mark.reliability
+def test_a_broken_pair_is_reported_offender_by_offender_and_still_answers_200(
+    api: ApiClient,
+) -> None:
+    """Validation's outcome is the body, and it names every rule broken, not the first."""
+    response = api.post(
+        VALIDATE_DEFINITIONS,
+        json_body={"measures": [_BROKEN_MEASURE], "metrics": [_BROKEN_METRIC]},
+    )
+    assert response.status_code == 200, (
+        f"an invalid set answered {response.status_code} rather than reporting itself: "
+        f"{response.text[:300]}"
+    )
+
+    judged = response.parse(ValidateDefinitionsResponse)
+    assert not judged.valid
+    assert {error.kind for error in judged.errors} == {"dataset_not_found", "measure_not_found"}, (
+        f"expected both halves to be judged, got {judged.errors}"
+    )
+    assert all(error.message for error in judged.errors), (
+        f"an offender was reported without saying what it broke: {judged.errors}"
+    )
+
+
+@pytest.mark.security
+def test_a_metric_that_only_validated_does_not_join_the_catalogue(api: ApiClient) -> None:
+    """The dry run keeps nothing — the probe metric is unknown to discovery afterwards."""
+    accepted = api.post(
+        VALIDATE_DEFINITIONS,
+        json_body={"measures": [_VALID_MEASURE], "metrics": [_VALID_METRIC]},
+    )
+    assert accepted.status_code == 200, f"status={accepted.status_code} {accepted.text[:300]}"
+    assert accepted.parse(ValidateDefinitionsResponse).valid
+
+    catalogued = api.get(CATALOG_METRICS)
+    assert catalogued.status_code == 200, f"status={catalogued.status_code} {catalogued.text[:300]}"
+    keys = [metric.key for metric in catalogued.parse(MetricCatalogResponse).metrics]
+    assert PROBE_METRIC not in keys, f"a validated metric was installed: {keys}"

--- a/tests/stand/api/analytics/test_request_contracts.py
+++ b/tests/stand/api/analytics/test_request_contracts.py
@@ -61,6 +61,7 @@ BODY_ROUTES: tuple[tuple[str, str], ...] = (
     ("POST", "/v1/query/comparisons"),
     ("POST", "/v1/query/distributions"),
     ("POST", "/v1/query/rows"),
+    ("POST", "/v1/definitions/validate"),
     ("POST", "/v1/metrics"),
     ("PUT", f"/v1/metrics/{scratch.UNKNOWN_METRIC_KEY}"),
     ("POST", "/v1/metrics/import"),

--- a/tests/stand/api/operations.py
+++ b/tests/stand/api/operations.py
@@ -99,7 +99,7 @@ def _i(method: str, suffix: str) -> Operation:
     return Operation(method=method, path=identity_path(suffix), service="identity")
 
 
-#: analytics — 26 operations.
+#: analytics — 28 operations.
 ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("GET", "/v1/queries"),
     _a("POST", "/v1/queries"),
@@ -108,6 +108,11 @@ ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("DELETE", f"/v1/queries/{SOME_ID}"),
     _a("POST", f"/v1/queries/{SOME_ID}/run"),
     _a("GET", "/v1/metric-definitions"),
+    # Discovery over the semantic definitions, and the authoring dry run against
+    # them. Both are tenant-invariant: the first reads no context, the second
+    # writes nothing.
+    _a("GET", "/v1/catalog/metrics"),
+    _a("POST", "/v1/definitions/validate"),
     _a("POST", "/v1/metric-results"),
     _a("POST", "/v1/metric-drilldown"),
     # The only operation here that does not answer JSON — it serves CSV or

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -25,11 +25,20 @@ service serialises timestamps with no offset. See `common.UnzonedDatetime`.
 from __future__ import annotations
 
 from .common import UnzonedDatetime
-from pydantic import BaseModel, ConfigDict, Field, RootModel
 from enum import StrEnum
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 from typing import Any
 from uuid import UUID
 from datetime import date as date_aliased
+
+
+class Aggregation(StrEnum):
+    count = 'count'
+    sum = 'sum'
+    avg = 'avg'
+    min = 'min'
+    max = 'max'
+    count_distinct = 'count_distinct'
 
 
 class AiConfigResponse(BaseModel):
@@ -62,6 +71,88 @@ class Bucket(StrEnum):
     day = 'day'
     week = 'week'
     month = 'month'
+
+
+class Type(StrEnum):
+    direct = 'direct'
+
+
+class CatalogComputation1(BaseModel):
+    """
+    How the value is computed, named without the measures it is computed from.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Type
+
+
+class Type1(StrEnum):
+    ratio = 'ratio'
+
+
+class CatalogComputation2(BaseModel):
+    """
+    How the value is computed, named without the measures it is computed from.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Type1
+
+
+class Type2(StrEnum):
+    percentile = 'percentile'
+
+
+class CatalogComputation3(BaseModel):
+    """
+    How the value is computed, named without the measures it is computed from.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Type2
+
+
+class Type3(StrEnum):
+    stddev = 'stddev'
+
+
+class CatalogComputation4(BaseModel):
+    """
+    How the value is computed, named without the measures it is computed from.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Type3
+
+
+class Type4(StrEnum):
+    derived = 'derived'
+
+
+class CatalogComputation5(BaseModel):
+    """
+    How the value is computed, named without the measures it is computed from.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Type4
+
+
+class CatalogComputation(RootModel[CatalogComputation1 | CatalogComputation2 | CatalogComputation3 | CatalogComputation4 | CatalogComputation5]):
+    root: CatalogComputation1 | CatalogComputation2 | CatalogComputation3 | CatalogComputation4 | CatalogComputation5 = Field(..., description='How the value is computed, named without the measures it is computed from.')
+
+
+class CatalogDimension(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    key: str = Field(..., description='What a filter, a split or a display dimension names.')
+    label: str
 
 
 class ColumnKind(StrEnum):
@@ -101,7 +192,97 @@ class Comparison(BaseModel):
     value: float | None = Field(None, description='What the same question answered over the compared window.')
 
 
-class Computation(StrEnum):
+class Type5(StrEnum):
+    direct = 'direct'
+
+
+class Computation1(BaseModel):
+    """
+    A percentile is metric-level because a percentile of pre-aggregated values
+    is not a percentile; a standard deviation is metric-level for the same
+    reason.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    measure: str
+    type: Type5
+
+
+class Type6(StrEnum):
+    ratio = 'ratio'
+
+
+class Computation2(BaseModel):
+    """
+    A percentile is metric-level because a percentile of pre-aggregated values
+    is not a percentile; a standard deviation is metric-level for the same
+    reason.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    denominator: str
+    numerator: str
+    type: Type6
+
+
+class Type7(StrEnum):
+    percentile = 'percentile'
+
+
+class Computation3(BaseModel):
+    """
+    A percentile is metric-level because a percentile of pre-aggregated values
+    is not a percentile; a standard deviation is metric-level for the same
+    reason.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    measure: str
+    quantile: float = Field(..., description='The quantile to serve, in `(0, 1)`.')
+    type: Type7
+
+
+class Type8(StrEnum):
+    stddev = 'stddev'
+
+
+class Computation4(BaseModel):
+    """
+    A percentile is metric-level because a percentile of pre-aggregated values
+    is not a percentile; a standard deviation is metric-level for the same
+    reason.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    measure: str
+    type: Type8
+
+
+class Type9(StrEnum):
+    derived = 'derived'
+
+
+class Computation5(BaseModel):
+    """
+    Arithmetic over measures the expression names by alias.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    expr: str
+    inputs: dict[str, str] = Field(..., description='Alias to measure key. The alias is what `expr` may reference.')
+    type: Type9
+
+
+class Computation(RootModel[Computation1 | Computation2 | Computation3 | Computation4 | Computation5]):
+    root: Computation1 | Computation2 | Computation3 | Computation4 | Computation5 = Field(..., description='A percentile is metric-level because a percentile of pre-aggregated values\nis not a percentile; a standard deviation is metric-level for the same\nreason.')
+
+
+class Computation6(StrEnum):
     sum = 'sum'
 
 
@@ -109,10 +290,10 @@ class ComputationDto1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation
+    computation: Computation6
 
 
-class Computation1(StrEnum):
+class Computation7(StrEnum):
     ratio = 'ratio'
 
 
@@ -120,11 +301,11 @@ class ComputationDto2(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation1
+    computation: Computation7
     scale: float
 
 
-class Computation2(StrEnum):
+class Computation8(StrEnum):
     median = 'median'
 
 
@@ -132,10 +313,10 @@ class ComputationDto3(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation2
+    computation: Computation8
 
 
-class Computation3(StrEnum):
+class Computation9(StrEnum):
     percentile = 'percentile'
 
 
@@ -143,11 +324,11 @@ class ComputationDto4(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation3
+    computation: Computation9
     q: float = Field(..., description='The quantile — a probability, matching the definition validation.', ge=0.0, le=1.0)
 
 
-class Computation4(StrEnum):
+class Computation10(StrEnum):
     stddev = 'stddev'
 
 
@@ -155,10 +336,10 @@ class ComputationDto5(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation4
+    computation: Computation10
 
 
-class Computation5(StrEnum):
+class Computation11(StrEnum):
     distinct_count = 'distinct_count'
 
 
@@ -166,7 +347,7 @@ class ComputationDto6(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation5
+    computation: Computation11
 
 
 class ComputationDto(RootModel[ComputationDto1 | ComputationDto2 | ComputationDto3 | ComputationDto4 | ComputationDto5 | ComputationDto6]):
@@ -185,6 +366,15 @@ class CreateSavedQueryRequest(BaseModel):
     sql: str
 
 
+class DimensionBinding(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    key: str
+    label_field: str | None = None
+    value_field: str
+
+
 class DimensionFilter(BaseModel):
     """
     Keeps only the rows whose dimension holds one of the named values.
@@ -194,6 +384,19 @@ class DimensionFilter(BaseModel):
     )
     dimension: str = Field(..., description="A dimension key the metric's grain measure declares.")
     values: list[str]
+
+
+class Direction(StrEnum):
+    higher_is_better = 'higher_is_better'
+    lower_is_better = 'lower_is_better'
+    neutral = 'neutral'
+
+
+class DistributionQuestions(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    admitted: bool = Field(..., description="Whether the metric's computation is taken over per-row values, which is\nwhat having a distribution means.")
 
 
 class EntityType(StrEnum):
@@ -251,12 +454,32 @@ class FeedbackRequest(BaseModel):
     path: str | None = Field(None, description='The screen the sender was on. Empty when the SPA cannot name one.')
 
 
+class FilterOp(StrEnum):
+    eq = 'eq'
+    neq = 'neq'
+    gt = 'gt'
+    gte = 'gte'
+    lt = 'lt'
+    lte = 'lte'
+    in_ = 'in'
+    not_in = 'not_in'
+    is_null = 'is_null'
+    not_null = 'not_null'
+
+
 class Fold(StrEnum):
     """
     Whether each subject keeps its own value or the subjects fold into one.
     """
     per_subject = 'per_subject'
     combined = 'combined'
+
+
+class Format(StrEnum):
+    integer = 'integer'
+    decimal = 'decimal'
+    currency = 'currency'
+    percent = 'percent'
 
 
 class Grain(StrEnum):
@@ -270,11 +493,11 @@ class Grain(StrEnum):
     month = 'month'
 
 
-class Type(StrEnum):
+class Type10(StrEnum):
     dimensions = 'dimensions'
 
 
-class Type1(StrEnum):
+class Type11(StrEnum):
     remainder = 'remainder'
 
 
@@ -285,7 +508,7 @@ class Group2(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    type: Type1
+    type: Type11
 
 
 class GroupDimension(BaseModel):
@@ -381,7 +604,7 @@ class MetricDrilldownColumnType(StrEnum):
     number = 'number'
 
 
-class Type2(StrEnum):
+class Type12(StrEnum):
     person = 'person'
 
 
@@ -390,10 +613,10 @@ class MetricDrilldownEntity1(BaseModel):
         extra='forbid',
     )
     id: str
-    type: Type2
+    type: Type12
 
 
-class Type3(StrEnum):
+class Type13(StrEnum):
     persons = 'persons'
 
 
@@ -407,10 +630,10 @@ class MetricDrilldownEntity2(BaseModel):
         extra='forbid',
     )
     ids: list[str]
-    type: Type3
+    type: Type13
 
 
-class Type4(StrEnum):
+class Type14(StrEnum):
     tenant = 'tenant'
 
 
@@ -418,7 +641,7 @@ class MetricDrilldownEntity3(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    type: Type4
+    type: Type14
 
 
 class MetricDrilldownEntity(RootModel[MetricDrilldownEntity1 | MetricDrilldownEntity2 | MetricDrilldownEntity3]):
@@ -505,7 +728,7 @@ class MetricOrigin(StrEnum):
     custom = 'custom'
 
 
-class Computation6(StrEnum):
+class Computation12(StrEnum):
     sum = 'sum'
 
 
@@ -513,10 +736,10 @@ class MetricResultDto1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation6
+    computation: Computation12
 
 
-class Computation7(StrEnum):
+class Computation13(StrEnum):
     ratio = 'ratio'
 
 
@@ -524,11 +747,11 @@ class MetricResultDto2(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation7
+    computation: Computation13
     scale: float
 
 
-class Computation8(StrEnum):
+class Computation14(StrEnum):
     median = 'median'
 
 
@@ -536,10 +759,10 @@ class MetricResultDto3(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation8
+    computation: Computation14
 
 
-class Computation9(StrEnum):
+class Computation15(StrEnum):
     percentile = 'percentile'
 
 
@@ -547,11 +770,11 @@ class MetricResultDto4(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation9
+    computation: Computation15
     q: float = Field(..., description='The quantile — a probability, matching the definition validation.', ge=0.0, le=1.0)
 
 
-class Computation10(StrEnum):
+class Computation16(StrEnum):
     stddev = 'stddev'
 
 
@@ -559,10 +782,10 @@ class MetricResultDto5(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation10
+    computation: Computation16
 
 
-class Computation11(StrEnum):
+class Computation17(StrEnum):
     distinct_count = 'distinct_count'
 
 
@@ -570,7 +793,7 @@ class MetricResultDto6(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    computation: Computation11
+    computation: Computation17
 
 
 class View(StrEnum):
@@ -601,7 +824,7 @@ class View6(StrEnum):
     error = 'error'
 
 
-class Type5(StrEnum):
+class Type15(StrEnum):
     person = 'person'
 
 
@@ -610,10 +833,10 @@ class MetricResultsEntity1(BaseModel):
         extra='forbid',
     )
     ids: list[str]
-    type: Type5
+    type: Type15
 
 
-class Type6(StrEnum):
+class Type16(StrEnum):
     tenant = 'tenant'
 
 
@@ -621,14 +844,14 @@ class MetricResultsEntity2(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    type: Type6
+    type: Type16
 
 
 class MetricResultsEntity(RootModel[MetricResultsEntity1 | MetricResultsEntity2]):
     root: MetricResultsEntity1 | MetricResultsEntity2
 
 
-class Type7(StrEnum):
+class Type17(StrEnum):
     person = 'person'
 
 
@@ -637,10 +860,10 @@ class MetricResultsEntityDto1(BaseModel):
         extra='forbid',
     )
     ids: list[str]
-    type: Type7
+    type: Type17
 
 
-class Type8(StrEnum):
+class Type18(StrEnum):
     tenant = 'tenant'
 
 
@@ -648,7 +871,7 @@ class MetricResultsEntityDto2(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    type: Type8
+    type: Type18
 
 
 class MetricResultsEntityDto(RootModel[MetricResultsEntityDto1 | MetricResultsEntityDto2]):
@@ -795,7 +1018,7 @@ class Point(BaseModel):
     value: float | None = None
 
 
-class Type9(StrEnum):
+class Type19(StrEnum):
     cohort = 'cohort'
 
 
@@ -808,10 +1031,10 @@ class Population1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    type: Type9
+    type: Type19
 
 
-class Type10(StrEnum):
+class Type20(StrEnum):
     tenant = 'tenant'
 
 
@@ -824,7 +1047,7 @@ class Population2(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    type: Type10
+    type: Type20
 
 
 class Population(RootModel[Population1 | Population2]):
@@ -915,6 +1138,13 @@ class RowColumn(BaseModel):
     label: str = Field(..., description="The column's name as a reader sees it, derived from its key.")
 
 
+class RowsQuestions(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    inputs: list[str] = Field(..., description='The parts of the computation a page of rows may be asked for.')
+
+
 class RunResponse(BaseModel):
     """
     Result of `POST /v1/queries/{id}/run`.
@@ -969,6 +1199,10 @@ class SavedQuerySummary(BaseModel):
     description: str | None = None
     id: UUID
     name: str
+
+
+class Scalar(RootModel[bool | float | str]):
+    root: bool | float | str
 
 
 class SchemaStatus(StrEnum):
@@ -1029,7 +1263,7 @@ class SplitLimit(BaseModel):
     top: int = Field(..., description='How many groups to keep.', ge=0)
 
 
-class Type11(StrEnum):
+class Type21(StrEnum):
     persons = 'persons'
 
 
@@ -1042,10 +1276,10 @@ class Subjects1(BaseModel):
         extra='forbid',
     )
     ids: list[str]
-    type: Type11
+    type: Type21
 
 
-class Type12(StrEnum):
+class Type22(StrEnum):
     tenant = 'tenant'
 
 
@@ -1057,7 +1291,7 @@ class Subjects2(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    type: Type12
+    type: Type22
 
 
 class Subjects(RootModel[Subjects1 | Subjects2]):
@@ -1124,6 +1358,20 @@ class TimeseriesPointDto(BaseModel):
     )
     bucket_start: str
     value: float | None = None
+
+
+class Transform(BaseModel):
+    """
+    Post-aggregation shaping: `clamp(min, max, multiplier * value + offset)`.
+    Absent fields are the identity.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    clamp_max: float | None = None
+    clamp_min: float | None = None
+    multiplier: float | None = None
+    offset: float | None = None
 
 
 class UpdateContextRequest(BaseModel):
@@ -1217,6 +1465,38 @@ class UsageTotals(BaseModel):
     visits: int = Field(..., ge=0)
 
 
+class ValidationErrorKind(StrEnum):
+    """
+    Which rule was broken, as a discriminant a machine can branch on.
+    """
+    key_shape = 'key_shape'
+    metric_key_shape = 'metric_key_shape'
+    duplicate_key = 'duplicate_key'
+    dataset_not_found = 'dataset_not_found'
+    field_not_found = 'field_not_found'
+    role_mismatch = 'role_mismatch'
+    filter = 'filter'
+    expression = 'expression'
+    operand = 'operand'
+    measure_not_found = 'measure_not_found'
+    quantile_out_of_range = 'quantile_out_of_range'
+    mixed_datasets = 'mixed_datasets'
+    distribution_without_value = 'distribution_without_value'
+    no_derived_inputs = 'no_derived_inputs'
+    metric_expression = 'metric_expression'
+    unknown_derived_input = 'unknown_derived_input'
+    unused_derived_input = 'unused_derived_input'
+    dimension_bindings_disagree = 'dimension_bindings_disagree'
+
+
+class ValidationFailure(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    kind: ValidationErrorKind
+    message: str
+
+
 class ValueTransform(BaseModel):
     """
     Affine + clamp shaping for a computed metric value:
@@ -1230,6 +1510,16 @@ class ValueTransform(BaseModel):
     clamp_min: float | None = None
     multiplier: float | None = None
     offset: float | None = None
+
+
+class ValuesQuestions(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    compare: list[CompareOffset] = Field(..., description='The earlier windows the same question may be set beside.')
+    folds: list[Fold]
+    grains: list[Grain]
+    split: bool = Field(..., description='Whether the metric declares a dimension to break its value out by.')
 
 
 class BreakdownValueDto(BaseModel):
@@ -1260,6 +1550,13 @@ class ComparisonQuery(BaseModel):
     population: Population
     targets: list[str] = Field(..., description='The people the answer reports a value for.')
     time: TimeRange
+
+
+class ComparisonQuestions(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    populations: list[Population] = Field(..., description="Written as a comparison question's `population` field takes them.")
 
 
 class ComparisonsRequest(BaseModel):
@@ -1360,6 +1657,10 @@ class DistributionsRequest(BaseModel):
     queries: list[DistributionQuery]
 
 
+class FilterValue(RootModel[Scalar | list[Scalar]]):
+    root: Scalar | list[Scalar]
+
+
 class Group1(BaseModel):
     """
     Which slice of the split a row belongs to.
@@ -1368,7 +1669,7 @@ class Group1(BaseModel):
         extra='forbid',
     )
     dimensions: list[GroupDimension]
-    type: Type
+    type: Type10
 
 
 class Group(RootModel[Group1 | Group2]):
@@ -1422,6 +1723,21 @@ class HistogramValueDto(BaseModel):
     bins: list[HistogramBinDto] = Field(..., description="Empty when a listed entity has no events in the period — the entity is\nstill listed, mirroring the period view's every-requested-entity rule.")
     dimensions: list[MetricDimensionDto] | None = None
     entity_id: str | None = None
+
+
+class MetricDefinition(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    cohort_key: str | None = None
+    computation: Computation
+    description: str | None = None
+    direction: Direction
+    entity_type: str
+    format: Format
+    key: str
+    label: str | None = None
+    transform: Transform | None = None
 
 
 class MetricDefinitionView(BaseModel):
@@ -1481,6 +1797,16 @@ class MetricDrilldownResponse(BaseModel):
     next_cursor: str | None = None
     rows: list[MetricDrilldownRow]
     selection: MetricDrilldownSelection
+
+
+class MetricQuestions(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    comparisons: ComparisonQuestions
+    distributions: DistributionQuestions
+    rows: RowsQuestions
+    values: ValuesQuestions
 
 
 class MetricRequest(BaseModel):
@@ -1725,6 +2051,14 @@ class UsageSummaryResponse(BaseModel):
     until: str
 
 
+class ValidateDefinitionsResponse(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    errors: list[ValidationFailure] = Field(..., description='Every offender, not the first one.')
+    valid: bool
+
+
 class ValuesQuery(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
@@ -1743,6 +2077,22 @@ class ValuesRequest(BaseModel):
         extra='forbid',
     )
     queries: list[ValuesQuery]
+
+
+class CatalogMetric(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    cohort_key: str | None = Field(None, description='The grouping a cohort comparison reads; absent when the metric declares\nnone, and then no cohort comparison is offered.')
+    computation: CatalogComputation
+    description: str | None = None
+    dimensions: list[CatalogDimension]
+    direction: Direction
+    entity_type: str = Field(..., description="What the metric's values are keyed by, such as `person`.")
+    format: Format
+    key: str = Field(..., description='The key a question names, such as `git.commits`.')
+    label: str | None = None
+    questions: MetricQuestions
 
 
 class ComparisonResult(BaseModel):
@@ -1836,6 +2186,15 @@ class ExportCustomMetricsResponse(BaseModel):
     metrics: list[CustomMetric]
 
 
+class FilterLeaf(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str
+    op: FilterOp
+    value: FilterValue | None = None
+
+
 class ImportCustomMetricsRequest(BaseModel):
     """
     `POST /v1/metrics/import` body.
@@ -1844,6 +2203,13 @@ class ImportCustomMetricsRequest(BaseModel):
         extra='forbid',
     )
     metrics: list[CustomMetric]
+
+
+class MetricCatalogResponse(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    metrics: list[CatalogMetric] = Field(..., description='Every metric the definitions carry, in key order.')
 
 
 class MetricDefinitionListResponse(BaseModel):
@@ -1949,3 +2315,61 @@ class MetricResultsResponse(BaseModel):
         extra='forbid',
     )
     metrics: list[MetricResultDto]
+
+
+class AllNode(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    all: list[FilterTree]
+
+
+class AnyNode(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    any: list[FilterTree]
+
+
+class MeasureDefinition(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    aggregation: Aggregation
+    dataset: str
+    description: str | None = None
+    dimensions: list[DimensionBinding] | None = None
+    entity: str
+    event_time: str
+    filter: FilterTree | None = None
+    key: str
+    subject_expr: str | None = Field(None, description='What `count_distinct` counts one of.')
+    value_expr: str | None = Field(None, description='The operand for the numeric folds; absent for `count`/`count_distinct`.')
+
+
+class NotNode(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    not_: FilterTree = Field(..., alias='not')
+
+
+class ValidateDefinitionsRequest(BaseModel):
+    """
+    Definitions to judge, in the shape the authored YAML parses into.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    measures: list[MeasureDefinition] | None = None
+    metrics: list[MetricDefinition] | None = None
+
+
+class FilterTree(RootModel[AllNode | AnyNode | NotNode | FilterLeaf]):
+    root: AllNode | AnyNode | NotNode | FilterLeaf
+
+
+AllNode.model_rebuild()
+AnyNode.model_rebuild()
+MeasureDefinition.model_rebuild()
+NotNode.model_rebuild()


### PR DESCRIPTION
**Why.** The query surface answers questions but nothing tells a client which metrics exist, what each can be asked, or whether a definition would be accepted.

**What changed.** `GET /v1/catalog/metrics` — every served metric with its entity grain, admitted grains and folds, dimensions, distributions, comparison populations, and drilldown inputs, all derived from the same answerability predicate that validates requests (one predicate decides advertisement and refusal, so they cannot drift). `POST /v1/definitions/validate` — a pure in-memory dry-run of a definition document: parse, validate against the field catalog, report violations; nothing persists, nothing compiles to SQL.

**Verified.** `cargo test -p analytics --bin analytics`: 1121 passed, 0 failed at this tip; clippy `-D warnings`, fmt, OpenAPI + stand-schema drift clean. Stand suite covers the catalog contract (internal-consistency rules per entry) and the dry-run endpoint.
