### PR TITLE
feat(observability): provision service health, RED, and gateway dashboards

### DIFF
--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -678,7 +678,7 @@ endef
 # any other `$` syntax pass through untouched) into
 # $(RENDER_DIR)/system-values/ and helm reads the rendered copies.
 # Usage: $(call _system_values_args,<svc>)
-_system_ns_env = NS_INFRA=$(NS_INFRA) NS_MONITORING=$(NS_MONITORING)
+_system_ns_env = NS_INFRA=$(NS_INFRA) NS_MONITORING=$(NS_MONITORING) NS_APP=$(NS_APP)
 _system_values_args = $(or $(shell $(_system_ns_env) bash scripts/render-system-values.sh $(1) $(ENV) $(RENDER_DIR)/system-values),$(error render-system-values.sh failed for '$(1)' — see the message above))
 
 # Helper: require a sealed-secret named `<svc>-creds` to be present in

--- a/deploy/gitops/scripts/render-system-values.sh
+++ b/deploy/gitops/scripts/render-system-values.sh
@@ -22,7 +22,7 @@ SVC=${1:?usage: render-system-values.sh <svc> <env> <out-dir>}
 ENV_NAME=${2:?usage: render-system-values.sh <svc> <env> <out-dir>}
 OUT_DIR=${3:?usage: render-system-values.sh <svc> <env> <out-dir>}
 
-NS_VARS=(NS_INFRA NS_MONITORING)
+NS_VARS=(NS_INFRA NS_MONITORING NS_APP)
 
 SED_ARGS=()
 for v in "${NS_VARS[@]}"; do

--- a/deploy/gitops/system/alloy-metrics/values.yaml
+++ b/deploy/gitops/system/alloy-metrics/values.yaml
@@ -105,6 +105,40 @@ alloy:
         forward_to      = [prometheus.relabel.drop_noise.receiver]
       }
 
+      // ── Gateway nginx — connection + request rates (#2892) ──────────────
+      // Pod discovery, not the Service address: two replicas behind one
+      // Service would interleave counters from different pods into one series.
+      discovery.kubernetes "gateway_pods" {
+        role = "pod"
+        namespaces {
+          names = ["${NS_APP}"]
+        }
+        selectors {
+          role  = "pod"
+          label = "app.kubernetes.io/name=gateway"
+        }
+      }
+
+      discovery.relabel "gateway_metrics" {
+        targets = discovery.kubernetes.gateway_pods.targets
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_port_name"]
+          regex         = "metrics"
+          action        = "keep"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          target_label  = "pod"
+        }
+      }
+
+      prometheus.scrape "gateway_nginx" {
+        targets         = discovery.relabel.gateway_metrics.output
+        job_name        = "gateway-nginx"
+        scrape_interval = "30s"
+        forward_to      = [prometheus.relabel.drop_noise.receiver]
+      }
+
       // ── Series-level pruning, then remote_write ─────────────────────────
       prometheus.relabel "drop_noise" {
         // kubelet /metrics/resource re-exports cAdvisor's container_cpu/

--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -131,8 +131,10 @@ datasources:
           password: $CLICKHOUSE_GRAFANA_PASSWORD
 
 # ─── Dashboards as code ─────────────────────────────────────────────────
-# Provisioned into the "Insight" folder. Sources are LOG-based (LogQL over
-# the gateway access_log and pod logs) — no Prometheus needed yet.
+# Provisioned into the "Insight" folder. Sources: LogQL over the gateway
+# access_log and pod logs, and PromQL over VictoriaMetrics (cAdvisor +
+# kube-state-metrics, the services' http.server.request.duration histogram,
+# and the gateway's nginx exporter — #2893).
 # Deploy markers: every umbrella deploy runs the insight-post-upgrade hook
 # pod; its log lines drive the dashboard annotations. The "deploy output"
 # panel shows what scripts/push-deploy-log.sh ships ({job="deploy-insight"}).
@@ -263,6 +265,198 @@ dashboards:
              "datasource": {"type": "loki", "uid": "loki"},
              "options": {"showTime": true, "wrapLogMessage": true, "sortOrder": "Ascending"},
              "targets": [{"refId": "A", "expr": "{job=\"deploy-insight\"}"}]}
