### PR TITLE
fix(git-cli-proxy): bound concurrent page serves so blob-heavy windows cannot stack past the memory limit

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -667,6 +667,11 @@ gitCliProxy:
     # A fetch holds its entry's write lock while queued for a slot, so one
     # slow clone must not convoy every other repository's refresh.
     heavyOpsConcurrency: 2
+    # Concurrent page serves; the pod's peak memory is roughly this times the
+    # heaviest window's blob bytes, so this is the cap that bounds proxy
+    # memory. Serves are CPU-bound — extra slots past ~2x the CPU limit only
+    # add memory risk.
+    serveConcurrency: 4
     caCertPath: ""
   caCertSecret: ""
   # Bearer token the proxy requires on every /v1 request. Empty = generated on

--- a/src/backend/services/git-cli-proxy/config/insight.yaml
+++ b/src/backend/services/git-cli-proxy/config/insight.yaml
@@ -15,6 +15,7 @@
 #   APP__gears__git_cli_proxy__config__max_repo_bytes
 #   APP__gears__git_cli_proxy__config__default_max_staleness_seconds
 #   APP__gears__git_cli_proxy__config__heavy_ops_concurrency
+#   APP__gears__git_cli_proxy__config__serve_concurrency
 #   APP__gears__git_cli_proxy__config__proxy_token
 
 server:
@@ -51,6 +52,7 @@ gears:
       default_max_staleness_seconds: 0
       # Concurrency cap for heavy git operations (clone / fetch / repack).
       heavy_ops_concurrency: 0
+      serve_concurrency: 0
       # Service-to-service bearer token for /v1. Never committed.
       proxy_token: ""
       # PEM bundle for a self-hosted vendor behind a private CA. Empty = the

--- a/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
+++ b/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
@@ -46,6 +46,7 @@ data:
           max_repo_bytes: {{ required "cache.maxRepoBytes is required" .Values.cache.maxRepoBytes | int64 }}
           default_max_staleness_seconds: {{ required "cache.defaultMaxStalenessSeconds is required" .Values.cache.defaultMaxStalenessSeconds | int64 }}
           heavy_ops_concurrency: {{ required "cache.heavyOpsConcurrency is required" .Values.cache.heavyOpsConcurrency | int64 }}
+          serve_concurrency: {{ required "cache.serveConcurrency is required" .Values.cache.serveConcurrency | int64 }}
           ca_cert_path: {{ .Values.cache.caCertPath | quote }}
           # Not a values knob on purpose: a file:// origin reads the pod's own
           # filesystem, so no deployment may turn this on.

--- a/src/backend/services/git-cli-proxy/helm/tests/test_chart_contract.py
+++ b/src/backend/services/git-cli-proxy/helm/tests/test_chart_contract.py
@@ -85,6 +85,7 @@ def test_rendered_config_has_the_types_the_service_parses():
         "max_repo_bytes",
         "default_max_staleness_seconds",
         "heavy_ops_concurrency",
+        "serve_concurrency",
     ):
         assert isinstance(config[numeric], int), f"{numeric} must render as an integer"
     assert config["allow_file_repos"] is False
@@ -161,7 +162,7 @@ def test_byte_budgets_render_as_integers():
     config = one(render(), "ConfigMap")["data"]["insight.yaml"]
     parsed = yaml.safe_load(config)["gears"]["git-cli-proxy"]["config"]
 
-    for field in ("disk_budget_bytes", "max_repo_bytes", "default_max_staleness_seconds", "heavy_ops_concurrency"):
+    for field in ("disk_budget_bytes", "max_repo_bytes", "default_max_staleness_seconds", "heavy_ops_concurrency", "serve_concurrency"):
         assert isinstance(parsed[field], int), f"{field} must be an integer"
     assert parsed["disk_budget_bytes"] > parsed["max_repo_bytes"]
 

--- a/src/backend/services/git-cli-proxy/helm/values.yaml
+++ b/src/backend/services/git-cli-proxy/helm/values.yaml
@@ -78,6 +78,13 @@ cache:
   # fetch holds its entry's write lock while queued here — one slow clone
   # must not convoy every other repository's refresh behind it.
   heavyOpsConcurrency: 2
+  # Concurrent page serves. Each serve runs git children whose memory scales
+  # with the window's blob bytes, so the pod's peak is roughly this cap times
+  # the heaviest window — this is what bounds proxy memory, which is why
+  # resources.limits is read against it rather than raised on its own.
+  # Excess requests wait in-connection for a slot; serves are CPU-bound, so
+  # past ~2x the CPU limit extra slots only add memory risk.
+  serveConcurrency: 4
   # PEM bundle for self-hosted origins behind a private CA. Empty = system
   # trust store (correct for the public clouds).
   caCertPath: ""

