### PR TITLE
fix(frontend): backport the narrow-viewport card and table fixes to release-2026.08

### DIFF
--- a/src/frontend/docs/testing/storybook-component-tests.md
+++ b/src/frontend/docs/testing/storybook-component-tests.md
@@ -50,7 +50,8 @@ cyber-insight-front/
 ├─ src/test/storybook/
 │   ├─ test-router.ts          # createTestingRouter() — memory-history TanStack Router
 │   ├─ with-providers.tsx      # QueryClient + router + theme + i18n decorator
-│   └─ theme-decorators.ts     # addon-themes adapted to light/dark
+│   ├─ theme-decorators.ts     # addon-themes adapted to light/dark
+│   └─ layout.ts               # geometry assertions + the card widths stories measure at
 ├─ vitest.config.ts            # test.projects = [unit (jsdom), storybook (browser)]
 ├─ public/mockServiceWorker.js # already present (msw workerDirectory: public)
 └─ src/components/widgets/dashboard/kpi-tile.stories.tsx  # PoC story + play tests

--- a/src/frontend/src/components/widgets/dashboard/members-grid.stories.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.stories.tsx
@@ -1,0 +1,164 @@
+/**
+ * Browser component tests for the geometry of `<MembersGrid>` — the roster,
+ * one row per member and one column per metric.
+ *
+ * Which rows it draws, how it sorts them and what each cell says is covered by
+ * the jsdom tests in `members-grid.test.tsx`. What needs a real browser is the
+ * width: the member column is fixed and the table scrolls sideways past it, so
+ * on a phone a column sized for a desktop leaves no room for a single metric.
+ *
+ * See docs/testing/storybook-component-tests.md.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import { MembersGrid } from "@/components/widgets/dashboard/members-grid";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+import {
+  CARD_PX_AT_390,
+  CARD_PX_WIDE,
+  expectHorizontallyContained,
+} from "@/test/storybook/layout";
+
+/** Long enough that a member column crushed to nothing is unmistakable. */
+const MEMBERS = [
+  { entityId: "019e27bc-dec0-7626-81a9-c5524662a6a9", displayName: "Alexandra Fernandez" },
+  { entityId: "019e27bc-dec0-7626-81a9-c5524662a6b0", displayName: "Bo Ng" },
+];
+
+function metric(key: string, shortLabel: string): MetricResult {
+  return {
+    metric_key: key,
+    label: `${shortLabel} over the period`,
+    short_label: shortLabel,
+    unit: null,
+    format: "integer",
+    computation: "sum",
+    direction: "higher_is_better",
+    views: [
+      {
+        view: "period",
+        values: MEMBERS.map((m, index) => ({
+          entity_id: m.entityId,
+          value: 100 + index,
+        })),
+      },
+      {
+        view: "peer",
+        values: MEMBERS.map((m, index) => ({
+          entity_id: m.entityId,
+          target_value: 100 + index,
+          p25: 50,
+          median: 100,
+          p75: 150,
+          min: 0,
+          max: 200,
+          n: 12,
+        })),
+      },
+    ],
+  } as unknown as MetricResult;
+}
+
+/** Enough columns that the table overruns any container these stories use. */
+const RESULTS = [
+  metric("git.commits", "Commits"),
+  metric("git.prs_merged", "PRs merged"),
+  metric("git.code_lines", "Code lines"),
+  metric("collab.messages", "Msgs"),
+  metric("collab.meeting_hours", "Mtg hrs"),
+  metric("ai.active_days", "AI days"),
+];
+
+const meta: Meta<typeof MembersGrid> = {
+  title: "Widgets/Dashboard/MembersGrid",
+  component: MembersGrid,
+  args: {
+    members: MEMBERS,
+    metricKeys: RESULTS.map((r) => r.metric_key),
+    byKey: normalizeMetricResults(RESULTS),
+    caption: "Members grid",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof MembersGrid>;
+
+/** Demo story for the Storybook UI (untagged — not a test). */
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** The column the names sit in is the one that holds the scroller's width. */
+function memberColumnWidth(table: Element): number {
+  const header = table.querySelector("thead th");
+  return Math.round(header!.getBoundingClientRect().width);
+}
+
+/**
+ * On a phone the first metric column reads in full beside the names.
+ *
+ * The failure this pins is invisible to a text query: every cell is in the DOM
+ * and correct, and the member column simply holds a desktop width the viewport
+ * does not have — so the roster shows names, part of one metric, and nothing
+ * else, with the rest hidden behind a sideways scroll nobody looks for.
+ */
+export const TestNarrowRosterShowsAWholeMetricColumn: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const table = canvas.getByRole("table", { name: "Members grid" });
+    const scroller = table.parentElement!;
+
+    const firstMetric = canvas.getByRole("button", {
+      name: "Commits over the period — sort by this column",
+    });
+    expectHorizontallyContained(
+      scroller,
+      [firstMetric.closest("th")!],
+      () => "the first metric column"
+    );
+
+    // Reaching that by shrinking the names to nothing would be no better than
+    // the bug: the column has to still hold a name.
+    const name = canvas.getByRole("link", { name: "Alexandra Fernandez" });
+    await expect(
+      Math.round(name.getBoundingClientRect().width),
+      "the member column collapsed the name away"
+    ).toBeGreaterThan(80);
+  },
+};
+
+/** Given the room, the names get the width they read best at. */
+export const TestWideRosterKeepsTheComfortableNameColumn: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const table = canvas.getByRole("table", { name: "Members grid" });
+    const width = memberColumnWidth(table);
+    await expect(
+      width,
+      `the member column is ${width}px on a ${CARD_PX_WIDE}px card`
+    ).toBe(256);
+  },
+};

--- a/src/frontend/src/components/widgets/dashboard/members-grid.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.tsx
@@ -64,6 +64,22 @@ import {
   withOwnTarget,
 } from "@/components/metric-evidence-context";
 