+          ]
+        }
+    insight-services:
+      json: |
+        {
+          "uid": "insight-services",
+          "title": "Insight · Service health",
+          "schemaVersion": 39,
+          "time": {"from": "now-6h", "to": "now"},
+          "refresh": "1m",
+          "annotations": {"list": [
+            {"name": "Deploys", "enable": true, "iconColor": "purple",
+             "datasource": {"type": "loki", "uid": "loki"},
+             "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"}
+          ]},
+          "panels": [
+            {"id": 1, "type": "timeseries", "title": "CPU by service (cores)",
+             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{container}}", "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|keycloak|analytics|identity-resolution|previews|git-cli-proxy|frontend\"}[$__rate_interval]))"}
+             ]},
+            {"id": 2, "type": "timeseries", "title": "Memory by service (working set)",
+             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "bytes", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{container}}", "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|keycloak|analytics|identity-resolution|previews|git-cli-proxy|frontend\"})"}
+             ]},
+            {"id": 3, "type": "timeseries", "title": "Container restarts",
+             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "bars", "fillOpacity": 60, "stacking": {"mode": "normal"}}}, "overrides": []},
+             "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["sum"]}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{container}}", "expr": "sum by (container) (increase(kube_pod_container_status_restarts_total{namespace=\"insight\"}[$__rate_interval])) > 0"}
+             ]},
+            {"id": 4, "type": "timeseries", "title": "Ready vs desired replicas",
+             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "short", "min": 0, "custom": {"drawStyle": "line", "fillOpacity": 0}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{deployment}} ready", "expr": "sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\"})"},
+               {"refId": "B", "legendFormat": "{{deployment}} desired", "expr": "sum by (deployment) (kube_deployment_spec_replicas{namespace=\"insight\"})"}
+             ]},
+            {"id": 5, "type": "timeseries", "title": "Unready pods",
+             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "short", "min": 0, "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{pod}}", "expr": "kube_pod_status_ready{namespace=\"insight\", condition=\"false\"} == 1"}
+             ]},
+            {"id": 6, "type": "timeseries", "title": "OOM kills / abnormal terminations",
+             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "bars", "fillOpacity": 60, "stacking": {"mode": "normal"}}}, "overrides": []},
+             "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["sum"]}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{container}} {{reason}}", "expr": "sum by (container, reason) (kube_pod_container_status_last_terminated_reason{namespace=\"insight\", reason!=\"Completed\"})"}
+             ]}
+          ]
+        }
+    insight-red:
+      json: |
+        {
+          "uid": "insight-red",
+          "title": "Insight · RED by service",
+          "schemaVersion": 39,
+          "time": {"from": "now-6h", "to": "now"},
+          "refresh": "1m",
+          "annotations": {"list": [
+            {"name": "Deploys", "enable": true, "iconColor": "purple",
+             "datasource": {"type": "loki", "uid": "loki"},
+             "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"}
+          ]},
+          "panels": [
+            {"id": 1, "type": "timeseries", "title": "Request rate by service",
+             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "reqps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{job}}", "expr": "sum by (job) (rate(http_server_request_duration_seconds_count[$__rate_interval]))"}
+             ]},
+            {"id": 2, "type": "timeseries", "title": "Error ratio by service (5xx, %)",
+             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "percent", "min": 0, "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{job}}", "expr": "100 * sum by (job) (rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[$__rate_interval])) / sum by (job) (rate(http_server_request_duration_seconds_count[$__rate_interval]))"}
+             ]},
+            {"id": 3, "type": "timeseries", "title": "Duration p50 / p99 by service",
+             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{job}} p50", "expr": "histogram_quantile(0.5, sum by (le, job) (rate(http_server_request_duration_seconds_bucket[$__rate_interval])))"},
+               {"refId": "B", "legendFormat": "{{job}} p99", "expr": "histogram_quantile(0.99, sum by (le, job) (rate(http_server_request_duration_seconds_bucket[$__rate_interval])))"}
+             ]},
+            {"id": 4, "type": "timeseries", "title": "Duration p95 by route",
+             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "s", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{job}} {{http_route}}", "expr": "histogram_quantile(0.95, sum by (le, job, http_route) (rate(http_server_request_duration_seconds_bucket[$__rate_interval])))"}
+             ]},
+            {"id": 5, "type": "timeseries", "title": "Request rate by route (top 10)",
+             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "reqps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["mean"]}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{job}} {{http_route}}", "expr": "topk(10, sum by (job, http_route) (rate(http_server_request_duration_seconds_count[$__rate_interval])))"}
+             ]},
+            {"id": 6, "type": "timeseries", "title": "Error rate by route (4xx / 5xx)",
+             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "reqps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{job}} {{http_route}} {{http_response_status_code}}", "expr": "sum by (job, http_route, http_response_status_code) (rate(http_server_request_duration_seconds_count{http_response_status_code=~\"[45]..\"}[$__rate_interval])) > 0"}
+             ]}
+          ]
+        }
+    insight-gateway:
+      json: |
+        {
+          "uid": "insight-gateway",
+          "title": "Insight · Gateway traffic",
+          "schemaVersion": 39,
+          "time": {"from": "now-6h", "to": "now"},
+          "refresh": "1m",
+          "annotations": {"list": [
+            {"name": "Deploys", "enable": true, "iconColor": "purple",
+             "datasource": {"type": "loki", "uid": "loki"},
+             "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"}
+          ]},
+          "panels": [
+            {"id": 1, "type": "timeseries", "title": "Request rate (nginx)",
+             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "reqps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{pod}}", "expr": "sum by (pod) (rate(nginx_http_requests_total{job=\"gateway-nginx\"}[$__rate_interval]))"}
+             ]},
+            {"id": 2, "type": "timeseries", "title": "Proxied responses by status class (rps)",
+             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "reqps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{status_class}}", "expr": "sum by (status_class) (label_replace(rate(http_server_request_duration_seconds_count[$__rate_interval]), \"status_class\", \"${1}xx\", \"http_response_status_code\", \"([0-9])..\"))"}
+             ]},
+            {"id": 3, "type": "timeseries", "title": "Connections",
+             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "short", "min": 0, "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{pod}} active", "expr": "nginx_connections_active{job=\"gateway-nginx\"}"},
+               {"refId": "B", "legendFormat": "{{pod}} reading", "expr": "nginx_connections_reading{job=\"gateway-nginx\"}"},
+               {"refId": "C", "legendFormat": "{{pod}} writing", "expr": "nginx_connections_writing{job=\"gateway-nginx\"}"},
+               {"refId": "D", "legendFormat": "{{pod}} waiting", "expr": "nginx_connections_waiting{job=\"gateway-nginx\"}"}
+             ]},
+            {"id": 4, "type": "timeseries", "title": "Connections accepted vs handled (per second)",
+             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "cps", "min": 0, "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
+             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{pod}} accepted", "expr": "rate(nginx_connections_accepted{job=\"gateway-nginx\"}[$__rate_interval])"},
+               {"refId": "B", "legendFormat": "{{pod}} handled", "expr": "rate(nginx_connections_handled{job=\"gateway-nginx\"}[$__rate_interval])"}
+             ]},
+            {"id": 5, "type": "stat", "title": "Exporter up",
+             "gridPos": {"h": 4, "w": 12, "x": 0, "y": 16},
+             "datasource": {"type": "prometheus", "uid": "vm"},
+             "fieldConfig": {"defaults": {"unit": "short", "mappings": [
+               {"type": "value", "options": {"0": {"text": "down", "color": "red"}, "1": {"text": "up", "color": "green"}}}
+             ]}, "overrides": []},
+             "options": {"colorMode": "background", "reduceOptions": {"calcs": ["lastNotNull"]}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{pod}}", "expr": "nginx_up{job=\"gateway-nginx\"}"}
+             ]}
           ]
         }
 


