### PR TITLE
fix(frontend): give the roster and the timeseries table room to read on a phone

### DIFF
--- a/src/frontend/src/components/widgets/dashboard/members-grid.stories.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.stories.tsx
@@ -1,0 +1,164 @@
+/**
+ * Browser component tests for the geometry of `<MembersGrid>` — the roster,
+ * one row per member and one column per metric.
+ *
+ * Which rows it draws, how it sorts them and what each cell says is covered by
+ * the jsdom tests in `members-grid.test.tsx`. What needs a real browser is the
+ * width: the member column is fixed and the table scrolls sideways past it, so
+ * on a phone a column sized for a desktop leaves no room for a single metric.
+ *
+ * See docs/testing/storybook-component-tests.md.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import { MembersGrid } from "@/components/widgets/dashboard/members-grid";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+import {
+  CARD_PX_AT_390,
+  CARD_PX_WIDE,
+  expectHorizontallyContained,
+} from "@/test/storybook/layout";
+
+/** Long enough that a member column crushed to nothing is unmistakable. */
+const MEMBERS = [
+  { entityId: "019e27bc-dec0-7626-81a9-c5524662a6a9", displayName: "Alexandra Fernandez" },
+  { entityId: "019e27bc-dec0-7626-81a9-c5524662a6b0", displayName: "Bo Ng" },
+];
+
+function metric(key: string, shortLabel: string): MetricResult {
+  return {
+    metric_key: key,
+    label: `${shortLabel} over the period`,
+    short_label: shortLabel,
+    unit: null,
+    format: "integer",
+    computation: "sum",
+    direction: "higher_is_better",
+    views: [
+      {
+        view: "period",
+        values: MEMBERS.map((m, index) => ({
+          entity_id: m.entityId,
+          value: 100 + index,
+        })),
+      },
+      {
+        view: "peer",
+        values: MEMBERS.map((m, index) => ({
+          entity_id: m.entityId,
+          target_value: 100 + index,
+          p25: 50,
+          median: 100,
+          p75: 150,
+          min: 0,
+          max: 200,
+          n: 12,
+        })),
+      },
+    ],
+  } as unknown as MetricResult;
+}
+
+/** Enough columns that the table overruns any container these stories use. */
+const RESULTS = [
+  metric("git.commits", "Commits"),
+  metric("git.prs_merged", "PRs merged"),
+  metric("git.code_lines", "Code lines"),
+  metric("collab.messages", "Msgs"),
+  metric("collab.meeting_hours", "Mtg hrs"),
+  metric("ai.active_days", "AI days"),
+];
+
+const meta: Meta<typeof MembersGrid> = {
+  title: "Widgets/Dashboard/MembersGrid",
+  component: MembersGrid,
+  args: {
+    members: MEMBERS,
+    metricKeys: RESULTS.map((r) => r.metric_key),
+    byKey: normalizeMetricResults(RESULTS),
+    caption: "Members grid",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof MembersGrid>;
+
+/** Demo story for the Storybook UI (untagged — not a test). */
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** The column the names sit in is the one that holds the scroller's width. */
+function memberColumnWidth(table: Element): number {
+  const header = table.querySelector("thead th");
+  return Math.round(header!.getBoundingClientRect().width);
+}
+
+/**
+ * On a phone the first metric column reads in full beside the names.
+ *
+ * The failure this pins is invisible to a text query: every cell is in the DOM
+ * and correct, and the member column simply holds a desktop width the viewport
+ * does not have — so the roster shows names, part of one metric, and nothing
+ * else, with the rest hidden behind a sideways scroll nobody looks for.
+ */
+export const TestNarrowRosterShowsAWholeMetricColumn: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const table = canvas.getByRole("table", { name: "Members grid" });
+    const scroller = table.parentElement!;
+
+    const firstMetric = canvas.getByRole("button", {
+      name: "Commits over the period — sort by this column",
+    });
+    expectHorizontallyContained(
+      scroller,
+      [firstMetric.closest("th")!],
+      () => "the first metric column"
+    );
+
+    // Reaching that by shrinking the names to nothing would be no better than
+    // the bug: the column has to still hold a name.
+    const name = canvas.getByRole("link", { name: "Alexandra Fernandez" });
+    await expect(
+      Math.round(name.getBoundingClientRect().width),
+      "the member column collapsed the name away"
+    ).toBeGreaterThan(80);
+  },
+};
+
+/** Given the room, the names get the width they read best at. */
+export const TestWideRosterKeepsTheComfortableNameColumn: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const table = canvas.getByRole("table", { name: "Members grid" });
+    const width = memberColumnWidth(table);
+    await expect(
+      width,
+      `the member column is ${width}px on a ${CARD_PX_WIDE}px card`
+    ).toBe(256);
+  },
+};

