### PR TITLE
fix(frontend): fold person section comparisons into current queries

### DIFF
--- a/src/frontend/src/components/portal/context-pane.test.tsx
+++ b/src/frontend/src/components/portal/context-pane.test.tsx
@@ -53,7 +53,10 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 // The sections nav asks where the person stands so it can mark each section;
 // the standings come from the section screens' own queries, which this test
 // has no reason to run.
-vi.mock("@/lib/portal/use-person-sections", () => ({
+// `useSelectedPersonSection` is left real: it reads the router mock above, and
+// it is what decides whether "At a glance" or a section row is the active one.
+vi.mock("@/lib/portal/use-person-sections", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
   usePersonSectionStandings: () => mocks.standings,
 }));
 

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -20,7 +20,10 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { visibleGroups } from "@/lib/insight/groups";
-import { usePersonSectionStandings } from "@/lib/portal/use-person-sections";
+import {
+  usePersonSectionStandings,
+  useSelectedPersonSection,
+} from "@/lib/portal/use-person-sections";
 import { STATUS_BG_CLASS } from "@/lib/status";
 import {
   lensRoadmap,
@@ -619,8 +622,7 @@ function PersonSectionsNav() {
   const standingById = new Map(standings.map((st) => [st.id as string, st]));
   const showPlanned = usePortalShowPlanned();
   const groups = visibleGroups(showPlanned);
-  const groupIds = groups.map((g) => g.id) as string[];
-  const glance = active == null || !groupIds.includes(active);
+  const glance = useSelectedPersonSection() == null;
   return (
     <SidebarGroup>
       <SidebarGroupLabel>Sections</SidebarGroupLabel>

--- a/src/frontend/src/components/portal/metric-groups-view.test.tsx
+++ b/src/frontend/src/components/portal/metric-groups-view.test.tsx
@@ -14,6 +14,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { MetricResult } from "@/api/metric-results-client";
+import { previousPeriodRange } from "@/api/period-to-date-range";
 import type { GroupId } from "@/lib/insight/groups";
 import { normalizeMetricResults } from "@/lib/metrics/collection";
 
@@ -28,6 +29,16 @@ const mocks = vi.hoisted(() => ({
   },
   set: new Map<string, { byKey: Map<string, never>; isPending: boolean; isError: boolean; refetch: () => void }>(),
   cohort: [] as string[],
+  period: "week" as const,
+  range: { from: "2026-07-20", to: "2026-07-26" },
+  // Every `useMetricCollectionSet` call, so a test can assert WHICH windows the
+  // view asked for — the mock returns one result set regardless of arguments.
+  setCalls: [] as Array<{
+    collections: unknown;
+    entity: { type: string; ids?: string[] };
+    range: { from: string; to: string };
+    compareTo?: { from: string; to: string };
+  }>,
 }));
 
 // usePersonSectionStandings now reads source availability from the tenant's
@@ -42,7 +53,15 @@ vi.mock("@/queries/metric-definitions", async (orig) => ({
 }));
 vi.mock("@/queries/metric-results", () => ({
   useMetricCollection: () => mocks.collection,
-  useMetricCollectionSet: () => mocks.set,
+  useMetricCollectionSet: (
+    collections: unknown,
+    entity: { type: string; ids?: string[] },
+    range: { from: string; to: string },
+    compareTo?: { from: string; to: string }
+  ) => {
+    mocks.setCalls.push({ collections, entity, range, compareTo });
+    return mocks.set;
+  },
   collectionSetPending: (set: Map<string, { isPending: boolean }>) =>
     [...set.values()].some((r) => r.isPending),
 }));
@@ -50,7 +69,7 @@ vi.mock("@/lib/portal/use-person-cohort", () => ({
   usePersonCohort: () => mocks.cohort,
 }));
 vi.mock("@/hooks/use-portal-period", () => ({
-  usePortalPeriod: () => ({ period: "week", dateRange: { from: "2026-07-20", to: "2026-07-26" } }),
+  usePortalPeriod: () => ({ period: mocks.period, dateRange: mocks.range }),
 }));
 vi.mock("@/hooks/use-settings", () => ({ useSettings: () => ({ focusMode: false }) }));
 vi.mock("@/components/widgets/dashboard/kpi-tile", () => ({
@@ -132,6 +151,7 @@ beforeEach(() => {
   mocks.collection.isPending = false;
   mocks.collection.isError = false;
   mocks.cohort = [];
+  mocks.setCalls.length = 0;
   seedSet();
 });
 
@@ -171,6 +191,41 @@ describe("MetricGroupsView", () => {
     render(<MetricGroupsView personId="p@x" groupIds={GROUPS} showKpis />);
     expect(screen.getByText("At a glance")).toBeInTheDocument();
     expect(screen.getByTestId("needs-attention")).toBeInTheDocument();
+  });
+
+  it("asks for the sections over one window pair, not a shifted second request", () => {
+    render(<MetricGroupsView personId="p@x" groupIds={GROUPS} showKpis />);
+    // Attention compares against the previous period. Asking for it over a
+    // SHIFTED range is the duplicate round trip this view stopped making
+    // (#2651), so every request runs over the period on screen.
+    for (const call of mocks.setCalls) {
+      expect(call.range, `range for ${JSON.stringify(call.entity)}`).toEqual(
+        mocks.range,
+      );
+    }
+    // The page and the nav mark both ask; identical arguments is what makes
+    // that one query key and one round trip, so the distinct signature — not
+    // the call count — is the thing under test.
+    const sections = mocks.setCalls.filter((c) => (c.entity.ids?.length ?? 0) > 0);
+    const signatures = new Set(sections.map((c) => JSON.stringify(c)));
+    expect(sections.length).toBeGreaterThan(1);
+    expect(signatures.size).toBe(1);
+    expect(sections[0]!.compareTo).toEqual(
+      previousPeriodRange(mocks.range, mocks.period),
+    );
+  });
+
+  it("asks for the slice cohort under one signature too", () => {
+    mocks.cohort = ["a@x", "b@x"];
+    render(<MetricGroupsView personId="p@x" groupIds={GROUPS} showKpis />);
+    // The same trap one hook over: the page and the nav mark each named their
+    // own group list for the cohort, so a narrower one would split it into a
+    // second key and a second request per section.
+    const cohort = mocks.setCalls.filter(
+      (c) => c.entity.ids?.join() === mocks.cohort.join(),
+    );
+    expect(cohort.length).toBeGreaterThan(1);
+    expect(new Set(cohort.map((c) => JSON.stringify(c))).size).toBe(1);
   });
 
   it("routes a KPI tile through onSelectGroup instead of the modal when provided", async () => {

--- a/src/frontend/src/components/portal/metric-groups-view.test.tsx
+++ b/src/frontend/src/components/portal/metric-groups-view.test.tsx
@@ -68,6 +68,11 @@ vi.mock("@/queries/metric-results", () => ({
 vi.mock("@/lib/portal/use-person-cohort", () => ({
   usePersonCohort: () => mocks.cohort,
 }));
+// This view only mounts on "At a glance", so no section is ever open under it;
+// `use-person-sections.test.tsx` covers the window scope on both routes.
+vi.mock("@/lib/portal/portal-nav", () => ({
+  usePortalItem: () => null,
+}));
 vi.mock("@/hooks/use-portal-period", () => ({
   usePortalPeriod: () => ({ period: mocks.period, dateRange: mocks.range }),
 }));

--- a/src/frontend/src/components/portal/metric-groups-view.tsx
+++ b/src/frontend/src/components/portal/metric-groups-view.tsx
@@ -7,7 +7,6 @@ import { GroupDrilldownSheet } from "@/components/widgets/dashboard/group-drilld
 import { IcNeedsAttention } from "@/components/widgets/dashboard/ic-needs-attention";
 import { PersonCoverage } from "@/components/widgets/dashboard/person-coverage";
 import { KpiTile } from "@/components/widgets/dashboard/kpi-tile";
-import { previousPeriodRange } from "@/api/period-to-date-range";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
 import type { PeriodValue } from "@/types/insight";
 import { useSettings } from "@/hooks/use-settings";
@@ -24,10 +23,7 @@ import {
 } from "@/lib/insight/groups";
 import { metricKpiTiles } from "@/lib/insight/kpi-row";
 import { injectCohortPeer } from "@/lib/insight/within-team-peer";
-import {
-  projectViews,
-  type MetricCollectionConfig,
-} from "@/lib/metrics/collection";
+import type { MetricCollectionConfig } from "@/lib/metrics/collection";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import { TEXT_EYEBROW } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
@@ -40,11 +36,14 @@ import {
   trendBucket,
   trendRange,
 } from "@/lib/portal/person-trend";
-import { usePersonSectionStandings } from "@/lib/portal/use-person-sections";
+import {
+  usePersonSectionCohort,
+  usePersonSectionCollection,
+  usePersonSectionStandings,
+} from "@/lib/portal/use-person-sections";
 import {
   collectionSetPending,
   useMetricCollection,
-  useMetricCollectionSet,
 } from "@/queries/metric-results";
 
 const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
@@ -125,28 +124,10 @@ export function MetricGroupsView({
     dateRange,
     { previousPeriod: period }
   );
-  const groupData = useMetricCollectionSet(
-    defs.map((def) => ({
-      key: def.id,
-      collection: projectViews(def.collection, ["period", "peer"]),
-    })),
-    entity,
-    dateRange
-  );
-  // The same collections over the previous period: attention needs to know
-  // whether a standing is also a change (see `metricAttentionItems`), and
-  // "period" alone is enough for that — no peer stats needed.
-  const previousRange = previousPeriodRange(dateRange, period);
-  const previousGroupData = useMetricCollectionSet(
-    showKpis
-      ? defs.map((def) => ({
-          key: def.id,
-          collection: projectViews(def.collection, ["period"]),
-        }))
-      : [],
-    showKpis ? entity : CLOSED_ENTITY,
-    previousRange
-  );
+  // Shared with the nav mark, comparison window included — see the invariant on
+  // `usePersonSectionCollection`. It covers every visible section; this view
+  // reads the `defs` it renders and leaves the rest in the map.
+  const groupData = usePersonSectionCollection(personId);
 
   // Slice cohort: the people who share this person's active-slice attribute
   // value. Only fetched when a slice is picked — otherwise the person's own
@@ -162,16 +143,8 @@ export function MetricGroupsView({
     cohortIds.length && showKpis ? cohortEntity : CLOSED_ENTITY,
     dateRange
   );
-  const cohortGroup = useMetricCollectionSet(
-    cohortIds.length
-      ? defs.map((def) => ({
-          key: def.id,
-          collection: projectViews(def.collection, ["period"]),
-        }))
-      : [],
-    cohortEntity,
-    dateRange
-  );
+  // Shared with the nav mark for the same reason `groupData` is.
+  const cohortGroup = usePersonSectionCohort(personId);
 
   const sectionStandings = usePersonSectionStandings(personId);
 
@@ -238,17 +211,14 @@ export function MetricGroupsView({
     cohortIds.length > 0 &&
     ((showKpis && cohortKpi.isPending) || collectionSetPending(cohortGroup));
   const isLoading =
-    (showKpis &&
-      (kpiData.isPending || collectionSetPending(previousGroupData))) ||
+    (showKpis && kpiData.isPending) ||
     collectionSetPending(groupData) ||
     cohortPending;
   if (isLoading) return <CenteredSpinner className="min-h-[60vh]" />;
 
   // Surface a backend failure as a retryable error, not empty section cards.
   const isError =
-    (showKpis &&
-      (kpiData.isError ||
-        [...previousGroupData.values()].some((r) => r.isError))) ||
+    (showKpis && kpiData.isError) ||
     [...groupData.values()].some((r) => r.isError) ||
     (cohortIds.length > 0 &&
       ((showKpis && cohortKpi.isError) ||
@@ -262,7 +232,6 @@ export function MetricGroupsView({
           onRetry={() => {
             kpiData.refetch();
             groupData.forEach((r) => r.refetch());
-            previousGroupData.forEach((r) => r.refetch());
             cohortKpi.refetch();
             cohortGroup.forEach((r) => r.refetch());
           }}
@@ -311,7 +280,7 @@ export function MetricGroupsView({
           metricAttentionItems(
             def,
             groupResult(def.id)?.byKey ?? new Map(),
-            previousGroupData.get(def.id)?.byKey ?? null,
+            groupData.get(def.id)?.previousByKey ?? null,
             entityId,
             headlineKeys
           )

--- a/src/frontend/src/components/portal/person-view.tsx
+++ b/src/frontend/src/components/portal/person-view.tsx
@@ -1,9 +1,10 @@
 import { MetricGroupsView } from "@/components/portal/metric-groups-view";
 import { PersonHeader } from "@/components/portal/person-header";
 import { SingleGroupView } from "@/components/portal/single-group-view";
-import { visibleGroups, type GroupId } from "@/lib/insight/groups";
-import { usePortalItem, usePortalNavActions } from "@/lib/portal/portal-nav";
+import { visibleGroups } from "@/lib/insight/groups";
+import { usePortalNavActions } from "@/lib/portal/portal-nav";
 import { usePortalShowPlanned } from "@/lib/portal/portal-store";
+import { useSelectedPersonSection } from "@/lib/portal/use-person-sections";
 
 /**
  * Person zone: one specific person.
@@ -18,17 +19,16 @@ import { usePortalShowPlanned } from "@/lib/portal/portal-store";
  * again, in the middle of the page, what the navigation says on its left edge.
  */
 export function PersonView({ person }: { person: string }) {
-  const item = usePortalItem();
   const { setItem } = usePortalNavActions();
   const showPlanned = usePortalShowPlanned();
   const groupIds = visibleGroups(showPlanned).map((group) => group.id);
-  const isSection = item != null && (groupIds as string[]).includes(item);
+  const selectedSection = useSelectedPersonSection();
 
   return (
     <>
       <PersonHeader person={person} />
-      {isSection ? (
-        <SingleGroupView personId={person} groupId={item as GroupId} />
+      {selectedSection ? (
+        <SingleGroupView personId={person} groupId={selectedSection} />
       ) : (
         // "At a glance" — the headline row and what needs attention.
         //

--- a/src/frontend/src/lib/portal/use-person-sections.test.tsx
+++ b/src/frontend/src/lib/portal/use-person-sections.test.tsx
@@ -19,6 +19,15 @@ const mocks = vi.hoisted(() => ({
   byKey: new Map<string, unknown>(),
   isPending: false,
   cohort: [] as string[],
+  /** The open section, or null on "At a glance". */
+  item: null as string | null,
+  // Every `useMetricCollectionSet` call, so a test can assert WHICH windows
+  // were asked for — the mock answers the same set whatever the arguments.
+  setCalls: [] as Array<{
+    entity: { type: string; ids?: string[] };
+    range: { from: string; to: string };
+    compareTo?: { from: string; to: string };
+  }>,
 }));
 
 vi.mock("@/queries/metric-definitions", () => ({
@@ -27,9 +36,18 @@ vi.mock("@/queries/metric-definitions", () => ({
     isPending: mocks.definitionsPending,
   }),
 }));
+vi.mock("@/lib/portal/portal-nav", () => ({
+  usePortalItem: () => mocks.item,
+}));
 vi.mock("@/queries/metric-results", () => ({
-  useMetricCollectionSet: () =>
-    new Map(
+  useMetricCollectionSet: (
+    _collections: unknown,
+    entity: { type: string; ids?: string[] },
+    range: { from: string; to: string },
+    compareTo?: { from: string; to: string }
+  ) => {
+    mocks.setCalls.push({ entity, range, compareTo });
+    return new Map(
       [
         "task_delivery",
         "git_output",
@@ -47,7 +65,8 @@ vi.mock("@/queries/metric-results", () => ({
           refetch: vi.fn(),
         },
       ])
-    ),
+    );
+  },
 }));
 vi.mock("@/lib/portal/use-person-cohort", () => ({
   usePersonCohort: () => mocks.cohort,
@@ -59,7 +78,10 @@ vi.mock("@/hooks/use-portal-period", () => ({
   }),
 }));
 
-import { usePersonSectionStandings } from "./use-person-sections";
+import {
+  usePersonSectionCollection,
+  usePersonSectionStandings,
+} from "./use-person-sections";
 
 const ME = "019e27bc-dec0-7626-81a9-c5524662a6a9";
 
@@ -106,6 +128,50 @@ beforeEach(() => {
   mocks.byKey = new Map();
   mocks.isPending = false;
   mocks.cohort = [];
+  mocks.item = null;
+  mocks.setCalls.length = 0;
+});
+
+describe("usePersonSectionCollection", () => {
+  /** The person's own set; the cohort's rides the same hook with other ids. */
+  const personCalls = () =>
+    mocks.setCalls.filter((c) => c.entity.ids?.[0] === ME);
+
+  it("asks for the comparison window on the overview", () => {
+    renderHook(() => usePersonSectionCollection(ME));
+    // "At a glance" is the only surface reading `previousByKey` — the
+    // attention block needs a standing that is also a change.
+    expect(personCalls()[0]!.compareTo).toEqual({
+      from: "2026-06-01",
+      to: "2026-06-30",
+    });
+  });
+
+  it("drops it once a section is open", () => {
+    mocks.item = "git_output";
+    renderHook(() => usePersonSectionCollection(ME));
+    // Only the nav mark is left reading this set, and it ranks the current
+    // window alone. Asking for a second window would buy backend work for a
+    // number nothing on screen reads.
+    expect(personCalls()[0]!.compareTo).toBeUndefined();
+    expect(personCalls()[0]!.range).toEqual({
+      from: "2026-07-01",
+      to: "2026-07-31",
+    });
+  });
+
+  it("keeps one signature per window scope across its consumers", () => {
+    // The overview and the nav mark both call it. Identical arguments are what
+    // make that one query key and one round trip (#2651), so the signature —
+    // not the call count — is the thing under test.
+    renderHook(() => {
+      usePersonSectionCollection(ME);
+      usePersonSectionStandings(ME);
+    });
+    const signatures = new Set(personCalls().map((c) => JSON.stringify(c)));
+    expect(personCalls().length).toBeGreaterThan(1);
+    expect(signatures.size).toBe(1);
+  });
 });
 
 describe("usePersonSectionStandings", () => {

--- a/src/frontend/src/lib/portal/use-person-sections.ts
+++ b/src/frontend/src/lib/portal/use-person-sections.ts
@@ -15,8 +15,12 @@ import { usePersonCohort } from "@/lib/portal/use-person-cohort";
 import type { Status } from "@/lib/status";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
 import { usePortalShowPlanned } from "@/lib/portal/portal-store";
+import { previousPeriodRange } from "@/api/period-to-date-range";
 import { useMetricDefinitionsResponse } from "@/queries/metric-definitions";
-import { useMetricCollectionSet } from "@/queries/metric-results";
+import {
+  useMetricCollectionSet,
+  type MetricCollectionResult,
+} from "@/queries/metric-results";
 
 export interface SectionStanding {
   id: GroupId;
@@ -46,6 +50,67 @@ export interface SectionStanding {
 const CLOSED_ENTITY = { type: "person" as const, ids: [] as string[] };
 
 /**
+ * The section collection every person surface reads — the nav mark, the
+ * overview and the attention block alike.
+ *
+ * INVARIANT: this is the only place the set is requested. The surfaces share
+ * one query key, so they cost one round trip between them; a second call site
+ * differing in any argument — a narrower group list, a missing comparison
+ * window — mints a second key and a second request per section (#2651).
+ *
+ * The comparison window rides inside the request rather than as its own
+ * shifted-period call: the `period` view answers over both windows in one pass.
+ * It is asked for unconditionally, because a caller that skipped it would be
+ * exactly the divergence above.
+ */
+export function usePersonSectionCollection(
+  personId: string
+): Map<string, MetricCollectionResult> {
+  const { period, dateRange } = usePortalPeriod();
+  const entityId = normalizePersonId(personId);
+  const showPlanned = usePortalShowPlanned();
+
+  return useMetricCollectionSet(
+    visibleGroups(showPlanned).map((def) => ({
+      key: def.id,
+      collection: projectViews(def.collection, ["period", "peer"]),
+    })),
+    { type: "person" as const, ids: [entityId] },
+    dateRange,
+    previousPeriodRange(dateRange, period)
+  );
+}
+
+/**
+ * The cohort readings a section's peer stats are rebased on once a slice is
+ * picked — an empty collection otherwise, so nothing goes out.
+ *
+ * INVARIANT: as with `usePersonSectionCollection`, this is the only place the
+ * cohort set is requested; a call site narrowing the group list mints its own
+ * key and its own request per section.
+ */
+export function usePersonSectionCohort(
+  personId: string
+): Map<string, MetricCollectionResult> {
+  const { dateRange } = usePortalPeriod();
+  const cohortIds = usePersonCohort(normalizePersonId(personId));
+  const showPlanned = usePortalShowPlanned();
+
+  return useMetricCollectionSet(
+    cohortIds.length
+      ? visibleGroups(showPlanned).map((def) => ({
+          key: def.id,
+          collection: projectViews(def.collection, ["period"]),
+        }))
+      : [],
+    cohortIds.length
+      ? { type: "person" as const, ids: cohortIds }
+      : CLOSED_ENTITY,
+    dateRange
+  );
+}
+
+/**
  * Where a person stands in each section, for the nav.
  *
  * The person page is an OVERVIEW and every section has its own screen, so the
@@ -54,24 +119,16 @@ const CLOSED_ENTITY = { type: "person" as const, ids: [] as string[] };
  * different question and duplicated the list of sections that was already on
  * screen to their left.
  *
- * The queries here are the same ones the section screens run, so react-query
- * serves them from cache: the mark costs no extra request.
+ * The reading comes from `usePersonSectionCollection`, the same query the
+ * section screens run, so react-query serves it from cache: the mark costs no
+ * extra request.
  */
 export function usePersonSectionStandings(personId: string): SectionStanding[] {
-  const { dateRange } = usePortalPeriod();
   const entityId = normalizePersonId(personId);
-  const entity = { type: "person" as const, ids: [entityId] };
   const showPlanned = usePortalShowPlanned();
   const groups = visibleGroups(showPlanned);
 
-  const groupData = useMetricCollectionSet(
-    groups.map((def) => ({
-      key: def.id,
-      collection: projectViews(def.collection, ["period", "peer"]),
-    })),
-    entity,
-    dateRange,
-  );
+  const groupData = usePersonSectionCollection(personId);
 
   // Same query key as the availability gate, so this rides its cache.
   const definitions = useMetricDefinitionsResponse();
@@ -79,16 +136,7 @@ export function usePersonSectionStandings(personId: string): SectionStanding[] {
   // The same cohort the screens compare against, so the nav mark and the
   // section it points at cannot disagree.
   const cohortIds = usePersonCohort(entityId);
-  const cohortGroup = useMetricCollectionSet(
-    cohortIds.length
-      ? groups.map((def) => ({
-          key: def.id,
-          collection: projectViews(def.collection, ["period"]),
-        }))
-      : [],
-    cohortIds.length ? { type: "person" as const, ids: cohortIds } : CLOSED_ENTITY,
-    dateRange,
-  );
+  const cohortGroup = usePersonSectionCohort(personId);
 
   const reachable = reachableMetricKeys(definitions.data?.metrics ?? []);
 

--- a/src/frontend/src/lib/portal/use-person-sections.ts
+++ b/src/frontend/src/lib/portal/use-person-sections.ts
@@ -14,6 +14,7 @@ import { derivePeerStanding } from "@/lib/metrics/peer-standing";
 import { usePersonCohort } from "@/lib/portal/use-person-cohort";
 import type { Status } from "@/lib/status";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
+import { usePortalItem } from "@/lib/portal/portal-nav";
 import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 import { previousPeriodRange } from "@/api/period-to-date-range";
 import { useMetricDefinitionsResponse } from "@/queries/metric-definitions";
@@ -50,6 +51,23 @@ export interface SectionStanding {
 const CLOSED_ENTITY = { type: "person" as const, ids: [] as string[] };
 
 /**
+ * The section the person zone has open, or null on "At a glance".
+ *
+ * INVARIANT: every surface branching on this reads it here. The collection
+ * below carries a comparison window only on the overview, so a screen deciding
+ * the same thing its own way would either ask for a window nothing reads or
+ * disagree about the key and split the request in two.
+ */
+export function useSelectedPersonSection(): GroupId | null {
+  const item = usePortalItem();
+  const showPlanned = usePortalShowPlanned();
+
+  return visibleGroups(showPlanned).some((def) => def.id === item)
+    ? (item as GroupId)
+    : null;
+}
+
+/**
  * The section collection every person surface reads — the nav mark, the
  * overview and the attention block alike.
  *
@@ -60,8 +78,10 @@ const CLOSED_ENTITY = { type: "person" as const, ids: [] as string[] };
  *
  * The comparison window rides inside the request rather than as its own
  * shifted-period call: the `period` view answers over both windows in one pass.
- * It is asked for unconditionally, because a caller that skipped it would be
- * exactly the divergence above.
+ * Only the overview reads it, through the attention block. With a section open
+ * the nav mark is the lone consumer and ranks the current window alone, so the
+ * window is scoped here rather than by a caller — a caller deciding it would be
+ * the divergence above.
  */
 export function usePersonSectionCollection(
   personId: string
@@ -69,6 +89,7 @@ export function usePersonSectionCollection(
   const { period, dateRange } = usePortalPeriod();
   const entityId = normalizePersonId(personId);
   const showPlanned = usePortalShowPlanned();
+  const selectedSection = useSelectedPersonSection();
 
   return useMetricCollectionSet(
     visibleGroups(showPlanned).map((def) => ({
@@ -77,7 +98,7 @@ export function usePersonSectionCollection(
     })),
     { type: "person" as const, ids: [entityId] },
     dateRange,
-    previousPeriodRange(dateRange, period)
+    selectedSection == null ? previousPeriodRange(dateRange, period) : undefined
   );
 }
 

--- a/src/frontend/src/screens/dashboard.tsx
+++ b/src/frontend/src/screens/dashboard.tsx
@@ -65,24 +65,16 @@ export function DashboardScreen({ personId }: DashboardScreenProps) {
   // exist for the drilldown. Fetch the light projection here so a card paints
   // as fast as a KPI tile, and let the open drilldown fetch the full
   // collection lazily below.
+  // The comparison window rides inside the same request. Attention reports a
+  // standing that is ALSO a change, so without it the block would go silent
+  // here — which reads as "nothing to see" rather than "not compared" (#2651).
   const groupData = useMetricCollectionSet(
     GROUPS.map((def) => ({
       key: def.id,
       collection: projectViews(def.collection, ["period", "peer"]),
     })),
     entity,
-    dateRange
-  );
-
-  // The same collections over the previous period. Attention reports a
-  // standing that is ALSO a change, so without this the block would go silent
-  // here — which reads as "nothing to see" rather than "not compared".
-  const previousGroupData = useMetricCollectionSet(
-    GROUPS.map((def) => ({
-      key: def.id,
-      collection: projectViews(def.collection, ["period"]),
-    })),
-    entity,
+    dateRange,
     previousPeriodRange(dateRange, period)
   );
 
@@ -121,9 +113,7 @@ export function DashboardScreen({ personId }: DashboardScreenProps) {
   // paint before it could say anything — and an empty attention block reads as
   // "nothing to see" rather than "not compared yet".
   const isLoading =
-    kpiData.isPending ||
-    collectionSetPending(groupData) ||
-    collectionSetPending(previousGroupData);
+    kpiData.isPending || collectionSetPending(groupData);
   // Identity failing is not a metric failure: with no person there is no name,
   // no reports, and the metrics below are unauthorized anyway. A 404 means the
   // id is gone or outside the viewer's visible set — say so, rather than paint
@@ -146,7 +136,7 @@ export function DashboardScreen({ personId }: DashboardScreenProps) {
       metricAttentionItems(
         def,
         groupData.get(def.id)?.byKey ?? new Map(),
-        previousGroupData.get(def.id)?.byKey ?? null,
+        groupData.get(def.id)?.previousByKey ?? null,
         entityId,
         headlineKeys
       )
@@ -221,7 +211,7 @@ export function DashboardScreen({ personId }: DashboardScreenProps) {
             {/* A failed comparison is an error, not silence: without it the
                 block cannot judge a change, and rendering nothing claims the
                 person has nothing worth looking at. */}
-            {[...previousGroupData.values()].some((r) => r.isError) ? (
+            {[...groupData.values()].some((r) => r.isError) ? (
               <section className="flex flex-col gap-3">
                 <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
                   Needs attention
@@ -230,7 +220,7 @@ export function DashboardScreen({ personId }: DashboardScreenProps) {
                   variant="card"
                   state="error"
                   onRetry={() =>
-                    previousGroupData.forEach((r) => {
+                    groupData.forEach((r) => {
                       if (r.isError) r.refetch();
                     })
                   }


### PR DESCRIPTION
Closes #2651.

**Why.** A person page asked for every section twice — the period on screen, then the same metric sets over the period before it, only to fill the delta arrows.

**What changed.** Sections ask for the comparison window inside the same `metric-results` request, in the live person shell and the legacy dashboard shell alike. The backend still computes the comparison; a second round trip per section goes away.

**One hook owns the window, not each call site.** The nav mark shares the query key, and the window is part of it — a call site omitting the window splits every section into two keys again. The slice cohort had the same shape and moves with it.

**The window is scoped to the overview, inside that hook.** Only the attention block reads it; with a section open the nav mark is the set's lone consumer and ranks the current window alone.

A local headless count of one person-page open went 12 → 7 requests.

**Out of scope.** Collapsing the five remaining section requests into one — not investigated; latency, backend limits and cache reuse need measuring first.

**Verified.** typecheck, lint and the unit suite — 2353 pass. `report-builder-view.test.tsx` fails identically on `upstream/main`, so it is not from this branch. The 12 → 7 count predates the window scoping and the rebase onto current main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Dashboard and portal metric views now load current and previous-period comparisons together.
  * Metric data is shared across related sections, cohort views, standings, and navigation indicators for more consistent results.
  * Loading, error, retry, and attention indicators now reflect the combined metric data.
  * Reduced duplicate metric requests may improve responsiveness when viewing sections and cohort comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
