### PR TITLE
fix(git-cli-proxy): bound concurrent page serves so blob-heavy windows cannot stack past the memory limit

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -628,6 +628,10 @@ gitCliProxy:
     maxRepoBytes: 10737418240
     defaultMaxStalenessSeconds: 300
     heavyOpsConcurrency: 4
+    # Concurrent page serves; the pod's peak memory is roughly this times the
+    # heaviest window's blob bytes. Size with the CPU limit — serves are
+    # CPU-bound and extra slots past ~2x it only add memory risk.
+    serveConcurrency: 4
     caCertPath: ""
   caCertSecret: ""
   # Bearer token the proxy requires on every /v1 request. Empty = generated on

--- a/src/backend/services/git-cli-proxy/config/insight.yaml
+++ b/src/backend/services/git-cli-proxy/config/insight.yaml
@@ -15,6 +15,7 @@
 #   APP__gears__git_cli_proxy__config__max_repo_bytes
 #   APP__gears__git_cli_proxy__config__default_max_staleness_seconds
 #   APP__gears__git_cli_proxy__config__heavy_ops_concurrency
+#   APP__gears__git_cli_proxy__config__serve_concurrency
 #   APP__gears__git_cli_proxy__config__proxy_token
 
 server:
@@ -51,6 +52,7 @@ gears:
       default_max_staleness_seconds: 0
       # Concurrency cap for heavy git operations (clone / fetch / repack).
       heavy_ops_concurrency: 0
+      serve_concurrency: 0
       # Service-to-service bearer token for /v1. Never committed.
       proxy_token: ""
       # PEM bundle for a self-hosted vendor behind a private CA. Empty = the

--- a/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
+++ b/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
@@ -31,6 +31,7 @@ data:
           max_repo_bytes: {{ required "cache.maxRepoBytes is required" .Values.cache.maxRepoBytes | int64 }}
           default_max_staleness_seconds: {{ required "cache.defaultMaxStalenessSeconds is required" .Values.cache.defaultMaxStalenessSeconds | int64 }}
           heavy_ops_concurrency: {{ required "cache.heavyOpsConcurrency is required" .Values.cache.heavyOpsConcurrency | int64 }}
+          serve_concurrency: {{ required "cache.serveConcurrency is required" .Values.cache.serveConcurrency | int64 }}
           ca_cert_path: {{ .Values.cache.caCertPath | quote }}
           # Not a values knob on purpose: a file:// origin reads the pod's own
           # filesystem, so no deployment may turn this on.

--- a/src/backend/services/git-cli-proxy/helm/tests/test_chart_contract.py
+++ b/src/backend/services/git-cli-proxy/helm/tests/test_chart_contract.py
@@ -85,6 +85,7 @@ def test_rendered_config_has_the_types_the_service_parses():
         "max_repo_bytes",
         "default_max_staleness_seconds",
         "heavy_ops_concurrency",
+        "serve_concurrency",
     ):
         assert isinstance(config[numeric], int), f"{numeric} must render as an integer"
     assert config["allow_file_repos"] is False
@@ -161,7 +162,7 @@ def test_byte_budgets_render_as_integers():
     config = one(render(), "ConfigMap")["data"]["insight.yaml"]
     parsed = yaml.safe_load(config)["gears"]["git-cli-proxy"]["config"]
 
-    for field in ("disk_budget_bytes", "max_repo_bytes", "default_max_staleness_seconds", "heavy_ops_concurrency"):
+    for field in ("disk_budget_bytes", "max_repo_bytes", "default_max_staleness_seconds", "heavy_ops_concurrency", "serve_concurrency"):
         assert isinstance(parsed[field], int), f"{field} must be an integer"
     assert parsed["disk_budget_bytes"] > parsed["max_repo_bytes"]
 

--- a/src/backend/services/git-cli-proxy/helm/values.yaml
+++ b/src/backend/services/git-cli-proxy/helm/values.yaml
@@ -61,6 +61,12 @@ cache:
   defaultMaxStalenessSeconds: 300
   # Concurrency cap for clone/fetch/repack.
   heavyOpsConcurrency: 4
+  # Concurrent page serves. Each serve runs git children whose memory scales
+  # with the window's blob bytes, so the pod's peak is roughly this cap times
+  # the heaviest window; excess requests wait in-connection for a slot. Size
+  # it with resources.limits: serves are CPU-bound, so past ~2x the CPU limit
+  # extra slots only add memory risk.
+  serveConcurrency: 4
   # PEM bundle for self-hosted origins behind a private CA. Empty = system
   # trust store (correct for the public clouds).
   caCertPath: ""

