### PR TITLE
fix(frontend): stop the identity search fields at the length the service accepts

### DIFF
--- a/src/frontend/src/components/portal/account-search-view.test.tsx
+++ b/src/frontend/src/components/portal/account-search-view.test.tsx
@@ -79,6 +79,7 @@ vi.mock("@/queries/identity-resolution", async (importOriginal) => ({
   }),
 }));
 
+import { MAX_SEARCH_CHARS } from "@/queries/identity-resolution";
 import { portalRouter } from "@/test/portal-router";
 
 import { scrollEndIntoView } from "@/test/intersection-observer";
@@ -154,6 +155,18 @@ describe("AccountSearchView", () => {
   // One letter reaches most of what the connectors reported and costs the fold a
   // pass to say so. Going silent would read as a broken field, so the mode says
   // what it is waiting for — and shows no rows it did not ask for.
+  // The service refuses a needle past 200 characters, so a field that accepted
+  // one would turn an ordinary paste — an id, a url, a line from a log — into a
+  // refusal the operator has no way to read as "too long".
+  it("stops at the length the service accepts", () => {
+    render(<AccountSearchView />);
+
+    expect(screen.getByRole("searchbox")).toHaveAttribute(
+      "maxlength",
+      String(MAX_SEARCH_CHARS),
+    );
+  });
+
   it("asks for a second character instead of searching on one", async () => {
     hooks.search.data = page([match()]);
     render(<AccountSearchView />);

--- a/src/frontend/src/components/portal/account-search-view.tsx
+++ b/src/frontend/src/components/portal/account-search-view.tsx
@@ -42,6 +42,7 @@ import { usePortalSearch } from "@/lib/portal/portal-search";
 import {
   belowAccountFloor,
   listsAnyAccount,
+  MAX_SEARCH_CHARS,
   MIN_SEARCH_CHARS,
   SEARCH_DEBOUNCE_MS,
   useAccountList,
@@ -120,6 +121,10 @@ export function AccountSearchView() {
           onChange={(event) => setQuery(event.target.value)}
           placeholder={t("identities.accounts.placeholder")}
           aria-label={t("identities.accounts.placeholder")}
+          // The service refuses a longer needle. Without the stop the field
+          // accepts a paste it cannot search — an id, a url, a log line — and
+          // the operator gets a refusal instead of a result.
+          maxLength={MAX_SEARCH_CHARS}
           className="ps-9"
         />
         {loading ? (

--- a/src/frontend/src/components/portal/person-picker.test.tsx
+++ b/src/frontend/src/components/portal/person-picker.test.tsx
@@ -42,6 +42,7 @@ vi.mock("@/hooks/use-debounced-value", () => ({
 }));
 
 import { SCROLL_ENDS_AFTER_ROWS } from "@/components/widgets/scroll-to-ends";
+import { MAX_SEARCH_CHARS } from "@/queries/identity-resolution";
 import { scrollEndIntoView } from "@/test/intersection-observer";
 
 import { PersonPicker } from "./person-picker";
@@ -99,6 +100,18 @@ describe("PersonPicker", () => {
   // One letter names most of the roster: the answer is no use and the service
   // pays a pass over the journal for it. Going silent instead would read as a
   // broken field, so the picker says what it is waiting for.
+  // `/v1/persons` refuses a needle past 200 characters, the same ceiling the
+  // account search carries. The field stops there rather than letting a paste
+  // become a refusal the reader cannot interpret.
+  it("stops at the length the service accepts", () => {
+    render(<PersonPicker onPick={vi.fn()} />);
+
+    expect(screen.getByRole("searchbox")).toHaveAttribute(
+      "maxlength",
+      String(MAX_SEARCH_CHARS),
+    );
+  });
+
   it("asks for a second character instead of searching on one", async () => {
     list.state.data = { pages: [page([BOB])] };
     render(<PersonPicker onPick={vi.fn()} />);

--- a/src/frontend/src/components/portal/person-picker.tsx
+++ b/src/frontend/src/components/portal/person-picker.tsx
@@ -30,6 +30,7 @@ import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import {
   belowPersonFloor,
   listsAnyone,
+  MAX_SEARCH_CHARS,
   MIN_SEARCH_CHARS,
   SEARCH_DEBOUNCE_MS,
   usePersonList,
@@ -127,6 +128,7 @@ export function PersonPicker({
           className="ps-8"
           placeholder={t("identities.picker.placeholder")}
           aria-label={t("identities.picker.placeholder")}
+          maxLength={MAX_SEARCH_CHARS}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />

--- a/src/frontend/src/queries/identity-resolution.ts
+++ b/src/frontend/src/queries/identity-resolution.ts
@@ -172,6 +172,15 @@ export type AccountListIntent = "browse" | "match";
 export const MIN_SEARCH_CHARS = 2;
 
 /**
+ * The ceiling both identity search surfaces are checked against server-side —
+ * `listing::MAX_QUERY_CHARS` on `/v1/persons` and `/v1/visible-persons`, and
+ * the same value on `/v1/resolution/accounts`. Declared here so a field can
+ * stop at the limit rather than let the operator type past it and receive a
+ * refusal they cannot read as "too long".
+ */
+export const MAX_SEARCH_CHARS = 200;
+
+/**
  * How long a field waits before it searches. Past the gap between two
  * keystrokes of ordinary typing (150-300 ms), so a typed word costs one search
  * of the journal rather than one per letter.


### PR DESCRIPTION
**Why.** #3010 capped the identity search needle at 200 characters server-side. The fields did not, so pasting something ordinary into the account search — an id, a url, a line from a log — now builds a request that cannot succeed, and the operator gets a refusal where they expected results.

**What changed.** Both identity search fields carry that cap, as one exported constant beside the floor they already share, so the field stops where the service stops.

**The other half of this is not fixed here, and it is worse.** When that request comes back 400 the console keeps the previous result list on screen with no error affordance — so the rows an operator is reading answer a search they did not make. Capping the field removes the way they reach it by accident; it does not fix the underlying render.

Reproduced twice on the dev stand, from a fresh page each time: the request answers 400 and **49 rows stay on screen for 16 seconds**, while `Account search failed. Try again.` never renders — although the branch for it exists in `account-search-view.tsx` and `ComingSoon` would carry that string as an accessible name. Why `isError` does not reach that branch I could not establish, so there is no speculative change to that component in this PR.

**Verified.** Reproduction and the fixed field behaviour observed on the dev stand in a real browser. **The two new frontend cases were not run locally** — the frontend requires Node 24 and this machine has 22, so CI is their first run.
