### PR TITLE
fix(identity): make a refused correction readable, and cover the surface that shows it

### DIFF
--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -192,6 +192,7 @@
             "$ref": "#/components/schemas/AccountRef"
           },
           "comment": {
+            "maxLength": 500,
             "type": "string"
           }
         },
@@ -369,6 +370,7 @@
             "type": "array"
           },
           "comment": {
+            "maxLength": 500,
             "type": "string"
           }
         },
@@ -617,6 +619,7 @@
       "MergeRequest": {
         "properties": {
           "comment": {
+            "maxLength": 500,
             "type": "string"
           },
           "source_person_id": {

--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -2896,7 +2896,7 @@
         "operationId": "identity_resolution.resolution.search_accounts",
         "parameters": [
           {
-            "description": "Needle matched against every value the account's row shows, case-insensitively: a substring of the current address, handle, id or observed name (whole, or composed from parts). The source is the exception — it matches a whole `_`/`-` separated segment from its start, so `github` and `entra` list those connectors' accounts while `hub` lists none. Absent or blank lists every open account.",
+            "description": "Needle matched against every value the account's row shows, case-insensitively: a substring of the current address, handle, id or observed name (whole, or composed from parts). The source is the exception — it matches a whole `_`/`-` separated segment from its start, so `github` and `entra` list those connectors' accounts while `hub` lists none. At most 200 characters. Absent or blank lists every open account.",
             "in": "query",
             "name": "q",
             "required": false,

--- a/src/backend/services/identity-resolution/src/api/http_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/api/http_live_tests.rs
@@ -2094,3 +2094,145 @@ async fn every_operator_route_refuses_a_caller_the_gateway_did_not_name() -> Tes
     }
     Ok(())
 }
+
+/// The four correction verbs, each with a body its extractor accepts — so a
+/// case below varies ONE thing and the refusal is about that thing.
+fn correction_verbs(f: &Fixture, person: Uuid) -> Vec<(&'static str, Value)> {
+    let account = json!({"account": account_ref(f, "acct-extractor")});
+    vec![
+        (
+            "/v1/resolution/bind",
+            bind_body(f, "acct-extractor", person),
+        ),
+        (
+            "/v1/resolution/merge",
+            json!({
+                "source_person_id": person.to_string(),
+                "target_person_id": Uuid::now_v7().to_string(),
+            }),
+        ),
+        ("/v1/resolution/detach", account.clone()),
+        ("/v1/resolution/exclude", account),
+    ]
+}
+
+#[tokio::test]
+async fn a_correction_body_that_will_not_parse_is_refused_in_the_canonical_shape() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = operator(&f).await?;
+    let person = f.person("extractor@http-live.test").await?;
+    f.bound_at("acct-extractor", person, FIXTURE_REASON, 60)
+        .await?;
+
+    for (uri, _) in correction_verbs(&f, person) {
+        let req = Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/json")
+            .body(Body::from("{not json"))?;
+        let resp = app(&f, caller).oneshot(req).await?;
+        let status = resp.status();
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_owned();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+        let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{uri}: {body}");
+        assert!(
+            content_type.starts_with("application/problem+json"),
+            "{uri} answered {content_type} — the console reads the problem \
+             document to say what went wrong, and gets nothing from a plain \
+             extractor rejection"
+        );
+        assert_eq!(
+            body["context"]["field_violations"][0]["field"], "body",
+            "{uri}: {body}"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_correction_without_a_json_content_type_is_refused_on_the_media_type() -> TestResult {
+    // Held before the extractor swap too — axum's own `Json` refuses on the
+    // media type as well. Kept as the guard that the swap did not trade the
+    // 415 away for a parse attempt, not as a rule this change introduced.
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = operator(&f).await?;
+    let person = f.person("media-type@http-live.test").await?;
+    f.bound_at("acct-extractor", person, FIXTURE_REASON, 60)
+        .await?;
+
+    for (uri, body) in correction_verbs(&f, person) {
+        let req = Request::builder()
+            .method("POST")
+            .uri(uri)
+            .body(Body::from(body.to_string()))?;
+        let resp = app(&f, caller).oneshot(req).await?;
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "{uri} parsed a body that declared no media type"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_comment_past_the_cap_is_refused_before_the_correction_applies() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = operator(&f).await?;
+    let person = f.person("comment-cap@http-live.test").await?;
+    f.bound_at("acct-extractor", person, FIXTURE_REASON, 60)
+        .await?;
+
+    // `journal()` records on failure alone, so an oversize comment that reached
+    // the store would apply the binding and lose the only explanation of why.
+    let oversize = "c".repeat(501);
+    for (uri, mut body) in correction_verbs(&f, person) {
+        body["comment"] = Value::String(oversize.clone());
+        let (status, answer) = post(app(&f, caller), uri, &body).await?;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{uri}: {answer}");
+        assert_eq!(
+            answer["context"]["field_violations"][0]["field"], "comment",
+            "{uri}: {answer}"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn an_account_search_needle_past_the_cap_is_refused() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = operator(&f).await?;
+
+    // `/v1/persons` and `/v1/visible-persons` both bound their needle at 200
+    // characters; this listing handed the raw one to the evidence reader.
+    let needle = "n".repeat(201);
+    let (status, body) = get(
+        app(&f, caller),
+        &format!("/v1/resolution/accounts?q={needle}"),
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(
+        body["context"]["field_violations"][0]["field"], "q",
+        "{body}"
+    );
+    Ok(())
+}

--- a/src/backend/services/identity-resolution/src/api/http_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/api/http_live_tests.rs
@@ -2197,8 +2197,6 @@ async fn a_comment_past_the_cap_is_refused_before_the_correction_applies() -> Te
     f.bound_at("acct-extractor", person, FIXTURE_REASON, 60)
         .await?;
 
-    // `journal()` records on failure alone, so an oversize comment that reached
-    // the store would apply the binding and lose the only explanation of why.
     let oversize = "c".repeat(501);
     for (uri, mut body) in correction_verbs(&f, person) {
         body["comment"] = Value::String(oversize.clone());

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -313,7 +313,8 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
              or observed name (whole, or composed from parts). The source is the \
              exception — it matches a whole `_`/`-` separated segment from its \
              start, so `github` and `entra` list those connectors' accounts \
-             while `hub` lists none. Absent or blank lists every open account.",
+             while `hub` lists none. At most 200 characters. Absent or blank \
+             lists every open account.",
             "string",
         )
         .query_param_typed(

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -18,6 +18,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::AppState;
+use super::canonical_json::CanonicalJson;
 use super::error::CorrectionError;
 use super::gate::require_admin;
 use crate::domain::person_card::{self, PersonCard};
@@ -39,6 +40,12 @@ const MAX_ACCOUNT_OPERATIONS: u64 = 50;
 /// How many accounts one bulk call may carry — a prepared matching table is
 /// pasted by a human, not streamed.
 pub(super) const MAX_BULK_ITEMS: usize = 1_000;
+
+/// The same ceiling `reason` carries on the grant routes. A correction's
+/// comment is the only explanation of the decision that reaches whoever reads
+/// the journal later, and `journal()` records on failure alone — so an
+/// unchecked comment loses the audit row while the binding still applies.
+const MAX_COMMENT_LEN: usize = 500;
 
 /// A source-native account, as named by the caller.
 ///
@@ -135,11 +142,12 @@ impl toolkit::api::api_dto::ResponseApiDto for CorrectionResponse {}
 pub async fn bind(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
-    Json(req): Json<BindRequest>,
+    CanonicalJson(req): CanonicalJson<BindRequest>,
 ) -> Result<impl IntoResponse, CanonicalError> {
     let operator = require_admin(&state.db, &ctx).await?;
     let tenant = ctx.subject_tenant_id();
 
+    reject_long_comment(&req.comment)?;
     reject_empty(req.bindings.is_empty(), "bindings")?;
     reject_oversized(req.bindings.len())?;
 
@@ -190,11 +198,12 @@ pub async fn bind(
 pub async fn merge(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
-    Json(req): Json<MergeRequest>,
+    CanonicalJson(req): CanonicalJson<MergeRequest>,
 ) -> Result<impl IntoResponse, CanonicalError> {
     let operator = require_admin(&state.db, &ctx).await?;
     let tenant = ctx.subject_tenant_id();
 
+    reject_long_comment(&req.comment)?;
     if req.source_person_id == req.target_person_id {
         return Err(invalid(
             "target_person_id",
@@ -238,11 +247,12 @@ pub async fn merge(
 pub async fn detach(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
-    Json(req): Json<AccountRequest>,
+    CanonicalJson(req): CanonicalJson<AccountRequest>,
 ) -> Result<impl IntoResponse, CanonicalError> {
     let operator = require_admin(&state.db, &ctx).await?;
     let tenant = ctx.subject_tenant_id();
 
+    reject_long_comment(&req.comment)?;
     let account = SourceAccountKey::from(&req.account);
     require_known_account(&state, tenant, &account).await?;
 
@@ -280,11 +290,12 @@ pub async fn detach(
 pub async fn exclude(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
-    Json(req): Json<AccountRequest>,
+    CanonicalJson(req): CanonicalJson<AccountRequest>,
 ) -> Result<impl IntoResponse, CanonicalError> {
     let operator = require_admin(&state.db, &ctx).await?;
     let tenant = ctx.subject_tenant_id();
 
+    reject_long_comment(&req.comment)?;
     let account = SourceAccountKey::from(&req.account);
     require_known_account(&state, tenant, &account).await?;
 
@@ -622,6 +633,16 @@ fn reject_excluded_person(person_id: Uuid, field: &str) -> Result<(), CanonicalE
         return Err(invalid(
             field,
             "the reserved excluded person cannot take part in a correction; use the exclude verb",
+        ));
+    }
+    Ok(())
+}
+
+fn reject_long_comment(comment: &str) -> Result<(), CanonicalError> {
+    if comment.chars().count() > MAX_COMMENT_LEN {
+        return Err(invalid(
+            "comment",
+            &format!("at most {MAX_COMMENT_LEN} characters are accepted"),
         ));
     }
     Ok(())
@@ -988,6 +1009,15 @@ pub async fn search_accounts(
     let tenant = ctx.subject_tenant_id();
 
     let needle = params.q.unwrap_or_default().trim().to_owned();
+    if needle.chars().count() > super::listing::MAX_QUERY_CHARS {
+        return Err(invalid(
+            "q",
+            &format!(
+                "at most {} characters are accepted",
+                super::listing::MAX_QUERY_CHARS
+            ),
+        ));
+    }
     let limit = super::listing::clamp_limit(
         params.limit,
         DEFAULT_ACCOUNT_SEARCH_LIMIT,

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -86,6 +86,7 @@ pub struct BindRequest {
     /// One or more bindings; a prepared matching table is submitted as one call.
     pub bindings: Vec<BindItem>,
     #[serde(default)]
+    #[schema(max_length = 500)]
     pub comment: String,
 }
 impl toolkit::api::api_dto::RequestApiDto for BindRequest {}
@@ -97,6 +98,7 @@ pub struct MergeRequest {
     /// The surviving person, named explicitly by the operator.
     pub target_person_id: Uuid,
     #[serde(default)]
+    #[schema(max_length = 500)]
     pub comment: String,
 }
 impl toolkit::api::api_dto::RequestApiDto for MergeRequest {}
@@ -105,6 +107,7 @@ impl toolkit::api::api_dto::RequestApiDto for MergeRequest {}
 pub struct AccountRequest {
     pub account: AccountRef,
     #[serde(default)]
+    #[schema(max_length = 500)]
     pub comment: String,
 }
 impl toolkit::api::api_dto::RequestApiDto for AccountRequest {}

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -21,6 +21,7 @@ use super::AppState;
 use super::canonical_json::CanonicalJson;
 use super::error::CorrectionError;
 use super::gate::require_admin;
+use super::listing;
 use crate::domain::person_card::{self, PersonCard};
 use crate::domain::resolution::{self, EXCLUDED_PERSON, Target, Verb};
 use crate::domain::review_queue::{self, EvidenceAccount, ItemKind, Review};
@@ -41,10 +42,9 @@ const MAX_ACCOUNT_OPERATIONS: u64 = 50;
 /// pasted by a human, not streamed.
 pub(super) const MAX_BULK_ITEMS: usize = 1_000;
 
-/// The same ceiling `reason` carries on the grant routes. A correction's
-/// comment is the only explanation of the decision that reaches whoever reads
-/// the journal later, and `journal()` records on failure alone — so an
-/// unchecked comment loses the audit row while the binding still applies.
+/// The ceiling `reason` carries on the grant routes, applied to the other
+/// free-text field an operator writes. Not a column limit: `request_json` is
+/// JSON, and the journal takes whatever it is given.
 const MAX_COMMENT_LEN: usize = 500;
 
 /// A source-native account, as named by the caller.
@@ -638,6 +638,21 @@ fn reject_excluded_person(person_id: Uuid, field: &str) -> Result<(), CanonicalE
     Ok(())
 }
 
+/// The needle is bound in length only, not in term count: unlike the person
+/// listings this one never splits `q`, so there is no fan-out to cap.
+fn reject_long_query(needle: &str) -> Result<(), CanonicalError> {
+    if needle.chars().count() > listing::MAX_QUERY_CHARS {
+        return Err(invalid(
+            "q",
+            &format!(
+                "at most {} characters are accepted",
+                listing::MAX_QUERY_CHARS
+            ),
+        ));
+    }
+    Ok(())
+}
+
 fn reject_long_comment(comment: &str) -> Result<(), CanonicalError> {
     if comment.chars().count() > MAX_COMMENT_LEN {
         return Err(invalid(
@@ -1009,15 +1024,7 @@ pub async fn search_accounts(
     let tenant = ctx.subject_tenant_id();
 
     let needle = params.q.unwrap_or_default().trim().to_owned();
-    if needle.chars().count() > super::listing::MAX_QUERY_CHARS {
-        return Err(invalid(
-            "q",
-            &format!(
-                "at most {} characters are accepted",
-                super::listing::MAX_QUERY_CHARS
-            ),
-        ));
-    }
+    reject_long_query(&needle)?;
     let limit = super::listing::clamp_limit(
         params.limit,
         DEFAULT_ACCOUNT_SEARCH_LIMIT,

--- a/src/ingestion/tests/e2e/identity/test_github_directory_member_id_binding.py
+++ b/src/ingestion/tests/e2e/identity/test_github_directory_member_id_binding.py
@@ -161,6 +161,23 @@ def _run_connector_dbt_path(
     tracked_models.run(["identity_inputs"], worker_ctx=worker_ctx)
 
 
+def _person_id_by_email(identity_svc, email: str) -> str | None:
+    """The person an address names, the second way in.
+
+    Used to say WHICH person a member id must resolve to: the id and the
+    roster address are two independent handles on one member, so agreeing on
+    a person is a claim `is not None` cannot make.
+    """
+    with identity_svc.client(
+        sub=str(seed.SEED_ADMIN), tenant=str(seed.SEED_TENANT), sub_type="service", roles="service"
+    ) as svc:
+        r = svc.get("/internal/persons/by-email-override", params={"email": email})
+    if r.status_code == 404:
+        return None
+    assert r.status_code == 200, f"status={r.status_code} body={r.text}"
+    return r.json()["insight_source_id"]
+
+
 def _resolve_by_external_id(identity_svc, external_id: str) -> str | None:
     """Resolve exactly as the authenticator's login-bootstrap does."""
     with identity_svc.client(
@@ -236,9 +253,21 @@ def test_github_member_id_resolves_a_person_through_the_real_connector_pipeline(
     res = identity_svc.run_seed_cli(tenant=str(seed.SEED_TENANT), force=True)
     assert res.returncode == 0, f"rc={res.returncode}\n{res.stdout}\n{res.stderr}"
 
-    assert _resolve_by_external_id(identity_svc, str(member_id)) is not None, (
+    resolved = _resolve_by_external_id(identity_svc, str(member_id))
+    assert resolved is not None, (
         "persons carries no row the login-bootstrap lookup can find for "
         f"(source_type=github, external_id={member_id})"
+    )
+
+    # WHICH person, not merely some person. The member id and the roster
+    # address are two independent handles on the same member, so a sign-in
+    # landing on a real-but-wrong person — the failure this criterion exists
+    # to rule out — satisfies `is not None` and fails this.
+    by_address = _person_id_by_email(identity_svc, f"pipeline.dev.{run_tag}@e2e.test")
+    assert by_address is not None, "the roster address names no person"
+    assert resolved == by_address, (
+        f"the member id resolves to {resolved}, the roster address to {by_address} — "
+        "a sign-in through this connector lands on someone other than the member"
     )
 
 

--- a/src/ingestion/tools/seed/tests/test_preflight.py
+++ b/src/ingestion/tools/seed/tests/test_preflight.py
@@ -659,9 +659,12 @@ class WriterNamespaceParityTests(unittest.TestCase):
     not an error."""
 
     def test_every_scratch_constant_matches_the_stand_suite_s_own(self) -> None:
-        scratch = _find_upwards("tests", "stand", "api", "scratch.py")
+        # The literals live in the shared package, not in the API suite's
+        # `scratch.py`, which imports them: both stand suites file corrections
+        # under one pair, so there is one place to read.
+        scratch = _find_upwards("tests", "lib", "insight_stand", "scratch_identity.py")
         if scratch is None:
-            self.skipTest("tests/stand/api/scratch.py is not in this tree")
+            self.skipTest("tests/lib/insight_stand/scratch_identity.py is not in this tree")
 
         for mine, theirs in (
             (config.STAND_SCRATCH_PREFIX, "SCRATCH_PREFIX"),

--- a/tests/lib/insight_stand/__init__.py
+++ b/tests/lib/insight_stand/__init__.py
@@ -71,6 +71,14 @@ from .personas import (
     resolve_by_realm_role,
     verify_realm_roles,
 )
+from .scratch_identity import (
+    RUN_TAG,
+    SCRATCH_PREFIX,
+    SCRATCH_SOURCE_ID,
+    SCRATCH_SOURCE_TYPE,
+    issued_names,
+    scratch_name,
+)
 from .service_token import (
     ASSERTION_TYPE,
     IDENTITY_URL_ENV,
@@ -122,6 +130,10 @@ __all__: Sequence[str] = (
     "PASSWORD_ENV",
     "REALM_EXPORT_PATH",
     "ROLE_TO_REALM_ROLES",
+    "RUN_TAG",
+    "SCRATCH_PREFIX",
+    "SCRATCH_SOURCE_ID",
+    "SCRATCH_SOURCE_TYPE",
     "SERVICE_NAME",
     "SESSION_COOKIE_NAME",
     "SUPPORTED_MANIFEST_VERSION",
@@ -156,6 +168,7 @@ __all__: Sequence[str] = (
     "expected_realm_roles",
     "governs_vector",
     "identity_path",
+    "issued_names",
     "load_manifest",
     "open_service_session",
     "open_session",
@@ -164,6 +177,7 @@ __all__: Sequence[str] = (
     "resolve_base_url",
     "resolve_by_realm_role",
     "resolve_endpoint",
+    "scratch_name",
     "verify_realm_roles",
     "wait_for",
     "wait_until",

--- a/tests/lib/insight_stand/scratch_identity.py
+++ b/tests/lib/insight_stand/scratch_identity.py
@@ -1,0 +1,61 @@
+"""How a stand recognises rows a test run created, rather than the seed.
+
+A stand persists between runs and is reset by volume teardown, never by
+TRUNCATE — so anything a test writes and cannot delete has to be identifiable
+on sight instead. Two things make it so: a name carrying a fixed prefix and
+this run's own token, and a fixed connector instance every correction is filed
+under.
+
+That matters most for the correction journal, which is append-only: a decision
+written under a SEEDED connector is indistinguishable from real identity data,
+and the seed preflight refuses to seed a stand that carries any — so the next
+`up` fails until the volumes are torn down. Filing under the pair below is
+what keeps a correction exempt.
+
+Lives here, in the package both suites import, because it describes the STAND
+rather than either suite: `tests/stand/api/scratch.py` re-exports it with the
+sweep that only the API suite can run, and the UI journeys take it directly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Final
+
+#: Marks every row the suites create, so a leak is identifiable on sight.
+#: INVARIANT: must match insight_seed.config.STAND_SCRATCH_PREFIX — the seed
+#: preflight uses it to recognise leftover journal rows.
+SCRATCH_PREFIX: Final[str] = "stand-scratch"
+
+#: The connector instance every correction a test writes is filed under — the
+#: other half of what makes an undeletable journal row recognisable. Fixed, not
+#: random: a stable pair keeps those rows attributable.
+#: INVARIANT: must match insight_seed.config.STAND_SCRATCH_SOURCE_TYPE, and the
+#: literal `github` segment in `operations.py`'s account-read template — the
+#: coverage gate folds a recorded path onto a template by exact segment
+#: equality, so a divergence here makes that operation read as never exercised.
+SCRATCH_SOURCE_TYPE: Final[str] = "github"
+
+#: INVARIANT: must match insight_seed.config.STAND_SCRATCH_SOURCE_ID. Unlike the
+#: type, this segment is a `{source_id}` in the coverage template, so it folds
+#: whatever its value.
+SCRATCH_SOURCE_ID: Final[str] = "01900000-0000-7000-8000-00000000feed"
+
+#: One token per session: a leak becomes attributable to the run that made it.
+RUN_TAG: Final[str] = uuid.uuid4().hex[:8]
+
+#: Every name this session issued. The API suite's sweep reads it; formatting a
+#: name by hand would satisfy the prefix rule and silently blind that sweep,
+#: which is why `scratch_name` is the only way to make one.
+_ISSUED: set[str] = set()
+
+
+def scratch_name(tag: str) -> str:
+    """A unique, greppable, attributable name — and register it for the sweep."""
+    name = f"{SCRATCH_PREFIX}-{RUN_TAG}-{tag}-{uuid.uuid4().hex[:8]}"
+    _ISSUED.add(name)
+    return name
+
+
+def issued_names() -> frozenset[str]:
+    return frozenset(_ISSUED)

--- a/tests/stand/api/identity/test_request_contracts.py
+++ b/tests/stand/api/identity/test_request_contracts.py
@@ -48,6 +48,16 @@ MALFORMED_QUERY_ADMIN_ROUTES: tuple[str, ...] = (
     "/v1/persons-sync?limit=abc",
     "/v1/person-roles?person=not-a-uuid",
     "/v1/visibility?active=maybe",
+    # The reads an operator's console works from, which take the same `limit`
+    # and were outside this table: a silently dropped page size on the review
+    # queue is a shorter list read as a shorter backlog. `/v1/visible-persons`
+    # is `.authenticated()` rather than admin-gated, and belongs here anyway —
+    # the extractor refuses before any gate runs, which is the property under
+    # test.
+    "/v1/resolution/attention?limit=abc",
+    "/v1/resolution/accounts?limit=abc",
+    "/v1/persons?limit=abc",
+    "/v1/visible-persons?limit=abc",
 )
 
 #: `/v1/subchart` is `.authenticated()`, not admin-gated.

--- a/tests/stand/api/identity/test_resolution.py
+++ b/tests/stand/api/identity/test_resolution.py
@@ -46,6 +46,17 @@ from ..schemas import (
 )
 from ..scratch import SCRATCH_SOURCE_ID, SCRATCH_SOURCE_TYPE
 
+#: The correction verbs, each with a body its extractor accepts, so a case
+#: that varies one thing draws a refusal about that thing. The ids name
+#: nobody — a refusal at the extractor or a validator must not depend on the
+#: referenced rows existing.
+CORRECTION_VERBS: tuple[tuple[str, str], ...] = (
+    ("bind", "bindings"),
+    ("merge", "source_person_id"),
+    ("detach", "account"),
+    ("exclude", "account"),
+)
+
 ATTENTION = identity_path("/v1/resolution/attention")
 ACCOUNT_SEARCH = identity_path("/v1/resolution/accounts")
 
@@ -561,3 +572,69 @@ def test_a_cursor_issued_for_another_needle_is_refused(
         ACCOUNT_SEARCH, params={"limit": 1, "q": "nobody-by-this-name", "cursor": cursor}
     )
     _refused(resumed, 400, field="cursor")
+
+
+def _verb_body(verb: str, person_id: str) -> dict[str, object]:
+    if verb == "bind":
+        return {"bindings": [{"account": _account("never-observed-account"), "person_id": person_id}]}
+    if verb == "merge":
+        return {"source_person_id": person_id, "target_person_id": UNKNOWN_PERSON}
+    return {"account": _account("never-observed-account")}
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.reliability
+@pytest.mark.parametrize("verb", [v for v, _ in CORRECTION_VERBS])
+def test_a_correction_body_that_will_not_parse_is_refused_in_the_canonical_shape(
+    admin_operator_session: PersonaSession, verb: str
+) -> None:
+    """#2486 scenario 3. A mistyped correction is answered in the shape the
+    console can read.
+
+    These four verbs took axum's own `Json`, while every other write route on
+    the service takes the canonical extractor — so a body that would not parse
+    answered below the canonical error layer, as `text/plain` with no problem
+    document at all. The console extracts its message from that document, so
+    an operator saw the generic failure text and no reason.
+    """
+    response = admin_operator_session.client.post(
+        identity_path(f"/v1/resolution/{verb}"),
+        content=b"{not json",
+        headers={"Content-Type": "application/json"},
+    )
+    _refused(response, 400, field="body")
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.reliability
+@pytest.mark.parametrize("verb", [v for v, _ in CORRECTION_VERBS])
+def test_a_comment_past_the_cap_is_refused_before_the_correction_applies(
+    admin_operator_session: PersonaSession, stand_manifest: Manifest, verb: str
+) -> None:
+    """#2486 scenario 3. The audit field is bounded, like `reason` on the
+    grant routes.
+
+    A correction's comment is the only explanation of the decision that
+    reaches whoever reads the journal later, and the journal records on
+    failure alone — so an unchecked comment loses the audit row while the
+    binding still applies. Refused before any lookup, so no write happens.
+    """
+    body = _verb_body(verb, stand_manifest.fixture("dev_lead").uuid)
+    body["comment"] = "c" * 501
+
+    response = admin_operator_session.client.post(
+        identity_path(f"/v1/resolution/{verb}"), json_body=body
+    )
+    _refused(response, 400, field="comment")
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.reliability
+def test_an_account_search_needle_past_the_cap_is_refused(
+    admin_operator_session: PersonaSession,
+) -> None:
+    """#2486 scenario 3. `/v1/persons` and `/v1/visible-persons` both bound
+    their needle at 200 characters; this listing handed the raw one to the
+    evidence reader."""
+    response = admin_operator_session.client.get(ACCOUNT_SEARCH, params={"q": "n" * 201})
+    _refused(response, 400, field="q")

--- a/tests/stand/api/identity/test_resolution.py
+++ b/tests/stand/api/identity/test_resolution.py
@@ -72,26 +72,40 @@ def _account_path(account_id: str) -> str:
     )
 
 
-def _refused(response: ApiResponse, code: int, field: str | None = None) -> None:
+def _refused(
+    response: ApiResponse,
+    code: int,
+    field: str | None = None,
+    resource: str | None = None,
+) -> None:
     """A correction refusal is only actionable if the operator can read it.
 
-    Every handler refusal on this surface is built by `invalid()`, which
-    stamps `field_violations` into the problem document — that is what the
-    console turns into "which box you got wrong". Asserting the status alone
-    would keep passing if the body degraded to an unreadable rejection, and
-    the operator would see the generic failure text with every test green.
+    A validation refusal is built by `invalid()`, which stamps
+    `field_violations` into the problem document — what the console turns into
+    "which box you got wrong". A 404 instead names the thing that was not
+    found in `resource_name`, and that field is what separates two refusals
+    that read alike: both merge sides answer "person not found", so a merge
+    checking only its source would pass the target case on the source's
+    refusal. Asserting the status alone would keep passing through either
+    degradation, with the operator left on generic failure text.
     """
     assert response.status_code == code, f"{response.status_code} {response.text[:300]}"
 
     problem = response.parse(ProblemDocument)
     assert problem.status == code, problem
-    if field is None:
-        return
+    if field is not None:
+        violations = problem.context.get("field_violations")
+        assert violations, f"no field_violations to act on: {problem.context}"
+        named = [entry.get("field") for entry in violations]
+        assert field in named, (
+            f"refusal names {named}, not the field the caller got wrong ({field})"
+        )
 
-    violations = problem.context.get("field_violations")
-    assert violations, f"no field_violations to act on: {problem.context}"
-    named = [entry.get("field") for entry in violations]
-    assert field in named, f"refusal names {named}, not the field the caller got wrong ({field})"
+    if resource is not None:
+        assert problem.context.get("resource_name") == resource, (
+            f"the refusal names {problem.context.get('resource_name')!r} rather than the "
+            f"thing that was not found ({resource!r})"
+        )
 
 
 @pytest.mark.security
@@ -485,7 +499,11 @@ def test_the_verbs_that_need_an_account_refuse_one_nobody_ever_saw(
         identity_path(f"/v1/resolution/{verb}"),
         json_body={"account": _account("never-observed-account")},
     )
-    _refused(response, 404)
+    _refused(
+        response,
+        404,
+        resource=f"{SCRATCH_SOURCE_TYPE}:{SCRATCH_SOURCE_ID}:never-observed-account",
+    )
 
 
 @pytest.mark.requires_seed("admin_operator", "dev_lead")
@@ -513,7 +531,10 @@ def test_merge_refuses_a_person_the_tenant_never_had(
     response = admin_operator_session.client.post(
         identity_path("/v1/resolution/merge"), json_body=body
     )
-    _refused(response, 404)
+    # Naming the id is what makes the two cases distinct. Both sides answer
+    # "person not found", so a merge that checked only its source would pass
+    # the target case on the source's own refusal.
+    _refused(response, 404, resource=UNKNOWN_PERSON)
 
 
 @pytest.mark.requires_seed("admin_operator")

--- a/tests/stand/api/identity/test_resolution.py
+++ b/tests/stand/api/identity/test_resolution.py
@@ -36,7 +36,14 @@ from __future__ import annotations
 import json
 
 import pytest
-from insight_stand import ApiClient, ApiResponse, Manifest, PersonaSession, identity_path
+from insight_stand import (
+    ApiClient,
+    ApiResponse,
+    JsonValue,
+    Manifest,
+    PersonaSession,
+    identity_path,
+)
 
 from .. import scratch
 from ..schemas import (
@@ -75,7 +82,7 @@ EXCLUDED_PERSON = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 UNKNOWN_PERSON = "00000000-0000-0000-0000-000000000000"
 
 
-def _account(account_id: str) -> dict[str, str]:
+def _account(account_id: str) -> dict[str, JsonValue]:
     """One account under the suite's own connector instance — the only place a
     correction this module writes may land (`scratch.py` rule 5)."""
     return {"source": SCRATCH_SOURCE_TYPE, "source_id": SCRATCH_SOURCE_ID, "id": account_id}
@@ -496,7 +503,10 @@ def test_the_excluded_sentinel_is_not_a_merge_side(
     at once (as source), or mass-excludes a person's accounts while the
     journal records a merge (as target). Refused as validation, no write."""
     lead = stand_manifest.fixture("dev_lead")
-    body = {"source_person_id": lead.uuid, "target_person_id": lead.uuid}
+    body: dict[str, JsonValue] = {
+        "source_person_id": lead.uuid,
+        "target_person_id": lead.uuid,
+    }
     body[side] = EXCLUDED_PERSON
     response = admin_operator_session.client.post(
         identity_path("/v1/resolution/merge"), json_body=body
@@ -550,7 +560,10 @@ def test_merge_refuses_a_person_the_tenant_never_had(
     reads the same before and after.
     """
     lead = stand_manifest.fixture("dev_lead")
-    body = {"source_person_id": lead.uuid, "target_person_id": lead.uuid}
+    body: dict[str, JsonValue] = {
+        "source_person_id": lead.uuid,
+        "target_person_id": lead.uuid,
+    }
     body[unknown_side] = UNKNOWN_PERSON
 
     response = admin_operator_session.client.post(
@@ -588,7 +601,7 @@ def test_a_cursor_issued_for_another_needle_is_refused(
     _refused(resumed, 400, field="cursor")
 
 
-def _verb_body(verb: str, person_id: str) -> dict[str, object]:
+def _verb_body(verb: str, person_id: str) -> dict[str, JsonValue]:
     if verb == "bind":
         return {"bindings": [{"account": _account("never-observed-account"), "person_id": person_id}]}
     if verb == "merge":
@@ -613,7 +626,7 @@ def test_a_correction_body_that_will_not_parse_is_refused_in_the_canonical_shape
     """
     response = admin_operator_session.client.post(
         identity_path(f"/v1/resolution/{verb}"),
-        content=b"{not json",
+        content="{not json",
         headers={"Content-Type": "application/json"},
     )
     _refused(response, 400, field="body")
@@ -670,7 +683,7 @@ def test_a_correction_without_a_json_content_type_is_refused_on_the_media_type(
     body = _verb_body(verb, stand_manifest.fixture("dev_lead").uuid)
     response = admin_operator_session.client.post(
         identity_path(f"/v1/resolution/{verb}"),
-        content=json.dumps(body).encode(),
+        content=json.dumps(body),
         headers={"Content-Type": "text/plain"},
     )
     assert response.status_code == 415, f"{response.status_code} {response.text[:300]}"

--- a/tests/stand/api/identity/test_resolution.py
+++ b/tests/stand/api/identity/test_resolution.py
@@ -1,13 +1,13 @@
 """The operator correction surface — the manual-resolution routes on the deployed path.
 
     GET  /v1/resolution/attention                         200 rates arithmetic · 403 realm admin
-    GET  /v1/resolution/accounts                          200 search + holder + by source · 403 realm admin
+    GET  /v1/resolution/accounts                          200 search + holder + by source · 400 stale cursor · 403 realm admin
     GET  /v1/resolution/accounts/{source}/{sid}/{aid}     200 binding + history (round trip)
     GET  /v1/resolution/persons/{id}/accounts             200 for a seeded person
     POST /v1/resolution/bind                              200 applied → already_decided (round trip) · 400 excluded sentinel
-    POST /v1/resolution/merge                             400 source == target · excluded sentinel (validation, no write)
+    POST /v1/resolution/merge                             400 source == target · excluded sentinel · 404 unknown person, either side (validation, no write)
     POST /v1/resolution/detach                            404 unseen account (no write)
-    POST /v1/resolution/exclude                           200 applied (the round trip's cleanup)
+    POST /v1/resolution/exclude                           200 applied (the round trip's cleanup) · 404 unseen account
 
 The verbs append to an append-only journal, so the scratch policy cannot be
 "create and delete". The round trip instead ends in `exclude`, whose end state
@@ -21,13 +21,19 @@ Merge and detach are exercised through pure-validation refusals: proving the
 route answers with a session without moving a single seeded binding — the
 stand must read the same before and after this module.
 
+Every refusal here is asserted through `_refused`, which reads the problem
+document rather than the status line alone: the console renders
+`field_violations` as "which box you got wrong", so a refusal that degraded
+to an unreadable body would leave the operator staring at generic failure
+text with the status assertion still green.
+
 The 401 half is in `test_gateway.py`, swept over every operation.
 """
 
 from __future__ import annotations
 
 import pytest
-from insight_stand import ApiClient, Manifest, PersonaSession, identity_path
+from insight_stand import ApiClient, ApiResponse, Manifest, PersonaSession, identity_path
 
 from .. import scratch
 from ..schemas import (
@@ -36,6 +42,7 @@ from ..schemas import (
     AttentionResponse,
     CorrectionResponse,
     PersonAccountsResponse,
+    ProblemDocument,
 )
 from ..scratch import SCRATCH_SOURCE_ID, SCRATCH_SOURCE_TYPE
 
@@ -48,6 +55,10 @@ ACCOUNT_SEARCH = identity_path("/v1/resolution/accounts")
 #: guard.
 EXCLUDED_PERSON = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 
+#: Well-formed, right type, names nobody — so the refusal it draws is the
+#: existence check rather than the uuid parser.
+UNKNOWN_PERSON = "00000000-0000-0000-0000-000000000000"
+
 
 def _account(account_id: str) -> dict[str, str]:
     """One account under the suite's own connector instance — the only place a
@@ -59,6 +70,28 @@ def _account_path(account_id: str) -> str:
     return identity_path(
         f"/v1/resolution/accounts/{SCRATCH_SOURCE_TYPE}/{SCRATCH_SOURCE_ID}/{account_id}"
     )
+
+
+def _refused(response: ApiResponse, code: int, field: str | None = None) -> None:
+    """A correction refusal is only actionable if the operator can read it.
+
+    Every handler refusal on this surface is built by `invalid()`, which
+    stamps `field_violations` into the problem document — that is what the
+    console turns into "which box you got wrong". Asserting the status alone
+    would keep passing if the body degraded to an unreadable rejection, and
+    the operator would see the generic failure text with every test green.
+    """
+    assert response.status_code == code, f"{response.status_code} {response.text[:300]}"
+
+    problem = response.parse(ProblemDocument)
+    assert problem.status == code, problem
+    if field is None:
+        return
+
+    violations = problem.context.get("field_violations")
+    assert violations, f"no field_violations to act on: {problem.context}"
+    named = [entry.get("field") for entry in violations]
+    assert field in named, f"refusal names {named}, not the field the caller got wrong ({field})"
 
 
 @pytest.mark.security
@@ -389,7 +422,7 @@ def test_merge_refuses_a_person_merged_into_themselves(
         identity_path("/v1/resolution/merge"),
         json_body={"source_person_id": lead.uuid, "target_person_id": lead.uuid},
     )
-    assert response.status_code == 400, f"{response.status_code} {response.text[:300]}"
+    _refused(response, 400, field="target_person_id")
 
 
 @pytest.mark.requires_seed("admin_operator")
@@ -411,7 +444,7 @@ def test_the_excluded_sentinel_is_not_a_bind_target(
             ]
         },
     )
-    assert response.status_code == 400, f"{response.status_code} {response.text[:300]}"
+    _refused(response, 400, field="person_id")
 
 
 @pytest.mark.requires_seed("admin_operator", "dev_lead")
@@ -429,18 +462,81 @@ def test_the_excluded_sentinel_is_not_a_merge_side(
     response = admin_operator_session.client.post(
         identity_path("/v1/resolution/merge"), json_body=body
     )
-    assert response.status_code == 400, f"{response.status_code} {response.text[:300]}"
+    _refused(response, 400, field=side)
 
 
 @pytest.mark.requires_seed("admin_operator")
 @pytest.mark.reliability
-def test_detach_refuses_an_account_nobody_ever_saw(
-    admin_operator_session: PersonaSession,
+@pytest.mark.parametrize("verb", ["detach", "exclude"])
+def test_the_verbs_that_need_an_account_refuse_one_nobody_ever_saw(
+    admin_operator_session: PersonaSession, verb: str
 ) -> None:
-    """Binding an unseen account is allowed (pre-registration); detaching one
-    is not — there is nothing to detach. 404, and no write happens."""
+    """#2486 scenario 3. Binding an unseen account is allowed — that is
+    pre-registration, the one deliberate asymmetry of the grammar. Detaching
+    or excluding one is a typo: there is nothing to detach, and an excluded
+    binding for an account no connector ever reported is a decision about
+    nobody.
+
+    Both verbs share `require_known_account`, so the pair is what proves the
+    guard rather than one caller of it: a refactor that moves the check into
+    `detach` alone would leave `exclude` minting journal rows for typos.
+    """
     response = admin_operator_session.client.post(
-        identity_path("/v1/resolution/detach"),
+        identity_path(f"/v1/resolution/{verb}"),
         json_body={"account": _account("never-observed-account")},
     )
-    assert response.status_code == 404, f"{response.status_code} {response.text[:300]}"
+    _refused(response, 404)
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.reliability
+@pytest.mark.parametrize("unknown_side", ["source_person_id", "target_person_id"])
+def test_merge_refuses_a_person_the_tenant_never_had(
+    admin_operator_session: PersonaSession, stand_manifest: Manifest, unknown_side: str
+) -> None:
+    """#2486 scenario 3. A merge may not invent either of its two people.
+
+    `bind` proves `require_known_person` for its own single target; merge
+    calls the same guard twice, and the two calls are not one test. The
+    target side is the one that would go unnoticed: an unknown SOURCE merges
+    an empty set of accounts and looks like a harmless no-op, while an
+    unknown TARGET would rebind every account of a real person onto an id
+    nobody holds — accounts alive in the journal and attached to no one.
+
+    Pure validation: the guard runs before any account is read, so the stand
+    reads the same before and after.
+    """
+    lead = stand_manifest.fixture("dev_lead")
+    body = {"source_person_id": lead.uuid, "target_person_id": lead.uuid}
+    body[unknown_side] = UNKNOWN_PERSON
+
+    response = admin_operator_session.client.post(
+        identity_path("/v1/resolution/merge"), json_body=body
+    )
+    _refused(response, 404)
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.reliability
+def test_a_cursor_issued_for_another_needle_is_refused(
+    admin_operator_session: PersonaSession,
+) -> None:
+    """#2486 scenario 3. The account listing's cursor is bound to the search
+    that issued it — the response schema says so in its own description
+    ("Only valid for the query that issued it — narrowing `q` starts over").
+
+    Resuming a narrowed search where a wider one left off would skip every
+    account before that position, silently, and only for the operator who
+    typed one more letter into the box. `/v1/persons` refuses it; this is the
+    same rule on the surface where the accounts an operator is deciding about
+    actually live.
+    """
+    first = admin_operator_session.client.get(ACCOUNT_SEARCH, params={"limit": 1})
+    assert first.status_code == 200, f"{first.status_code} {first.text[:300]}"
+    cursor = first.parse(AccountSearchResponse).next_cursor
+    assert cursor, "a one-row page of the observed accounts must offer a next page"
+
+    resumed = admin_operator_session.client.get(
+        ACCOUNT_SEARCH, params={"limit": 1, "q": "nobody-by-this-name", "cursor": cursor}
+    )
+    _refused(resumed, 400, field="cursor")

--- a/tests/stand/api/identity/test_resolution.py
+++ b/tests/stand/api/identity/test_resolution.py
@@ -1,13 +1,14 @@
 """The operator correction surface — the manual-resolution routes on the deployed path.
 
     GET  /v1/resolution/attention                         200 rates arithmetic · 403 realm admin
-    GET  /v1/resolution/accounts                          200 search + holder + by source · 400 stale cursor · 403 realm admin
+    GET  /v1/resolution/accounts                          200 search + holder + by source · 400 stale cursor · 400 needle over cap · 403 realm admin
     GET  /v1/resolution/accounts/{source}/{sid}/{aid}     200 binding + history (round trip)
     GET  /v1/resolution/persons/{id}/accounts             200 for a seeded person
-    POST /v1/resolution/bind                              200 applied → already_decided (round trip) · 400 excluded sentinel
+    POST /v1/resolution/bind                              200 applied → already_decided (round trip) · 400 excluded sentinel · 400 empty / over cap / named twice
     POST /v1/resolution/merge                             400 source == target · excluded sentinel · 404 unknown person, either side (validation, no write)
     POST /v1/resolution/detach                            404 unseen account (no write)
     POST /v1/resolution/exclude                           200 applied (the round trip's cleanup) · 404 unseen account
+    POST /v1/resolution/{bind,merge,detach,exclude}       400 unparseable body · 400 comment over cap · 415 wrong media type
 
 The verbs append to an append-only journal, so the scratch policy cannot be
 "create and delete". The round trip instead ends in `exclude`, whose end state
@@ -31,6 +32,8 @@ The 401 half is in `test_gateway.py`, swept over every operation.
 """
 
 from __future__ import annotations
+
+import json
 
 import pytest
 from insight_stand import ApiClient, ApiResponse, Manifest, PersonaSession, identity_path
@@ -582,7 +585,7 @@ def _verb_body(verb: str, person_id: str) -> dict[str, object]:
     return {"account": _account("never-observed-account")}
 
 
-@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.requires_seed("admin_operator")
 @pytest.mark.reliability
 @pytest.mark.parametrize("verb", [v for v, _ in CORRECTION_VERBS])
 def test_a_correction_body_that_will_not_parse_is_refused_in_the_canonical_shape(
@@ -611,13 +614,12 @@ def test_a_correction_body_that_will_not_parse_is_refused_in_the_canonical_shape
 def test_a_comment_past_the_cap_is_refused_before_the_correction_applies(
     admin_operator_session: PersonaSession, stand_manifest: Manifest, verb: str
 ) -> None:
-    """#2486 scenario 3. The audit field is bounded, like `reason` on the
-    grant routes.
+    """#2486 scenario 3. The other free-text field an operator writes is
+    bounded, at the ceiling `reason` already carries on the grant routes.
 
-    A correction's comment is the only explanation of the decision that
-    reaches whoever reads the journal later, and the journal records on
-    failure alone — so an unchecked comment loses the audit row while the
-    binding still applies. Refused before any lookup, so no write happens.
+    Not a column limit — the journal stores JSON and would take any length.
+    The point is that one free-text field on this service is not unbounded
+    while its twin is. Refused before any lookup, so no write happens.
     """
     body = _verb_body(verb, stand_manifest.fixture("dev_lead").uuid)
     body["comment"] = "c" * 501
@@ -638,3 +640,72 @@ def test_an_account_search_needle_past_the_cap_is_refused(
     evidence reader."""
     response = admin_operator_session.client.get(ACCOUNT_SEARCH, params={"q": "n" * 201})
     _refused(response, 400, field="q")
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.reliability
+@pytest.mark.parametrize("verb", [v for v, _ in CORRECTION_VERBS])
+def test_a_correction_without_a_json_content_type_is_refused_on_the_media_type(
+    admin_operator_session: PersonaSession, stand_manifest: Manifest, verb: str
+) -> None:
+    """#2486 scenario 7. Refused on the media type, never parsed.
+
+    Held before the extractor swap too, since axum's own `Json` refuses on
+    content type as well — so this is not a rule the swap introduced. It is
+    here because the swap is exactly the change that could trade the 415 away
+    for a parse attempt, and because a gateway is the other place a media type
+    can be rewritten in flight: the in-process case cannot see that.
+    """
+    body = _verb_body(verb, stand_manifest.fixture("dev_lead").uuid)
+    response = admin_operator_session.client.post(
+        identity_path(f"/v1/resolution/{verb}"),
+        content=json.dumps(body).encode(),
+        headers={"Content-Type": "text/plain"},
+    )
+    assert response.status_code == 415, f"{response.status_code} {response.text[:300]}"
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.reliability
+def test_a_bulk_bind_outside_its_bounds_is_refused(
+    admin_operator_session: PersonaSession, stand_manifest: Manifest
+) -> None:
+    """#2486 scenario 7. The shapes a prepared matching table can arrive in
+    wrongly: nothing to do, more than a human pasted, and one account claimed
+    twice.
+
+    All three are pinned in the in-process lanes already. They are here
+    because scenario 7 says EVERY correction operation, and because these are
+    the refusals a deployed path can change without the service moving: a
+    gateway body-size limit turns the over-cap case into someone else's error
+    long before `MAX_BULK_ITEMS` is consulted.
+    """
+    person = stand_manifest.fixture("dev_lead").uuid
+    account = _account("never-observed-account")
+
+    empty = admin_operator_session.client.post(
+        identity_path("/v1/resolution/bind"), json_body={"bindings": [], "comment": "nothing"}
+    )
+    _refused(empty, 400, field="bindings")
+
+    over_cap = admin_operator_session.client.post(
+        identity_path("/v1/resolution/bind"),
+        json_body={
+            "bindings": [
+                {"account": _account(f"never-observed-{index}"), "person_id": person}
+                for index in range(1001)
+            ]
+        },
+    )
+    _refused(over_cap, 400, field="bindings")
+
+    twice = admin_operator_session.client.post(
+        identity_path("/v1/resolution/bind"),
+        json_body={
+            "bindings": [
+                {"account": account, "person_id": person},
+                {"account": account, "person_id": person},
+            ]
+        },
+    )
+    _refused(twice, 400, field="bindings")

--- a/tests/stand/api/identity/test_resolution.py
+++ b/tests/stand/api/identity/test_resolution.py
@@ -40,6 +40,7 @@ from insight_stand import ApiClient, ApiResponse, Manifest, PersonaSession, iden
 
 from .. import scratch
 from ..schemas import (
+    PROBLEM_CONTENT_TYPE,
     AccountBindingResponse,
     AccountSearchResponse,
     AttentionResponse,
@@ -104,13 +105,23 @@ def _refused(
     degradation, with the operator left on generic failure text.
     """
     assert response.status_code == code, f"{response.status_code} {response.text[:300]}"
+    # The media type is half the contract: a body that parses as a problem
+    # document but arrives as `application/json` is not one, and a consumer
+    # switching on content type would fall through to its generic handler.
+    assert response.content_type.startswith(PROBLEM_CONTENT_TYPE), (
+        f"refusal arrived as {response.content_type!r}, not {PROBLEM_CONTENT_TYPE!r}"
+    )
 
     problem = response.parse(ProblemDocument)
     assert problem.status == code, problem
     if field is not None:
         violations = problem.context.get("field_violations")
-        assert violations, f"no field_violations to act on: {problem.context}"
-        named = [entry.get("field") for entry in violations]
+        assert isinstance(violations, list) and violations, (
+            f"no field_violations to act on: {problem.context}"
+        )
+        named = [
+            entry.get("field") for entry in violations if isinstance(entry, dict)
+        ]
         assert field in named, (
             f"refusal names {named}, not the field the caller got wrong ({field})"
         )

--- a/tests/stand/api/schemas/identity.py
+++ b/tests/stand/api/schemas/identity.py
@@ -50,7 +50,7 @@ class AccountRequest(BaseModel):
         extra='forbid',
     )
     account: AccountRef
-    comment: str | None = None
+    comment: str | None = Field(None, max_length=500)
 
 
 class BatchProfilesRequest(BaseModel):
@@ -87,7 +87,7 @@ class BindRequest(BaseModel):
         extra='forbid',
     )
     bindings: list[BindItem] = Field(..., description='One or more bindings; a prepared matching table is submitted as one call.')
-    comment: str | None = None
+    comment: str | None = Field(None, max_length=500)
 
 
 class CreatePersonRoleRequest(BaseModel):
@@ -155,7 +155,7 @@ class MergeRequest(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    comment: str | None = None
+    comment: str | None = Field(None, max_length=500)
     source_person_id: UUID = Field(..., description='The person being absorbed — its accounts move to the target.')
     target_person_id: UUID = Field(..., description='The surviving person, named explicitly by the operator.')
 

--- a/tests/stand/api/scratch.py
+++ b/tests/stand/api/scratch.py
@@ -31,7 +31,18 @@ import uuid
 from collections.abc import Sequence
 from typing import Final
 
-from insight_stand import ANALYTICS_PREFIX, ApiClient, analytics_path, identity_path
+from insight_stand import (
+    ANALYTICS_PREFIX,
+    RUN_TAG,
+    SCRATCH_PREFIX,
+    SCRATCH_SOURCE_ID,
+    SCRATCH_SOURCE_TYPE,
+    ApiClient,
+    analytics_path,
+    identity_path,
+    issued_names,
+    scratch_name,
+)
 
 from .schemas import CustomMetric, ListResponse, SavedQuery
 
@@ -41,27 +52,10 @@ from .schemas import CustomMetric, ListResponse, SavedQuery
 #: would couple the sweep to every schema change that does not concern it.
 _Named = ListResponse[dict[str, object]]
 
-#: Marks every row this suite creates, so a leak is identifiable on sight.
-#: INVARIANT: must match insight_seed.config.STAND_SCRATCH_PREFIX — the seed
-#: preflight uses it to recognise this suite's leftover journal rows.
-SCRATCH_PREFIX: Final[str] = "stand-scratch"
-
-#: The connector instance every correction this suite writes is filed under — the
-#: other half of what makes an undeletable journal row recognisable (rule 5).
-#: Fixed, not random: a stable pair keeps those rows attributable to this suite.
-#: INVARIANT: must match insight_seed.config.STAND_SCRATCH_SOURCE_TYPE, and the
-#: literal `github` segment in `operations.py`'s account-read template — the
-#: coverage gate folds a recorded path onto a template by exact segment equality,
-#: so a divergence here makes that operation read as never exercised.
-SCRATCH_SOURCE_TYPE: Final[str] = "github"
-
-#: INVARIANT: must match insight_seed.config.STAND_SCRATCH_SOURCE_ID. Unlike the
-#: type, this segment is a `{source_id}` in the coverage template, so it folds
-#: whatever its value.
-SCRATCH_SOURCE_ID: Final[str] = "01900000-0000-7000-8000-00000000feed"
-
-#: One token per session: a leak becomes attributable to the run that made it.
-RUN_TAG: Final[str] = uuid.uuid4().hex[:8]
+# The naming and the connector instance now live in `insight_stand`, so the UI
+# journeys can file a correction under the same pair without importing across
+# suites. Re-exported here because every existing caller reads them from this
+# module, and because the issued-name registry must stay single.
 
 #: SQL the query gate accepts (a single `SELECT … FROM db.table`) that executes
 #: deterministically on ANY ClickHouse — `system.one` has exactly one row — so
@@ -105,24 +99,10 @@ SCRATCH_OBSERVATION_SQL: Final[str] = (
     "FROM system.one"
 )
 
-#: Names handed out this session, checked for survivors at the end.
-_ISSUED: set[str] = set()
-
 #: Rows this session created that have NO name to namespace — a person-role
 #: assignment and a visibility grant are identified only by their id. Tracked as
 #: (listing path, id field, id) so the sweep can look for them the same way.
 _CREATED_IDS: list[tuple[str, str, str]] = []
-
-
-def scratch_name(tag: str) -> str:
-    """A unique, greppable, attributable name — and register it for the sweep."""
-    name = f"{SCRATCH_PREFIX}-{RUN_TAG}-{tag}-{uuid.uuid4().hex[:8]}"
-    _ISSUED.add(name)
-    return name
-
-
-def issued_names() -> frozenset[str]:
-    return frozenset(_ISSUED)
 
 
 def tracked_ids() -> tuple[str, ...]:
@@ -276,7 +256,8 @@ def surviving_scratch_rows(*, analytics: ApiClient, identity: ApiClient) -> list
     So a tracked row is judged by `valid_to` when the listing reports one, and
     by mere presence when it does not.
     """
-    if not _ISSUED and not _CREATED_IDS:
+    issued = issued_names()
+    if not issued and not _CREATED_IDS:
         return []
 
     def client_for(path: str) -> ApiClient:
@@ -287,7 +268,7 @@ def surviving_scratch_rows(*, analytics: ApiClient, identity: ApiClient) -> list
     for listing in _NAMED_LISTINGS:
         for item in _listing_items(client_for(listing), listing):
             name = item.get("name")
-            if isinstance(name, str) and name in _ISSUED:
+            if isinstance(name, str) and name in issued:
                 leaked.append(f"{listing} -> {name}")
 
     for listing, id_field, value in _CREATED_IDS:

--- a/tests/stand/ui/pages/identities_view.py
+++ b/tests/stand/ui/pages/identities_view.py
@@ -1,0 +1,96 @@
+"""Manage → Identities — the operator's correction console. Locators and navigation only.
+
+The console is one screen in three modes, all of them query state on
+`/portal`: `zone=manage`, `item=identities`, `mode=queue|person|accounts`,
+plus `acct=<source>:<source_id>:<account_id>` for the account window. That is
+deliberate on the product's side — "a reload restores the same screen, a link
+reproduces it for someone else" — and it is what lets a journey assert that a
+correction survives a refresh rather than only that it rendered once.
+
+Accessibility-first, like every page object here: the published SPA carries no
+`data-testid` attributes, so roles and accessible names are the only stable
+handles. An account opens into a modal dialog named after the account itself,
+and while it is open the rest of the screen is hidden from accessibility — so
+the window, not the page, is what a journey scopes its assertions to.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from playwright.sync_api import Locator, Page
+
+#: The person picker inside an account window, labelled the same way.
+PICKER_LABEL = "Search people by name, email, handle or person id…"
+
+
+def account_key(source: str, source_id: str, account_id: str) -> str:
+    """The `?acct=` key, packed exactly as `account-key.ts` packs it.
+
+    Each part is URI-encoded before joining on `:`, so an `account_id`
+    containing the separator cannot forge a different triple. A journey builds
+    the key here rather than reading it off the URL when it needs to open one
+    account directly.
+    """
+    return ":".join(quote(part, safe="") for part in (source, source_id, account_id))
+
+
+class IdentitiesView:
+    """The console screen, its account listing, and the window a row opens."""
+
+    def __init__(self, page: Page) -> None:
+        self.page = page
+
+    def go(self, mode: str = "accounts", acct: str | None = None) -> None:
+        query = f"?zone=manage&item=identities&mode={mode}"
+        if acct is not None:
+            query += f"&acct={quote(acct, safe='')}"
+        self.page.goto(f"/portal{query}")
+
+    # --- the account window ---------------------------------------------
+    #
+    # A modal dialog: while it is open the rest of the screen is hidden from
+    # accessibility, so nothing outside it — the console heading included —
+    # can be asserted at the same time. Everything below is scoped to it.
+
+    def account_window(self, account_label: str) -> Locator:
+        """The window one account is decided in, named by the account itself."""
+        return self.page.get_by_role("dialog", name=account_label)
+
+    def current_binding(self, window: Locator) -> Locator:
+        """The section naming who holds the account RIGHT NOW.
+
+        Scoped to the section rather than the window, and that is the whole
+        point: the window also carries a decision history, in which every
+        person the account was ever bound to is named. An assertion over the
+        whole window would be satisfied by a history entry — it would pass
+        even if the correction had not moved the binding at all.
+        """
+        return window.locator("section").filter(
+            has=self.page.get_by_text("Currently bound to", exact=True)
+        )
+
+    def person_search(self) -> Locator:
+        """The picker sits open on the screen — there is no button to reveal it.
+
+        Its section is labelled "Assign to a person", or "Assign to someone
+        else" once the account has a holder; the field itself is labelled the
+        same either way, so a journey does not have to know which.
+        """
+        return self.page.get_by_role("searchbox", name=PICKER_LABEL)
+
+    def person_option(self, display_name: str) -> Locator:
+        """One person offered by the picker.
+
+        A `role="button"` rather than a listbox option, and deliberately so on
+        the product's side: the card inside carries its own copy control, and
+        a button may not nest a button.
+        """
+        return self.page.get_by_role("button", name=display_name, exact=True)
+
+    def confirmation(self, title: str) -> Locator:
+        """The second dialog — a correction is always confirmed before it is sent."""
+        return self.page.get_by_role("dialog", name=title)
+
+    def confirm(self, label: str) -> Locator:
+        return self.page.get_by_role("button", name=label, exact=True)

--- a/tests/stand/ui/pages/identities_view.py
+++ b/tests/stand/ui/pages/identities_view.py
@@ -68,14 +68,16 @@ class IdentitiesView:
             has_text="Identities is an admin surface"
         )
 
-    def rate_tile(self, label: str) -> Locator:
-        """One headline figure with its label, as one card.
+    def rate_figure(self, label: str) -> Locator:
+        """The number on one headline tile, as its own node.
 
-        The figure is the card's other text node, so the TILE is what a
-        journey reads: asserting on the label alone would pass on a card whose
-        number never arrived.
+        The figure, not the tile: a tile-wide substring match would accept any
+        number CONTAINING the expected one — 1 passes on 10 and on 21 — so the
+        assertion has to land on the element whose whole text is the figure.
+        The label is the tile's other child, which is what finds the tile.
         """
-        return self.page.get_by_text(label, exact=True).locator("xpath=..")
+        tile = self.page.get_by_text(label, exact=True).locator("xpath=..")
+        return tile.locator("div").first
 
     def person_window(self, person_id: str) -> Locator:
         """The window one person is worked in, opened by `?person=`.

--- a/tests/stand/ui/pages/identities_view.py
+++ b/tests/stand/ui/pages/identities_view.py
@@ -41,11 +41,52 @@ class IdentitiesView:
     def __init__(self, page: Page) -> None:
         self.page = page
 
-    def go(self, mode: str = "accounts", acct: str | None = None) -> None:
+    def go(
+        self,
+        mode: str = "accounts",
+        acct: str | None = None,
+        person: str | None = None,
+    ) -> None:
         query = f"?zone=manage&item=identities&mode={mode}"
         if acct is not None:
             query += f"&acct={quote(acct, safe='')}"
+        if person is not None:
+            query += f"&person={quote(person, safe='')}"
         self.page.goto(f"/portal{query}")
+
+    def heading(self) -> Locator:
+        return self.page.get_by_role("heading", name="Identities", exact=True)
+
+    def refusal(self) -> Locator:
+        """What a caller without the admin role gets instead of the console.
+
+        `role="alert"` on the product's side. The gate fails CLOSED while the
+        check is in flight, so a journey asserting the refusal must also
+        assert the console is absent — otherwise it would pass on a spinner.
+        """
+        return self.page.get_by_role("alert").filter(
+            has_text="Identities is an admin surface"
+        )
+
+    def rate_tile(self, label: str) -> Locator:
+        """One headline figure with its label, as one card.
+
+        The figure is the card's other text node, so the TILE is what a
+        journey reads: asserting on the label alone would pass on a card whose
+        number never arrived.
+        """
+        return self.page.get_by_text(label, exact=True).locator("xpath=..")
+
+    def person_window(self, person_id: str) -> Locator:
+        """The window one person is worked in, opened by `?person=`.
+
+        Found by the id it carries rather than by its heading: arriving by a
+        link there is no card to name them — search resolves values, not ids —
+        so the product titles the window "Unnamed person" and prints the id
+        beside it. Filtering on the id keeps this working whichever way the
+        window was reached.
+        """
+        return self.page.get_by_role("dialog").filter(has_text=person_id)
 
     # --- the account window ---------------------------------------------
     #

--- a/tests/stand/ui/test_identities_console.py
+++ b/tests/stand/ui/test_identities_console.py
@@ -12,15 +12,18 @@ unprovable by construction: a reload there restarts the mock.
 So this journey is the only place where the console, the gateway, the service
 and the store are the real ones at the same time.
 
-**The account is reassigned and put back, not attached from nothing.** A
-seeded stand has no unbound account to attach — every observed account
-belongs to the employee it was reported for — and staging one would mean
-changing seed data the whole suite reads. Reassignment is the same verb
-through the same screen, and it is the only correction whose undo restores
-the visible state exactly: the account returns to the holder it had. What
-remains is journal rows, which is what every operator decision leaves behind
-by design (`tests/stand/api/identity/test_resolution.py` says the same about
-its own round trip).
+**The account is the journey's own, under the suite's scratch connector.**
+`scratch.py` rule 5: the correction journal cannot be deleted from, so a
+decision written under a seeded connector blocks the next seed of the stand.
+A journey that reassigned a real employee's account would leave exactly that
+— which is why the account here is created by this test, through the API,
+under `SCRATCH_SOURCE_TYPE` / `SCRATCH_SOURCE_ID`, and ends in `exclude`, the
+one end state the seed preflight exempts.
+
+The console reaches it by its `?acct=` deep link rather than through the
+account search, which is what makes this possible at all: the search lists
+accounts a connector observed, while the account window reads one by its
+triple whether or not any connector ever reported it.
 
 No metric value is asserted. Every expectation is an identity fact read at
 runtime — the manifest's people, and the account the service itself reports.
@@ -31,7 +34,14 @@ from __future__ import annotations
 from collections.abc import Callable
 
 import pytest
-from insight_stand import Manifest, PersonaSession, identity_path
+from insight_stand import (
+    SCRATCH_SOURCE_ID,
+    SCRATCH_SOURCE_TYPE,
+    Manifest,
+    PersonaSession,
+    identity_path,
+    scratch_name,
+)
 from playwright.sync_api import BrowserContext, Page, expect
 
 from .flows import sign_in
@@ -56,16 +66,10 @@ def context(context: BrowserContext) -> BrowserContext:
     return context
 
 
-def _bind(session: PersonaSession, account: dict[str, str], person_id: str, why: str) -> None:
-    """Put a binding back, over HTTP — teardown, never the thing under test."""
-    response = session.client.post(
-        identity_path("/v1/resolution/bind"),
-        json_body={
-            "bindings": [{"account": account, "person_id": person_id}],
-            "comment": f"stand ui journey: {why}",
-        },
-    )
-    assert response.status_code == 200, f"restore: {response.status_code} {response.text[:300]}"
+def _correct(session: PersonaSession, verb: str, body: dict[str, object]) -> None:
+    """A correction over HTTP — setup and teardown, never the thing under test."""
+    response = session.client.post(identity_path(f"/v1/resolution/{verb}"), json_body=body)
+    assert response.status_code == 200, f"{verb}: {response.status_code} {response.text[:300]}"
 
 
 @pytest.mark.requires_seed("admin_operator", "dev_lead", "development_ic")
@@ -85,42 +89,34 @@ def test_an_operator_reassigns_an_account_and_the_change_outlives_a_reload(
     holder = stand_manifest.fixture("dev_lead")
     new_holder = stand_manifest.fixture("development_ic")
 
-    # The account to move, and who has it, read from the service rather than
-    # named here: which connector reports the roster is the seed's business,
-    # and a journey that hardcoded one would fail as a broken test the day
-    # that changed.
-    found = operator.client.get(
-        identity_path("/v1/resolution/accounts"), params={"q": holder.email, "limit": 1}
+    account_id = scratch_name("console")
+    account = {"source": SCRATCH_SOURCE_TYPE, "source_id": SCRATCH_SOURCE_ID, "id": account_id}
+
+    # Pre-registration: `bind` is the one verb that accepts an account no
+    # connector reported, which is what gives this journey a subject of its
+    # own instead of a seeded person's.
+    _correct(
+        operator,
+        "bind",
+        {
+            "bindings": [{"account": account, "person_id": holder.uuid}],
+            "comment": "stand ui journey: the account this test decides about",
+        },
     )
-    assert found.status_code == 200, f"{found.status_code} {found.text[:300]}"
-    matches = found.json()["items"]
-    assert matches, f"no observed account carries {holder.email} — is the stand seeded?"
-
-    match = matches[0]
-    account = {
-        "source": match["source"],
-        "source_id": match["source_id"],
-        "id": match["account_id"],
-    }
-    assert match["person"] and match["person"]["person_id"] == holder.uuid, (
-        f"the account for {holder.email} is held by {match['person']}, not by the "
-        "person the manifest names — the stand is not in its seeded state"
-    )
-
-    sign_in(page, base_url, operator)
-
-    label = match["email"] or match["username"] or match["account_id"]
-
-    console = IdentitiesView(page)
-    console.go(
-        "accounts",
-        acct=account_key(match["source"], match["source_id"], match["account_id"]),
-    )
-    window = console.account_window(label)
-    expect(window).to_be_visible()
-    expect(console.current_binding(window)).to_contain_text(holder.display_name)
 
     try:
+        sign_in(page, base_url, operator)
+
+        console = IdentitiesView(page)
+        console.go("accounts", acct=account_key(SCRATCH_SOURCE_TYPE, SCRATCH_SOURCE_ID, account_id))
+        window = console.account_window(account_id)
+        expect(window).to_be_visible()
+        # By person id, not by name. The window renders a person CARD only
+        # where it can hydrate one, and an account no connector observed has
+        # nothing to hydrate from — so it falls back to the raw id. That is
+        # the stricter oracle anyway: two people can share a display name.
+        expect(console.current_binding(window)).to_contain_text(holder.uuid)
+
         console.person_search().fill(new_holder.display_name)
         console.person_option(new_holder.display_name).click()
         expect(console.confirmation("Bind this account?")).to_be_visible()
@@ -129,25 +125,29 @@ def test_an_operator_reassigns_an_account_and_the_change_outlives_a_reload(
         # The service's answer, not the console's optimism: reload and read
         # the screen again from whatever the store now holds.
         page.reload()
-        window = console.account_window(label)
+        window = console.account_window(account_id)
         binding = console.current_binding(window)
-        expect(binding).to_contain_text(new_holder.display_name)
-        expect(binding).not_to_contain_text(holder.display_name)
+        expect(binding).to_contain_text(new_holder.uuid)
+        expect(binding).not_to_contain_text(holder.uuid)
 
         owned = operator.client.get(
             identity_path(f"/v1/resolution/persons/{new_holder.uuid}/accounts")
         )
         assert owned.status_code == 200, f"{owned.status_code} {owned.text[:300]}"
-        assert account["id"] in [a["account_id"] for a in owned.json()["accounts"]], (
+        assert account_id in [a["account_id"] for a in owned.json()["accounts"]], (
             "the screen shows the new holder but the service does not list the "
             "account under them"
         )
     finally:
-        _bind(operator, account, holder.uuid, "return the account to its seeded holder")
+        _correct(
+            operator,
+            "exclude",
+            {"account": account, "comment": "stand ui journey: scratch cleanup"},
+        )
 
-    restored = operator.client.get(
-        identity_path(f"/v1/resolution/persons/{holder.uuid}/accounts")
+    owned = operator.client.get(
+        identity_path(f"/v1/resolution/persons/{new_holder.uuid}/accounts")
     )
-    assert account["id"] in [a["account_id"] for a in restored.json()["accounts"]], (
-        "the account did not return to its seeded holder — the stand is dirty"
+    assert account_id not in [a["account_id"] for a in owned.json()["accounts"]], (
+        "the excluded scratch account still lists under the person — the stand is dirty"
     )

--- a/tests/stand/ui/test_identities_console.py
+++ b/tests/stand/ui/test_identities_console.py
@@ -37,6 +37,7 @@ import pytest
 from insight_stand import (
     SCRATCH_SOURCE_ID,
     SCRATCH_SOURCE_TYPE,
+    JsonValue,
     Manifest,
     PersonaSession,
     identity_path,
@@ -68,7 +69,48 @@ def context(context: BrowserContext) -> BrowserContext:
     return context
 
 
-def _correct(session: PersonaSession, verb: str, body: dict[str, object]) -> None:
+def _count(payload: JsonValue, *names: str) -> int:
+    """A whole-number field, narrowed at the read rather than at its use."""
+    value: JsonValue = payload
+    for name in names:
+        value = _field(value, name)
+    assert isinstance(value, int), f"expected a number at {'.'.join(names)}, got {value!r}"
+    return value
+
+
+def _field(payload: JsonValue, name: str) -> JsonValue:
+    """One field of a JSON object answer.
+
+    The typed response models live in the API suite's `schemas/`, which a UI
+    module cannot import — `ui` and `api` are sibling top-level packages. This
+    keeps the reads narrow and typed instead of indexing an unnarrowed
+    `JsonValue`, which is neither.
+    """
+    assert isinstance(payload, dict), f"expected a JSON object, got {payload!r}"
+    return payload[name]
+
+
+def _account_ids(payload: JsonValue) -> list[str]:
+    """The `account_id`s of a `{"accounts": [...]}` answer."""
+    accounts = _field(payload, "accounts")
+    assert isinstance(accounts, list), f"expected a list of accounts, got {accounts!r}"
+    return [str(_field(entry, "account_id")) for entry in accounts]
+
+
+def _release(session: PersonaSession, account: dict[str, JsonValue]) -> None:
+    """Best-effort teardown, the way `scratch.py` rule 4 asks for it.
+
+    Unchecked on purpose: the journey may have failed before the account was
+    ever bound, and an `exclude` on an account nothing observed is a 404. A
+    teardown that asserted would replace the real failure with its own.
+    """
+    session.client.post(
+        identity_path("/v1/resolution/exclude"),
+        json_body={"account": account, "comment": "stand ui journey: scratch cleanup"},
+    )
+
+
+def _correct(session: PersonaSession, verb: str, body: dict[str, JsonValue]) -> None:
     """A correction over HTTP — setup and teardown, never the thing under test.
 
     The outcome is checked, not just the status: a correction that was refused
@@ -78,7 +120,9 @@ def _correct(session: PersonaSession, verb: str, body: dict[str, object]) -> Non
     """
     response = session.client.post(identity_path(f"/v1/resolution/{verb}"), json_body=body)
     assert response.status_code == 200, f"{verb}: {response.status_code} {response.text[:300]}"
-    assert response.json()["applied"] == 1, f"{verb} was not applied: {response.text[:300]}"
+    assert _count(response.json(), "applied") == 1, (
+        f"{verb} was not applied: {response.text[:300]}"
+    )
 
 
 @pytest.mark.requires_seed("admin_operator", "dev_lead", "development_ic")
@@ -100,25 +144,32 @@ def test_an_operator_reassigns_an_account_and_the_change_outlives_a_reload(
     new_holder = stand_manifest.fixture("development_ic")
 
     account_id = scratch_name("console")
-    account = {"source": SCRATCH_SOURCE_TYPE, "source_id": SCRATCH_SOURCE_ID, "id": account_id}
+    account: dict[str, JsonValue] = {
+        "source": SCRATCH_SOURCE_TYPE,
+        "source_id": SCRATCH_SOURCE_ID,
+        "id": account_id,
+    }
+    deep_link = account_key(SCRATCH_SOURCE_TYPE, SCRATCH_SOURCE_ID, account_id)
 
-    # Pre-registration: `bind` is the one verb that accepts an account no
-    # connector reported, which is what gives this journey a subject of its
-    # own instead of a seeded person's.
-    _correct(
-        operator,
-        "bind",
-        {
-            "bindings": [{"account": account, "person_id": holder.uuid}],
-            "comment": "stand ui journey: the account this test decides about",
-        },
-    )
-
+    # The bind is inside the try: it is a write, and a failure anywhere after
+    # the request leaves the stand carrying a binding this run must take back.
     try:
+        # Pre-registration: `bind` is the one verb that accepts an account no
+        # connector reported, which is what gives this journey a subject of
+        # its own instead of a seeded person's.
+        _correct(
+            operator,
+            "bind",
+            {
+                "bindings": [{"account": account, "person_id": holder.uuid}],
+                "comment": "stand ui journey: the account this test decides about",
+            },
+        )
+
         sign_in(page, base_url, operator)
 
         console = IdentitiesView(page)
-        console.go("accounts", acct=account_key(SCRATCH_SOURCE_TYPE, SCRATCH_SOURCE_ID, account_id))
+        console.go("accounts", acct=deep_link)
         window = console.account_window(account_id)
         expect(window).to_be_visible()
         # By person id, not by name. The window renders a person CARD only
@@ -132,9 +183,17 @@ def test_an_operator_reassigns_an_account_and_the_change_outlives_a_reload(
         expect(console.confirmation("Bind this account?")).to_be_visible()
         console.confirm("Bind").click()
 
-        # The service's answer, not the console's optimism: reload and read
-        # the screen again from whatever the store now holds.
-        page.reload()
+        # The correction closing its own window is the SPA saying the request
+        # came back. Without waiting for it, what follows races the POST: the
+        # console clears `?acct=` on success, so a navigation issued too early
+        # either reloads a url that still names the account and reads a store
+        # that has not been written yet, or reloads one that no longer does.
+        expect(window).not_to_be_visible()
+
+        # A fresh document at the same link — a stronger form of "survives a
+        # reload" than `reload()`, since nothing of the previous page's state
+        # can carry over.
+        console.go("accounts", acct=deep_link)
         window = console.account_window(account_id)
         binding = console.current_binding(window)
         expect(binding).to_contain_text(new_holder.uuid)
@@ -144,21 +203,17 @@ def test_an_operator_reassigns_an_account_and_the_change_outlives_a_reload(
             identity_path(f"/v1/resolution/persons/{new_holder.uuid}/accounts")
         )
         assert owned.status_code == 200, f"{owned.status_code} {owned.text[:300]}"
-        assert account_id in [a["account_id"] for a in owned.json()["accounts"]], (
+        assert account_id in _account_ids(owned.json()), (
             "the screen shows the new holder but the service does not list the "
             "account under them"
         )
     finally:
-        _correct(
-            operator,
-            "exclude",
-            {"account": account, "comment": "stand ui journey: scratch cleanup"},
-        )
+        _release(operator, account)
 
     owned = operator.client.get(
         identity_path(f"/v1/resolution/persons/{new_holder.uuid}/accounts")
     )
-    assert account_id not in [a["account_id"] for a in owned.json()["accounts"]], (
+    assert account_id not in _account_ids(owned.json()), (
         "the excluded scratch account still lists under the person — the stand is dirty"
     )
 
@@ -190,7 +245,7 @@ def test_the_console_renders_the_figures_the_service_reports(
     operator = session_for("admin_operator")
     queue = operator.client.get(identity_path("/v1/resolution/attention"))
     assert queue.status_code == 200, f"{queue.status_code} {queue.text[:300]}"
-    observed = queue.json()["rates"]["observed"]
+    observed = _count(queue.json(), "rates", "observed")
     assert observed > 0, "a seeded stand reports no observed accounts — nothing to render"
 
     sign_in(page, base_url, operator)
@@ -198,7 +253,7 @@ def test_the_console_renders_the_figures_the_service_reports(
     console = IdentitiesView(page)
     console.go("queue")
     expect(console.heading()).to_be_visible()
-    expect(console.rate_tile("Accounts")).to_contain_text(str(observed))
+    expect(console.rate_figure("Accounts")).to_have_text(str(observed))
 
 
 @pytest.mark.requires_seed("dev_lead")
@@ -259,7 +314,7 @@ def test_a_persons_window_lists_the_accounts_the_service_gives_them(
 
     owned = operator.client.get(identity_path(f"/v1/resolution/persons/{person.uuid}/accounts"))
     assert owned.status_code == 200, f"{owned.status_code} {owned.text[:300]}"
-    accounts = [a["account_id"] for a in owned.json()["accounts"]]
+    accounts = _account_ids(owned.json())
     assert accounts, f"the service gives {person.display_name} no accounts — nothing to render"
 
     sign_in(page, base_url, operator)

--- a/tests/stand/ui/test_identities_console.py
+++ b/tests/stand/ui/test_identities_console.py
@@ -47,7 +47,9 @@ from playwright.sync_api import BrowserContext, Page, expect
 from .flows import sign_in
 from .pages.identities_view import IdentitiesView, account_key
 
-pytestmark = pytest.mark.reliability
+# No module-level vector: this module is mixed. The gate journey is `security`
+# and the rest are `reliability`, and a module default plus a per-test marker
+# would leave both on the item and break `-m` selection.
 
 
 @pytest.fixture
@@ -73,6 +75,7 @@ def _correct(session: PersonaSession, verb: str, body: dict[str, object]) -> Non
 
 
 @pytest.mark.requires_seed("admin_operator", "dev_lead", "development_ic")
+@pytest.mark.reliability
 def test_an_operator_reassigns_an_account_and_the_change_outlives_a_reload(
     page: Page,
     base_url: str,
@@ -151,3 +154,111 @@ def test_an_operator_reassigns_an_account_and_the_change_outlives_a_reload(
     assert account_id not in [a["account_id"] for a in owned.json()["accounts"]], (
         "the excluded scratch account still lists under the person — the stand is dirty"
     )
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.stand_smoke
+@pytest.mark.reliability
+def test_the_console_renders_the_figures_the_service_reports(
+    page: Page,
+    base_url: str,
+    session_for: Callable[[str], PersonaSession],
+) -> None:
+    """The identity console is on screen after a deploy, with real figures.
+
+    Marked `stand_smoke`: the post-deploy gate proves a seeded persona can
+    read their org chart over HTTP, and that the shipped SPA renders the
+    product's own screens — but nothing proved the ADMIN surface renders at
+    all. A console that answers every API call and paints an empty shell
+    passes the rest of the gate.
+
+    Read-only by design. The gate runs against real deployed stands, and a
+    correction is an append-only journal row: a smoke that wrote one would
+    leave a decision behind on every deploy.
+
+    The expectation comes from the service at run time, not from the manifest
+    and not from a number written here — the point is that the figure on
+    screen is the one the service reports, which no API test can show.
+    """
+    operator = session_for("admin_operator")
+    queue = operator.client.get(identity_path("/v1/resolution/attention"))
+    assert queue.status_code == 200, f"{queue.status_code} {queue.text[:300]}"
+    observed = queue.json()["rates"]["observed"]
+    assert observed > 0, "a seeded stand reports no observed accounts — nothing to render"
+
+    sign_in(page, base_url, operator)
+
+    console = IdentitiesView(page)
+    console.go("queue")
+    expect(console.heading()).to_be_visible()
+    expect(console.rate_tile("Accounts")).to_contain_text(str(observed))
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.security
+def test_a_pasted_console_url_refuses_a_caller_without_the_admin_role(
+    page: Page,
+    base_url: str,
+    session_for: Callable[[str], PersonaSession],
+) -> None:
+    """The nav hides the surface; the URL does not, so the screen refuses.
+
+    #2486 AC-5 in the browser. The API half is swept over all 22 admin-gated
+    operations in `tests/stand/api/identity/test_request_contracts.py`, and
+    the frontend suite has its own gate cases — but those mock the client, so
+    what they prove is that the component reacts to a mocked answer. Nothing
+    proved that a real non-admin session, on a real deployed stand, is refused
+    the screen.
+
+    Both halves are asserted. The gate fails CLOSED while the role check is in
+    flight, so the refusal alone would also be satisfied by a spinner that
+    never resolved — the console's own figures must be absent as well.
+    """
+    lead = session_for("dev_lead")
+    sign_in(page, base_url, lead)
+
+    console = IdentitiesView(page)
+    console.go("queue")
+
+    expect(console.refusal()).to_be_visible()
+    expect(page.get_by_text("Needs attention", exact=True)).not_to_be_visible()
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.reliability
+def test_a_persons_window_lists_the_accounts_the_service_gives_them(
+    page: Page,
+    base_url: str,
+    session_for: Callable[[str], PersonaSession],
+    stand_manifest: Manifest,
+) -> None:
+    """#2486 AC-3. The console's other read path, through the browser.
+
+    The accounts journey enters from an account and asks who holds it; this
+    enters from a person and asks what they hold — a different endpoint
+    (`/v1/resolution/persons/{id}/accounts`) behind a different mode, and the
+    one an operator actually starts from when the question is "this person's
+    work looks split".
+
+    Every account expected here is read from the service at run time. Opened
+    by deep link, so the window carries the person id rather than their name —
+    search resolves values, not ids, and there is no card to name them on
+    arrival.
+    """
+    operator = session_for("admin_operator")
+    person = stand_manifest.fixture("dev_lead")
+
+    owned = operator.client.get(identity_path(f"/v1/resolution/persons/{person.uuid}/accounts"))
+    assert owned.status_code == 200, f"{owned.status_code} {owned.text[:300]}"
+    accounts = [a["account_id"] for a in owned.json()["accounts"]]
+    assert accounts, f"the service gives {person.display_name} no accounts — nothing to render"
+
+    sign_in(page, base_url, operator)
+
+    console = IdentitiesView(page)
+    console.go("person", person=person.uuid)
+
+    window = console.person_window(person.uuid)
+    expect(window).to_be_visible()
+    for account_id in accounts:
+        expect(window).to_contain_text(account_id)

--- a/tests/stand/ui/test_identities_console.py
+++ b/tests/stand/ui/test_identities_console.py
@@ -1,0 +1,153 @@
+"""Journey — an operator reassigns an account in Manage → Identities.
+
+#2486 scenario 5. Why this is a browser test and not an API test: the four
+correction verbs are already proven over HTTP in `tests/stand/api/identity/`
+and in the identity rig, so nothing here is trying to re-prove that the
+service binds an account. What no API call can show is that a decision an
+operator makes THROUGH THE SCREEN reaches the service and comes back — and
+the frontend's own suite cannot show it either, because every one of its
+cases mocks the identity client, which makes "the change survives a refresh"
+unprovable by construction: a reload there restarts the mock.
+
+So this journey is the only place where the console, the gateway, the service
+and the store are the real ones at the same time.
+
+**The account is reassigned and put back, not attached from nothing.** A
+seeded stand has no unbound account to attach — every observed account
+belongs to the employee it was reported for — and staging one would mean
+changing seed data the whole suite reads. Reassignment is the same verb
+through the same screen, and it is the only correction whose undo restores
+the visible state exactly: the account returns to the holder it had. What
+remains is journal rows, which is what every operator decision leaves behind
+by design (`tests/stand/api/identity/test_resolution.py` says the same about
+its own round trip).
+
+No metric value is asserted. Every expectation is an identity fact read at
+runtime — the manifest's people, and the account the service itself reports.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from insight_stand import Manifest, PersonaSession, identity_path
+from playwright.sync_api import BrowserContext, Page, expect
+
+from .flows import sign_in
+from .pages.identities_view import IdentitiesView, account_key
+
+pytestmark = pytest.mark.reliability
+
+
+@pytest.fixture
+def context(context: BrowserContext) -> BrowserContext:
+    """The first journey here that drives the PORTAL rather than the legacy shell.
+
+    `conftest.py` writes `insight.legacyShell` into every context, because the
+    journeys written before this one were written against that shell. The
+    identities console exists only in the portal, so this one takes the hatch
+    back out. Init scripts run in the order they were added, and both run
+    before any app code, so removing the key after the shared fixture set it
+    is the whole override — the surrounding fixture keeps working for every
+    other module unchanged.
+    """
+    context.add_init_script("window.localStorage.removeItem('insight.legacyShell')")
+    return context
+
+
+def _bind(session: PersonaSession, account: dict[str, str], person_id: str, why: str) -> None:
+    """Put a binding back, over HTTP — teardown, never the thing under test."""
+    response = session.client.post(
+        identity_path("/v1/resolution/bind"),
+        json_body={
+            "bindings": [{"account": account, "person_id": person_id}],
+            "comment": f"stand ui journey: {why}",
+        },
+    )
+    assert response.status_code == 200, f"restore: {response.status_code} {response.text[:300]}"
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead", "development_ic")
+def test_an_operator_reassigns_an_account_and_the_change_outlives_a_reload(
+    page: Page,
+    base_url: str,
+    session_for: Callable[[str], PersonaSession],
+    stand_manifest: Manifest,
+) -> None:
+    """A correction made on screen is the service's answer afterwards.
+
+    The reload is the assertion that matters. Without it the test would pass
+    on a console that renders its own optimistic result and never sent
+    anything — the exact failure the mocked frontend suite cannot see.
+    """
+    operator = session_for("admin_operator")
+    holder = stand_manifest.fixture("dev_lead")
+    new_holder = stand_manifest.fixture("development_ic")
+
+    # The account to move, and who has it, read from the service rather than
+    # named here: which connector reports the roster is the seed's business,
+    # and a journey that hardcoded one would fail as a broken test the day
+    # that changed.
+    found = operator.client.get(
+        identity_path("/v1/resolution/accounts"), params={"q": holder.email, "limit": 1}
+    )
+    assert found.status_code == 200, f"{found.status_code} {found.text[:300]}"
+    matches = found.json()["items"]
+    assert matches, f"no observed account carries {holder.email} — is the stand seeded?"
+
+    match = matches[0]
+    account = {
+        "source": match["source"],
+        "source_id": match["source_id"],
+        "id": match["account_id"],
+    }
+    assert match["person"] and match["person"]["person_id"] == holder.uuid, (
+        f"the account for {holder.email} is held by {match['person']}, not by the "
+        "person the manifest names — the stand is not in its seeded state"
+    )
+
+    sign_in(page, base_url, operator)
+
+    label = match["email"] or match["username"] or match["account_id"]
+
+    console = IdentitiesView(page)
+    console.go(
+        "accounts",
+        acct=account_key(match["source"], match["source_id"], match["account_id"]),
+    )
+    window = console.account_window(label)
+    expect(window).to_be_visible()
+    expect(console.current_binding(window)).to_contain_text(holder.display_name)
+
+    try:
+        console.person_search().fill(new_holder.display_name)
+        console.person_option(new_holder.display_name).click()
+        expect(console.confirmation("Bind this account?")).to_be_visible()
+        console.confirm("Bind").click()
+
+        # The service's answer, not the console's optimism: reload and read
+        # the screen again from whatever the store now holds.
+        page.reload()
+        window = console.account_window(label)
+        binding = console.current_binding(window)
+        expect(binding).to_contain_text(new_holder.display_name)
+        expect(binding).not_to_contain_text(holder.display_name)
+
+        owned = operator.client.get(
+            identity_path(f"/v1/resolution/persons/{new_holder.uuid}/accounts")
+        )
+        assert owned.status_code == 200, f"{owned.status_code} {owned.text[:300]}"
+        assert account["id"] in [a["account_id"] for a in owned.json()["accounts"]], (
+            "the screen shows the new holder but the service does not list the "
+            "account under them"
+        )
+    finally:
+        _bind(operator, account, holder.uuid, "return the account to its seeded holder")
+
+    restored = operator.client.get(
+        identity_path(f"/v1/resolution/persons/{holder.uuid}/accounts")
+    )
+    assert account["id"] in [a["account_id"] for a in restored.json()["accounts"]], (
+        "the account did not return to its seeded holder — the stand is dirty"
+    )

--- a/tests/stand/ui/test_identities_console.py
+++ b/tests/stand/ui/test_identities_console.py
@@ -69,9 +69,16 @@ def context(context: BrowserContext) -> BrowserContext:
 
 
 def _correct(session: PersonaSession, verb: str, body: dict[str, object]) -> None:
-    """A correction over HTTP — setup and teardown, never the thing under test."""
+    """A correction over HTTP — setup and teardown, never the thing under test.
+
+    The outcome is checked, not just the status: a correction that was refused
+    still answers 200 with `applied: 0`, and a setup that silently placed no
+    binding would send the journey looking for a screen that was never
+    supposed to change.
+    """
     response = session.client.post(identity_path(f"/v1/resolution/{verb}"), json_body=body)
     assert response.status_code == 200, f"{verb}: {response.status_code} {response.text[:300]}"
+    assert response.json()["applied"] == 1, f"{verb} was not applied: {response.text[:300]}"
 
 
 @pytest.mark.requires_seed("admin_operator", "dev_lead", "development_ic")
@@ -234,11 +241,13 @@ def test_a_persons_window_lists_the_accounts_the_service_gives_them(
 ) -> None:
     """#2486 AC-3. The console's other read path, through the browser.
 
-    The accounts journey enters from an account and asks who holds it; this
-    enters from a person and asks what they hold — a different endpoint
-    (`/v1/resolution/persons/{id}/accounts`) behind a different mode, and the
-    one an operator actually starts from when the question is "this person's
-    work looks split".
+    That the endpoint answers with these accounts is already proven over HTTP
+    by `test_a_seeded_person_lists_their_accounts`, so the data is not what is
+    under test here. What no API call can show is that the deployed SPA,
+    handed a bare `?person=` id with no picker card to hydrate a name from,
+    still resolves that id, fetches the person's accounts and renders every
+    one of them — the deep-link path an operator arrives on from a shared
+    link, and the one where the window has the least to work with.
 
     Every account expected here is read from the service at run time. Opened
     by deep link, so the window carries the person id rather than their name —

--- a/tests/stand/ui/test_identities_console.py
+++ b/tests/stand/ui/test_identities_console.py
@@ -180,15 +180,28 @@ def test_an_operator_reassigns_an_account_and_the_change_outlives_a_reload(
 
         console.person_search().fill(new_holder.display_name)
         console.person_option(new_holder.display_name).click()
-        expect(console.confirmation("Bind this account?")).to_be_visible()
-        console.confirm("Bind").click()
+        confirmation = console.confirmation("Bind this account?")
+        expect(confirmation).to_be_visible()
 
-        # The correction closing its own window is the SPA saying the request
-        # came back. Without waiting for it, what follows races the POST: the
-        # console clears `?acct=` on success, so a navigation issued too early
-        # either reloads a url that still names the account and reads a store
-        # that has not been written yet, or reloads one that no longer does.
-        expect(window).not_to_be_visible()
+        # Wait for the RESPONSE, not for a dialog. An open confirmation hides
+        # the window behind it from role queries (the SPA's own suite says so
+        # in `person-dialog.test.tsx`), so "the account window went away" is
+        # already true the moment the confirmation opened — before the click —
+        # and would be no wait at all. Navigating on that would cancel the
+        # request in flight or cross the teardown.
+        with page.expect_response(
+            lambda response: response.request.method == "POST"
+            and response.url.endswith("/v1/resolution/bind")
+        ) as bind_call:
+            console.confirm("Bind").click()
+        assert bind_call.value.status == 200, (
+            f"the correction the console sent was refused: {bind_call.value.status}"
+        )
+
+        # And then for the SPA to have acted on it: the confirmation closes on
+        # success, which is what tells a reader the console believed the answer
+        # rather than merely receiving it.
+        expect(confirmation).not_to_be_visible()
 
         # A fresh document at the same link — a stronger form of "survives a
         # reload" than `reload()`, since nothing of the previous page's state


### PR DESCRIPTION
Refs #2486.

**Why.** The operator-correction surface had rules the code enforced and no test held: a shared guard proven through one of its two callers, a merge checked on one of its two sides, a refusal whose body the console could not read. The console itself had no browser test at all.

**What changed.** Every one of those rules is now pinned in both API lanes, the console gets four browser journeys where it had none, and three refusals the service should have made but didn't — an unparseable body answered below the canonical error layer, an uncapped `comment`, an uncapped `q` — now behave like their siblings elsewhere on the service.

**An off-schema body moves 422 → 400.** Swapping the four verbs to `CanonicalJson` changes the status as well as the envelope. 422 was never in the published contract and the suite already names it `LEGACY_422`; reverting is a one-line extractor swap.

**The console journey reassigns its own scratch account rather than a seeded one.** A seeded stand has no unbound account, and staging one means changing seed data the whole suite reads. `scratch.py` rule 5 also forbids writing a correction under a seeded connector — it blocks the next seed of the stand.

Measured: 14 API cases added, 4 browser journeys where there were 0, smoke lane 8 → 9 with its first admin screen. Every new rule was confirmed by mutation — broken in the code or the test, and seen to fail.

## Open after this

1. **Scenario 6 is not proven end to end.** The metric-coverage gate is static analysis of the YAML corpus: it proves an assertion exists per metric, not that a result was non-empty. The attribution fixture injects bindings through the rig's `identity_accounts:` block, bypassing the roster connector, and asserts one metric. The chain roster → binding → all GitHub feeds → all development metrics non-empty stays unproven.
2. **The scratch parity guard never runs in CI.** The seeder's tests run inside the seed image, which ships no `tests/` tree, so the guard always skips. Pre-existing; needs a checkout-side run.
3. **`CanonicalJson` collapses axum's 413 into 400** for an oversize body, across all seven routes using it. No `payload_too_large` type exists in this service's vocabulary yet.
4. **Merging into a provisional person is unenforced.** The frontend states the rule, the service computes `provisional` for display only, and no layer applies it. Needs a product decision before a test can go either way.

**Verified.** Full stand suite 544 passed / 1 skipped / 13 xfailed against a stand built from this tree; 380 service tests with the live-HTTP lane against a real store; console journeys green three consecutive runs; OpenAPI drift gate clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to reject comments longer than 500 characters.
  * Added validation to reject account-search queries longer than 200 characters.
  * Correction requests now require valid JSON content types and return structured error details for invalid input.
  * Expanded identity console coverage, including account reassignment, account details, queue metrics, and access restrictions.

* **Bug Fixes**
  * Invalid pagination values are now rejected instead of silently ignored.

* **Tests**
  * Expanded API, integration, and browser coverage for identity resolution workflows and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->