--- a/src/backend/services/git-cli-proxy/src/api/data.rs
+++ b/src/backend/services/git-cli-proxy/src/api/data.rs
@@ -561,6 +561,13 @@ where
     F: Fn(RepoGuard) -> BoxFuture<'a, Result<Page<T>, ApiError>>,
 {
     let guard = open(state, context, paging).await?;
+    // INVARIANT: the permit spans the whole serve, including the promotion
+    // retry below — the semaphore IS the cap on concurrent page serves, and
+    // the pod's peak memory is that cap times the heaviest window. Taken
+    // AFTER open, so a slot is never spent waiting on a preparation.
+    // Holding the entry's read guard while queueing here delays only that
+    // entry's own writers, and the long-poll ceiling bounds the queueing.
+    let _slot = serve_slot(state).await?;
     let outcome = read(guard).await;
     check_for_drift(state, context);
     match outcome {
@@ -584,6 +591,29 @@ where
     let outcome = read(guard).await;
     check_for_drift(state, context);
     outcome
+}
+
+/// Take a page-serve slot, or answer 429 when none frees up in time.
+///
+/// Serves queue in-connection like every other wait, so a taken slot costs
+/// the caller nothing but time; the bounded wait is the backstop that keeps
+/// a saturated pod answering instead of accumulating held requests forever.
+async fn serve_slot(state: &Arc<AppState>) -> Result<tokio::sync::OwnedSemaphorePermit, ApiError> {
+    acquire_within(state.serves.clone(), crate::engine::store::PREPARATION_WAIT).await
+}
+
+async fn acquire_within(
+    serves: Arc<tokio::sync::Semaphore>,
+    budget: Duration,
+) -> Result<tokio::sync::OwnedSemaphorePermit, ApiError> {
+    match tokio::time::timeout(budget, serves.acquire_owned()).await {
+        Ok(Ok(permit)) => Ok(permit),
+        // The semaphore is never closed; a closed error is a bug surfacing.
+        Ok(Err(e)) => Err(ApiError::Serialization(format!(
+            "serve semaphore closed: {e}"
+        ))),
+        Err(_) => Err(ApiError::ServeSaturated),
+    }
 }
 
 /// Hand the entry to the store's post-serve purge, detached.
@@ -933,5 +963,37 @@ mod tests {
         );
         assert!(rows.is_empty());
         assert_eq!(cursor, None);
+    }
+
+    #[tokio::test]
+    async fn a_serve_waits_for_a_slot_and_gets_one_when_it_frees() {
+        let serves = Arc::new(tokio::sync::Semaphore::new(1));
+        let held = match serves.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(e) => panic!("stage: {e}"),
+        };
+
+        let waiter = tokio::spawn(acquire_within(serves, Duration::from_secs(5)));
+        drop(held);
+        match waiter.await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => panic!("a freed slot must be handed to the waiter: {e}"),
+            Err(e) => panic!("waiter died: {e}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_saturated_pod_answers_429_rather_than_holding_forever() {
+        let serves = Arc::new(tokio::sync::Semaphore::new(1));
+        let _held = match serves.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(e) => panic!("stage: {e}"),
+        };
+
+        match acquire_within(serves, Duration::from_millis(20)).await {
+            Err(ApiError::ServeSaturated) => {}
+            Err(e) => panic!("expected ServeSaturated, got {e}"),
+            Ok(_) => panic!("no slot exists; the wait must expire"),
+        }
     }
 }

