### PR TITLE
docs(deploy): align deploy docs with the current chart and pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ cd deploy/gitops
 cp environments/local/inventory.yaml.template environments/local/inventory.yaml
 # Edit:
 #   kubeContext: <ctx>                       # required
-#   bootstrap.{ingressNginx,certManager,sealedSecrets}: true|false
+#   bootstrap.{envoyGateway,certManager,sealedSecrets}: true|false
 #   system.{airbyte,argoWorkflows,redpandaConsole,loki,alloy,grafana}: true|false
 
 # 2. Umbrella overlay: image tags / OIDC / tenant id / L2 hosts.
@@ -183,8 +183,10 @@ cp environments/local/values.yaml.template environments/local/values.yaml
 #   authenticator.oidc.issuerUrl: <idp>      #   authenticator.oidc.* at a real IdP
 #   <l2>.host / <l2>.port                    # only when <l2>.deploy=false
 # The `__INGRESS_LB_IP__` placeholders (authenticator.oidc.issuerUrl,
-# keycloak.hostname) must be replaced with your ingress-nginx LoadBalancer IP
-# (`kubectl -n ingress-nginx get svc ingress-nginx-controller`).
+# keycloak.hostname) must be replaced with the address of the Envoy
+# data-plane Service that Envoy Gateway creates for the shared Gateway:
+# (`kubectl -n envoy-gateway-system get svc \
+#    -l gateway.envoyproxy.io/owning-gateway-name=insight`).
 
 # 3. Cleartext secret store (read by `make seal`, never committed).
 cp secrets-store.yaml.template secrets-store.yaml

--- a/charts/insight/README.md
+++ b/charts/insight/README.md
@@ -11,14 +11,20 @@ Single canonical unit of delivery for the Insight platform.
 The umbrella bundles ONLY the first-party application services. Each is a
 local `file://` subchart:
 
