### PR TITLE
fix(chatgpt-team): keep the day cursor request window inside one day

### DIFF
--- a/src/ingestion/connectors/ai/chatgpt-team/connector.yaml
+++ b/src/ingestion/connectors/ai/chatgpt-team/connector.yaml
@@ -63,15 +63,15 @@ definitions:
       type: MinMaxDatetime
       datetime: "{{ config.get('start_date') or day_delta(-7, format='%Y-%m-%d') }}"
       datetime_format: "%Y-%m-%d"
-    end_datetime:
-      type: MinMaxDatetime
-      datetime: "{{ day_delta(-1, format='%Y-%m-%d') }}"
-      datetime_format: "%Y-%m-%d"
+    # INVARIANT: no end bound. An end pinned to a calendar midnight makes the
+    # cursor's final window span two days, and `date` below is stamped from the
+    # window's start — so a day's rows land under the previous date. Letting the
+    # window end at the read time keeps the final one inside today.
     step: P1D
     cursor_granularity: P1D
     # Re-pull a 2-day tail so late-arriving / still-accumulating "yesterday"
     # analytics rows reach Bronze. The dbt models' 3-day window can't fix data
-    # Bronze never received. (claude-team's day cursor has the same gap.)
+    # Bronze never received.
     lookback_window: P2D
     start_time_option:
       type: RequestOption

--- a/src/ingestion/connectors/ai/chatgpt-team/descriptor.yaml
+++ b/src/ingestion/connectors/ai/chatgpt-team/descriptor.yaml
@@ -19,7 +19,11 @@ name: chatgpt-team
 # 2.1.0: emits the new class-contract column seat_status, constant NULL — this
 #   source reports no seat lifecycle state. MINOR per ADR-0015: a full refresh
 #   would reproduce the same NULLs, so there is nothing to re-materialize.
-version: "2.1.0"
+# 2.2.0: the shared day cursor loses its end bound, so its final request window
+#   stays inside one day and a day's rows stop landing under the previous date.
+#   MINOR per ADR-0015: the manifest has to reach Airbyte, and a full refresh
+#   would not undo the rows already stored under the wrong date.
+version: "2.2.0"
 # Daily at 04:00 UTC — off-peak. The customer's proxy runs a single browser
 # instance, so we avoid scheduling chatgpt-team next to anything else that
 # may also hit it (same rationale as claude-team).

--- a/src/ingestion/connectors/ai/chatgpt-team/tests/test_chatgpt_team_day_cursor.py
+++ b/src/ingestion/connectors/ai/chatgpt-team/tests/test_chatgpt_team_day_cursor.py
@@ -1,0 +1,88 @@
+"""The day cursor must never ask for more than one calendar day at a time.
+
+The streams sharing `day_cursor` stamp their `date` from the request window's
+start, because the vendor returns no date inside the per-user object. A window
+covering two days therefore files the second day's rows under the first, and
+nothing downstream can tell them apart.
+
+An end bound pinned to a calendar midnight produces exactly that: the cursor's
+final window runs from the previous midnight to the bound. These tests pin the
+clock and walk the windows the CDK actually generates.
+"""
+
+from __future__ import annotations
+
+import pytest
+from freezegun import freeze_time
+
+from connector_tests import get_source
+
+_CONNECTOR = "ai/chatgpt-team"
+_DAY_CURSOR_STREAMS = ["chatgpt_team_chat_activity", "chatgpt_team_codex_user_daily"]
+
+
+def _config(start_date: str | None = None) -> dict[str, str]:
+    config = {
+        "insight_tenant_id": "11111111-1111-1111-1111-111111111111",
+        "insight_source_id": "chatgpt-team-test",
+        "chatgpt_account_id": "acc-1",
+        "proxy_url": "https://proxy.invalid",
+        "proxy_auth_token": "token",
+    }
+    if start_date:
+        config["start_date"] = start_date
+    return config
+
+
+def _windows(stream_name: str, now: str, start_date: str | None) -> list[tuple[str, str]]:
+    config = _config(start_date)
+    with freeze_time(now):
+        source = get_source(_CONNECTOR, config)
+        stream = next(s for s in source.streams(config) if s.name == stream_name)
+        return [
+            (p.to_slice()["start_time"], p.to_slice()["end_time"])
+            for p in stream.generate_partitions()
+        ]
+
+
+@pytest.mark.parametrize("stream_name", _DAY_CURSOR_STREAMS)
+@pytest.mark.parametrize(
+    "now",
+    [
+        "2026-08-19T11:30:00Z",  # mid-day, the ordinary case
+        "2026-08-19T00:04:00Z",  # just after midnight
+        "2026-08-19T23:56:00Z",  # just before the next one
+    ],
+)
+@pytest.mark.parametrize(
+    "start_date",
+    [
+        None,  # the manifest default, today - 7
+        "2026-08-18",  # one day of window
+        "2026-08-17",  # two days — an even span
+        "2026-08-01",  # a long backfill
+    ],
+)
+def test_every_request_window_stays_inside_one_day(stream_name, now, start_date):
+    windows = _windows(stream_name, now, start_date)
+
+    assert windows, f"{stream_name} generated no request window"
+    wider = [(a, b) for a, b in windows if a != b]
+    assert not wider, (
+        f"{stream_name} asked for a window spanning more than one day: {wider}. "
+        f"Records from it are stamped with {wider[0][0]}, so the later day's rows "
+        f"would be stored under the earlier date."
+    )
+
+
+@pytest.mark.parametrize("stream_name", _DAY_CURSOR_STREAMS)
+def test_the_window_walk_is_contiguous_and_reaches_today(stream_name):
+    windows = _windows(stream_name, "2026-08-19T11:30:00Z", "2026-08-15")
+
+    assert [a for a, _ in windows] == [
+        "2026-08-15",
+        "2026-08-16",
+        "2026-08-17",
+        "2026-08-18",
+        "2026-08-19",
+    ]