--- a/src/backend/services/git-cli-proxy/src/api/data.rs
+++ b/src/backend/services/git-cli-proxy/src/api/data.rs
@@ -561,6 +561,13 @@ where
     F: Fn(RepoGuard) -> BoxFuture<'a, Result<Page<T>, ApiError>>,
 {
     let guard = open(state, context, paging).await?;
+    // INVARIANT: the permit spans the whole serve, including the promotion
+    // retry below — the semaphore IS the cap on concurrent page serves, and
+    // the pod's peak memory is that cap times the heaviest window. Taken
+    // AFTER open, so a slot is never spent waiting on a preparation.
+    // Holding the entry's read guard while queueing here delays only that
+    // entry's own writers, and the long-poll ceiling bounds the queueing.
+    let _slot = serve_slot(state).await?;
     let outcome = read(guard).await;
     check_for_drift(state, context);
     match outcome {
@@ -584,6 +591,29 @@ where
     let outcome = read(guard).await;
     check_for_drift(state, context);
     outcome
+}
+
+/// Take a page-serve slot, or answer 429 when none frees up in time.
+///
+/// Serves queue in-connection like every other wait, so a taken slot costs
+/// the caller nothing but time; the bounded wait is the backstop that keeps
+/// a saturated pod answering instead of accumulating held requests forever.
+async fn serve_slot(state: &Arc<AppState>) -> Result<tokio::sync::OwnedSemaphorePermit, ApiError> {
+    acquire_within(state.serves.clone(), crate::engine::store::PREPARATION_WAIT).await
+}
+
+async fn acquire_within(
+    serves: Arc<tokio::sync::Semaphore>,
+    budget: Duration,
+) -> Result<tokio::sync::OwnedSemaphorePermit, ApiError> {
+    match tokio::time::timeout(budget, serves.acquire_owned()).await {
+        Ok(Ok(permit)) => Ok(permit),
+        // The semaphore is never closed; a closed error is a bug surfacing.
+        Ok(Err(e)) => Err(ApiError::Serialization(format!(
+            "serve semaphore closed: {e}"
+        ))),
+        Err(_) => Err(ApiError::ServeSaturated),
+    }
 }
 
 /// Hand the entry to the store's post-serve purge, detached.
@@ -933,5 +963,37 @@ mod tests {
         );
         assert!(rows.is_empty());
         assert_eq!(cursor, None);
+    }
+
+    #[tokio::test]
+    async fn a_serve_waits_for_a_slot_and_gets_one_when_it_frees() {
+        let serves = Arc::new(tokio::sync::Semaphore::new(1));
+        let held = match serves.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(e) => panic!("stage: {e}"),
+        };
+
+        let waiter = tokio::spawn(acquire_within(serves, Duration::from_secs(5)));
+        drop(held);
+        match waiter.await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => panic!("a freed slot must be handed to the waiter: {e}"),
+            Err(e) => panic!("waiter died: {e}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_saturated_pod_answers_429_rather_than_holding_forever() {
+        let serves = Arc::new(tokio::sync::Semaphore::new(1));
+        let _held = match serves.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(e) => panic!("stage: {e}"),
+        };
+
+        match acquire_within(serves, Duration::from_millis(20)).await {
+            Err(ApiError::ServeSaturated) => {}
+            Err(e) => panic!("expected ServeSaturated, got {e}"),
+            Ok(_) => panic!("no slot exists; the wait must expire"),
+        }
     }
 }