--- a/src/backend/services/git-cli-proxy/src/api/data.rs
+++ b/src/backend/services/git-cli-proxy/src/api/data.rs
@@ -159,7 +159,7 @@ pub async fn list_commits(
     let paging = Paging::parse(query.page_token.as_deref(), query.page_size)?;
     let selected = parse_sha_filter(query.sha.as_deref())?;
 
-    let page = read_snapshot(&state, &context, &paging, |guard: RepoGuard| {
+    let (page, _slot) = read_snapshot(&state, &context, &paging, |guard: RepoGuard| {
         let (state, context, paging) = (&state, &context, &paging);
         let since = query.since.as_deref();
         let selected = selected.as_ref();
@@ -251,7 +251,7 @@ pub async fn list_file_changes(
     let include_patch = query.include_patch.unwrap_or(true);
     let max_patch_bytes = clamp_patch_bytes(query.max_patch_bytes);
 
-    let page = read_snapshot(&state, &context, &paging, |guard: RepoGuard| {
+    let (page, _slot) = read_snapshot(&state, &context, &paging, |guard: RepoGuard| {
         let (state, context, paging) = (&state, &context, &paging);
         let since = query.since.as_deref();
         let selected = selected.as_ref();
@@ -409,7 +409,7 @@ pub async fn list_branches(
     let context = RequestContext::from_parts(&headers, repo, state.clone_url_policy())?;
     let paging = Paging::parse(query.page_token.as_deref(), query.page_size)?;
 
-    let page = read_snapshot(&state, &context, &paging, |guard: RepoGuard| {
+    let (page, _slot) = read_snapshot(&state, &context, &paging, |guard: RepoGuard| {
         let (state, context, paging) = (&state, &context, &paging);
         Box::pin(async move {
             let mut all =
@@ -448,7 +448,7 @@ pub async fn list_authors(
     let context = RequestContext::from_parts(&headers, repo, state.clone_url_policy())?;
     let paging = Paging::parse(query.page_token.as_deref(), query.page_size)?;
 
-    let page = read_snapshot(&state, &context, &paging, |guard: RepoGuard| {
+    let (page, _slot) = read_snapshot(&state, &context, &paging, |guard: RepoGuard| {
         let (state, context, paging) = (&state, &context, &paging);
         let since = query.since.as_deref();
         Box::pin(async move {
@@ -553,7 +553,7 @@ async fn read_snapshot<'a, T, F>(
     context: &'a RequestContext,
     paging: &'a Paging,
     read: F,
-) -> Result<Page<T>, ApiError>
+) -> Result<(Page<T>, tokio::sync::OwnedSemaphorePermit), ApiError>
 where
     // INVARIANT: the reader takes the guard BY VALUE, so it is released before
     // promotion is requested. Promotion takes the entry's write lock, and
@@ -561,17 +561,20 @@ where
     F: Fn(RepoGuard) -> BoxFuture<'a, Result<Page<T>, ApiError>>,
 {
     let guard = open(state, context, paging).await?;
-    // INVARIANT: the permit spans the whole serve, including the promotion
-    // retry below — the semaphore IS the cap on concurrent page serves, and
-    // the pod's peak memory is that cap times the heaviest window. Taken
-    // AFTER open, so a slot is never spent waiting on a preparation.
-    // Holding the entry's read guard while queueing here delays only that
-    // entry's own writers, and the long-poll ceiling bounds the queueing.
-    let _slot = serve_slot(state).await?;
+    // INVARIANT: the permit spans the whole serve — the promotion retry below
+    // AND the caller's serialization, which is why it is returned alongside
+    // the page: a serialized patch page holds the whole body in memory, so
+    // dropping the slot before encoding would let bodies stack uncapped. The
+    // semaphore IS the cap on concurrent page serves, and the pod's peak
+    // memory is that cap times the heaviest window. Taken AFTER open, so a
+    // slot is never spent waiting on a preparation; holding the entry's read
+    // guard while queueing here delays only that entry's own writers, and
+    // the long-poll ceiling bounds the queueing.
+    let slot = serve_slot(state).await?;
     let outcome = read(guard).await;
     check_for_drift(state, context);
     match outcome {
-        Ok(page) => return Ok(page),
+        Ok(page) => return Ok((page, slot)),
         Err(e) if !refuses_promisor_wants(&e) => return Err(e),
         Err(_) => {}
     }
@@ -590,7 +593,7 @@ where
     let guard = open(state, context, paging).await?;
     let outcome = read(guard).await;
     check_for_drift(state, context);
-    outcome
+    outcome.map(|page| (page, slot))
 }
 
 /// Take a page-serve slot, or answer 429 when none frees up in time.
@@ -974,6 +977,9 @@ mod tests {
         };
 
         let waiter = tokio::spawn(acquire_within(serves, Duration::from_secs(5)));
+        // Let the waiter reach acquire_owned() so the release below is what
+        // serves it — otherwise the test never exercises the wait path.
+        tokio::task::yield_now().await;
         drop(held);
         match waiter.await {
             Ok(Ok(_)) => {}

--- a/src/backend/services/git-cli-proxy/src/api/data.rs
+++ b/src/backend/services/git-cli-proxy/src/api/data.rs
@@ -736,6 +736,71 @@ mod tests {
     use crate::engine::read::patches::Patch;
 
     #[tokio::test]
+    async fn a_serve_holds_its_slot_until_the_caller_is_done_with_the_page() {
+        // The cap bounds SERVES, not merely the read inside one: a page's rows
+        // and the body it serializes into coexist, so the slot has to outlive
+        // the read and come back only when the caller drops it.
+        let fixture = crate::engine::store::tests::fixture("api-serve-slot");
+        let state = Arc::new(AppState {
+            store: Arc::clone(&fixture.store),
+            config: crate::config::GearConfig {
+                bind_addr: "127.0.0.1:0".to_owned(),
+                data_dir: fixture.root.display().to_string(),
+                disk_budget_bytes: 1_000_000_000,
+                max_repo_bytes: 500_000_000,
+                default_max_staleness_seconds: 300,
+                heavy_ops_concurrency: 2,
+                serve_concurrency: 1,
+                proxy_token: "t0ken".to_owned(),
+                ca_cert_path: String::new(),
+                allow_file_repos: true,
+                allowed_repo_hosts: Vec::new(),
+            },
+            serves: Arc::new(tokio::sync::Semaphore::new(1)),
+        });
+        let context = RequestContext {
+            key: crate::engine::store::tests::key(&fixture),
+            creds: crate::engine::store::tests::creds(),
+            max_staleness: None,
+        };
+        let Ok(paging) = Paging::parse(None, None) else {
+            panic!("default paging must parse")
+        };
+
+        let served = read_snapshot(&state, &context, &paging, |guard: RepoGuard| {
+            Box::pin(async move {
+                Ok(Page {
+                    items: vec![guard.generation()],
+                    next_page_token: None,
+                })
+            })
+        })
+        .await;
+        let (page, slot) = match served {
+            Ok(served) => served,
+            Err(e) => panic!("a fixture repository must serve a page: {e}"),
+        };
+
+        assert_eq!(
+            page.items,
+            vec![1],
+            "the clone's first generation is served"
+        );
+        assert_eq!(
+            state.serves.available_permits(),
+            0,
+            "the slot stays taken while the page is alive"
+        );
+
+        drop(slot);
+        assert_eq!(
+            state.serves.available_permits(),
+            1,
+            "and returns once the caller is done with the page"
+        );
+    }
+
+    #[tokio::test]
     async fn a_page_declares_its_own_length() {
         // The response-size histogram reads this header. Left to the wire
         // layer it is absent here, and every page is recorded as zero bytes.

--- a/src/backend/services/git-cli-proxy/src/api/data.rs
+++ b/src/backend/services/git-cli-proxy/src/api/data.rs
@@ -561,15 +561,13 @@ where
     F: Fn(RepoGuard) -> BoxFuture<'a, Result<Page<T>, ApiError>>,
 {
     let guard = open(state, context, paging).await?;
-    // INVARIANT: the permit spans the whole serve — the promotion retry below
-    // AND the caller's serialization, which is why it is returned alongside
-    // the page: a serialized patch page holds the whole body in memory, so
-    // dropping the slot before encoding would let bodies stack uncapped. The
-    // semaphore IS the cap on concurrent page serves, and the pod's peak
-    // memory is that cap times the heaviest window. Taken AFTER open, so a
-    // slot is never spent waiting on a preparation; holding the entry's read
-    // guard while queueing here delays only that entry's own writers, and
-    // the long-poll ceiling bounds the queueing.
+    // INVARIANT: the permit spans the read AND the caller's serialization,
+    // which is why it is returned alongside the page — a serialized patch
+    // page holds the whole body in memory, so releasing the slot before
+    // encoding would let bodies stack uncapped. The semaphore IS the cap on
+    // concurrent page serves, and the pod's peak memory is that cap times
+    // the heaviest window. Taken AFTER open, so a slot is never spent
+    // waiting on a preparation.
     let slot = serve_slot(state).await?;
     let outcome = read(guard).await;
     check_for_drift(state, context);
@@ -578,6 +576,14 @@ where
         Err(e) if !refuses_promisor_wants(&e) => return Err(e),
         Err(_) => {}
     }
+
+    // SAFETY: the slot is released before promotion and taken again after.
+    // Promotion takes the entry's WRITE lock, and a concurrent request that
+    // already holds that entry's read guard queues here for a slot — keeping
+    // this one would leave the promoter waiting for the reader while the
+    // reader waits for the slot, both stalled until the queue ceiling
+    // expires. No slot holder may await a write lock.
+    drop(slot);
 
     let generation = state
         .store
@@ -591,6 +597,7 @@ where
     }
 
     let guard = open(state, context, paging).await?;
+    let slot = serve_slot(state).await?;
     let outcome = read(guard).await;
     check_for_drift(state, context);
     outcome.map(|page| (page, slot))
@@ -797,6 +804,77 @@ mod tests {
             state.serves.available_permits(),
             1,
             "and returns once the caller is done with the page"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_promoting_serve_does_not_hold_the_slot_its_writer_waits_behind() {
+        // Promotion takes the entry's WRITE lock. A second request already
+        // holding that entry's read guard queues for a slot, so a promoter
+        // that kept its own slot would wait for the reader while the reader
+        // waits for the slot — deadlocked until the queue ceiling expires.
+        // Without the release this test reaches its timeout.
+        let fixture = crate::engine::store::tests::fixture("api-promote-slot");
+        let state = Arc::new(AppState {
+            store: Arc::clone(&fixture.store),
+            config: crate::config::GearConfig {
+                bind_addr: "127.0.0.1:0".to_owned(),
+                data_dir: fixture.root.display().to_string(),
+                disk_budget_bytes: 1_000_000_000,
+                max_repo_bytes: 500_000_000,
+                default_max_staleness_seconds: 300,
+                heavy_ops_concurrency: 2,
+                serve_concurrency: 1,
+                proxy_token: "t0ken".to_owned(),
+                ca_cert_path: String::new(),
+                allow_file_repos: true,
+                allowed_repo_hosts: Vec::new(),
+            },
+            serves: Arc::new(tokio::sync::Semaphore::new(1)),
+        });
+        let context = RequestContext {
+            key: crate::engine::store::tests::key(&fixture),
+            creds: crate::engine::store::tests::creds(),
+            max_staleness: None,
+        };
+        let Ok(paging) = Paging::parse(None, None) else {
+            panic!("default paging must parse")
+        };
+
+        // Warm the entry so neither side waits on a clone.
+        match open(&state, &context, &paging).await {
+            Ok(guard) => drop(guard),
+            Err(e) => panic!("the fixture must open: {e}"),
+        }
+        let reader = match open(&state, &context, &paging).await {
+            Ok(guard) => guard,
+            Err(e) => panic!("the fixture must open: {e}"),
+        };
+
+        let raced = tokio::time::timeout(Duration::from_secs(30), async {
+            tokio::join!(
+                read_snapshot(&state, &context, &paging, |_guard: RepoGuard| {
+                    Box::pin(async {
+                        Err::<Page<u64>, ApiError>(ApiError::Git(GitError::PromisorRefused))
+                    })
+                }),
+                async {
+                    let slot = serve_slot(&state).await;
+                    // Release the read guard only once the slot is in hand:
+                    // the promoter must have let go of it on its own.
+                    drop(reader);
+                    slot.is_ok()
+                }
+            )
+        })
+        .await;
+
+        let Ok((_, queued_serve_got_a_slot)) = raced else {
+            panic!("the promoting serve and the queued serve deadlocked")
+        };
+        assert!(
+            queued_serve_got_a_slot,
+            "the queued serve must get the slot the promoter released"
         );
     }
 

--- a/src/backend/services/git-cli-proxy/src/api/error.rs
+++ b/src/backend/services/git-cli-proxy/src/api/error.rs
@@ -28,6 +28,8 @@ pub enum ApiError {
     Git(#[from] GitError),
     #[error("the proxy token was missing or wrong")]
     ProxyTokenRejected,
+    #[error("every page-serve slot is taken; retry shortly")]
+    ServeSaturated,
     #[error("failed to serialize the response: {0}")]
     Serialization(String),
 }
@@ -47,6 +49,9 @@ const ADMISSION_RETRY_AFTER_SECONDS: u64 = 30;
 /// Origin asked this client to slow down. Longer than the cache's own hint:
 /// a vendor rate-limit window outlives a reader releasing an entry.
 const THROTTLED_RETRY_AFTER_SECONDS: u64 = 60;
+/// Every serve slot stayed taken for the whole bounded wait; slots turn over
+/// as pages finish, so the caller is asked back on the short cadence.
+const SERVE_RETRY_AFTER_SECONDS: u64 = 30;
 
 /// A prefetch refused for space schedules a pressure purge as it rejects, so
 /// "later" is one repack away — much sooner than a full admission cycle.
@@ -60,6 +65,9 @@ impl IntoResponse for ApiError {
         match &self {
             Self::Store(StoreError::Busy { .. }) => {
                 metrics::record_rejection(metrics::RejectReason::PreparationWait);
+            }
+            Self::ServeSaturated => {
+                metrics::record_rejection(metrics::RejectReason::ServeSaturated);
             }
             Self::Store(StoreError::Throttled) | Self::Git(GitError::Throttled) => {
                 metrics::record_rejection(metrics::RejectReason::OriginThrottled);
@@ -118,7 +126,8 @@ impl ApiError {
                 StatusCode::NOT_FOUND.as_u16()
             }
             Self::Store(StoreError::SnapshotChanged { .. }) => StatusCode::CONFLICT.as_u16(),
-            Self::Store(StoreError::Busy { .. } | StoreError::Throttled)
+            Self::ServeSaturated
+            | Self::Store(StoreError::Busy { .. } | StoreError::Throttled)
             | Self::Git(
                 GitError::AdmissionRejected | GitError::TransientlyOverCap | GitError::Throttled,
             ) => StatusCode::TOO_MANY_REQUESTS.as_u16(),
@@ -138,6 +147,7 @@ impl ApiError {
     fn retry_after(&self) -> Option<u64> {
         match self {
             Self::Store(StoreError::Busy { retry_after }) => Some(retry_after.as_secs()),
+            Self::ServeSaturated => Some(SERVE_RETRY_AFTER_SECONDS),
             Self::Git(GitError::AdmissionRejected) => Some(ADMISSION_RETRY_AFTER_SECONDS),
             Self::Git(GitError::TransientlyOverCap) => Some(PRESSURE_RETRY_AFTER_SECONDS),
             Self::Store(StoreError::Throttled) | Self::Git(GitError::Throttled) => {
@@ -203,6 +213,16 @@ impl ApiError {
                 RepositoryError::resource_exhausted("repository is being prepared")
                     .with_quota_violation("repository_preparation", "clone or fetch in progress")
                     .with_quota_violation_retry_after_seconds(retry_after.as_secs())
+                    .create()
+            }
+            // Ours, not the entry's: every serve slot is taken. Same shape as
+            // the other 429s so the connector backs off identically, distinct
+            // quota subject so an operator can tell saturation from
+            // preparation.
+            Self::ServeSaturated => {
+                RepositoryError::resource_exhausted("every page-serve slot is taken")
+                    .with_quota_violation("serve_concurrency", "all serve slots in use")
+                    .with_quota_violation_retry_after_seconds(SERVE_RETRY_AFTER_SECONDS)
                     .create()
             }
             // The vendor's own limiter, not ours. Same shape as a cache

--- a/src/backend/services/git-cli-proxy/src/api/error.rs
+++ b/src/backend/services/git-cli-proxy/src/api/error.rs
@@ -421,12 +421,23 @@ mod tests {
                 GitError::AdmissionRejected.into(),
                 StatusCode::TOO_MANY_REQUESTS,
             ),
+            // Ours, not the entry's: every page-serve slot is taken.
+            (ApiError::ServeSaturated, StatusCode::TOO_MANY_REQUESTS),
+            (
+                ApiError::Serialization("boom".to_owned()),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
         ];
         for (error, expected) in cases {
             let label = error.to_string();
+            // INVARIANT: what a request is RECORDED against and what it is
+            // ANSWERED with are the same status — the metrics middleware
+            // reads the former off the error before the latter exists.
+            let recorded = error.status_code();
             let (status, _, body) = problem(error).await;
             assert_eq!(status, expected, "for {label}");
             assert_eq!(body["status"], expected.as_u16(), "for {label}");
+            assert_eq!(recorded, expected.as_u16(), "recorded status for {label}");
         }
     }
 

--- a/src/backend/services/git-cli-proxy/src/api/error.rs
+++ b/src/backend/services/git-cli-proxy/src/api/error.rs
@@ -75,7 +75,11 @@ impl IntoResponse for ApiError {
             Self::Store(StoreError::OriginUnavailable) | Self::Git(GitError::OriginUnavailable) => {
                 metrics::record_origin_unavailable();
             }
-            _ => {}
+            Self::BadRequest(_)
+            | Self::Store(_)
+            | Self::Git(_)
+            | Self::ProxyTokenRejected
+            | Self::Serialization(_) => {}
         }
 
         let retry_after = self.retry_after();
@@ -131,7 +135,9 @@ impl ApiError {
             | Self::Git(
                 GitError::AdmissionRejected | GitError::TransientlyOverCap | GitError::Throttled,
             ) => StatusCode::TOO_MANY_REQUESTS.as_u16(),
-            _ => StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+            Self::Store(_) | Self::Git(_) | Self::Serialization(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR.as_u16()
+            }
         }
     }
 
@@ -140,7 +146,12 @@ impl ApiError {
             Self::Store(StoreError::TooLarge { .. }) | Self::Git(GitError::TooLarge { .. }) => {
                 Some(REPO_TOO_LARGE)
             }
-            _ => None,
+            Self::BadRequest(_)
+            | Self::Store(_)
+            | Self::Git(_)
+            | Self::ProxyTokenRejected
+            | Self::ServeSaturated
+            | Self::Serialization(_) => None,
         }
     }
 
@@ -153,7 +164,11 @@ impl ApiError {
             Self::Store(StoreError::Throttled) | Self::Git(GitError::Throttled) => {
                 Some(THROTTLED_RETRY_AFTER_SECONDS)
             }
-            _ => None,
+            Self::BadRequest(_)
+            | Self::Store(_)
+            | Self::Git(_)
+            | Self::ProxyTokenRejected
+            | Self::Serialization(_) => None,
         }
     }
 
@@ -303,6 +318,19 @@ mod tests {
     use std::time::Duration;
 
     use axum::body::to_bytes;
+
+    #[test]
+    fn serve_saturation_answers_429_with_a_retry_hint() {
+        use axum::response::IntoResponse;
+
+        let response = ApiError::ServeSaturated.into_response();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let retry_after = match response.headers().get(header::RETRY_AFTER) {
+            Some(value) => value.to_str().unwrap_or_default().to_owned(),
+            None => panic!("saturation must tell the caller when to come back"),
+        };
+        assert_eq!(retry_after, SERVE_RETRY_AFTER_SECONDS.to_string());
+    }
 
     use super::*;
 

--- a/src/backend/services/git-cli-proxy/src/api/mod.rs
+++ b/src/backend/services/git-cli-proxy/src/api/mod.rs
@@ -21,6 +21,9 @@ use crate::engine::url::CloneUrlPolicy;
 pub struct AppState {
     pub store: Arc<RepoStore>,
     pub config: GearConfig,
+    /// Page-serve slots. Each serve runs git children whose memory scales
+    /// with the window's blob bytes; this cap is what bounds the pod's peak.
+    pub serves: Arc<tokio::sync::Semaphore>,
 }
 
 impl AppState {
@@ -415,10 +418,12 @@ mod tests {
                 max_repo_bytes: 500_000,
                 default_max_staleness_seconds: 300,
                 heavy_ops_concurrency: 2,
+                serve_concurrency: 2,
                 proxy_token: "t0ken".to_owned(),
                 ca_cert_path: String::new(),
                 allow_file_repos: true,
             },
+            serves: Arc::new(tokio::sync::Semaphore::new(2)),
         })
     }
 

--- a/src/backend/services/git-cli-proxy/src/config.rs
+++ b/src/backend/services/git-cli-proxy/src/config.rs
@@ -32,6 +32,11 @@ pub struct GearConfig {
     pub default_max_staleness_seconds: u64,
     /// Concurrency cap for heavy git operations (clone / fetch / repack).
     pub heavy_ops_concurrency: usize,
+    /// Concurrency cap for page serves. Each serve runs git children whose
+    /// memory scales with the window's blob bytes, so the pod's peak is
+    /// roughly this cap times the heaviest window; excess requests wait
+    /// in-connection for a slot.
+    pub serve_concurrency: usize,
     /// Static bearer token protecting every `/v1` route (service-to-service
     /// auth; the service is cluster-internal and never behind the platform
     /// gateway). Supplied per-deployment, never committed.
@@ -76,6 +81,7 @@ impl std::fmt::Debug for GearConfig {
                 &self.default_max_staleness_seconds,
             )
             .field("heavy_ops_concurrency", &self.heavy_ops_concurrency)
+            .field("serve_concurrency", &self.serve_concurrency)
             .field("ca_cert_path", &self.ca_cert_path)
             .field("allow_file_repos", &self.allow_file_repos)
             .field("allowed_repo_hosts", &self.allowed_repo_hosts)
@@ -111,6 +117,9 @@ impl GearConfig {
         }
         if self.heavy_ops_concurrency == 0 {
             missing.push("heavy_ops_concurrency (clone/fetch/repack cap, > 0)");
+        }
+        if self.serve_concurrency == 0 {
+            missing.push("serve_concurrency (page-serve cap, > 0)");
         }
         if self.proxy_token.is_empty() {
             missing.push("proxy_token (service-to-service bearer token)");
@@ -148,6 +157,7 @@ mod tests {
             max_repo_bytes: 2_000_000_000,
             default_max_staleness_seconds: 300,
             heavy_ops_concurrency: 4,
+            serve_concurrency: 4,
             proxy_token: "secret".to_owned(),
             ca_cert_path: String::new(),
             allow_file_repos: false,
@@ -209,6 +219,13 @@ mod tests {
                 },
             ),
             (
+                "serve_concurrency",
+                GearConfig {
+                    serve_concurrency: 0,
+                    ..valid()
+                },
+            ),
+            (
                 "proxy_token",
                 GearConfig {
                     proxy_token: String::new(),
@@ -238,6 +255,7 @@ mod tests {
             "max_repo_bytes",
             "default_max_staleness_seconds",
             "heavy_ops_concurrency",
+            "serve_concurrency",
             "proxy_token",
         ] {
             assert!(

--- a/src/backend/services/git-cli-proxy/src/engine/metrics.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/metrics.rs
@@ -68,6 +68,8 @@ pub enum RejectReason {
     PreparationWait,
     /// Origin is throttling this client.
     OriginThrottled,
+    /// Every page-serve slot stayed taken for the whole bounded wait.
+    ServeSaturated,
 }
 
 impl RejectReason {
@@ -78,6 +80,7 @@ impl RejectReason {
             Self::AdmissionExhausted => "admission_exhausted",
             Self::PreparationWait => "preparation_wait",
             Self::OriginThrottled => "origin_throttled",
+            Self::ServeSaturated => "serve_saturated",
         }
     }
 }

--- a/src/backend/services/git-cli-proxy/src/engine/store.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/store.rs
@@ -23,7 +23,7 @@ use super::runner::{GitCredentials, GitError, GitRunner};
 /// INVARIANT: must stay under `api::HANDLER_BUDGET`, or the typed `Busy`
 /// answer below loses to the blanket 503.
 pub(crate) const PREPARATION_WAIT: Duration = Duration::from_mins(55);
-const COLD_RETRY_AFTER: Duration = Duration::from_secs(30);
+pub(crate) const COLD_RETRY_AFTER: Duration = Duration::from_secs(30);
 /// Probe wait for opportunistic work that a concurrent writer makes moot.
 const MEASURE_WAIT: Duration = Duration::from_secs(15);
 const REPROOF_ATTEMPTS: usize = 2;

--- a/src/backend/services/git-cli-proxy/src/gear.rs
+++ b/src/backend/services/git-cli-proxy/src/gear.rs
@@ -104,7 +104,12 @@ impl Gear for GitCliProxyGear {
         // every admission check, so the collector's callback does no I/O.
         crate::engine::metrics::register_disk_gauges(store.gauges());
 
-        let state = AppState { store, config };
+        let serves = Arc::new(tokio::sync::Semaphore::new(config.serve_concurrency));
+        let state = AppState {
+            store,
+            config,
+            serves,
+        };
         self.state
             .set(Arc::new(state))
             .map_err(|_| anyhow::anyhow!("{} gear already initialized", Self::MODULE_NAME))?;

--- a/src/backend/services/git-cli-proxy/tests/boot.rs
+++ b/src/backend/services/git-cli-proxy/tests/boot.rs
@@ -71,6 +71,7 @@ gears:
       max_repo_bytes: 500000000
       default_max_staleness_seconds: 300
       heavy_ops_concurrency: 2
+      serve_concurrency: 2
       proxy_token: "{token}"
       allow_file_repos: {allow_file_repos}
 "#,


### PR DESCRIPTION
**Why.** Nothing bounds how many page serves run at once: `heavyOpsConcurrency` caps clones/fetches/repacks, but each serve spawns git children whose memory scales with the window's blob bytes, so enough concurrent blob-heavy windows OOM-kill the pod — and now that long preparations are held instead of bounced, heavy serves actually run long enough to stack.

**What changed.** A `serve_concurrency` semaphore (config-required like its heavy sibling; chart value `cache.serveConcurrency`, default 4) gates the serve phase of every data endpoint at the shared `read_snapshot` choke point. The permit is taken after `open()` so a slot is never spent waiting on a preparation, and excess requests wait in-connection; a wait that outlives the preparation ceiling answers a typed 429 with its own quota subject (`serve_concurrency`) and rejection metric (`serve_saturated`), distinct from preparation Busy.

**Verified.** `cargo test -p git-cli-proxy` (217 lib + 20 boot), helm contract suite (27), `cargo fmt --check`, clippy pedantic clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable concurrency limits for page-serving requests, with a default of four simultaneous serves.
  * Additional requests wait briefly for an available serving slot, helping control resource usage.
* **Bug Fixes**
  * When all serving slots remain busy, requests now return a clear “Too Many Requests” response with 30-second retry guidance.
* **Configuration**
  * Added support for configuring the concurrency limit through deployment values and environment overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->