+/**
+ * INVARIANT: every step leaves room for the names plus one whole metric column
+ * (`METRIC_COL_PX`) inside the container it applies to — a step wider than
+ * that is the bug this replaced, where the roster showed names and nothing
+ * else. A container query, not a viewport one: a drilldown pane on a desktop
+ * is as narrow as a phone.
+ */
+const MEMBER_COL_WIDTH =
+  "[--member-col:9rem] @min-[26rem]:[--member-col:12rem] @min-[32rem]:[--member-col:16rem]";
+
+/** Falls back rather than collapsing to `auto` if the wrapper ever loses it. */
+const MEMBER_COL_CELL =
+  "sticky start-0 z-10 w-[var(--member-col,16rem)] bg-card text-left";
+
+const METRIC_COL_PX = 108;
+
 export interface MembersGridMember {
   /** Canonical person id — keys every metric lookup AND the IC link. */
   entityId: string;
@@ -359,8 +375,8 @@ export function MembersGrid({
   const memberSortActive = sort.key === "issues" || sort.key === "name";
 
   return (
-    <div className={cn("flex flex-col gap-3", className)}>
-      <div className="overflow-x-auto">
+    <div className={cn("@container flex flex-col gap-3", className)}>
+      <div className={cn("overflow-x-auto", MEMBER_COL_WIDTH)}>
         {/* Fixed layout so metric columns are uniform — auto layout sizes
             each column to its own content, making them ragged. The member
             column takes a fixed width; the metric columns split the rest
@@ -370,7 +386,9 @@ export function MembersGrid({
             wrapper scrolls instead of crushing columns. */}
         <table
           className="w-full max-w-[1600px] table-fixed border-separate border-spacing-1"
-          style={{ minWidth: `${256 + columns.length * 108}px` }}
+          style={{
+            minWidth: `calc(var(--member-col, 16rem) + ${columns.length * METRIC_COL_PX}px)`,
+          }}
         >
           <caption className="sr-only">{caption}</caption>
           <thead>
@@ -378,7 +396,7 @@ export function MembersGrid({
               <th
                 scope="col"
                 aria-sort={memberDirection}
-                className="sticky left-0 z-10 w-64 bg-card px-2 text-left"
+                className={cn(MEMBER_COL_CELL, "px-2")}
               >
                 {hasIssuesFacet ? (
                   // Two member orderings (issues / name) → a small header menu,
@@ -496,7 +514,7 @@ function MemberRow({
     <tr>
       <th
         scope="row"
-        className="sticky left-0 z-10 w-64 bg-card px-2 py-1 text-left font-normal"
+        className={cn(MEMBER_COL_CELL, "px-2 py-1 font-normal")}
       >
         <div className="flex min-h-12 flex-col justify-center gap-0.5">
           <div className="flex items-center gap-1.5">

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.stories.tsx
@@ -1,0 +1,162 @@
+/**
+ * Browser component tests for the header of `<MetricActivity>` — the metric's
+ * name on one side, its total and the two comparisons on the other.
+ *
+ * The rest of the section (the event list, the day strip) is covered by the
+ * jsdom tests in `metric-activity.test.tsx`; what needs a real browser is the
+ * header's geometry, which no text query can see. The fixture declares no
+ * granularity on purpose: that leaves the detail query disabled, so the
+ * section renders its header and nothing that fetches.
+ *
+ * See docs/testing/storybook-component-tests.md.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import { MetricActivity } from "@/components/widgets/metric-views/metric-activity";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+import { CARD_PX_AT_390, CARD_PX_WIDE } from "@/test/storybook/layout";
+
+const ENTITY_ID = "019e27bc-dec0-7626-81a9-c5524662a6a9";
+const METRIC_KEY = "git.prs_merged";
+
+/**
+ * A long name against a long pair of comparisons — the shape that has no room
+ * for both on one line, and the only shape this test is about.
+ */
+function result(value: number, withPeer: boolean): MetricResult {
+  return {
+    metric_key: METRIC_KEY,
+    label: "Pull requests merged",
+    description: "Authored pull requests merged",
+    unit: "PRs",
+    format: "integer",
+    computation: "sum",
+    direction: "higher_is_better",
+    views: [
+      { view: "period", values: [{ entity_id: ENTITY_ID, value }] },
+      ...(withPeer
+        ? [
+            {
+              view: "peer",
+              values: [
+                {
+                  entity_id: ENTITY_ID,
+                  target_value: value,
+                  p25: 1,
+                  median: 3,
+                  p75: 7,
+                },
+              ],
+            },
+          ]
+        : []),
+    ],
+    selection: {
+      metric_key: METRIC_KEY,
+      entity: { type: "person", ids: [ENTITY_ID] },
+      period: { from: "2026-08-24", to: "2026-08-30" },
+      filters: [],
+    },
+  } as unknown as MetricResult;
+}
+
+function normalized(value: number, withPeer: boolean) {
+  return normalizeMetricResults([result(value, withPeer)]).get(METRIC_KEY)!;
+}
+
+const meta: Meta<typeof MetricActivity> = {
+  title: "Widgets/MetricViews/MetricActivity",
+  component: MetricActivity,
+  args: {
+    metric: normalized(11, true),
+    previous: normalized(14, false),
+    entityId: ENTITY_ID,
+    periodNoun: "week",
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof MetricActivity>;
+
+/** Demo story for the Storybook UI (untagged — not a test). */
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/**
+ * Where a line fits both, the name and the figures share it.
+ *
+ * The narrow case below only proves something if the wide case is still one
+ * line — a header that always stacks would pass it and be a different bug.
+ */
+export const TestWideHeaderStaysOnOneLine: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const name = canvas.getByText("Pull requests merged");
+    const total = canvas.getByText("11 PRs");
+
+    // They share a line — asserted as overlapping vertical bands rather than
+    // equal tops, which an inline box and a block box never have.
+    const nameBox = name.getBoundingClientRect();
+    const totalBox = total.getBoundingClientRect();
+
+    await expect(totalBox.top).toBeLessThan(nameBox.bottom);
+    await expect(nameBox.top).toBeLessThan(totalBox.bottom);
+  },
+};
+
+/**
+ * Too narrow for both, the header stacks and the name keeps the whole line.
+ *
+ * Unfixed, the name column collapsed and the name wrapped into a stack of
+ * single words beside the figures — unreadable, while every `getByText` still
+ * passed. Only geometry can see it.
+ */
+export const TestNarrowHeaderStacksInsteadOfOverlapping: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    // The column, not the text in it: the name renders as an inline span, which
+    // keeps its own width by overflowing a column collapsed to nothing.
+    const name = canvas.getByText("Pull requests merged");
+    const column = name.closest("div")!;
+    const columnBox = column.getBoundingClientRect();
+    const rowBox = column.parentElement!.getBoundingClientRect();
+    const totalBox = canvas.getByText("11 PRs").getBoundingClientRect();
+
+    await expect(
+      totalBox.top,
+      `the figures share the name's line (name ends ${columnBox.bottom}, figures start ${totalBox.top})`
+    ).toBeGreaterThanOrEqual(columnBox.bottom);
+
+    // Stacking is only worth the line it costs if the name got that line: a
+    // column narrow enough to break the name into single words satisfies the
+    // assertion above just as well.
+    await expect(
+      columnBox.width,
+      `the name column is ${columnBox.width}px of a ${rowBox.width}px row`
+    ).toBeGreaterThan(rowBox.width / 2);
+  },
+};

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -91,8 +91,11 @@ export function MetricActivity({
 
   return (
     <section className="flex flex-col gap-2 border-t py-4 first:border-t-0">
-      <header className="flex items-baseline justify-between gap-4">
-        <div className="min-w-0">
+      <header className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+        {/* INVARIANT: a fixed basis, because a flex line breaks on content
+            size — with none, the untruncated description decides the width at
+            which the figures drop to their own line. */}
+        <div className="min-w-0 flex-[1_1_16rem]">
           <MetricName metric={metric} className="text-sm font-medium" />
           {help?.description ? (
             <p className="truncate text-xs text-muted-foreground">
@@ -100,7 +103,7 @@ export function MetricActivity({
             </p>
           ) : null}
         </div>
-        <div className="shrink-0 text-right">
+        <div className="ms-auto shrink-0 text-right">
           <div className="text-sm tabular-nums">{total}</div>
           {/* Both readings, stated and neither judged. The reader's own last
               period comes first because it is the one they can act on; the

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-chart.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-chart.tsx
@@ -1,4 +1,5 @@
 import { format } from "date-fns";
+import type { MouseHandlerDataParam } from "recharts";
 
 import {
   BarChart,
@@ -29,9 +30,10 @@ export interface MetricTimeseriesChartProps {
   model: MetricTimeseriesModel;
   selectedMetricKey: string;
   multiMetric?: MetricTimeseriesChartConfig["multiMetric"];
+  /** `columnKey` null drills the whole bucket, narrowed by no dimension value. */
   onEvidence?: (
     metricKey: string,
-    columnKey: string,
+    columnKey: string | null,
     bucketStart: string | null
   ) => void;
 }
@@ -138,18 +140,45 @@ export function MetricTimeseriesChart({
       />
     </>
   );
-  const openPoint = (
+  // Recharts reports no active bucket as null, and `Number(null)` is 0 — which
+  // would read as the first bucket rather than as "none".
+  const bucketAt = (index: MouseHandlerDataParam["activeTooltipIndex"]) =>
+    index == null ? undefined : data[Number(index)]?.bucketStart;
+  const openBucketFrom = (bucketStart: string) =>
+    onEvidence?.(chartModel.valueMetric.metric_key, null, bucketStart);
+  const openSegment = (
     series: MetricTimeseriesChartModel["series"][number],
-    state: unknown
+    entry: unknown
   ) => {
-    const point = state as { payload?: { bucketStart?: string } };
+    const point = entry as { payload?: { bucketStart?: string } };
     const bucketStart = point.payload?.bucketStart;
+    if (!bucketStart) return;
+
     const column = model.columns.find(
       (candidate) => candidate.key === series.columnKey
     );
-    if (bucketStart && column && !column.remainder) {
+    // The remainder gathers the dimension values that missed the top N, so no
+    // filter selects it: clicking it reads as clicking past every segment.
+    if (column && !column.remainder) {
       onEvidence?.(series.metricKey, series.columnKey, bucketStart);
+    } else {
+      openBucketFrom(bucketStart);
     }
+  };
+  /**
+   * The column outside its drawn segments. A click on a segment reaches here
+   * too, and asking the event where it landed is what keeps both from
+   * answering it — no assumption about which handler runs first.
+   */
+  const openBucket = (
+    state: MouseHandlerDataParam,
+    event: { target: EventTarget | null }
+  ) => {
+    const target = event.target as Element | null;
+    if (target?.closest?.(".recharts-bar-rectangle")) return;
+
+    const bucketStart = bucketAt(state.activeTooltipIndex);
+    if (bucketStart) openBucketFrom(bucketStart);
   };
 
   return (
@@ -162,6 +191,7 @@ export function MetricTimeseriesChart({
           <BarChart
             data={data}
             margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+            onClick={openBucket}
           >
             {chartContent}
             <TimeseriesXAxis data={data} />
@@ -173,7 +203,7 @@ export function MetricTimeseriesChart({
                 fill={`var(--color-${series.key})`}
                 name={series.label}
                 radius={[2, 2, 0, 0]}
-                onClick={(point) => openPoint(series, point)}
+                onClick={(point) => openSegment(series, point)}
               />
             ))}
           </BarChart>
@@ -181,6 +211,7 @@ export function MetricTimeseriesChart({
           <LineChart
             data={data}
             margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+            onClick={openBucket}
           >
             {chartContent}
             <TimeseriesXAxis data={data} numeric />
@@ -219,7 +250,6 @@ export function MetricTimeseriesChart({
                 // a straight line drawn across it.
                 connectNulls={false}
                 name={series.label}
-                onClick={(point) => openPoint(series, point)}
               />
             ))}
           </LineChart>

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-chrome.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-chrome.tsx
@@ -147,7 +147,7 @@ export function TimeseriesBody({
   onVerticalOverflow?: (overflows: boolean) => void;
   onEvidence?: (
     metricKey: string,
-    columnKey: string,
+    columnKey: string | null,
     bucketStart: string | null
   ) => void;
 }) {

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-presentations.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-presentations.test.tsx
@@ -190,7 +190,7 @@ describe("metric timeseries presentations", () => {
     const row = screen.getByText("Grand total").closest("tr")!;
     const totals = row.querySelectorAll("td")[1]!.querySelector("span")!;
     expect(totals.className).toContain("sticky");
-    expect(totals.className).toContain("start-28");
+    expect(totals.className).toContain("start-24");
   });
 
   it("hides the grand-total row when every total is missing", () => {

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.stories.tsx
@@ -1,0 +1,204 @@
+/**
+ * Browser component tests for the geometry of `<MetricTimeseriesTable>` — the
+ * scroll controls and the room they leave the data.
+ *
+ * What the table renders, and where a page scrolls to, is covered by the jsdom
+ * tests in `metric-timeseries-presentations.test.tsx`, which hand it fake
+ * geometry. What needs a real browser is the geometry itself: the controls sit
+ * in gutters taken out of the scrollport, and both the sticky bucket column and
+ * a whole value column have to survive that on a phone.
+ *
+ * `metric-timeseries-view.stories.tsx` covers the same table inside its card;
+ * this file renders it in a box of a chosen size, which is the only way to
+ * reach the short-table case.
+ *
+ * See docs/testing/storybook-component-tests.md.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, waitFor } from "storybook/test";
+
+import { MetricTimeseriesTable } from "@/components/widgets/metric-views/metric-timeseries-table";
+import { groupedTimeseriesModel } from "@/components/widgets/metric-views/metric-timeseries.test-fixtures";
+import {
+  CARD_PX_AT_390,
+  expectNothingOverlaps,
+} from "@/test/storybook/layout";
+
+/** Short enough that the three rows overrun it, so the row controls render. */
+const SHORT_PX = 180;
+
+/** Mirrors the gutter the component reserves — see the widening story. */
+const GUTTER_PX = 48;
+
+const meta: Meta<typeof MetricTimeseriesTable> = {
+  title: "Widgets/MetricViews/MetricTimeseriesTable",
+  component: MetricTimeseriesTable,
+  args: { model: groupedTimeseriesModel() },
+};
+export default meta;
+
+type Story = StoryObj<typeof MetricTimeseriesTable>;
+
+/** Demo story for the Storybook UI (untagged — not a test). */
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: 900, height: 300 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+function scrollControls(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>('button[aria-label^="Show "]')
+  );
+}
+
+function nameOf(element: Element): string {
+  return element.getAttribute("aria-label") ?? "a scroll control";
+}
+
+/**
+ * Scrolling both ways, the four controls clear the cells and each other.
+ *
+ * The row pair shares the end gutter with the column control, so this is the
+ * arrangement that stops being obvious: three chevrons in one lane, held apart
+ * only by the height the caller gives the table.
+ */
+export const TestShortTableKeepsItsControlsApart: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390, height: SHORT_PX }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["test"],
+  play: async ({ canvasElement }) => {
+    const table = canvasElement.querySelector("table")!;
+    const scrollport = table.parentElement!;
+    const controls = scrollControls(canvasElement);
+
+    const labels = controls.map(nameOf);
+    await expect(
+      labels,
+      `the table scrolls both ways, so it renders a control for each (${labels.join(", ")})`
+    ).toEqual(
+      expect.arrayContaining(["Show later columns", "Show later rows"])
+    );
+
+    expectNothingOverlaps(scrollport, controls, nameOf);
+    for (const control of controls) {
+      expectNothingOverlaps(
+        control,
+        controls.filter((other) => other !== control),
+        nameOf
+      );
+    }
+  },
+};
+
+/**
+ * On a phone the bucket column and a whole value column both still read.
+ *
+ * Moving the controls off the cells costs the scrollport two gutters, and the
+ * sticky bucket column is taken out of what is left. Clearing the cells by
+ * taking the room they needed would leave the table exactly as unreadable as
+ * the controls painted over it did.
+ */
+export const TestNarrowTableLeavesRoomForAValueColumn: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390, height: 400 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["test"],
+  play: async ({ canvasElement }) => {
+    const table = canvasElement.querySelector("table")!;
+    const scrollport = table.parentElement!;
+    const cells = Array.from(
+      table.querySelectorAll<HTMLElement>("tbody tr:first-child > *")
+    );
+
+    await expect(
+      cells.length,
+      "the first row has a bucket cell and at least one value"
+    ).toBeGreaterThan(1);
+
+    const room = scrollport.clientWidth;
+    const bucket = cells[0].getBoundingClientRect().width;
+    const value = cells[1].getBoundingClientRect().width;
+    await expect(
+      Math.round(bucket + value),
+      `the bucket column (${Math.round(bucket)}px) and the first value ` +
+        `(${Math.round(value)}px) do not fit the ${room}px scrollport`
+    ).toBeLessThanOrEqual(room);
+
+    // The date is what the bucket column is narrow for; a column that clips it
+    // would satisfy the width check and tell the reader nothing.
+    const date = cells[0];
+    await expect(
+      date.scrollWidth,
+      `the bucket cell clips its date (${date.scrollWidth}px of text in ${date.clientWidth}px)`
+    ).toBeLessThanOrEqual(date.clientWidth);
+  },
+};
+
+/**
+ * Given the room back, the table gives the gutters back.
+ *
+ * The gutters are the wrapper's padding, so measuring the overflow on the
+ * scrollport feeds them their own effect: the width they took makes the
+ * overflow that keeps them. That latches — a card that was ever narrow keeps a
+ * sideways scroll and two empty gutters at every width afterwards — and only a
+ * resize in both directions catches it.
+ */
+export const TestWidenedTableReleasesItsGutters: Story = {
+  decorators: [
+    (Story) => (
+      <div data-testid="box" style={{ width: CARD_PX_AT_390, height: 400 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ["test"],
+  play: async ({ canvasElement }) => {
+    const box = canvasElement.querySelector<HTMLElement>('[data-testid="box"]')!;
+    const table = canvasElement.querySelector("table")!;
+    const wrapper = table.parentElement!.parentElement!;
+
+    await waitFor(() =>
+      expect(
+        scrollControls(canvasElement).length,
+        "the narrow table scrolls sideways to begin with"
+      ).toBeGreaterThan(0)
+    );
+
+    // One gutter's worth of room past the table is the width that catches a
+    // latch and nothing else does: wide enough that the table fits with no
+    // gutters, narrow enough that it does not once a stale pair is subtracted.
+    box.style.width = `${table.offsetWidth + GUTTER_PX}px`;
+
+    await waitFor(() =>
+      expect(
+        scrollControls(canvasElement).map(nameOf),
+        "the widened table still offers to scroll"
+      ).toEqual([])
+    );
+
+    const scrollport = table.parentElement!;
+    await expect(
+      scrollport.scrollWidth,
+      `the widened table still scrolls sideways (${scrollport.scrollWidth}px of table in ${scrollport.clientWidth}px)`
+    ).toBeLessThanOrEqual(scrollport.clientWidth);
+    await expect(
+      wrapper.className,
+      "the wrapper kept a gutter it no longer has a control for"
+    ).not.toContain("ps-12");
+  },
+};

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.tsx
@@ -36,7 +36,7 @@ export interface MetricTimeseriesTableProps {
   onVerticalOverflow?: (overflows: boolean) => void;
   onEvidence?: (
     metricKey: string,
-    columnKey: string,
+    columnKey: string | null,
     bucketStart: string | null
   ) => void;
 }

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.tsx
@@ -51,6 +51,8 @@ const NOTHING_MORE: Record<Side, boolean> = {
   down: false,
 };
 
+const NO_GUTTERS = { start: false, end: false };
+
 /** Sub-pixel scroll offsets are noise, not a side with content on it. */
 const EDGE_SLACK_PX = 1;
 
@@ -58,9 +60,13 @@ const EDGE_SLACK_PX = 1;
 const NEARLY_A_FRAME = 0.8;
 
 /**
- * The vertical pair is offset toward the end rather than centred: the sticky
- * header carries the group names and the sticky footer the totals, and a
- * control parked over either hides what that row is pinned for.
+ * Every control sits in a gutter beside the scrollport rather than over it, so
+ * none of them can hide a cell.
+ *
+ * INVARIANT: the end gutter stacks three — rows up at the top, columns forward
+ * in the middle, rows down at the bottom — which needs about 104px of height to
+ * keep them apart. Every caller renders the table taller than that; one that
+ * does not gets three chevrons in a heap.
  */
 const SIDE_CHROME: Record<
   Side,
@@ -79,14 +85,37 @@ const SIDE_CHROME: Record<
   up: {
     icon: ChevronUp,
     label: "Show earlier rows",
-    place: "top-1 end-10",
+    place: "top-1 end-1",
   },
   down: {
     icon: ChevronDown,
     label: "Show later rows",
-    place: "bottom-1 end-10",
+    place: "bottom-1 end-1",
   },
 };
+
+/**
+ * The gutters, wide enough for a control plus the inset it is placed at.
+ *
+ * INVARIANT: `GUTTER_PX` is what these classes render as. The measure pass
+ * subtracts it to decide whether the table overflows, so the two disagreeing
+ * makes the controls appear against a width the layout never had.
+ */
+const GUTTER_START = "ps-12";
+const GUTTER_END = "pe-12";
+const GUTTER_PX = 48;
+
+/**
+ * The bucket column, sticky at the start of every row, and the offset the
+ * grand-total row sticks at to clear it.
+ *
+ * INVARIANT: the two widths are the same number. Wide enough for a full
+ * `YYYY-MM-DD` plus the cells' own padding, and no wider — this column and the
+ * gutters come out of one scrollport, which on a phone has a single data
+ * column's room to spare between them.
+ */
+const BUCKET_COL = "w-24 max-w-24 min-w-24";
+const PAST_BUCKET_COL = "start-24";
 
 const BUCKET_LABEL = {
   day: "Day",
@@ -179,11 +208,14 @@ export function MetricTimeseriesTable({
     )
   );
 
+  const wrapRef = useRef<HTMLDivElement | null>(null);
   const boxRef = useRef<HTMLDivElement | null>(null);
   const [more, setMore] = useState(NOTHING_MORE);
+  const [gutters, setGutters] = useState(NO_GUTTERS);
   const measure = useCallback(() => {
     const box = boxRef.current;
-    if (!box) return;
+    const wrap = wrapRef.current;
+    if (!box || !wrap) return;
     // `scrollLeft` is negative in RTL.
     const across = Math.abs(box.scrollLeft);
     const acrossRoom = box.scrollWidth - box.clientWidth;
@@ -199,7 +231,26 @@ export function MetricTimeseriesTable({
     setMore((prev) =>
       SIDES.every((side) => prev[side] === next[side]) ? prev : next
     );
-    onVerticalOverflow?.(downRoom > EDGE_SLACK_PX);
+
+    // The wrapper's own width, not the scrollport's: the gutters are its
+    // padding, so this figure is the one thing they cannot move. Deciding from
+    // the scrollport feeds a gutter its own effect — the width it took makes
+    // the overflow that keeps it — and the table then scrolls sideways forever
+    // over a card that has long since grown wide enough.
+    const rows = box.querySelector("table");
+    const naturalWidth = rows?.offsetWidth ?? box.scrollWidth;
+    const scrollsDown = downRoom > EDGE_SLACK_PX;
+    // The table never wraps a cell (`min-w-max`), so its height owes nothing to
+    // any of this and the end gutter can be subtracted without circling back.
+    const roomAcross = wrap.clientWidth - (scrollsDown ? GUTTER_PX : 0);
+    const scrollsAcross = naturalWidth > roomAcross + EDGE_SLACK_PX;
+    setGutters((prev) =>
+      prev.start === scrollsAcross && prev.end === (scrollsAcross || scrollsDown)
+        ? prev
+        : { start: scrollsAcross, end: scrollsAcross || scrollsDown }
+    );
+
+    onVerticalOverflow?.(scrollsDown);
   }, [onVerticalOverflow]);
   useEffect(() => {
     measure();
@@ -238,7 +289,14 @@ export function MetricTimeseriesTable({
   }
 
   return (
-    <div className="relative h-full">
+    <div
+      ref={wrapRef}
+      className={cn(
+        "relative h-full",
+        gutters.start && GUTTER_START,
+        gutters.end && GUTTER_END
+      )}
+    >
       {/* Rendered, not hidden: opacity would leave them in the tab order. */}
       {SIDES.filter((side) => more[side]).map((side) => {
         const { icon: Icon, label, place } = SIDE_CHROME[side];
@@ -252,7 +310,6 @@ export function MetricTimeseriesTable({
             title={label}
             onClick={() => page(side)}
             className={cn(
-              // Opaque, so they stay legible over whatever cell they land on.
               "absolute z-40 rounded-full bg-card shadow-md",
               place
             )}
@@ -269,7 +326,7 @@ export function MetricTimeseriesTable({
       <TableHeader className="[&_tr]:border-b-0">
         {model.dimensions.length === 0 ? (
           <TableRow>
-            <TableHead className="sticky top-0 left-0 z-30 h-10 w-28 max-w-28 min-w-28 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+            <TableHead className={cn(BUCKET_COL, "sticky top-0 left-0 z-30 h-10 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
               {BUCKET_LABEL[model.bucket]}
             </TableHead>
             {tableColumns.map((column, columnIndex) => (
@@ -287,7 +344,7 @@ export function MetricTimeseriesTable({
           </TableRow>
         ) : tableColumns.length === 1 ? (
           <TableRow>
-            <TableHead className="sticky top-0 left-0 z-30 h-10 w-28 max-w-28 min-w-28 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+            <TableHead className={cn(BUCKET_COL, "sticky top-0 left-0 z-30 h-10 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
               {BUCKET_LABEL[model.bucket]}
             </TableHead>
             {model.columns.map((column, index) => (
@@ -306,7 +363,7 @@ export function MetricTimeseriesTable({
         ) : (
           <>
             <TableRow>
-              <TableHead className="sticky top-0 left-0 z-30 h-10 w-28 max-w-28 min-w-28 bg-card py-0 after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+              <TableHead className={cn(BUCKET_COL, "sticky top-0 left-0 z-30 h-10 bg-card py-0 after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
                 {BUCKET_LABEL[model.bucket]}
               </TableHead>
               {model.columns.map((column, index) => (
@@ -326,7 +383,7 @@ export function MetricTimeseriesTable({
             <TableRow>
               <TableHead
                 aria-hidden
-                className="sticky top-10 left-0 z-30 h-9 w-28 max-w-28 min-w-28 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border"
+                className={cn(BUCKET_COL, "sticky top-10 left-0 z-30 h-9 bg-card py-0 shadow-[inset_0_-1px_0_0_var(--border)] after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}
               />
               {model.columns.flatMap((column, columnIndex) =>
                 tableColumns.map((tableColumn, tableColumnIndex) => (
@@ -349,7 +406,7 @@ export function MetricTimeseriesTable({
       <TableBody>
         {model.buckets.map((bucketStart) => (
           <TableRow key={bucketStart}>
-            <TableCell className="sticky left-0 z-10 w-28 max-w-28 min-w-28 bg-card px-2 py-1 font-medium tabular-nums after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+            <TableCell className={cn(BUCKET_COL, "sticky left-0 z-10 bg-card px-2 py-1 font-medium tabular-nums after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
               {bucketStart}
             </TableCell>
             {model.columns.flatMap((column, columnIndex) =>
@@ -390,7 +447,7 @@ export function MetricTimeseriesTable({
           need the row behind them gone, not softened. */}
       <TableFooter className="sticky bottom-0 z-20 bg-muted shadow-[inset_0_1px_0_0_var(--border)]">
         <TableRow>
-          <TableCell className="sticky left-0 z-10 w-28 max-w-28 min-w-28 bg-muted px-2 py-1 font-semibold after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+          <TableCell className={cn(BUCKET_COL, "sticky left-0 z-10 bg-muted px-2 py-1 font-semibold after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
             Total
           </TableCell>
           {model.columns.flatMap((column, columnIndex) =>
@@ -419,7 +476,7 @@ export function MetricTimeseriesTable({
         </TableRow>
         {model.dimensions.length > 0 && hasGrandTotal ? (
           <TableRow>
-            <TableCell className="sticky left-0 z-10 w-28 max-w-28 min-w-28 bg-muted px-2 pt-1 pb-5 font-semibold after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
+            <TableCell className={cn(BUCKET_COL, "sticky left-0 z-10 bg-muted px-2 pt-1 pb-5 font-semibold after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border")}>
               Grand total
             </TableCell>
             <TableCell
@@ -428,7 +485,7 @@ export function MetricTimeseriesTable({
             >
               {/* Stuck past the label column, since the cell spans every group
                   and its own start edge scrolls away. */}
-              <span className="sticky start-28 inline-flex flex-wrap items-center gap-1.5">
+              <span className={cn(PAST_BUCKET_COL, "sticky inline-flex flex-wrap items-center gap-1.5")}>
                 {tableColumns.map((tableColumn, index) => (
                   <span
                     key={tableColumn.key}

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
@@ -34,6 +34,10 @@ import {
   metricResultsHandler,
   RANGE,
 } from "@/components/widgets/metric-views/metric-timeseries.story-fixtures";
+import {
+  CARD_PX_AT_390,
+  expectNothingOverlaps,
+} from "@/test/storybook/layout";
 
 const TOP_REPOSITORIES = {
   default: "repository",
@@ -609,5 +613,49 @@ export const TestXlsxExport: Story = {
       "Commits: 10 · Lines added: 98"
     );
     await expect(sheet?.views[0]).toMatchObject({ xSplit: 1, ySplit: 2 });
+  },
+};
+
+/**
+ * On a card too narrow for both, the header stacks instead of overlapping.
+ *
+ * The failure this pins is invisible to a text query: with the toolbar holding
+ * its width and the title column free to collapse, the title was laid out
+ * under the buttons — every `getByText` still passed while the card could not
+ * be identified on screen. So this reads the boxes the browser produced.
+ */
+export const TestNarrowHeaderStacksInsteadOfOverlapping: Story = {
+  tags: ["test"],
+  args: { groupBy: TOP_REPOSITORIES, defaultPresentation: "table" },
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const title = await canvas.findByRole("heading", {
+      name: /By repository/,
+    });
+    // The header row only — the table below it scrolls sideways by design, and
+    // its cells are buttons that leave the card's box on purpose.
+    const header = title.closest('[data-slot="card"] > *');
+    await expect(header, "the card renders a header row").not.toBeNull();
+    const controls = Array.from(header!.querySelectorAll("button"));
+
+    await expect(controls.length, "the header has controls to clear").toBeGreaterThan(0);
+    expectNothingOverlaps(title, controls, (element) =>
+      element.getAttribute("aria-label") ?? element.textContent ?? "a control"
+    );
+
+    // Clearing the controls by shrinking the title to nothing would satisfy
+    // the check above; the title has to still be readable.
+    const label = title.querySelector("span");
+    await expect(label, "the title renders its truncating span").not.toBeNull();
+    await expect(
+      label!.scrollWidth,
+      `the title is clipped (${label!.scrollWidth}px of text in ${label!.clientWidth}px)`
+    ).toBeLessThanOrEqual(label!.clientWidth);
   },
 };

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
@@ -15,11 +15,19 @@
  * See docs/testing/storybook-component-tests.md.
  */
 
+import type { ReactNode } from "react";
+
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, screen, userEvent, waitFor } from "storybook/test";
 
+import type { MetricEvidenceSelection } from "@/api/metric-drilldown-client";
+import {
+  EvidenceDialogContext,
+  type EvidenceDialogTarget,
+} from "@/components/metric-evidence-context";
 import { MetricTimeseriesView } from "@/components/widgets/metric-views/metric-timeseries-view";
 import {
+  BUCKETS,
   COMMITS,
   ENTITY_ID,
   LINES_ADDED,
@@ -84,6 +92,80 @@ function captureDownloads(): () => void {
 async function openExportMenu(): Promise<void> {
   await userEvent.click(screen.getByRole("button", { name: "Export" }));
 }
+
+/** One entry per drilldown the chart asked for, holding all of its targets. */
+const drilled: MetricEvidenceSelection[][] = [];
+
+/**
+ * Stands in for the dialog provider: the assertion is which selection a click
+ * produced, and mounting the real dialog would answer that through a second
+ * request instead.
+ */
+function captureDrilldowns(Story: () => ReactNode) {
+  drilled.length = 0;
+  return (
+    <EvidenceDialogContext.Provider
+      value={{
+        openEvidence: (selection) => drilled.push([selection]),
+        openEvidenceTargets: (targets: readonly EvidenceDialogTarget[]) =>
+          drilled.push(targets.map((target) => target.selection)),
+        openEvidencePeople: () => {},
+      }}
+    >
+      <Story />
+    </EvidenceDialogContext.Provider>
+  );
+}
+
+const barSegments = (canvasElement: HTMLElement): HTMLElement[] => [
+  ...canvasElement.querySelectorAll<HTMLElement>(".recharts-bar-rectangle"),
+];
+
+interface ChartPoint {
+  clientX: number;
+  clientY: number;
+}
+
+const centreOf = (element: Element): ChartPoint => {
+  const box = element.getBoundingClientRect();
+  return {
+    clientX: box.left + box.width / 2,
+    clientY: box.top + box.height / 2,
+  };
+};
+
+/**
+ * A point inside one bucket's band that nothing is drawn over: the band's own
+ * centre line at the top edge of the plot, which every bucket but the tallest
+ * leaves empty.
+ */
+function emptySpotInBucket(
+  canvasElement: HTMLElement,
+  bucketIndex: number
+): ChartPoint {
+  const plot = canvasElement
+    .querySelector(".recharts-cartesian-grid")!
+    .getBoundingClientRect();
+  return {
+    clientX: plot.left + (plot.width / BUCKETS.length) * (bucketIndex + 0.5),
+    clientY: plot.top + 4,
+  };
+}
+
+/**
+ * Recharts reads the pointer's position off the chart wrapper, so every gesture
+ * carries coordinates. The target is what a real pointer would be over — the
+ * segment where there is one, the wrapper where the column is empty — because a
+ * dispatched event reaches the wrapper by bubbling but never travels back down.
+ */
+const pointAt = (target: Element, coords: ChartPoint) =>
+  userEvent.pointer({ target, coords });
+
+const clickAt = (target: Element, coords: ChartPoint) =>
+  userEvent.pointer([
+    { target, coords },
+    { keys: "[MouseLeft]", target, coords },
+  ]);
 
 const meta: Meta<typeof MetricTimeseriesView> = {
   title: "Widgets/MetricViews/MetricTimeseriesView",
@@ -152,6 +234,120 @@ export const TestChartPresentation: Story = {
     await waitFor(() =>
       expect(canvasElement.querySelector("svg.recharts-surface")).toBeTruthy()
     );
+  },
+};
+
+/**
+ * The click target is the whole column, not the drawn stack: a segment drills
+ * its own series, a point above them drills the bucket unnarrowed, and each
+ * click opens exactly one thing — the two handlers never both answer it.
+ */
+export const TestColumnClickDrilldown: Story = {
+  tags: ["test"],
+  args: { id: "column-click", groupBy: TOP_REPOSITORIES },
+  decorators: [captureDrilldowns],
+  play: async ({ canvas, canvasElement }) => {
+    await canvas.findByText("org/repo-a");
+    await waitFor(() =>
+      expect(barSegments(canvasElement).length).toBeGreaterThan(2)
+    );
+
+    const wrapper = canvasElement.querySelector<HTMLElement>(
+      ".recharts-wrapper"
+    )!;
+    // Recharts rebuilds its rectangles as the pointer moves, so a segment held
+    // across one gesture is a detached node by the next.
+    // The series render in rank order, making the first segment org/repo-a's.
+    const segment = () => barSegments(canvasElement)[0]!;
+
+    // A click with nothing under the pointer yet: recharts reports the active
+    // bucket as null there, and null must not read as the first bucket. Raw,
+    // because any pointer gesture would activate a bucket on its way in. What
+    // it must not do is land in `drilled` — the assertions below would then be
+    // reading it instead of the clicks they name.
+    wrapper.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        clientX: wrapper.getBoundingClientRect().left + 4,
+        clientY: wrapper.getBoundingClientRect().top + 4,
+      })
+    );
+
+    await clickAt(segment(), centreOf(segment()));
+    await waitFor(() => expect(drilled).toHaveLength(1));
+    await expect(drilled[0]?.[0]).toMatchObject({
+      metric_key: COMMITS,
+      period: { from: "2026-04-20", to: "2026-04-26" },
+      filters: [{ dimension: "repository", values: ["org/repo-a"] }],
+    });
+
+    // 2026-04-27 carries one commit against a six-commit peak, so the top of
+    // its band is the empty space this issue is about.
+    const spot = emptySpotInBucket(canvasElement, 1);
+    await pointAt(wrapper, spot);
+    // The panel reads that week there, so the empty space is inside the band
+    // rather than outside the chart's reach.
+    await waitFor(() =>
+      expect(canvas.getByText("April 27, 2026")).toBeInTheDocument()
+    );
+
+    await clickAt(wrapper, spot);
+    await waitFor(() => expect(drilled).toHaveLength(2));
+    await expect(drilled[1]?.[0]).toMatchObject({
+      metric_key: COMMITS,
+      period: { from: "2026-04-27", to: "2026-05-03" },
+      filters: [],
+    });
+
+    // Two clicks, two drilldowns: neither one was answered by both the
+    // segment's handler and the chart's.
+    await expect(drilled).toHaveLength(2);
+  },
+};
+
+/**
+ * The ungrouped line view drills the bucket its band covers. The click never
+ * has to land on the curve, which is two pixels wide.
+ */
+export const TestLineClickDrilldown: Story = {
+  tags: ["test"],
+  args: { id: "line-click", chart: { multiMetric: "combined" } },
+  decorators: [captureDrilldowns],
+  play: async ({ canvas, canvasElement }) => {
+    await canvas.findByText("Commits & Lines added");
+    await waitFor(() =>
+      expect(canvasElement.querySelector(".recharts-line-curve")).toBeTruthy()
+    );
+
+    const wrapper = canvasElement.querySelector<HTMLElement>(
+      ".recharts-wrapper"
+    )!;
+    // The panel has to read the bucket before the click can open it, which is
+    // the order a pointer arrives in anyway.
+    const spot = emptySpotInBucket(canvasElement, 1);
+    await pointAt(wrapper, spot);
+    await waitFor(() =>
+      expect(canvas.getByText("April 27, 2026")).toBeInTheDocument()
+    );
+
+    await clickAt(wrapper, spot);
+
+    await waitFor(() => expect(drilled).toHaveLength(1));
+    const bucket = { from: "2026-04-27", to: "2026-05-03" };
+    await expect(drilled[0]?.[0]).toMatchObject({
+      metric_key: COMMITS,
+      period: bucket,
+      filters: [],
+    });
+    // Both metrics reach the dialog, and picking the other one there must not
+    // widen the period back out to the widget's own range.
+    await expect(drilled[0]?.map((selection) => selection.metric_key)).toEqual([
+      COMMITS,
+      LINES_ADDED,
+    ]);
+    await expect(
+      drilled[0]?.map((selection) => selection.period)
+    ).toEqual([bucket, bucket]);
   },
 };
 

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.stories.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/widgets/metric-views/metric-timeseries.story-fixtures";
 import {
   CARD_PX_AT_390,
+  expectHorizontallyContained,
   expectNothingOverlaps,
 } from "@/test/storybook/layout";
 
@@ -659,3 +660,69 @@ export const TestNarrowHeaderStacksInsteadOfOverlapping: Story = {
     ).toBeLessThanOrEqual(label!.clientWidth);
   },
 };
+
+/**
+ * The scroll controls sit beside the table, never over a cell.
+ *
+ * The failure this pins is invisible to a text query too: the controls were
+ * drawn over the scrollport, so on a narrow card the one that pages backwards
+ * covered the date column — the reader could see a value and not what it was
+ * measured on.
+ */
+export const TestNarrowTableKeepsItsScrollControlsOffTheCells: Story = {
+  tags: ["test"],
+  args: { groupBy: TOP_REPOSITORIES, defaultPresentation: "table" },
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const table = await canvas.findByRole("table");
+    const scrollport = table.parentElement!;
+    const controlsNow = () =>
+      canvas.getAllByRole("button", { name: /^Show (earlier|later) / });
+
+    await expect(
+      controlsNow().length,
+      "the table has scroll controls to clear"
+    ).toBeGreaterThan(0);
+    expectNothingOverlaps(scrollport, controlsNow(), (element) =>
+      element.getAttribute("aria-label") ?? "a scroll control"
+    );
+
+    // Clearing the cells by taking the room they needed would satisfy the check
+    // above and leave the table just as unreadable: the gutters and the sticky
+    // bucket column come out of the same width, and a whole value column has to
+    // survive both.
+    const firstValue = table.querySelectorAll("tbody tr td")[0];
+    expectHorizontallyContained(
+      scrollport,
+      [table.querySelector("tbody th, tbody tr > *:first-child")!, firstValue],
+      (element) => `the ${element.tagName.toLowerCase()} in the first row`
+    );
+
+    // Paging brings the backwards control in. Its gutter is reserved up front,
+    // so the columns under the reader's eye must not move when it appears.
+    const before = scrollport.getBoundingClientRect().width;
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Show later columns" })
+    );
+    await waitFor(() =>
+      expect(
+        canvas.getByRole("button", { name: "Show earlier columns" })
+      ).toBeVisible()
+    );
+
+    expectNothingOverlaps(scrollport, controlsNow(), (element) =>
+      element.getAttribute("aria-label") ?? "a scroll control"
+    );
+    await expect(
+      scrollport.getBoundingClientRect().width,
+      "the scrollport resized when a control appeared"
+    ).toBe(before);
+  },
+};
+

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.test.tsx
@@ -6,7 +6,10 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { EvidenceDialogContext } from "@/components/metric-evidence-context";
+import {
+  EvidenceDialogContext,
+  type EvidenceDialogTarget,
+} from "@/components/metric-evidence-context";
 import { MetricTimeseriesView } from "@/components/widgets/metric-views/metric-timeseries-view";
 import {
   ENTITY_ID,
@@ -35,7 +38,7 @@ vi.mock("@/components/widgets/metric-views/metric-timeseries-chart", () => ({
   }: {
     onEvidence?: (
       metricKey: string,
-      columnKey: string,
+      columnKey: string | null,
       bucketStart: string | null
     ) => void;
   }) => (
@@ -48,6 +51,12 @@ vi.mock("@/components/widgets/metric-views/metric-timeseries-chart", () => ({
         }
       >
         drill point
+      </button>
+      <button
+        type="button"
+        onClick={() => onEvidence?.("git.commits", null, "2026-04-20")}
+      >
+        drill bucket
       </button>
     </div>
   ),
@@ -549,8 +558,7 @@ describe("MetricTimeseriesView", () => {
     );
   });
 
-  it("opens a grouped point with its exact period and dimensions", async () => {
-    const user = userEvent.setup();
+  function renderDrillableGroupedChart(id: string): ReturnType<typeof vi.fn> {
     const byKey = timeseriesByKey();
     const metric = byKey.get("git.commits");
     if (!metric) throw new Error("missing fixture metric");
@@ -563,6 +571,7 @@ describe("MetricTimeseriesView", () => {
     };
     mocks.collection.mockReturnValue({ ...ready, byKey });
     mocks.evidenceColumn = groupedTimeseriesModel().columns[0]?.key ?? "";
+
     const openEvidenceTargets = vi.fn();
     render(
       <EvidenceDialogContext.Provider
@@ -573,7 +582,7 @@ describe("MetricTimeseriesView", () => {
       }}
       >
         <MetricTimeseriesView
-          id="point-evidence"
+          id={id}
           entityId={ENTITY_ID}
           range={RANGE}
           metricKeys={["git.commits"]}
@@ -581,6 +590,60 @@ describe("MetricTimeseriesView", () => {
         />
       </EvidenceDialogContext.Provider>
     );
+    return openEvidenceTargets;
+  }
+
+  it("holds every combined target to the clicked bucket", async () => {
+    const user = userEvent.setup();
+    const byKey = timeseriesByKey();
+    for (const metric of byKey.values()) {
+      metric.drilldown = { granularity: ["event"] };
+      metric.selection = {
+        metric_key: metric.metric_key,
+        entity: { type: "person", ids: [ENTITY_ID] },
+        period: RANGE,
+        filters: [],
+      };
+    }
+    mocks.collection.mockReturnValue({ ...ready, byKey });
+    const openEvidenceTargets = vi.fn();
+    render(
+      <EvidenceDialogContext.Provider
+        value={{
+        openEvidence: vi.fn(),
+        openEvidenceTargets,
+        openEvidencePeople: vi.fn(),
+      }}
+      >
+        <MetricTimeseriesView
+          id="combined-bucket"
+          entityId={ENTITY_ID}
+          range={RANGE}
+          metricKeys={["git.commits", "git.lines_added"]}
+          chart={{ multiMetric: "combined" }}
+        />
+      </EvidenceDialogContext.Provider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "drill bucket" }));
+    const [targets, options] = openEvidenceTargets.mock.calls.at(-1) ?? [];
+    expect(
+      targets.map((target: EvidenceDialogTarget) => target.selection.metric_key)
+    ).toEqual(["git.commits", "git.lines_added"]);
+    // Picking the other metric in the dialog must not widen the period back
+    // out to the widget's own range.
+    for (const target of targets as EvidenceDialogTarget[]) {
+      expect(target.selection.period).toEqual({
+        from: "2026-04-20",
+        to: "2026-04-26",
+      });
+    }
+    expect(options).toEqual({ activeMetricKey: "git.commits" });
+  });
+
+  it("opens a grouped point with its exact period and dimensions", async () => {
+    const user = userEvent.setup();
+    const openEvidenceTargets = renderDrillableGroupedChart("point-evidence");
 
     await user.click(screen.getByRole("button", { name: "drill point" }));
     expect(openEvidenceTargets).toHaveBeenCalledWith(
@@ -595,6 +658,27 @@ describe("MetricTimeseriesView", () => {
                 values: ["org/repo-a"],
               },
             ],
+            display_dimensions: ["repository"],
+          }),
+          label: "Commits",
+        },
+      ],
+      { activeMetricKey: "git.commits" }
+    );
+  });
+
+  it("opens a whole bucket with no dimension narrowing", async () => {
+    const user = userEvent.setup();
+    const openEvidenceTargets = renderDrillableGroupedChart("bucket-evidence");
+
+    await user.click(screen.getByRole("button", { name: "drill bucket" }));
+    expect(openEvidenceTargets).toHaveBeenCalledWith(
+      [
+        {
+          selection: expect.objectContaining({
+            metric_key: "git.commits",
+            period: { from: "2026-04-20", to: "2026-04-26" },
+            filters: [],
             display_dimensions: ["repository"],
           }),
           label: "Commits",

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.tsx
@@ -503,11 +503,14 @@ export function MetricTimeseriesView({
         data.isFetching && "opacity-60"
       )}
     >
-      <div className="flex items-center justify-between gap-2 border-b p-2">
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2 border-b p-2">
+        {/* INVARIANT: a fixed basis, because a flex line breaks on content
+            size — with none, the untruncated title decides the width at which
+            the controls drop to their own line. */}
+        <div className="flex min-w-0 flex-[1_1_8rem] flex-wrap items-center gap-2">
           {selectedMetric ? (
             shouldCombineMetrics ? (
-              <h3 className="px-2 text-sm font-semibold">
+              <h3 className="min-w-0 truncate px-2 text-sm font-semibold">
                 {model.metrics.map((metric) => metric.label).join(" & ")}
               </h3>
             ) : model.metrics.length > 1 && presentation === "chart" ? (
@@ -520,7 +523,7 @@ export function MetricTimeseriesView({
                 <SelectTrigger
                   size="sm"
                   aria-label="Metric"
-                  className="border-transparent bg-transparent ps-2 pe-2 font-semibold shadow-none hover:bg-muted/50 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/40 data-popup-open:bg-muted/50 dark:bg-transparent dark:hover:bg-muted/50"
+                  className="min-w-0 max-w-full border-transparent bg-transparent ps-2 pe-2 font-semibold shadow-none hover:bg-muted/50 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/40 data-popup-open:bg-muted/50 dark:bg-transparent dark:hover:bg-muted/50 [&>span]:truncate"
                 >
                   <SelectValue>{selectedMetric.label}</SelectValue>
                 </SelectTrigger>
@@ -540,20 +543,22 @@ export function MetricTimeseriesView({
               // columns. The count is load-bearing: such a table is usually
               // wider than the screen, and the grand total below covers groups
               // the reader cannot see.
-              <h3 className="px-2 text-sm font-semibold">
-                {breakdownHeading([selectedGroupBy])}
-                <span className="ps-1.5 font-normal text-muted-foreground">
+              <h3 className="flex min-w-0 items-baseline px-2 text-sm font-semibold">
+                <span className="truncate">
+                  {breakdownHeading([selectedGroupBy])}
+                </span>
+                <span className="shrink-0 ps-1.5 font-normal text-muted-foreground">
                   · {model.columns.length}
                 </span>
               </h3>
             ) : model.metrics.length === 1 ? (
-              <h3 className="px-2 text-sm font-semibold">
+              <h3 className="min-w-0 truncate px-2 text-sm font-semibold">
                 {selectedMetric.label}
               </h3>
             ) : null
           ) : null}
         </div>
-        <div className="flex shrink-0 items-center justify-end gap-2">
+        <div className="ms-auto flex min-w-0 flex-wrap items-center justify-end gap-2">
           {dimensionOptions.length > 1 || filterModels.length > 0 ? (
             <DimensionControls
               dimensions={dimensionOptions}

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.tsx
@@ -358,21 +358,29 @@ export function MetricTimeseriesView({
       : selectedMetric
         ? [selectedMetric]
         : [];
-  const evidenceTargets = evidenceMetrics.flatMap<EvidenceDialogTarget>(
-    (metric) => {
+  /**
+   * Every metric the dialog can offer, over one period. Switching metric in the
+   * dialog must not switch period with it, so the caller's period reaches all
+   * of them rather than only the one that was opened.
+   */
+  const evidenceTargetsOver = (
+    period: DateRange,
+    exactFilters: typeof filters
+  ): EvidenceDialogTarget[] =>
+    evidenceMetrics.flatMap<EvidenceDialogTarget>((metric) => {
       if (!metric.drilldown) return [];
       const selection = evidenceSelection(
         metric.selection,
         entityId,
-        range,
-        filters,
+        period,
+        exactFilters,
         metric.computation !== "ratio" && selectedGroupBy
           ? [selectedGroupBy]
           : []
       );
       return selection ? [{ selection, label: metric.label }] : [];
-    }
-  );
+    });
+  const evidenceTargets = evidenceTargetsOver(range, filters);
   const filterModels = dimensionOptions
     .filter((dimension) => dimension !== selectedGroupBy)
     .map((dimension) => {
@@ -432,20 +440,21 @@ export function MetricTimeseriesView({
 
   function openTimeseriesEvidence(
     metricKey: string,
-    columnKey: string,
+    columnKey: string | null,
     bucketStart: string | null
   ): void {
     const metric = model.metrics.find(
       (candidate) => candidate.metric_key === metricKey
     );
+    if (!metric?.drilldown) return;
     const column = model.columns.find(
       (candidate) => candidate.key === columnKey
     );
-    if (!metric?.drilldown || !column || column.remainder) return;
+    if (columnKey !== null && (!column || column.remainder)) return;
     const exactFilters = new Map(
       filters.map((filter) => [filter.dimension, filter])
     );
-    for (const dimension of column.dimensions ?? []) {
+    for (const dimension of column?.dimensions ?? []) {
       exactFilters.set(dimension.key, {
         dimension: dimension.key,
         values: [dimension.value],
@@ -466,18 +475,22 @@ export function MetricTimeseriesView({
           : range.to,
       };
     }
+    const narrowed = [...exactFilters.values()].sort((left, right) =>
+      left.dimension.localeCompare(right.dimension)
+    );
     const selection = evidenceSelection(
       metric.selection,
       entityId,
       period,
-      [...exactFilters.values()].sort((left, right) =>
-        left.dimension.localeCompare(right.dimension)
-      ),
+      narrowed,
       metric.computation !== "ratio" && selectedGroupBy ? [selectedGroupBy] : []
     );
     if (selection) {
       evidenceContext?.openEvidenceTargets(
-        withOwnTarget(evidenceTargets, { selection, label: metric.label }),
+        withOwnTarget(evidenceTargetsOver(period, narrowed), {
+          selection,
+          label: metric.label,
+        }),
         { activeMetricKey: selection.metric_key }
       );
     }

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries.story-fixtures.ts
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries.story-fixtures.ts
@@ -258,6 +258,13 @@ export function buildStoryMetricResults(
         format: "integer",
         direction: "higher_is_better",
         computation: "sum",
+        drilldown: { granularity: ["event"] },
+        selection: {
+          metric_key: key,
+          entity: { type: "person", ids: [ENTITY_ID] },
+          period: RANGE,
+          filters: metricRequest.filters ?? [],
+        },
         views: resultViews(key, metricRequest),
       },
     ];

--- a/src/frontend/src/components/widgets/metric-views/section-metric-index.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/section-metric-index.stories.tsx
@@ -1,0 +1,179 @@
+/**
+ * Browser component tests for the geometry of `<SectionMetricIndex>` — the
+ * "Also measured here" list, one metric per row: name, value, the pool's
+ * middle, and the mark on the shared axis.
+ *
+ * What order the rows come in and which of them are dropped is covered by the
+ * jsdom tests in `section-metric-index.test.tsx`. What needs a real browser is
+ * the row: the readings hold a fixed width, so a name sharing their line has
+ * whatever is left — which on a phone is nothing, and a name truncated to
+ * nothing leaves a column of numbers belonging to no metric.
+ *
+ * See docs/testing/storybook-component-tests.md.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect } from "storybook/test";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import { SectionMetricIndex } from "@/components/widgets/metric-views/section-metric-index";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+import {
+  CARD_PX_AT_390,
+  CARD_PX_WIDE,
+  expectHorizontallyContained,
+} from "@/test/storybook/layout";
+
+const ENTITY_ID = "019e27bc-dec0-7626-81a9-c5524662a6a9";
+
+/** The row's name, long enough that a collapsed column is unmistakable. */
+const LONG_NAME = "Merges without approval rate";
+
+function metric(
+  key: string,
+  label: string,
+  value: number,
+  unit: string | null,
+  median: number
+): MetricResult {
+  return {
+    metric_key: key,
+    label,
+    unit,
+    format: "integer",
+    computation: "sum",
+    direction: "higher_is_better",
+    views: [
+      { view: "period", values: [{ entity_id: ENTITY_ID, value }] },
+      {
+        view: "peer",
+        values: [
+          {
+            entity_id: ENTITY_ID,
+            target_value: value,
+            p25: 1,
+            median,
+            p75: 100000,
+          },
+        ],
+      },
+    ],
+  } as unknown as MetricResult;
+}
+
+const RESULTS = [
+  metric("git.long", LONG_NAME, 325, null, 731),
+  metric("git.short", "Merge rate", 12408, "lines", 9),
+];
+
+const meta: Meta<typeof SectionMetricIndex> = {
+  title: "Widgets/MetricViews/SectionMetricIndex",
+  component: SectionMetricIndex,
+  args: {
+    collection: { metrics: RESULTS.map((r) => ({ key: r.metric_key, views: [] })) },
+    byKey: normalizeMetricResults(RESULTS),
+    entityId: ENTITY_ID,
+    shown: new Set<string>(),
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof SectionMetricIndex>;
+
+/** Demo story for the Storybook UI (untagged — not a test). */
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** Where a line fits both, the name and its readings share it. */
+export const TestWideRowStaysOnOneLine: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas, canvasElement }) => {
+    const name = canvas.getByText(LONG_NAME).getBoundingClientRect();
+    const value = canvas.getByText("325").getBoundingClientRect();
+
+    await expect(value.top, "the readings dropped to their own line").toBeLessThan(
+      name.bottom
+    );
+    await expect(name.top).toBeLessThan(value.bottom);
+
+    // The container query is what puts the readings back into fixed columns;
+    // without it the rows still render, just unaligned, so nothing else here
+    // would notice it failing to compile.
+    const readings = canvasElement.querySelectorAll("dd");
+    // The value and the median; the third child is the peer mark's own fixed
+    // 112px svg, which no breakpoint touches.
+    const columns = Array.from(readings).map((dd) =>
+      Array.from(dd.children)
+        .slice(0, 2)
+        .map((span) => Math.round(span.getBoundingClientRect().width))
+    );
+    await expect(
+      columns,
+      `the value and median columns are not the fixed 128/112 (${JSON.stringify(columns)})`
+    ).toEqual([
+      [128, 112],
+      [128, 112],
+    ]);
+  },
+};
+
+/**
+ * Too narrow for both, the row stacks and the name keeps its whole width.
+ *
+ * The failure this pins reads as data with no labels: the readings held their
+ * fixed columns, the name column collapsed to zero, and `truncate` cut the
+ * name away entirely — leaving numbers belonging to no metric.
+ */
+export const TestNarrowRowKeepsTheMetricName: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_AT_390 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas, canvasElement }) => {
+    // The column, not the text inside it: the name renders as an inline span,
+    // which keeps its full width by overflowing a column collapsed to zero.
+    const column = canvas.getByText(LONG_NAME).closest("dt")!;
+    const value = canvas.getByText("325");
+    const columnBox = column.getBoundingClientRect();
+
+    const list = canvasElement.querySelector("dl");
+    await expect(list, "the index renders its list").not.toBeNull();
+    const row = column.parentElement!.getBoundingClientRect();
+
+    // The readings having wrapped away, the name owns the row's whole width.
+    await expect(
+      columnBox.width,
+      `the name column is ${columnBox.width}px of a ${row.width}px row`
+    ).toBeGreaterThan(row.width / 2);
+    await expect(
+      value.getBoundingClientRect().top,
+      "the readings share the name's line"
+    ).toBeGreaterThanOrEqual(columnBox.bottom);
+
+    // The readings are 368px of fixed columns at full width; hanging outside
+    // the list drops the peer marks off the card.
+    expectHorizontallyContained(
+      list!,
+      Array.from(list!.querySelectorAll("dd")),
+      () => "a row's readings"
+    );
+  },
+};

--- a/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
+++ b/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
@@ -81,7 +81,10 @@ export function SectionMetricIndex({
           break at each row's padding and read as a dotted column; the whole
           point is an unbroken line for the ordinary readings to disappear
           into. */}
-      <dl className="relative pt-2">
+      {/* A container query, not a viewport one: this list is as narrow as
+          whatever holds it, which on a wide screen can still be a drilldown
+          pane. */}
+      <dl className="@container relative pt-2">
         <span
           aria-hidden
           className="pointer-events-none absolute inset-y-2 w-px bg-foreground/20"
@@ -90,17 +93,20 @@ export function SectionMetricIndex({
         {rest.map((metric) => (
           <div
             key={metric.metric_key}
-            className="flex items-center justify-between gap-4 border-b border-dashed py-1 last:border-b-0"
+            className="flex flex-wrap items-center gap-x-4 gap-y-0.5 border-b border-dashed py-1 last:border-b-0"
           >
-            <dt className={cn("min-w-0 flex-1 truncate", TEXT_NAME)}>
+            <dt className={cn("min-w-0 truncate", TEXT_NAME)}>
               <MetricName metric={metric} />
             </dt>
             {/* Layout only. Putting the label role on the container greyed
                 the person's own value along with its median, so the subject of
                 the row and the context around it read the same — which is the
                 distinction this scale exists to make. */}
-            <dd className="flex shrink-0 items-baseline gap-2 tabular-nums">
-              <span className={cn("w-32 text-right", TEXT_BODY)}>
+            {/* INVARIANT: 26rem is the readings' own 368px (128 + 112 + the
+                mark's 112, plus two gaps) with a name floor on top — the fixed
+                columns come back only where they fit. */}
+            <dd className="ms-auto flex min-w-0 flex-wrap items-baseline justify-end gap-2 tabular-nums">
+              <span className={cn("w-auto text-right @min-[26rem]:w-32", TEXT_BODY)}>
                 {formatMetricValue(
                   forEntity(metric, entityId).value,
                   metric.format,
@@ -111,7 +117,7 @@ export function SectionMetricIndex({
                   anything. Uncoloured: a list of thirty numbers lit up by
                   quartile is a scoreboard, and the reader did not ask to be
                   scored on every one of them. */}
-              <span className={cn("w-28 text-right", TEXT_LABEL)}>
+              <span className={cn("w-auto text-right @min-[26rem]:w-28", TEXT_LABEL)}>
                 {metricComparisons(metric, null, entityId).median ?? ""}
               </span>
               {/* And how far off that middle, on the axis every row shares.

--- a/src/frontend/src/test/storybook/layout.ts
+++ b/src/frontend/src/test/storybook/layout.ts
@@ -1,0 +1,78 @@
+/**
+ * Geometry assertions for stories that run in a real browser.
+ *
+ * A header whose title is painted under its own buttons still passes every
+ * query-by-text assertion — the text is in the DOM, it is just unreadable. So
+ * these read the boxes the browser actually laid out. They are meaningless in
+ * jsdom, which gives every element a zero rect.
+ */
+
+/** Two boxes share at least one pixel. Touching edges do not count. */
+function boxesOverlap(a: DOMRect, b: DOMRect): boolean {
+  return (
+    a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom
+  );
+}
+
+/**
+ * Nothing in `elements` is drawn over `subject`.
+ *
+ * The message names the offender and both boxes, because a bare "expected
+ * false" says nothing about which control landed on the title.
+ */
+export function expectNothingOverlaps(
+  subject: Element,
+  elements: readonly Element[],
+  describe: (element: Element) => string
+): void {
+  const box = subject.getBoundingClientRect();
+  for (const element of elements) {
+    const other = element.getBoundingClientRect();
+    if (!boxesOverlap(box, other)) continue;
+    throw new Error(
+      `${describe(element)} is drawn over the subject: ` +
+        `subject x ${box.left}–${box.right} y ${box.top}–${box.bottom}, ` +
+        `other x ${other.left}–${other.right} y ${other.top}–${other.bottom}`
+    );
+  }
+}
+
+/**
+ * Every element is laid out within `container`'s left and right edges.
+ *
+ * The inline axis only: a card clips what runs past its side, and a list that
+ * scrolls sideways is meant to exceed its box downward.
+ */
+export function expectHorizontallyContained(
+  container: Element,
+  elements: readonly Element[],
+  describe: (element: Element) => string
+): void {
+  const SLACK_PX = 1;
+  const box = container.getBoundingClientRect();
+  for (const element of elements) {
+    const other = element.getBoundingClientRect();
+    if (
+      other.left >= box.left - SLACK_PX &&
+      other.right <= box.right + SLACK_PX
+    ) {
+      continue;
+    }
+    throw new Error(
+      `${describe(element)} spills outside its container: ` +
+        `container x ${box.left}–${box.right}, ` +
+        `other x ${other.left}–${other.right}`
+    );
+  }
+}
+
+/**
+ * Card widths the narrow/wide stories measure at.
+ *
+ * A phone is 390px of viewport; a card in the single-column stack loses the
+ * page's own padding, which is what a component actually gets.
+ */
+export const CARD_PX_AT_390 = 296;
+
+/** A card in a full-width section on a desktop viewport. */
+export const CARD_PX_WIDE = 900;


### PR DESCRIPTION
**Why.** On a narrow viewport the release branch draws a metric card's title under its own toolbar buttons, and lets the roster and the timeseries table spill past their card and off the screen. Fixed on `main`, not here.

**What changed.** Three frontend commits cherry-picked from `main` (`-x`, so each body carries its origin SHA): card headers stack when one line cannot hold title and buttons, the roster and timeseries table get room to read at phone width, and a whole timeseries column opens its drilldown.

**#2926 rides along on purpose.** It is not a narrow-viewport fix, but it owns the same `metric-timeseries-view` surface the other two edit; taking it keeps the files identical to `main` instead of creating a release-only variant.

**Out of scope.** The server-side evidence sort (#2995, #3015) does not backport — it is written on top of query-time identity resolution and repository statistics, neither of which is on this branch. It rides a later release.

**Verified.** All three applied without conflict onto `release-2026.08` (0.5.300); diff is `src/frontend/**` plus one docs line — no backend, dbt or migration surface. Frontend tests were not run locally; CI on this PR is the check.