--- a/src/ingestion/connectors/ai/claude-team/tests/test_claude_team_day_cursor.py
+++ b/src/ingestion/connectors/ai/claude-team/tests/test_claude_team_day_cursor.py
@@ -1,0 +1,88 @@
+"""The day cursor must never ask for more than one calendar day at a time.
+
+Both code-metrics streams stamp `metric_date` from the request window's start,
+because the vendor returns no date inside the per-user object. A window covering
+two days therefore files the second day's rows under the first, and nothing
+downstream can tell them apart.
+
+An end bound pinned to a calendar midnight produces exactly that: the cursor's
+final window runs from the previous midnight to the bound. These tests pin the
+clock and walk the windows the CDK actually generates.
+"""
+
+from __future__ import annotations
+
+import pytest
+from freezegun import freeze_time
+
+from connector_tests import get_source
+
+_CONNECTOR = "ai/claude-team"
+_DAY_CURSOR_STREAMS = ["claude_team_code_metrics", "claude_team_code_metrics_org"]
+
+
+def _config(start_date: str | None = None) -> dict[str, str]:
+    config = {
+        "insight_tenant_id": "11111111-1111-1111-1111-111111111111",
+        "insight_source_id": "claude-team-test",
+        "claude_org_id": "org-1",
+        "proxy_url": "https://proxy.invalid",
+        "proxy_auth_token": "token",
+    }
+    if start_date:
+        config["start_date"] = start_date
+    return config
+
+
+def _windows(stream_name: str, now: str, start_date: str | None) -> list[tuple[str, str]]:
+    config = _config(start_date)
+    with freeze_time(now):
+        source = get_source(_CONNECTOR, config)
+        stream = next(s for s in source.streams(config) if s.name == stream_name)
+        return [
+            (p.to_slice()["start_time"], p.to_slice()["end_time"])
+            for p in stream.generate_partitions()
+        ]
+
+
+@pytest.mark.parametrize("stream_name", _DAY_CURSOR_STREAMS)
+@pytest.mark.parametrize(
+    "now",
+    [
+        "2026-08-19T11:30:00Z",  # mid-day, the ordinary case
+        "2026-08-19T00:04:00Z",  # just after midnight
+        "2026-08-19T23:56:00Z",  # just before the next one
+    ],
+)
+@pytest.mark.parametrize(
+    "start_date",
+    [
+        None,  # the manifest default, today - 7
+        "2026-08-18",  # one day of window
+        "2026-08-17",  # two days — an even span
+        "2026-08-01",  # a long backfill
+    ],
+)
+def test_every_request_window_stays_inside_one_day(stream_name, now, start_date):
+    windows = _windows(stream_name, now, start_date)
+
+    assert windows, f"{stream_name} generated no request window"
+    wider = [(a, b) for a, b in windows if a != b]
+    assert not wider, (
+        f"{stream_name} asked for a window spanning more than one day: {wider}. "
+        f"Records from it are stamped with {wider[0][0]}, so the later day's rows "
+        f"would be stored under the earlier date."
+    )
+
+
+@pytest.mark.parametrize("stream_name", _DAY_CURSOR_STREAMS)
+def test_the_window_walk_is_contiguous_and_reaches_today(stream_name):
+    windows = _windows(stream_name, "2026-08-19T11:30:00Z", "2026-08-15")
+
+    assert [a for a, _ in windows] == [
+        "2026-08-15",
+        "2026-08-16",
+        "2026-08-17",
+        "2026-08-18",
+        "2026-08-19",
+    ]


### PR DESCRIPTION
Refs #3029 — deliberately not `Closes`.

**Why.** A day's per-person AI usage could be stored under the previous date. The date is a label the connector stamps from the request window's start, and the shared `day_cursor`'s final window spanned two days.

**What changed.** The cursor loses its end bound, so every request window stays inside one calendar day; the daily step and the two-day lookback are untouched. Both connectors gain a regression suite over the real declarative cursor — claude-team's bound was removed earlier and is now pinned against coming back.

**The issue stays open on purpose.** This branch stops new misdated rows; the rows already stored are cleared operationally on the affected installations rather than by product code, so a one-off cleanup does not become permanent machinery in the medallion path.

**Verified.** 52 passed across both suites. Restoring the end bound turns 20 of them red, naming the two-day window.
