### PR TITLE
fix(chart): pin published ingestion images

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -195,14 +195,14 @@ ingestion:
   # `serviceaccount "argo-workflow" not found`.
   templates:
     enabled: true
-  toolboxImage: "ghcr.io/constructorfabric/insight-toolbox:2026.09.01.07.27-6d91673" # e.g. "ghcr.io/constructorfabric/insight-toolbox:2026.04.28.10.34-b08b460"
+  toolboxImage: "ghcr.io/constructorfabric/insight-toolbox:2026.09.02.03.28-6ce5abd" # e.g. "ghcr.io/constructorfabric/insight-toolbox:2026.04.28.10.34-b08b460"
   # The sample-data seeder's image, for TEST stands only. Nothing in the chart
   # runs it: `src/ingestion/tools/seed/seed-stand.sh` reads this value to render
   # a one-shot Job. Its own image rather than the toolbox on purpose — the
   # toolbox runs migrations on real stands and does not carry demo data. Empty
   # (the default) means the stand cannot be seeded until an operator names an
   # image, either here or with the script's `--image` flag.
-  seedImage: "ghcr.io/constructorfabric/insight-seed:2026.09.01.07.27-6d91673" # e.g. "ghcr.io/constructorfabric/insight-seed:2026.04.28.10.34-b08b460"
+  seedImage: "ghcr.io/constructorfabric/insight-seed:2026.09.02.03.28-6ce5abd" # e.g. "ghcr.io/constructorfabric/insight-seed:2026.04.28.10.34-b08b460"
   # airbyte-sync poll-job tunables — see templates/ingestion/airbyte-sync.yaml.
   # The poll loop replaces a wall-clock deadline with a progress watchdog:
   # it tracks (status, bytesEmitted, recordsEmitted, stateMessagesEmitted)


### PR DESCRIPTION
**Why.** Successful toolbox and seed images were not carried into the umbrella chart because unrelated connector image security gates blocked publication.

**What changed.** Pin the umbrella defaults to the published multi-architecture images so the chart-only workflow can publish them without rebuilding containers.

**Verified.** `git diff --check` passed. Registry manifests contain amd64 and arm64 images. Standalone `helm lint` lacks required dependencies and deployment values.
