### PR TITLE
fix(frontend): one grid for the drilldown table, and a spinner for a new question

### DIFF
--- a/src/frontend/src/components/metric-evidence-dialog.test.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.test.tsx
@@ -3,7 +3,6 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { keepPreviousData } from "@tanstack/react-query";
 
 import { AnalyticsApiError } from "@/api/analytics-client";
 import type { EvidenceDialogState } from "@/components/metric-evidence-context";
@@ -900,6 +899,23 @@ describe("MetricEvidenceDialog", () => {
       act(() => onSortChange(key));
     }
 
+    /** What the query would show while a read keyed `previousKey` is replaced. */
+    function placeholderAgainst(previousKey: unknown[]): unknown {
+      const placeholderData = mocks.queryOptions?.placeholderData as (
+        previous: unknown,
+        previousQuery: { queryKey: unknown[] }
+      ) => unknown;
+      return placeholderData("the rows already on screen", {
+        queryKey: previousKey,
+      });
+    }
+
+    /** The same read, asked for under a different order or needle. */
+    function placeholderFor(view: Record<string, unknown>): unknown {
+      const key = mocks.queryOptions?.queryKey as unknown[];
+      return placeholderAgainst([...key.slice(0, -1), view]);
+    }
+
     it("counts the records it is showing", () => {
       renderDialog();
       expect(screen.getByText("3 records")).toBeInTheDocument();
@@ -910,7 +926,25 @@ describe("MetricEvidenceDialog", () => {
     // mid-word and the scroll position with it.
     it("keeps the rows on screen while a new order is fetched", () => {
       renderDialog();
-      expect(mocks.queryOptions?.placeholderData).toBe(keepPreviousData);
+
+      expect(placeholderFor({ sort: { key: "ref", direction: "asc" } })).toBe(
+        "the rows already on screen"
+      );
+    });
+
+    // Closing one metric's records and opening another's asks a new question.
+    // Rows held over from the last one render under the new title, where they
+    // read as its answer until the real ones land.
+    it("drops the rows when the records of another metric are opened", () => {
+      renderDialog();
+      const key = mocks.queryOptions?.queryKey as unknown[];
+      const otherMetric = [
+        ...key.slice(0, 2),
+        { ...(key[2] as object), metric_key: "git.lines_added" },
+        key[3],
+      ];
+
+      expect(placeholderAgainst(otherMetric)).toBeUndefined();
     });
 
     // The debounce delays ASKING. A cleared box is not an ask, and leaving the

--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -1,4 +1,4 @@
-import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -52,6 +52,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { nextSort } from "@/lib/metrics/evidence-rows";
+import { sameEvidenceSubject } from "@/lib/metrics/evidence-placeholder";
 import { SEARCH_DEBOUNCE_MS } from "@/queries/identity-resolution";
 
 /** A records read taken out of a people list, and whose records they are. */
@@ -135,8 +136,9 @@ export function MetricEvidenceDialog({
     [sort, needle]
   );
 
+  const queryKey = ["metric-drilldown", sessionScope, selection, view];
   const query = useInfiniteQuery({
-    queryKey: ["metric-drilldown", sessionScope, selection, view],
+    queryKey,
     queryFn: ({ pageParam, signal }) => {
       if (!selection) throw new Error("Metric evidence selection is missing");
       return queryMetricDrilldown(
@@ -149,8 +151,12 @@ export function MetricEvidenceDialog({
     // A new order or a new needle is a new query key. Without this the table —
     // and the search box in the header above it — is replaced by a spinner on
     // every header click and every pause in typing, which loses the caret
-    // mid-word.
-    placeholderData: keepPreviousData,
+    // mid-word. A new SUBJECT gets the spinner: rows held over from the metric
+    // the reader just closed would sit under the new one's title as its answer.
+    placeholderData: (previous, previousQuery) =>
+      sameEvidenceSubject(previousQuery?.queryKey, queryKey)
+        ? previous
+        : undefined,
     enabled:
       sessionScope != null &&
       selection != null &&

--- a/src/frontend/src/components/metric-evidence-table.test.tsx
+++ b/src/frontend/src/components/metric-evidence-table.test.tsx
@@ -65,6 +65,32 @@ describe("MetricEvidenceTable", () => {
     });
   });
 
+  // A row that sized its own cells drifted out of the headings above it as
+  // soon as the two had different space to grow into, and put its last cell on
+  // a line of its own. One template decides both.
+  it("lays the headings and the rows out on one set of columns", () => {
+    renderTable();
+    const [header, ...body] = screen.getAllByRole("row");
+    const template = header!.style.gridTemplateColumns;
+
+    expect(template).not.toBe("");
+    for (const row of body) {
+      expect(row.style.gridTemplateColumns).toBe(template);
+      expect(row.style.flexWrap).toBe("");
+    }
+  });
+
+  // A column the reader can widen must widen in both places or the values slide
+  // out from under their heading.
+  it("gives every column a track, expander included", () => {
+    renderTable();
+    const header = screen.getAllByRole("row")[0]!;
+
+    expect(header.style.gridTemplateColumns.split(/\s+(?![^(]*\))/)).toHaveLength(
+      columns.length + 1
+    );
+  });
+
   it("renders a branch column the server sent, value and header alike", () => {
     // The branch is server-driven like every other column (#2806): the table
     // must not need to know the key to show it.

--- a/src/frontend/src/components/metric-evidence-table.tsx
+++ b/src/frontend/src/components/metric-evidence-table.tsx
@@ -117,6 +117,17 @@ export function MetricEvidenceTable({
   const minimumWidth = columns.reduce((total, column) => {
     return total + columnLayout(column).basisRem;
   }, EXPANDER_REM);
+  // INVARIANT: the header and every body row lay out on THIS template. Two
+  // rows sizing themselves independently drift apart as soon as one of them
+  // has different free space to grow into, and a value under the wrong
+  // heading is worse than no value.
+  const gridTemplate = useMemo(() => {
+    const tracks = columns.map((column) => {
+      const { basisRem, grow } = columnLayout(column);
+      return grow > 0 ? `minmax(${basisRem}rem, ${grow}fr)` : `${basisRem}rem`;
+    });
+    return [`${EXPANDER_REM}rem`, ...tracks].join(" ");
+  }, [columns]);
 
   function toggleRow(key: string): void {
     setExpanded((current) => {
@@ -168,17 +179,16 @@ export function MetricEvidenceTable({
         >
           <TableRow
             role="row"
-            className="flex w-full border-b-0 hover:bg-transparent"
+            className="grid w-full border-b-0 hover:bg-transparent"
+            style={{ gridTemplateColumns: gridTemplate }}
           >
             <TableHead
               role="columnheader"
-              className="flex h-10 shrink-0 items-center p-0"
-              style={{ flex: `0 0 ${EXPANDER_REM}rem` }}
+              className="flex h-10 items-center p-0"
             >
               <span className="sr-only">Expand record</span>
             </TableHead>
             {columns.map((column) => {
-              const layout = columnLayout(column);
               const state = sort?.key === column.key ? sort.direction : null;
               const numeric = column.type === "number";
               const label = (
@@ -210,9 +220,6 @@ export function MetricEvidenceTable({
                       ? "justify-end text-right"
                       : "justify-start text-left"
                   )}
-                  style={{
-                    flex: `${layout.grow} 0 ${layout.basisRem}rem`,
-                  }}
                 >
                   {/* A header the server cannot order by is a label, not a
                       control that does nothing when clicked. */}
@@ -257,15 +264,15 @@ export function MetricEvidenceTable({
                 aria-rowindex={virtualRow.index + 2}
                 aria-expanded={isOpen}
                 onClick={() => toggleRow(key)}
-                className="absolute top-0 left-0 flex w-full cursor-pointer flex-wrap hover:bg-muted/20"
+                className="absolute top-0 left-0 grid w-full cursor-pointer hover:bg-muted/20"
                 style={{
+                  gridTemplateColumns: gridTemplate,
                   transform: `translateY(${virtualRow.start}px)`,
                 }}
               >
                 <TableCell
                   role="cell"
-                  className="flex h-11 shrink-0 items-center justify-center p-0"
-                  style={{ flex: `0 0 ${EXPANDER_REM}rem` }}
+                  className="flex h-11 items-center justify-center p-0"
                 >
                   <Button
                     type="button"
@@ -285,7 +292,6 @@ export function MetricEvidenceTable({
                   </Button>
                 </TableCell>
                 {columns.map((column) => {
-                  const layout = columnLayout(column);
                   const value = row.values[column.key];
                   const text = cellText(value, column.type);
                   const full = summaryLine(text);
@@ -304,9 +310,6 @@ export function MetricEvidenceTable({
                         "h-11 min-w-0 truncate px-3 py-3 tabular-nums",
                         column.type === "number" && "text-right"
                       )}
-                      style={{
-                        flex: `${layout.grow} 0 ${layout.basisRem}rem`,
-                      }}
                       title={full}
                     >
                       {column.key === "ref" && value != null ? (
@@ -335,7 +338,10 @@ export function MetricEvidenceTable({
                     // INVARIANT: selecting text here must not reach the row's
                     // expand toggle.
                     onClick={(event) => event.stopPropagation()}
-                    className="w-full basis-full cursor-auto border-t bg-muted/40 px-3 py-3"
+                    className="cursor-auto border-t bg-muted/40 px-3 py-3"
+                    // The record entire, under the row it belongs to: a track
+                    // of its own across every column.
+                    style={{ gridColumn: "1 / -1" }}
                   >
                     {/* INVARIANT: a fixed cap, not a vh — the window can
                         exceed the table's own height. */}

--- a/src/frontend/src/components/portal/trend-drilldown-dialog.test.tsx
+++ b/src/frontend/src/components/portal/trend-drilldown-dialog.test.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { keepPreviousData } from "@tanstack/react-query";
 
 import { AnalyticsApiError } from "@/api/analytics-client";
 import {
@@ -118,6 +117,17 @@ function renderDialog(next: TrendDrilldownState = state) {
   return render(<TrendDrilldownDialog state={next} onClose={vi.fn()} />);
 }
 
+/** What the query would show while a read keyed `previousKey` is replaced. */
+function placeholderAgainst(previousKey: unknown[]): unknown {
+  const placeholderData = mocks.queryOptions?.placeholderData as (
+    previous: unknown,
+    previousQuery: { queryKey: unknown[] }
+  ) => unknown;
+  return placeholderData("the rows already on screen", {
+    queryKey: previousKey,
+  });
+}
+
 describe("TrendDrilldownDialog", () => {
   beforeEach(() => {
     mocks.query = readyQuery();
@@ -176,7 +186,28 @@ describe("TrendDrilldownDialog", () => {
 
   it("keeps the rows on screen while a new order is fetched", () => {
     renderDialog();
-    expect(mocks.queryOptions?.placeholderData).toBe(keepPreviousData);
+    const key = mocks.queryOptions?.queryKey as unknown[];
+
+    expect(
+      placeholderAgainst([
+        ...key.slice(0, -1),
+        { sort: { key: "ref", direction: "asc" } },
+      ])
+    ).toBe("the rows already on screen");
+  });
+
+  // Another chart, another member set, another period: a new question, whose
+  // answer waits for the spinner rather than borrowing the last one's rows.
+  it("drops the rows when another chart is opened", () => {
+    renderDialog();
+    const key = mocks.queryOptions?.queryKey as unknown[];
+    const otherChart = [
+      ...key.slice(0, 3),
+      { ...(key[3] as object), metric_key: "git.lines_added" },
+      key[4],
+    ];
+
+    expect(placeholderAgainst(otherChart)).toBeUndefined();
   });
 
   // A scope with nobody in it has no records; telling its reader to narrow it

--- a/src/frontend/src/components/portal/trend-drilldown-dialog.tsx
+++ b/src/frontend/src/components/portal/trend-drilldown-dialog.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { AnalyticsApiError } from "@/api/analytics-client";
 import {
@@ -29,6 +29,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { formatMetricNumber } from "@/lib/format";
 import { nextSort } from "@/lib/metrics/evidence-rows";
+import { sameEvidenceSubject } from "@/lib/metrics/evidence-placeholder";
 import { type BucketBreakdownRow } from "@/lib/portal/trend-drilldown";
 
 const PAGE_LIMIT = 100;
@@ -128,8 +129,9 @@ function Records({
     [metricKey, state.members, state.period],
   );
   const view = useMemo(() => (sort ? { sort } : {}), [sort]);
+  const queryKey = ["metric-drilldown", "trend", sessionScope, selection, view];
   const query = useInfiniteQuery({
-    queryKey: ["metric-drilldown", "trend", sessionScope, selection, view],
+    queryKey,
     queryFn: ({ pageParam, signal }) => {
       if (!selection) throw new Error("Metric evidence selection is missing");
       return queryMetricDrilldown(
@@ -140,8 +142,13 @@ function Records({
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (page) => page.next_cursor ?? undefined,
     // Re-ordering re-reads rows already on screen; without this the table
-    // blanks to a spinner on every header click.
-    placeholderData: keepPreviousData,
+    // blanks to a spinner on every header click. A different chart, member set
+    // or period is a different question, and its answer waits for the spinner
+    // rather than borrowing the last one's rows.
+    placeholderData: (previous, previousQuery) =>
+      sameEvidenceSubject(previousQuery?.queryKey, queryKey)
+        ? previous
+        : undefined,
     enabled: sessionScope != null && selection != null,
     // A busy drilldown answers 429, and asking again immediately is what made
     // it busy.

--- a/src/frontend/src/lib/metrics/evidence-placeholder.ts
+++ b/src/frontend/src/lib/metrics/evidence-placeholder.ts
@@ -1,0 +1,18 @@
+import { hashKey, type QueryKey } from "@tanstack/react-query";
+
+/**
+ * Whether two evidence reads are the same subject asked a different way.
+ *
+ * The last key segment carries the order and the needle: re-reading under one
+ * of those must keep the rows on screen, or a header click replaces the table
+ * — and the search box above it — with a spinner and loses the caret mid-word.
+ * Every earlier segment names WHAT is being read, and holding the previous
+ * metric's records under the new one's title presents them as its answer.
+ */
+export function sameEvidenceSubject(
+  previous: QueryKey | undefined,
+  current: QueryKey
+): boolean {
+  if (!previous || previous.length !== current.length) return false;
+  return hashKey(previous.slice(0, -1)) === hashKey(current.slice(0, -1));
+}


### PR DESCRIPTION
**Why.** Two defects in the evidence drilldown, both reported from the dev stand. The table's rows drifted out from under their headings and pushed their last cell onto a second line, because the header and the body rows sized themselves independently over bases summing to exactly the table's `min-width`. And a drilldown opened after another one showed the previous metric's records while it loaded, because `keepPreviousData` does not distinguish a re-order from a new question.

**What.** One `grid-template-columns` now drives the header and every row, with the expanded record on a track of its own. The query placeholder keeps rows only when the key matches apart from its last segment — the order and the needle — so a header click still never blanks the table.

**Where.** `src/frontend`: `metric-evidence-table`, `metric-evidence-dialog`, `portal/trend-drilldown-dialog`, plus a shared `lib/metrics/evidence-placeholder`.

**Verify.** `cd src/frontend && pnpm vitest run` (2372 pass). On a stand: open a metric's records — rows one line tall, values under their headings; close it and open another metric — a spinner, not the last one's rows; click a header — rows stay put.

**Out of scope.** The table's natural width (99.25rem) still exceeds the dialog cap (90rem), so the horizontal scroll stays — dropping the `Author` column was considered and rejected: it is the source's own string, and it differs from the resolved `Who` for a sixth of the people measured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Evidence and trend drilldown dialogs now retain displayed rows when sorting or searching within the same metric.
  - Rows are cleared and a loading state is shown when switching to a different metric or chart.
  - Evidence tables now maintain consistent column alignment across headers, rows, and expanded details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->