### PR TITLE
feat(observability): gateway nginx stub_status and prometheus-exporter sidecar

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -357,6 +357,9 @@ gateway:
   resources:
     requests: {cpu: 25m, memory: 32Mi}
     limits: {cpu: 500m, memory: 128Mi}
+  # nginx-prometheus-exporter sidecar; enable per-stand where it is scraped.
+  metrics:
+    enabled: false
   # The gateway's route attaches to the shared Gateway; it routes "/" internally.
   route:
     enabled: true

--- a/src/backend/services/gateway/helm/templates/deployment.yaml
+++ b/src/backend/services/gateway/helm/templates/deployment.yaml
@@ -85,6 +85,26 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics-exporter
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          args:
+            # Matches the loopback-only stub_status listener routegen emits.
+            - --nginx.scrape-uri=http://127.0.0.1:8090/stub_status
+            - --web.listen-address=:{{ .Values.metrics.port }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml .Values.metrics.resources | nindent 12 }}
+        {{- end }}
       volumes:
         - name: routes
           configMap:

--- a/src/backend/services/gateway/helm/templates/service.yaml
+++ b/src/backend/services/gateway/helm/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.metrics.enabled }}
+    - port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "insight-gateway.selectorLabels" . | nindent 4 }}

--- a/src/backend/services/gateway/helm/values.yaml
+++ b/src/backend/services/gateway/helm/values.yaml
@@ -70,6 +70,22 @@ gateway:
   # lua_shared_dict exchange-cache size (empty = routegen default 64m).
   jwtCacheSize: ""
 
+# nginx-prometheus-exporter sidecar serving stub_status as /metrics.
+metrics:
+  enabled: false
+  port: 9113
+  image:
+    repository: nginx/nginx-prometheus-exporter
+    tag: "1.5.3"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 5m
+      memory: 16Mi
+    limits:
+      cpu: 50m
+      memory: 32Mi
+
 resources:
   requests:
     cpu: 25m

--- a/src/backend/tools/routegen/src/emit.rs
+++ b/src/backend/tools/routegen/src/emit.rs
@@ -13,6 +13,9 @@ use url::Url;
 
 use crate::schema::{ResolvedRoute, RouteConfig};
 
+// INVARIANT: the gateway chart's exporter scrape URI must match this address.
+const STUB_STATUS_LISTEN: &str = "127.0.0.1:8090";
+
 /// Deployment settings that are not part of the route table itself (upstream
 /// authorities, timeouts, trusted proxies). The CLI fills them from env at
 /// container startup; defaults are the in-cluster values.
@@ -207,6 +210,8 @@ pub fn emit(config: &RouteConfig, settings: &Settings) -> anyhow::Result<String>
         &upstreams,
     )?;
 
+    emit_stub_status(&mut c)?;
+
     writeln!(c, "}}")?;
 
     Ok(c)
@@ -365,6 +370,22 @@ fn emit_server(
 
     writeln!(c, "    }}")?;
 
+    Ok(())
+}
+
+/// SAFETY: a dedicated loopback listener — a main-port allow/deny check could
+/// be spoofed, since `remote_addr` there is rewritten from X-Forwarded-For.
+fn emit_stub_status(c: &mut String) -> anyhow::Result<()> {
+    c.push('\n');
+    c.push_str("    # --- nginx counters for the metrics exporter sidecar: loopback-only ---\n");
+    writeln!(c, "    server {{")?;
+    writeln!(c, "        listen {STUB_STATUS_LISTEN};")?;
+    c.push('\n');
+    c.push_str("        location = /stub_status {\n");
+    c.push_str("            access_log off;\n");
+    c.push_str("            stub_status;\n");
+    c.push_str("        }\n");
+    writeln!(c, "    }}")?;
     Ok(())
 }
 

--- a/src/backend/tools/routegen/tests/fixtures/full.nginx.conf
+++ b/src/backend/tools/routegen/tests/fixtures/full.nginx.conf
@@ -155,4 +155,14 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
+
+    # --- nginx counters for the metrics exporter sidecar: loopback-only ---
+    server {
+        listen 127.0.0.1:8090;
+
+        location = /stub_status {
+            access_log off;
+            stub_status;
+        }
+    }
 }

--- a/src/backend/tools/routegen/tests/fixtures/stripprefix.nginx.conf
+++ b/src/backend/tools/routegen/tests/fixtures/stripprefix.nginx.conf
@@ -134,4 +134,14 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
+
+    # --- nginx counters for the metrics exporter sidecar: loopback-only ---
+    server {
+        listen 127.0.0.1:8090;
+
+        location = /stub_status {
+            access_log off;
+            stub_status;
+        }
+    }
 }

--- a/src/backend/tools/routegen/tests/golden.rs
+++ b/src/backend/tools/routegen/tests/golden.rs
@@ -93,6 +93,21 @@ fn real_ip_emitted_only_when_trusted_cidrs_configured() {
 }
 
 #[test]
+fn stub_status_is_loopback_only() {
+    let conf = generate(&fixture("full.routes.yaml"), &Settings::default()).unwrap();
+    let status_server = conf
+        .split("server {")
+        .find(|s| s.contains("stub_status;"))
+        .expect("a server block serving stub_status");
+    let listens: Vec<&str> = status_server
+        .lines()
+        .map(str::trim)
+        .filter(|l| l.starts_with("listen "))
+        .collect();
+    assert_eq!(listens, ["listen 127.0.0.1:8090;"]);
+}
+
+#[test]
 fn jwks_is_not_fronted_by_the_gateway() {
     // JWKS is public and served directly by the authenticator (the key issuer),
     // never proxied through the edge.


### PR DESCRIPTION
Closes #2892.

**Why.** Traffic at the nginx edge — connection and request rates — is invisible to the metrics pipeline: services push RED metrics over OTLP, but nginx itself exposes nothing a collector can scrape.

**What changed.** routegen now emits a `stub_status` server on a dedicated `127.0.0.1:8090` listener, and the gateway chart gains an optional `nginx-prometheus-exporter` sidecar (`metrics.enabled`, off by default) that serves those counters as `/metrics` on a `metrics` Service port.

**A loopback listener, not an `allow 127.0.0.1` location on the main port.** `remote_addr` there is rewritten from X-Forwarded-For (`set_real_ip_from`), so an address check could be spoofed. A `127.0.0.1` bind is unreachable off-pod by construction; trivial to relocate if the port is ever contended.

Evidence (local container run): an exporter sharing the gateway's network namespace with the exact args the chart renders reports `nginx_up 1`, `nginx_http_requests_total 1`, `nginx_connections_active 1`; on the exposed port `/stub_status` falls through to the SPA route instead of the counters page.

**Out of scope.** Per-route latency stays with the service RED middleware (#2890). Enabling the sidecar on dev and the Alloy scrape config land in insight-gitops.

**Verified.** `cargo test -p routegen` and clippy pedantic green; `helm lint`/`template` with metrics on and off, plus a render through the umbrella; the real image boots (`nginx -t` passes) and answers `/stub_status` on loopback only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Prometheus metrics for the gateway, disabled by default.
  * When enabled, exposes NGINX connection and request metrics through a configurable service port.
  * Metrics collection is restricted to an internal loopback endpoint.

* **Configuration**
  * Added settings for exporter image, port, pull policy, and resource limits.

* **Tests**
  * Added coverage verifying the metrics endpoint is loopback-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->