### PR DESCRIPTION
Closes #2893.

**Why.** The provisioned Grafana folder has only log-based dashboards; the metrics the observability epic wired up (cAdvisor, kube-state-metrics, the services' RED histogram, the gateway nginx exporter) have no dashboards reading them.

**What changed.** Three dashboards provisioned in `deploy/gitops/system/grafana/values.yaml`: service health (CPU/memory/restarts/readiness per service), RED by service (rate, 5xx ratio, duration percentiles by route over `http_server_request_duration_seconds`), and gateway traffic (nginx connections, request rate, exporter up). The alloy-metrics baseline gains the gateway-nginx scrape job its gitops mirror already carried, via a new `${NS_APP}` renderer placeholder.

**Status classes come from the RED histogram, not the nginx exporter.** stub_status exposes no per-status counters, so the gateway dashboard derives status classes from the services' `http_response_status_code` label in PromQL; edge-only responses (static assets, redirects) appear only in the nginx request-rate panel.

**Out of scope.** Per-environment rollout beyond the gitops dev overlay; alerts (#2895); the connector dashboard (#2894).

**Verified.** Values parse as YAML and every embedded dashboard decodes as JSON; `render-system-values.sh` run for alloy-metrics resolves `${NS_APP}`. Not verified live: rendering with data needs the #2892 sidecar (#3019) deployed on a stand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring for Gateway nginx metrics, including traffic, connections, and exporter status.
  * Added three Grafana dashboards covering service health, request/error/latency metrics, and Gateway performance.
  * Enabled dashboard queries to use both metrics and logs data sources.

* **Improvements**
  * System configuration rendering now supports application namespace values for monitoring discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->