--- a/src/frontend/src/components/widgets/dashboard/members-grid.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.tsx
@@ -64,6 +64,22 @@ import {
   withOwnTarget,
 } from "@/components/metric-evidence-context";
 
+/**
+ * INVARIANT: every step leaves room for the names plus one whole metric column
+ * (`METRIC_COL_PX`) inside the container it applies to — a step wider than
+ * that is the bug this replaced, where the roster showed names and nothing
+ * else. A container query, not a viewport one: a drilldown pane on a desktop
+ * is as narrow as a phone.
+ */
+const MEMBER_COL_WIDTH =
+  "[--member-col:9rem] @min-[26rem]:[--member-col:12rem] @min-[32rem]:[--member-col:16rem]";
+
+/** Falls back rather than collapsing to `auto` if the wrapper ever loses it. */
+const MEMBER_COL_CELL =
+  "sticky start-0 z-10 w-[var(--member-col,16rem)] bg-card text-left";
+
+const METRIC_COL_PX = 108;
+
 export interface MembersGridMember {
   /** Canonical person id — keys every metric lookup AND the IC link. */
   entityId: string;
@@ -359,8 +375,8 @@ export function MembersGrid({
   const memberSortActive = sort.key === "issues" || sort.key === "name";
 
   return (
-    <div className={cn("flex flex-col gap-3", className)}>
-      <div className="overflow-x-auto">
+    <div className={cn("@container flex flex-col gap-3", className)}>
+      <div className={cn("overflow-x-auto", MEMBER_COL_WIDTH)}>
         {/* Fixed layout so metric columns are uniform — auto layout sizes
             each column to its own content, making them ragged. The member
             column takes a fixed width; the metric columns split the rest
@@ -370,7 +386,9 @@ export function MembersGrid({
             wrapper scrolls instead of crushing columns. */}
         <table
           className="w-full max-w-[1600px] table-fixed border-separate border-spacing-1"
-          style={{ minWidth: `${256 + columns.length * 108}px` }}
+          style={{
+            minWidth: `calc(var(--member-col, 16rem) + ${columns.length * METRIC_COL_PX}px)`,
+          }}
         >
           <caption className="sr-only">{caption}</caption>
           <thead>
@@ -378,7 +396,7 @@ export function MembersGrid({
               <th
                 scope="col"
                 aria-sort={memberDirection}
-                className="sticky left-0 z-10 w-64 bg-card px-2 text-left"
+                className={cn(MEMBER_COL_CELL, "px-2")}
               >
                 {hasIssuesFacet ? (
                   // Two member orderings (issues / name) → a small header menu,
@@ -496,7 +514,7 @@ function MemberRow({
     <tr>
       <th
         scope="row"
-        className="sticky left-0 z-10 w-64 bg-card px-2 py-1 text-left font-normal"
+        className={cn(MEMBER_COL_CELL, "px-2 py-1 font-normal")}
       >
         <div className="flex min-h-12 flex-col justify-center gap-0.5">
           <div className="flex items-center gap-1.5">

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-presentations.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-presentations.test.tsx
@@ -190,7 +190,7 @@ describe("metric timeseries presentations", () => {
     const row = screen.getByText("Grand total").closest("tr")!;
     const totals = row.querySelectorAll("td")[1]!.querySelector("span")!;
     expect(totals.className).toContain("sticky");
-    expect(totals.className).toContain("start-28");
+    expect(totals.className).toContain("start-24");
   });
 
   it("hides the grand-total row when every total is missing", () => {

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.stories.tsx
@@ -1,0 +1,204 @@
+/**
+ * Browser component tests for the geometry of `<MetricTimeseriesTable>` — the
+ * scroll controls and the room they leave the data.
+ *
+ * What the table renders, and where a page scrolls to, is covered by the jsdom
+ * tests in `metric-timeseries-presentations.test.tsx`, which hand it fake
+ * geometry. What needs a real browser is the geometry itself: the controls sit
+ * in gutters taken out of the scrollport, and both the sticky bucket column and
+ * a whole value column have to survive that on a phone.
+ *
+ * `metric-timeseries-view.stories.tsx` covers the same table inside its card;
+ * this file renders it in a box of a chosen size, which is the only way to
+ * reach the short-table case.
+ *
+ * See docs/testing/storybook-component-tests.md.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, waitFor } from "storybook/test";
+
+import { MetricTimeseriesTable } from "@/components/widgets/metric-views/metric-timeseries-table";
+import { groupedTimeseriesModel } from "@/components/widgets/metric-views/metric-timeseries.test-fixtures";
+import {
+  CARD_PX_AT_390,
+  expectNothingOverlaps,
+} from "@/test/storybook/layout";
+
+/** Short enough that the three rows overrun it, so the row controls render. */
+const SHORT_PX = 180;
+
+/** Mirrors the gutter the component reserves — see the widening story. */
+const GUTTER_PX = 48;
+
+const meta: Meta<typeof MetricTimeseriesTable> = {
+  title: "Widgets/MetricViews/MetricTimeseriesTable",
+  component: MetricTimeseriesTable,
+  args: { model: groupedTimeseriesModel() },
+};
+export default meta;
+
+type Story = StoryObj<typeof MetricTimeseriesTable>;
+
+/** Demo story for the Storybook UI (untagged — not a test). */
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: 900, height: 300 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+function scrollControls(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>('button[aria-label^="Show "]')
+  );
+}
+
+function nameOf(element: Element): string {
+  return element.getAttribute("aria-label") ?? "a scroll control";
+}
+
+/**
+ * Scrolling both ways, the four controls clear the cells and each other.
+ *
+ * The row pair shares the end gutter with the column control, so this is the
+ * arrangement that stops being obvious: three chevrons in one lane, held apart
+ * only by the height the caller gives the table.
+ */
+export const TestShortTableKeepsItsControlsApart: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390, height: SHORT_PX }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["test"],
+  play: async ({ canvasElement }) => {
+    const table = canvasElement.querySelector("table")!;
+    const scrollport = table.parentElement!;
+    const controls = scrollControls(canvasElement);
+
+    const labels = controls.map(nameOf);
+    await expect(
+      labels,
+      `the table scrolls both ways, so it renders a control for each (${labels.join(", ")})`
+    ).toEqual(
+      expect.arrayContaining(["Show later columns", "Show later rows"])
+    );
+
+    expectNothingOverlaps(scrollport, controls, nameOf);
+    for (const control of controls) {
+      expectNothingOverlaps(
+        control,
+        controls.filter((other) => other !== control),
+        nameOf
+      );
+    }
+  },
+};
+
+/**
+ * On a phone the bucket column and a whole value column both still read.
+ *
+ * Moving the controls off the cells costs the scrollport two gutters, and the
+ * sticky bucket column is taken out of what is left. Clearing the cells by
+ * taking the room they needed would leave the table exactly as unreadable as
+ * the controls painted over it did.
+ */
+export const TestNarrowTableLeavesRoomForAValueColumn: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390, height: 400 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["test"],
+  play: async ({ canvasElement }) => {
+    const table = canvasElement.querySelector("table")!;
+    const scrollport = table.parentElement!;
+    const cells = Array.from(
+      table.querySelectorAll<HTMLElement>("tbody tr:first-child > *")
+    );
+
+    await expect(
+      cells.length,
+      "the first row has a bucket cell and at least one value"
+    ).toBeGreaterThan(1);
+
+    const room = scrollport.clientWidth;
+    const bucket = cells[0].getBoundingClientRect().width;
+    const value = cells[1].getBoundingClientRect().width;
+    await expect(
+      Math.round(bucket + value),
+      `the bucket column (${Math.round(bucket)}px) and the first value ` +
+        `(${Math.round(value)}px) do not fit the ${room}px scrollport`
+    ).toBeLessThanOrEqual(room);
+
+    // The date is what the bucket column is narrow for; a column that clips it
+    // would satisfy the width check and tell the reader nothing.
+    const date = cells[0];
+    await expect(
+      date.scrollWidth,
+      `the bucket cell clips its date (${date.scrollWidth}px of text in ${date.clientWidth}px)`
+    ).toBeLessThanOrEqual(date.clientWidth);
+  },
+};
+
+/**
+ * Given the room back, the table gives the gutters back.
+ *
+ * The gutters are the wrapper's padding, so measuring the overflow on the
+ * scrollport feeds them their own effect: the width they took makes the
+ * overflow that keeps them. That latches — a card that was ever narrow keeps a
+ * sideways scroll and two empty gutters at every width afterwards — and only a
+ * resize in both directions catches it.
+ */
+export const TestWidenedTableReleasesItsGutters: Story = {
+  decorators: [
+    (Story) => (
+      <div data-testid="box" style={{ width: CARD_PX_AT_390, height: 400 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["test"],
+  play: async ({ canvasElement }) => {
+    const box = canvasElement.querySelector<HTMLElement>('[data-testid="box"]')!;
+    const table = canvasElement.querySelector("table")!;
+    const wrapper = table.parentElement!.parentElement!;
+
+    await waitFor(() =>
+      expect(
+        scrollControls(canvasElement).length,
+        "the narrow table scrolls sideways to begin with"
+      ).toBeGreaterThan(0)
+    );
+
+    // One gutter's worth of room past the table is the width that catches a
+    // latch and nothing else does: wide enough that the table fits with no
+    // gutters, narrow enough that it does not once a stale pair is subtracted.
+    box.style.width = `${table.offsetWidth + GUTTER_PX}px`;
+
+    await waitFor(() =>
+      expect(
+        scrollControls(canvasElement).map(nameOf),
+        "the widened table still offers to scroll"
+      ).toEqual([])
+    );
+
+    const scrollport = table.parentElement!;
+    await expect(
+      scrollport.scrollWidth,
+      `the widened table still scrolls sideways (${scrollport.scrollWidth}px of table in ${scrollport.clientWidth}px)`
+    ).toBeLessThanOrEqual(scrollport.clientWidth);
+    await expect(
+      wrapper.className,
+      "the wrapper kept a gutter it no longer has a control for"
+    ).not.toContain("ps-12");
+  },
+};

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.tsx
@@ -51,6 +51,8 @@ const NOTHING_MORE: Record<Side, boolean> = {
   down: false,
 };
 
+const NO_GUTTERS = { start: false, end: false };
+
 /** Sub-pixel scroll offsets are noise, not a side with content on it. */
 const EDGE_SLACK_PX = 1;
 
@@ -58,9 +60,13 @@ const EDGE_SLACK_PX = 1;
 const NEARLY_A_FRAME = 0.8;
 
 /**
- * The vertical pair is offset toward the end rather than centred: the sticky
- * header carries the group names and the sticky footer the totals, and a
- * control parked over either hides what that row is pinned for.
+ * Every control sits in a gutter beside the scrollport rather than over it, so
+ * none of them can hide a cell.
+ *
+ * INVARIANT: the end gutter stacks three — rows up at the top, columns forward
+ * in the middle, rows down at the bottom — which needs about 104px of height to
+ * keep them apart. Every caller renders the table taller than that; one that
+ * does not gets three chevrons in a heap.
  */
 const SIDE_CHROME: Record<
   Side,
@@ -79,14 +85,37 @@ const SIDE_CHROME: Record<
   up: {
     icon: ChevronUp,
     label: "Show earlier rows",
-    place: "top-1 end-10",
+    place: "top-1 end-1",
   },
   down: {
     icon: ChevronDown,
     label: "Show later rows",
-    place: "bottom-1 end-10",
+    place: "bottom-1 end-1",
   },
 };
+
+/**
+ * The gutters, wide enough for a control plus the inset it is placed at.
+ *
+ * INVARIANT: `GUTTER_PX` is what these classes render as. The measure pass
+ * subtracts it to decide whether the table overflows, so the two disagreeing
+ * makes the controls appear against a width the layout never had.
+ */
+const GUTTER_START = "ps-12";
+const GUTTER_END = "pe-12";
+const GUTTER_PX = 48;
+
+/**
+ * The bucket column, sticky at the start of every row, and the offset the
+ * grand-total row sticks at to clear it.
+ *
+ * INVARIANT: the two widths are the same number. Wide enough for a full
+ * `YYYY-MM-DD` plus the cells' own padding, and no wider — this column and the
+ * gutters come out of one scrollport, which on a phone has a single data
+ * column's room to spare between them.
+ */
+const BUCKET_COL = "w-24 max-w-24 min-w-24";
+const PAST_BUCKET_COL = "start-24";
 
 const BUCKET_LABEL = {
   day: "Day",
@@ -179,11 +208,14 @@ export function MetricTimeseriesTable({
     )
   );
 
+  const wrapRef = useRef<HTMLDivElement | null>(null);
   const boxRef = useRef<HTMLDivElement | null>(null);
   const [more, setMore] = useState(NOTHING_MORE);
+  const [gutters, setGutters] = useState(NO_GUTTERS);
   const measure = useCallback(() => {
     const box = boxRef.current;
-    if (!box) return;
+    const wrap = wrapRef.current;
+    if (!box || !wrap) return;
     // `scrollLeft` is negative in RTL.
     const across = Math.abs(box.scrollLeft);
     const acrossRoom = box.scrollWidth - box.clientWidth;
@@ -199,7 +231,26 @@ export function MetricTimeseriesTable({
     setMore((prev) =>
       SIDES.every((side) => prev[side] === next[side]) ? prev : next
     );
-    onVerticalOverflow?.(downRoom > EDGE_SLACK_PX);
+
+    // The wrapper's own width, not the scrollport's: the gutters are its
+    // padding, so this figure is the one thing they cannot move. Deciding from
+    // the scrollport feeds a gutter its own effect — the width it took makes
+    // the overflow that keeps it — and the table then scrolls sideways forever
+    // over a card that has long since grown wide enough.
+    const rows = box.querySelector("table");
+    const naturalWidth = rows?.offsetWidth ?? box.scrollWidth;
+    const scrollsDown = downRoom > EDGE_SLACK_PX;
+    // The table never wraps a cell (`min-w-max`), so its height owes nothing to
+    // any of this and the end gutter can be subtracted without circling back.
+    const roomAcross = wrap.clientWidth - (scrollsDown ? GUTTER_PX : 0);
+    const scrollsAcross = naturalWidth > roomAcross + EDGE_SLACK_PX;
+    setGutters((prev) =>
+      prev.start === scrollsAcross && prev.end === (scrollsAcross || scrollsDown)
+        ? prev
+        : { start: scrollsAcross, end: scrollsAcross || scrollsDown }
+    );
+
+    onVerticalOverflow?.(scrollsDown);
   }, [onVerticalOverflow]);
   useEffect(() => {
     measure();
@@ -238,7 +289,14 @@ export function MetricTimeseriesTable({
   }
 
   return (
-    <div className="relative h-full">
+    <div
+      ref={wrapRef}
+      className={cn(
+        "relative h-full",
+        gutters.start && GUTTER_START,
+        gutters.end && GUTTER_END
+      )}
+    >
       {/* Rendered, not hidden: opacity would leave them in the tab order. */}
       {SIDES.filter((side) => more[side]).map((side) => {
         const { icon: Icon, label, place } = SIDE_CHROME[side];
@@ -252,7 +310,6 @@ export function MetricTimeseriesTable({
             title={label}
             onClick={() => page(side)}
             className={cn(
-              // Opaque, so they stay legible over whatever cell they land on.
               "absolute z-40 rounded-full bg-card shadow-md",
               place
             )}
@@ -269,7 +326,7 @@ export function MetricTimeseriesTable({
       <TableHeader className="[&_tr]:border-b-0">
         {model.dimensions.length === 0 ? (
           <TableRow>
-            <TableHead className="sticky top-0 left-0 z-30 h-10 w-28 max-w-28 min-w-28 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+            <TableHead className={cn(BUCKET_COL, "sticky top-0 left-0 z-30 h-10 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
               {BUCKET_LABEL[model.bucket]}
             </TableHead>
             {tableColumns.map((column, columnIndex) => (
@@ -287,7 +344,7 @@ export function MetricTimeseriesTable({
           </TableRow>
         ) : tableColumns.length === 1 ? (
           <TableRow>
-            <TableHead className="sticky top-0 left-0 z-30 h-10 w-28 max-w-28 min-w-28 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+            <TableHead className={cn(BUCKET_COL, "sticky top-0 left-0 z-30 h-10 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
               {BUCKET_LABEL[model.bucket]}
             </TableHead>
             {model.columns.map((column, index) => (
@@ -306,7 +363,7 @@ export function MetricTimeseriesTable({
         ) : (
           <>
             <TableRow>
-              <TableHead className="sticky top-0 left-0 z-30 h-10 w-28 max-w-28 min-w-28 bg-card py-0 after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+              <TableHead className={cn(BUCKET_COL, "sticky top-0 left-0 z-30 h-10 bg-card py-0 after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
                 {BUCKET_LABEL[model.bucket]}
               </TableHead>
               {model.columns.map((column, index) => (
@@ -326,7 +383,7 @@ export function MetricTimeseriesTable({
             <TableRow>
               <TableHead
                 aria-hidden
-                className="sticky top-10 left-0 z-30 h-9 w-28 max-w-28 min-w-28 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border"
+                className={cn(BUCKET_COL, "sticky top-10 left-0 z-30 h-9 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}
               />
               {model.columns.flatMap((column, columnIndex) =>
                 tableColumns.map((tableColumn, tableColumnIndex) => (
@@ -349,7 +406,7 @@ export function MetricTimeseriesTable({
       <TableBody>
         {model.buckets.map((bucketStart) => (
           <TableRow key={bucketStart}>
-            <TableCell className="sticky left-0 z-10 w-28 max-w-28 min-w-28 bg-card px-2 py-1 font-medium tabular-nums after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+            <TableCell className={cn(BUCKET_COL, "sticky left-0 z-10 bg-card px-2 py-1 font-medium tabular-nums after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
               {bucketStart}
             </TableCell>
             {model.columns.flatMap((column, columnIndex) =>
@@ -390,7 +447,7 @@ export function MetricTimeseriesTable({
           need the row behind them gone, not softened. */}
       <TableFooter className="sticky bottom-0 z-20 bg-muted shadow-[inset_0_1px_0_0_var(--border)]">
         <TableRow>
-          <TableCell className="sticky left-0 z-10 w-28 max-w-28 min-w-28 bg-muted px-2 py-1 font-semibold after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+          <TableCell className={cn(BUCKET_COL, "sticky left-0 z-10 bg-muted px-2 py-1 font-semibold after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
             Total
           </TableCell>
           {model.columns.flatMap((column, columnIndex) =>
@@ -419,7 +476,7 @@ export function MetricTimeseriesTable({
         </TableRow>
         {model.dimensions.length > 0 && hasGrandTotal ? (
           <TableRow>
-            <TableCell className="sticky left-0 z-10 w-28 max-w-28 min-w-28 bg-muted px-2 pt-1 pb-5 font-semibold after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+            <TableCell className={cn(BUCKET_COL, "sticky left-0 z-10 bg-muted px-2 pt-1 pb-5 font-semibold after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
               Grand total
             </TableCell>
             <TableCell
@@ -428,7 +485,7 @@ export function MetricTimeseriesTable({
             >
               {/* Stuck past the label column, since the cell spans every group
                   and its own start edge scrolls away. */}
-              <span className="sticky start-28 inline-flex flex-wrap items-center gap-1.5">
+              <span className={cn(PAST_BUCKET_COL, "sticky inline-flex flex-wrap items-center gap-1.5")}>
                 {tableColumns.map((tableColumn, index) => (
                   <span
                     key={tableColumn.key}

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/widgets/metric-views/metric-timeseries.story-fixtures";
 import {
   CARD_PX_AT_390,
+  expectHorizontallyContained,
   expectNothingOverlaps,
 } from "@/test/storybook/layout";
 
@@ -659,3 +660,69 @@ export const TestNarrowHeaderStacksInsteadOfOverlapping: Story = {
     ).toBeLessThanOrEqual(label!.clientWidth);
   },
 };
+
+/**
+ * The scroll controls sit beside the table, never over a cell.
+ *
+ * The failure this pins is invisible to a text query too: the controls were
+ * drawn over the scrollport, so on a narrow card the one that pages backwards
+ * covered the date column — the reader could see a value and not what it was
+ * measured on.
+ */
+export const TestNarrowTableKeepsItsScrollControlsOffTheCells: Story = {
+  tags: ["test"],
+  args: { groupBy: TOP_REPOSITORIES, defaultPresentation: "table" },
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const table = await canvas.findByRole("table");
+    const scrollport = table.parentElement!;
+    const controlsNow = () =>
+      canvas.getAllByRole("button", { name: /^Show (earlier|later) / });
+
+    await expect(
+      controlsNow().length,
+      "the table has scroll controls to clear"
+    ).toBeGreaterThan(0);
+    expectNothingOverlaps(scrollport, controlsNow(), (element) =>
+      element.getAttribute("aria-label") ?? "a scroll control"
+    );
+
+    // Clearing the cells by taking the room they needed would satisfy the check
+    // above and leave the table just as unreadable: the gutters and the sticky
+    // bucket column come out of the same width, and a whole value column has to
+    // survive both.
+    const firstValue = table.querySelectorAll("tbody tr td")[0];
+    expectHorizontallyContained(
+      scrollport,
+      [table.querySelector("tbody th, tbody tr > *:first-child")!, firstValue],
+      (element) => `the ${element.tagName.toLowerCase()} in the first row`
+    );
+
+    // Paging brings the backwards control in. Its gutter is reserved up front,
+    // so the columns under the reader's eye must not move when it appears.
+    const before = scrollport.getBoundingClientRect().width;
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Show later columns" })
+    );
+    await waitFor(() =>
+      expect(
+        canvas.getByRole("button", { name: "Show earlier columns" })
+      ).toBeVisible()
+    );
+
+    expectNothingOverlaps(scrollport, controlsNow(), (element) =>
+      element.getAttribute("aria-label") ?? "a scroll control"
+    );
+    await expect(
+      scrollport.getBoundingClientRect().width,
+      "the scrollport resized when a control appeared"
+    ).toBe(before);
+  },
+};
+


### PR DESCRIPTION
On a narrow viewport the members roster held a desktop-width name column, leaving part of one metric column visible and the rest off screen; the timeseries table drew its scroll controls over the scrollport, where the backwards control covered the bucket column. The name column now steps down through a container query, and the controls move into gutters beside the scrollport — with the bucket column narrowed to what a date needs, so a whole value column survives the width those gutters take.

Whether a gutter is needed is measured on the wrapper rather than the scrollport: the scrollport's width is the gutters' own effect, and measuring it there latches them on for good.

Closes #2834. Item 2 of that issue (the "Also measured here" card) was already fixed by #2997 and is not touched here.

**Where:** `src/frontend` — `members-grid.tsx`, `metric-timeseries-table.tsx`, plus browser component tests for both.

**Verify:** `cd src/frontend && pnpm vitest run` — six Storybook geometry tests cover this; each was checked to fail against the defect it names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive layouts for member and time-series tables on narrow screens.
  * Ensured key columns and metric values remain visible without overlapping controls.
  * Adjusted sticky columns and totals for more consistent alignment.
  * Improved table gutters and scrolling behavior as available space changes.

* **Tests**
  * Added browser-based coverage for table sizing, sticky columns, scrolling controls, and responsive layouts across narrow and wide viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->