-| Component             | Kind                 | Source                                       | Toggle                          |
-|-----------------------|----------------------|----------------------------------------------|---------------------------------|
-| API Gateway           | app service (req'd)  | `src/backend/services/api-gateway/helm`      | mandatory (no flag)             |
-| Analytics             | app service (req'd)  | `src/backend/services/analytics/helm`        | mandatory (no flag)             |
-| Frontend (SPA)        | app service (req'd)  | `src/frontend/helm`                          | mandatory (no flag)             |
-| Identity Resolution   | app service (opt)    | `src/backend/services/identity-resolution/helm` | `identityResolution.deploy`  |
+| Component            | Source                                              | Toggle                       | Default |
+|----------------------|-----------------------------------------------------|------------------------------|---------|
+| Gateway (edge)       | `src/backend/services/gateway/helm`                 | mandatory (no flag)          | on      |
+| Authenticator        | `src/backend/services/authenticator/helm`           | mandatory (no flag)          | on      |
+| Analytics            | `src/backend/services/analytics/helm`               | mandatory (no flag)          | on      |
+| Identity Resolution  | `src/backend/services/identity-resolution/helm`     | `identityResolution.deploy`  | on — the validator refuses `false` |
+| Keycloak (broker)    | `src/backend/services/keycloak/helm`                | `keycloak.deploy`            | off     |
+| Previews             | `src/backend/services/previews/helm`                | `previews.deploy`            | on      |
+| Git CLI proxy        | `src/backend/services/git-cli-proxy/helm`           | `gitCliProxy.deploy`         | on      |
+| Frontend (SPA)       | `src/frontend/helm`                                 | `frontend.deploy`            | on      |
 
-> Identity Resolution requires a populated `persons` table (seeded by the service's own `seed` subcommand, scheduled as a CronJob). Not an OIDC provider. Off by default.
+> Identity Resolution is required: the authenticator's login-bootstrap resolve
+> exists only there, so `insight.validate` fails the render when
+> `identityResolution.deploy` is false. It is not an OIDC provider.
 
 ## What it does NOT contain
 
@@ -29,7 +35,9 @@ local `file://` subchart:
 | Argo Workflows                     | Cluster-scoped infra, often shared across products    | Separate helm release                       |
 | Plugins                            | Runtime-managed via UI (not Helm — see architecture)  | Through platform API                        |
 
-See [`docs/distribution/README.md`](../../docs/distribution/README.md) for the full distribution model.
+See [`deploy/HELM_DEPLOY.md`](../../deploy/HELM_DEPLOY.md) for the full
+external-consumer runbook and [`deploy/gitops/README.md`](../../deploy/gitops/README.md)
+for the Makefile-driven deployment pipeline.
 
 ## Release name convention
 
@@ -39,20 +47,29 @@ Internal DNS references between app services (e.g. `http://insight-analytics:808
 
 If you install under a different name, override all cross-service URLs in your own values.yaml. Prefer sticking to the convention.
 
-## Install (quickstart)
+## Install
+
+The published artifact is the normal install path:
 
 ```bash
-# 1. Pull & resolve subcharts into charts/insight/charts/
-helm dependency update charts/insight
-
-# 2. Dry-run — check that values compose cleanly
-helm template insight charts/insight --namespace insight
-
-# 3. Install
-helm upgrade --install insight charts/insight \
+helm upgrade --install insight oci://ghcr.io/constructorfabric/charts/insight \
+  --version <x.y.z> \
   --namespace insight --create-namespace \
   -f my-values.yaml \
   --wait --timeout 10m
+```
+
+Omit `--version` for the latest published release. The full prerequisite list
+(Gateway API, OIDC IdP, external L2 systems, required Secrets) is in
+[`deploy/HELM_DEPLOY.md`](../../deploy/HELM_DEPLOY.md).
+
+To iterate on the chart from a working copy:
+
+```bash
+helm dependency update charts/insight
+helm template insight charts/insight --namespace insight   # dry-run render
+helm upgrade --install insight charts/insight \
+  --namespace insight --create-namespace -f my-values.yaml
 ```
 
 ## Install (production checklist)
@@ -64,7 +81,9 @@ Before going to prod:
   - **BYO / Constructor Platform:** pre-create `insight-db-creds` with all required keys (`clickhouse-password`, `mariadb-password`, `mariadb-root-password`, `redis-password`) before the first `helm install`. The umbrella picks them up. Missing/empty keys fail fast.
     - Works regardless of `credentials.autoGenerate`: the chart auto-detects BYO via absence of the `app.kubernetes.io/managed-by=Helm` label on the existing Secret and skips its own Secret-template emission, so Helm never tries to take ownership of the customer-managed Secret. No manual labeling required.
     - **Dry-run note**: `helm install --dry-run` (default, client-side) skips the `lookup` function, so the BYO preview will incorrectly show the chart emitting `insight-db-creds`. Use `helm install --dry-run=server` (Helm ≥3.13) for an accurate BYO sanity-check — it exercises `lookup` against the real cluster.
-- [ ] Set OIDC via `apiGateway.oidc.existingSecret` (preferred) or all three of `issuer` + `clientId` + `redirectUri` together. Never inline secrets.
+  - Rendering under a GitOps controller (`helm template`): set `deploymentMode: gitops` and `autoGenerate: false`, and supply the config Secrets out-of-band — the validator refuses `gitops` + `autoGenerate: true`.
+- [ ] Configure OIDC under `authenticator.oidc.*`: `issuerUrl`, `clientId`, `redirectUri`, and the client secret via a Secret (never inline in a committed values file).
+- [ ] Provide `insight-authenticator-signing-keys` (ES256 `current.pem`) — not auto-generated.
 - [ ] Attach routes to the shared Gateway: `gateway.route`, `frontend.route` (TLS terminates at the Gateway listener)
 - [ ] Bump resources where needed (default `requests` are conservative)
 - [ ] Provision the L2 infra (ClickHouse / MariaDB / Redis / Redpanda) out-of-chart and fill `<dep>.host` / `.port` / `.passwordSecret`. App-service URLs follow automatically (resolved by helpers).
@@ -79,7 +98,7 @@ L2 infra (ClickHouse, MariaDB, Redis, Redpanda) is always **external** — deplo
 - `<dep>.passwordSecret` points at a Secret in the namespace (e.g. `insight-db-creds`) — auto-generated by the umbrella, mirrored by a platform operator, or pre-created (BYO).
 - App-service URLs are computed by helpers from `<dep>.host` / `.port`, so no extra overrides are needed.
 
-The umbrella validator (`templates/_helpers.tpl` → `insight.validate`) fails fast on the typical typos: missing `<dep>.host` / `.brokers`, OIDC enabled without `existingSecret` or all inline fields, missing `passwordSecret.{name,key}`.
+The umbrella validator (`templates/_helpers.tpl` → `insight.validate`) fails fast on the typical misconfigurations: missing `<dep>.host` / `.brokers`, missing `passwordSecret.{name,key}`, `identityResolution.deploy: false`, incomplete `authenticator.oidc` (e.g. `resolveBy: email` without `identityResolution.rosterSourceType`), and the `gitops` + `autoGenerate: true` combination.
 
 ## Values reference
 
@@ -87,13 +106,14 @@ See comments in [`values.yaml`](./values.yaml) — every block is documented inl
 
 Key groups:
 
-- `credentials.autoGenerate` — toggle umbrella-managed `insight-db-creds`
-- `global.*` — cluster-wide defaults (pull secrets, storage class)
+- `credentials.deploymentMode` / `credentials.autoGenerate` — who owns the generated Secrets (`helm` with lookup-based reuse, or `gitops` with out-of-band Secrets)
+- `global.*` — cluster-wide defaults (pull secrets, storage class, `tenantDefaultId`, `observability.otlp.endpoint`)
 - `<dep>.host` / `<dep>.port` / `<dep>.passwordSecret` (Redpanda: `<dep>.brokers`) — external-infra wiring for ClickHouse, MariaDB, Redis, Redpanda
-- `apiGateway` / `analytics` / `frontend` — **mandatory** app services (no deploy-flag; the gateway is the single entrance and the product is one unit)
-- `identityResolution.deploy` — **optional** identity-resolution service (off by default; not an OIDC provider)
-- `apiGateway.oidc` — OIDC configuration (prefer `existingSecret`; inline requires `issuer` + `clientId` + `redirectUri` together)
-- `apiGateway.proxy.routes` — reverse-proxy config to downstream services
+- `gateway` / `authenticator` / `analytics` — **mandatory** app services (no deploy flag; the gateway is the single entrance and the product is one unit)
+- `authenticator.oidc.*` — OIDC upstream and login-resolution mode (`resolveBy: external_id | email`)
+- `identityResolution.*` — identity-resolution service (must stay deployed; `rosterSourceType` for email-mode logins)
+- `keycloak.deploy` + `keycloakConfig.*` — the in-stack identity broker and its realms-as-code hook
+- `previews.*`, `gitCliProxy.*`, `frontend.*` — optional services, on by default
 - `ingestion.templates.enabled` — whether to ship Argo WorkflowTemplates; requires Argo CRDs to be present in the cluster
 
 ## Operations
@@ -114,20 +134,11 @@ helm -n insight uninstall insight
 kubectl -n insight delete pvc -l app.kubernetes.io/part-of=insight
 ```
 
-## Publishing (release workflow — not wired up yet)
+## Publishing
 
-```bash
-# 1. Package
-helm package charts/insight -d dist/
-
-# 2. Push to OCI registry (ghcr.io example)
-helm push dist/insight-0.1.0.tgz oci://ghcr.io/constructorfabric/charts
-
-# 3. Customer install:
-helm upgrade --install insight oci://ghcr.io/constructorfabric/charts/insight \
-  --version 0.1.0 \
-  --namespace insight --create-namespace \
-  -f customer-values.yaml
-```
-
-Wire this up in GitHub Actions on tag `v*`. TODO separately.
+Publishing is automated: the `publish-chart` job in
+[`.github/workflows/build-images.yml`](../../.github/workflows/build-images.yml)
+packages the umbrella and pushes it to
+`oci://ghcr.io/constructorfabric/charts/insight` on every push to `main` and
+`release-*`, then commits the `version`/`appVersion` bump back to the branch.
+Do not push chart packages by hand.

--- a/deploy/CONNECTORS.md
+++ b/deploy/CONNECTORS.md
@@ -6,7 +6,7 @@ Connectors pull data from your tools — Jira issues, Slack messages, GitHub pul
 
 - A completed Insight install per the deployment runbook: [HELM_DEPLOY.md](./HELM_DEPLOY.md).
 - The `insight-reconcile-loop` CronWorkflow present in the `insight` namespace (installed as part of that runbook).
-- The `airbyte-auth-secrets` Secret mirrored into the `insight` namespace — done in Step 3 of the deployment runbook.
+- Airbyte reachable and `airbyte.namespace` set per Step 1 of the runbook. The reconcile loop reads Airbyte's `airbyte-auth-secrets` from Airbyte's own namespace at run time (the chart renders the Role/RoleBinding for it) — do **not** copy that Secret into `insight`.
 
 ## Contents
 
@@ -15,7 +15,7 @@ Connectors pull data from your tools — Jira issues, Slack messages, GitHub pul
 - [Prerequisites](#prerequisites)
 - [Contents](#contents)
 - [Anatomy of a connector Secret](#anatomy-of-a-connector-secret)
-- [The 19 available connectors](#the-19-available-connectors)
+- [The available connectors](#the-available-connectors)
 - [Example Secret for every connector](#example-secret-for-every-connector)
   - [AI & coding assistants](#ai--coding-assistants)
   - [Source control & CI](#source-control--ci)
@@ -52,16 +52,16 @@ stringData:
   jira_api_token:    "ATATT-CHANGE_ME"
 ```
 
-## The 19 available connectors
+## The available connectors
 
-Replace `CHANGE_ME` (and any other placeholder) values in whichever connector files you need, under `connectors/`:
+The canonical list is the descriptors in `src/ingestion/connectors/*/*/descriptor.yaml`; this document carries example Secrets for the common ones. Replace `CHANGE_ME` (and any other placeholder) values in whichever connector files you need, under `connectors/`:
 
 `jira`, `slack`, `github`, `gitlab`, `m365`, `zoom`, `confluence`, `zendesk`, `bamboohr`, `ms-entra`, `outline`, `hubspot`, `cursor`, `chatgpt-team`, `claude-team`, `claude-enterprise`, `bitbucket-cloud`, `zulip-proxy`, `github-directory`.
 
 Apply all of them at once, or one at a time:
 
 ```sh
-kubectl -n insight apply -f connectors/      # all 19 connectors at once
+kubectl -n insight apply -f connectors/      # all connectors at once
 # or one at a time:
 kubectl -n insight apply -f connectors/jira.yaml
 ```
@@ -389,4 +389,4 @@ stringData:
 
 | Problem | What to check |
 |---------|-----------------|
-| Connectors are not syncing | Confirm `airbyte-auth-secrets` was mirrored into the `insight` namespace (Step 3 of the deployment runbook, [HELM_DEPLOY.md](./HELM_DEPLOY.md)). The reconcile loop runs as an Argo `CronWorkflow` named `insight-reconcile-loop` — **not** the analytics pod — so inspect the Workflow pods it spawns: `kubectl -n insight get pods -l workflows.argoproj.io/cron-workflow=insight-reconcile-loop`, then `kubectl -n insight logs <pod>` (or `argo logs @latest -n insight` if the Argo CLI is available) |
+| Connectors are not syncing | Confirm `airbyte.namespace` points at the namespace holding Airbyte's `airbyte-auth-secrets` and that the chart's Role/RoleBinding exists there (Step 1/3 of the deployment runbook, [HELM_DEPLOY.md](./HELM_DEPLOY.md)). The reconcile loop runs as an Argo `CronWorkflow` named `insight-reconcile-loop` — **not** the analytics pod — so inspect the Workflow pods it spawns: `kubectl -n insight get pods -l workflows.argoproj.io/cron-workflow=insight-reconcile-loop`, then `kubectl -n insight logs <pod>` (or `argo logs @latest -n insight` if the Argo CLI is available) |

--- a/deploy/HELM_DEPLOY.md
+++ b/deploy/HELM_DEPLOY.md
@@ -405,7 +405,7 @@ Then open `https://<HOST>` — the host from Step 1 — and confirm the login re
 
 ## Step 6 — Configure connectors (optional)
 
-Configure connectors after the app is up. Each of the 25 connectors is a single Kubernetes Secret; the `insight-reconcile-loop` CronWorkflow discovers it and provisions the Airbyte source automatically, so there is nothing else to run.
+Configure connectors after the app is up. Each connector is a single Kubernetes Secret; the `insight-reconcile-loop` CronWorkflow discovers it and provisions the Airbyte source automatically, so there is nothing else to run.
 
 See [deploy/CONNECTORS.md](./CONNECTORS.md) for the connector list and a copy-paste Secret for each.
 

--- a/deploy/gitops/README.md
+++ b/deploy/gitops/README.md
@@ -29,12 +29,13 @@ deploy/gitops/
 ├── secrets-store.yaml.template  # template for the sample secret store; copy to secrets-store.yaml and fill in
 ├── bootstrap/
 │   ├── argo-rbac.yaml.template  # supplemental Argo RBAC; rendered + applied by Makefile
-│   └── local/                   # per-cluster L0 prereqs (one dir per env)
-│       ├── envoy-gateway-values.yaml
-│       ├── gateway.yaml         # shared GatewayClass + Gateway (applied at bootstrap)
-│       ├── cert-manager-values.yaml
-│       ├── sealed-secrets-values.yaml
-│       └── selfsigned-issuer.yaml
+│   ├── local/                   # per-cluster L0 prereqs (one dir per env)
+│   │   ├── envoy-gateway-values.yaml
+│   │   ├── gateway.yaml         # shared GatewayClass + Gateway (applied at bootstrap)
+│   │   ├── cert-manager-values.yaml
+│   │   ├── sealed-secrets-values.yaml
+│   │   └── selfsigned-issuer.yaml
+│   └── functional-ci/           # L0 prereqs for the ephemeral k3d smoke env
 ├── system/                      # L2 base values, one dir per service
 │   ├── README.md                # services table + secret layout
 │   ├── mariadb/                 # values.yaml + SECRETS.md
@@ -43,20 +44,29 @@ deploy/gitops/
 │   ├── redpanda/                # values.yaml
 │   ├── redpanda-console/        # values.yaml
 │   ├── airbyte/                 # values.yaml
-│   └── argo-workflows/          # values.yaml
+│   ├── argo-workflows/          # values.yaml
+│   └── victoriametrics/ loki/ tempo/ alloy/ alloy-metrics/
+│       kube-state-metrics/ grafana/   # observability stack values
 ├── environments/
-│   └── local/                   # sandbox env (also the starter template for new envs)
-│       ├── inventory.yaml.template  # what this cluster has (drives bootstrap / system / seal / deploy)
-│       ├── values.yaml.template     # umbrella overlay (L3) — wizard cp's to values.yaml on first `make deploy ENV=local`
-│       └── sealed-secrets/
-│           ├── insight-infra/*.yaml.template  # L2 sealed-secret shape (one folder per Kubernetes namespace)
-│           └── insight/*.yaml.template        # L3 sealed-secret shape
+│   ├── local/                   # sandbox env (also the starter template for new envs)
+│   │   ├── inventory.yaml.template  # what this cluster has (drives bootstrap / system / seal / deploy)
+│   │   ├── values.yaml.template     # umbrella overlay (L3) — wizard cp's to values.yaml on first `make deploy ENV=local`
+│   │   ├── keycloak/realms/         # broker realm content (keycloak-config-cli YAML)
+│   │   └── sealed-secrets/
+│   │       ├── insight-infra/*.yaml.template  # L2 sealed-secret shape (one folder per Kubernetes namespace)
+│   │       └── insight/*.yaml.template        # L3 sealed-secret shape
+│   ├── functional-ci/           # committed env for the k3d deployment smoke (functional-k3s.yml)
+│   └── test-stand/              # the published CI-deployed stand — see its README.md and INFRA.md
 └── scripts/
     ├── doctor.sh                # invoked by `make doctor`
     ├── render-diff.sh           # invoked by `make diff`
+    ├── render-system-values.sh  # substitutes ${NS_*} into L2 values before helm sees them
     ├── secret-fetch.sh          # password-manager stub for `make seal-secret`
-    ├── compose-app-secrets.sh   # derives insight-{analytics,identity-resolution}-config from insight-db-creds
-    └── airbyte-setup.sh         # post-install Airbyte setup-wizard automation
+    ├── compose-app-secrets.sh   # derives the app *-config Secrets from insight-db-creds
+    ├── airbyte-setup.sh         # post-install Airbyte setup-wizard automation
+    ├── provision-ci-deployer.sh # namespace-scoped ServiceAccount for the test-stand CI deploy
+    ├── recreate-test-stand.sh   # tear down + rebuild the test stand
+    └── push-deploy-log.sh       # ships the deploy log into in-cluster Loki
 ```
 
 The wizard at `../compose/insight-init.sh` is shared with the
@@ -226,10 +236,10 @@ make system     ENV=<new>
 make deploy     ENV=<new>           # protected envs need CONFIRM=yes-deploy-<new>
 ```
 
-The `local` env disables OIDC for sandbox convenience. For production
-or staging envs, set `apiGateway.authDisabled: false`, configure an
-OIDC IdP (Okta, Entra, Auth0, Keycloak, …), and seal a corresponding
-`insight-oidc` Secret — see
+Every env runs a real OIDC login — the chart has no auth-off toggle,
+and `local` wires the in-stack Keycloak subchart as its issuer. For
+production or staging envs, configure an OIDC IdP (Okta, Entra, Auth0,
+Keycloak, …) and seal a corresponding `insight-oidc` Secret — see
 [`environments/local/sealed-secrets/insight/insight-oidc-sealedsecret.yaml.template`](environments/local/sealed-secrets/insight/insight-oidc-sealedsecret.yaml.template)
 for the seven required keys.
 
@@ -338,10 +348,16 @@ real `*.yaml` siblings beside them, safe to commit.
 3. `make deploy` pulls the chart at the pinned semver and runs
    `helm upgrade --install --atomic`.
 
-### Automating the `.insight-version` bump (optional)
+### Automating the `.insight-version` bump
 
-This sample does NOT ship CI for auto-bumping `.insight-version` —
-it's CI-vendor-specific. The pattern is:
+In this repo the bump is automated: the `publish-chart` job in
+`.github/workflows/build-images.yml` writes the newly published semver
+into `deploy/gitops/.insight-version` and commits it at the end of each
+publish. (Consequence: a checkout of the SHA that triggered the publish
+still holds the PREVIOUS release in that file — resolve "latest" from
+the OCI registry, not from the file, when reacting to a publish event.)
+
+A standalone deployment repo has to wire its own bump; the pattern is:
 
 1. List semver tags at the chart registry on a cron schedule (e.g.
    hourly):

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -105,7 +105,7 @@ cd src/ingestion/tests/e2e
 
 ## 6. E2E
 
-- Real ingestion (Airbyte → Argo/Kestra → bronze → API), the umbrella-chart deployment, and UI flows (Playwright,
+- Real ingestion (Airbyte → Argo Workflows → bronze → API), the umbrella-chart deployment, and UI flows (Playwright,
   role + accessible-name locators — no accessibility or contrast checking).
 - The **deployment smoke** (chart installs + rollout) runs post-merge on `main`. Full ingestion + UI run in
   **Test**; a **shallow acceptance validation** runs in **Beta**.


### PR DESCRIPTION
Fixes documentation drift found while writing the deployment overview for #2944. Documentation only — no chart, template, or script changes.

- **charts/insight/README.md** — rewritten against the actual `Chart.yaml`: the real eight subcharts and their toggles (the old table listed an `api-gateway` service and missed authenticator/keycloak/previews/git-cli-proxy), `identityResolution.deploy` is on by default and the validator refuses `false`, OIDC lives under `authenticator.oidc.*` (the documented `apiGateway.*` keys are dead), publishing is automated by `publish-chart` (the doc said "not wired up yet"), the dead `docs/distribution/README.md` link now points at `deploy/HELM_DEPLOY.md`, and the install quickstart uses the OCI artifact.
- **deploy/gitops/README.md** — removed the `apiGateway.authDisabled` claim (the chart has no auth-off toggle; `local` uses the in-stack Keycloak); directory tree now matches the tree on disk (`functional-ci`/`test-stand` envs, observability system values, all scripts); the `.insight-version` section now states the bump is automated by `publish-chart`, including the trigger-SHA caveat.
- **CONTRIBUTING.md** — non-interactive k8s recipe: `bootstrap.ingressNginx` → `bootstrap.envoyGateway`; the `__INGRESS_LB_IP__` lookup now targets the Envoy data-plane Service instead of the removed ingress-nginx controller.
- **deploy/CONNECTORS.md** — the prerequisite and troubleshooting rows told users to mirror `airbyte-auth-secrets` into the app namespace, which `HELM_DEPLOY.md` Step 3 explicitly forbids; both now describe the `airbyte.namespace` + Role/RoleBinding model. Hardcoded connector counts (19 here, 25 in HELM_DEPLOY) disagreed with the descriptor set, so counts are dropped in favor of the canonical `descriptor.yaml` list.
- **docs/testing/TESTING.md** — "Argo/Kestra" → "Argo Workflows" (Kestra is gone from the deploy surface).