--- a/src/backend/services/git-cli-proxy/src/api/error.rs
+++ b/src/backend/services/git-cli-proxy/src/api/error.rs
@@ -28,6 +28,8 @@ pub enum ApiError {
     Git(#[from] GitError),
     #[error("the proxy token was missing or wrong")]
     ProxyTokenRejected,
+    #[error("every page-serve slot is taken; retry shortly")]
+    ServeSaturated,
     #[error("failed to serialize the response: {0}")]
     Serialization(String),
 }
@@ -47,6 +49,9 @@ const ADMISSION_RETRY_AFTER_SECONDS: u64 = 30;
 /// Origin asked this client to slow down. Longer than the cache's own hint:
 /// a vendor rate-limit window outlives a reader releasing an entry.
 const THROTTLED_RETRY_AFTER_SECONDS: u64 = 60;
+/// Every serve slot stayed taken for the whole bounded wait; slots turn over
+/// as pages finish, so the caller is asked back on the short cadence.
+const SERVE_RETRY_AFTER_SECONDS: u64 = 30;
 
 /// A prefetch refused for space schedules a pressure purge as it rejects, so
 /// "later" is one repack away — much sooner than a full admission cycle.
@@ -60,6 +65,9 @@ impl IntoResponse for ApiError {
         match &self {
             Self::Store(StoreError::Busy { .. }) => {
                 metrics::record_rejection(metrics::RejectReason::PreparationWait);
+            }
+            Self::ServeSaturated => {
+                metrics::record_rejection(metrics::RejectReason::ServeSaturated);
             }
             Self::Store(StoreError::Throttled) | Self::Git(GitError::Throttled) => {
                 metrics::record_rejection(metrics::RejectReason::OriginThrottled);
@@ -118,7 +126,8 @@ impl ApiError {
                 StatusCode::NOT_FOUND.as_u16()
             }
             Self::Store(StoreError::SnapshotChanged { .. }) => StatusCode::CONFLICT.as_u16(),
-            Self::Store(StoreError::Busy { .. } | StoreError::Throttled)
+            Self::ServeSaturated
+            | Self::Store(StoreError::Busy { .. } | StoreError::Throttled)
             | Self::Git(
                 GitError::AdmissionRejected | GitError::TransientlyOverCap | GitError::Throttled,
             ) => StatusCode::TOO_MANY_REQUESTS.as_u16(),
@@ -138,6 +147,7 @@ impl ApiError {
     fn retry_after(&self) -> Option<u64> {
         match self {
             Self::Store(StoreError::Busy { retry_after }) => Some(retry_after.as_secs()),
+            Self::ServeSaturated => Some(SERVE_RETRY_AFTER_SECONDS),
             Self::Git(GitError::AdmissionRejected) => Some(ADMISSION_RETRY_AFTER_SECONDS),
             Self::Git(GitError::TransientlyOverCap) => Some(PRESSURE_RETRY_AFTER_SECONDS),
             Self::Store(StoreError::Throttled) | Self::Git(GitError::Throttled) => {
@@ -203,6 +213,16 @@ impl ApiError {
                 RepositoryError::resource_exhausted("repository is being prepared")
                     .with_quota_violation("repository_preparation", "clone or fetch in progress")
                     .with_quota_violation_retry_after_seconds(retry_after.as_secs())
+                    .create()
+            }
+            // Ours, not the entry's: every serve slot is taken. Same shape as
+            // the other 429s so the connector backs off identically, distinct
+            // quota subject so an operator can tell saturation from
+            // preparation.
+            Self::ServeSaturated => {
+                RepositoryError::resource_exhausted("every page-serve slot is taken")
+                    .with_quota_violation("serve_concurrency", "all serve slots in use")
+                    .with_quota_violation_retry_after_seconds(SERVE_RETRY_AFTER_SECONDS)
                     .create()
             }
             // The vendor's own limiter, not ours. Same shape as a cache

--- a/src/backend/services/git-cli-proxy/src/api/mod.rs
+++ b/src/backend/services/git-cli-proxy/src/api/mod.rs
@@ -21,6 +21,9 @@ use crate::engine::url::CloneUrlPolicy;
 pub struct AppState {
     pub store: Arc<RepoStore>,
     pub config: GearConfig,
+    /// Page-serve slots. Each serve runs git children whose memory scales
+    /// with the window's blob bytes; this cap is what bounds the pod's peak.
+    pub serves: Arc<tokio::sync::Semaphore>,
 }
 
 impl AppState {
@@ -412,10 +415,12 @@ mod tests {
                 max_repo_bytes: 500_000,
                 default_max_staleness_seconds: 300,
                 heavy_ops_concurrency: 2,
+                serve_concurrency: 2,
                 proxy_token: "t0ken".to_owned(),
                 ca_cert_path: String::new(),
                 allow_file_repos: true,
             },
+            serves: Arc::new(tokio::sync::Semaphore::new(2)),
         })
     }
 

--- a/src/backend/services/git-cli-proxy/src/config.rs
+++ b/src/backend/services/git-cli-proxy/src/config.rs
@@ -32,6 +32,11 @@ pub struct GearConfig {
     pub default_max_staleness_seconds: u64,
     /// Concurrency cap for heavy git operations (clone / fetch / repack).
     pub heavy_ops_concurrency: usize,
+    /// Concurrency cap for page serves. Each serve runs git children whose
+    /// memory scales with the window's blob bytes, so the pod's peak is
+    /// roughly this cap times the heaviest window; excess requests wait
+    /// in-connection for a slot.
+    pub serve_concurrency: usize,
     /// Static bearer token protecting every `/v1` route (service-to-service
     /// auth; the service is cluster-internal and never behind the platform
     /// gateway). Supplied per-deployment, never committed.
@@ -76,6 +81,7 @@ impl std::fmt::Debug for GearConfig {
                 &self.default_max_staleness_seconds,
             )
             .field("heavy_ops_concurrency", &self.heavy_ops_concurrency)
+            .field("serve_concurrency", &self.serve_concurrency)
             .field("ca_cert_path", &self.ca_cert_path)
             .field("allow_file_repos", &self.allow_file_repos)
             .field("allowed_repo_hosts", &self.allowed_repo_hosts)
@@ -111,6 +117,9 @@ impl GearConfig {
         }
         if self.heavy_ops_concurrency == 0 {
             missing.push("heavy_ops_concurrency (clone/fetch/repack cap, > 0)");
+        }
+        if self.serve_concurrency == 0 {
+            missing.push("serve_concurrency (page-serve cap, > 0)");
         }
         if self.proxy_token.is_empty() {
             missing.push("proxy_token (service-to-service bearer token)");
@@ -148,6 +157,7 @@ mod tests {
             max_repo_bytes: 2_000_000_000,
             default_max_staleness_seconds: 300,
             heavy_ops_concurrency: 4,
+            serve_concurrency: 4,
             proxy_token: "secret".to_owned(),
             ca_cert_path: String::new(),
             allow_file_repos: false,
@@ -209,6 +219,13 @@ mod tests {
                 },
             ),
             (
+                "serve_concurrency",
+                GearConfig {
+                    serve_concurrency: 0,
+                    ..valid()
+                },
+            ),
+            (
                 "proxy_token",
                 GearConfig {
                     proxy_token: String::new(),
@@ -238,6 +255,7 @@ mod tests {
             "max_repo_bytes",
             "default_max_staleness_seconds",
             "heavy_ops_concurrency",
+            "serve_concurrency",
             "proxy_token",
         ] {
             assert!(

--- a/src/backend/services/git-cli-proxy/src/engine/metrics.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/metrics.rs
@@ -68,6 +68,8 @@ pub enum RejectReason {
     PreparationWait,
     /// Origin is throttling this client.
     OriginThrottled,
+    /// Every page-serve slot stayed taken for the whole bounded wait.
+    ServeSaturated,
 }
 
 impl RejectReason {
@@ -78,6 +80,7 @@ impl RejectReason {
             Self::AdmissionExhausted => "admission_exhausted",
             Self::PreparationWait => "preparation_wait",
             Self::OriginThrottled => "origin_throttled",
+            Self::ServeSaturated => "serve_saturated",
         }
     }
 }

--- a/src/backend/services/git-cli-proxy/src/engine/store.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/store.rs
@@ -23,7 +23,7 @@ use super::runner::{GitCredentials, GitError, GitRunner};
 /// INVARIANT: must stay under `api::HANDLER_BUDGET`, or the typed `Busy`
 /// answer below loses to the blanket 503.
 pub(crate) const PREPARATION_WAIT: Duration = Duration::from_mins(55);
-const COLD_RETRY_AFTER: Duration = Duration::from_secs(30);
+pub(crate) const COLD_RETRY_AFTER: Duration = Duration::from_secs(30);
 /// Probe wait for opportunistic work that a concurrent writer makes moot.
 const MEASURE_WAIT: Duration = Duration::from_secs(15);
 const REPROOF_ATTEMPTS: usize = 2;

--- a/src/backend/services/git-cli-proxy/src/gear.rs
+++ b/src/backend/services/git-cli-proxy/src/gear.rs
@@ -104,7 +104,12 @@ impl Gear for GitCliProxyGear {
         // every admission check, so the collector's callback does no I/O.
         crate::engine::metrics::register_disk_gauges(store.gauges());
 
-        let state = AppState { store, config };
+        let serves = Arc::new(tokio::sync::Semaphore::new(config.serve_concurrency));
+        let state = AppState {
+            store,
+            config,
+            serves,
+        };
         self.state
             .set(Arc::new(state))
             .map_err(|_| anyhow::anyhow!("{} gear already initialized", Self::MODULE_NAME))?;

--- a/src/backend/services/git-cli-proxy/tests/boot.rs
+++ b/src/backend/services/git-cli-proxy/tests/boot.rs
@@ -71,6 +71,7 @@ gears:
       max_repo_bytes: 500000000
       default_max_staleness_seconds: 300
       heavy_ops_concurrency: 2
+      serve_concurrency: 2
       proxy_token: "{token}"
       allow_file_repos: {allow_file_repos}
 "#,


### PR DESCRIPTION
Cherry-pick of #3032 into release-2026.08.

**Why.** Nothing bounds how many page serves run at once: `heavyOpsConcurrency` caps clones/fetches/repacks, but each serve spawns git children whose memory scales with the window's blob bytes, so enough concurrent blob-heavy windows OOM-kill the pod — and now that long preparations are held instead of bounced, heavy serves actually run long enough to stack.

**What changed.** A `serve_concurrency` semaphore (config-required like its heavy sibling; chart value `cache.serveConcurrency`, default 4) gates the serve phase of every data endpoint at the shared `read_snapshot` choke point. The permit is taken after `open()` so a slot is never spent waiting on a preparation, and excess requests wait in-connection; a wait that outlives the preparation ceiling answers a typed 429 with its own quota subject and rejection metric.

**Verified.** Clean cherry-pick. `cargo test -p git-cli-proxy` on this branch (215 lib + 20 boot), helm contract suite (27).