### PR TITLE
fix(ci): keep branch cleanup off untagged image digests

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -69,5 +69,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: ${{ env.SERVICE_IMAGES }} ${{ env.CONNECTOR_IMAGES }}
           image-tags: "*.${{ steps.suffix.outputs.safe }}"
+          # SAFETY: with `both`, a concurrent publication's per-arch digests
+          # (untagged until their manifest list lands) get deleted (#3020).
+          tag-selection: tagged
           cut-off: 0s
           dry-run: false


### PR DESCRIPTION
Closes #3020.

**Why.** Deleting a branch while a publication is in flight could delete the publication's freshly pushed per-arch image digests, failing the run at the manifest-merge step.

**What changed.** The branch-deletion cleanup job now passes `tag-selection: tagged`, so it only deletes versions carrying the deleted branch's tags; untagged digests are never candidates. Untagged orphans are still collected by the daily trunk job behind its 4-week cut-off.

**Verified.** actionlint passes locally; the change is one setting in `ghcr-cleanup.yml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved container image cleanup to target only tagged images.
  - Prevented active, untagged image components from being deleted while multi-architecture images are being published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->