### PR TITLE
fix(security): upgrade NLTK to 3.10.3

### DIFF
--- a/src/ingestion/connectors/ai/claude-team-invoices/Dockerfile
+++ b/src/ingestion/connectors/ai/claude-team-invoices/Dockerfile
@@ -4,13 +4,13 @@ COPY . /airbyte/integration_code
 RUN pip install /airbyte/integration_code
 
 # airbyte-cdk pins nltk==3.9.1 (fixable CVE-2025-14009, CVE-2026-0846,
-# CVE-2026-33231, CVE-2026-54293) but only uses it in the file-based
-# unstructured parser, which this connector never loads; defusedxml is
+# CVE-2026-33231, CVE-2026-54293, CVE-2026-79675) but only uses it in the
+# file-based unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
 # tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
 # arrives with the base image's keyring stack (SecretStorage); its wheel
 # bundles OpenSSL, and 50.0.1 is the first built against 4.0.2 (CVE-2026-63072).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.1 \
+RUN pip install --no-cache-dir --no-deps nltk==3.10.3 defusedxml==0.7.1 cryptography==50.0.1 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/ai/claude-team-invoices/pyproject.toml
+++ b/src/ingestion/connectors/ai/claude-team-invoices/pyproject.toml
@@ -26,9 +26,9 @@ source-claude-team-invoices = "source_claude_team_invoices.source:main"
 # Do not resolve a version published in the last week: a freshly pushed release is
 # where a compromised maintainer account shows up first.
 exclude-newer = "7 days"
-# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.3
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
-override-dependencies = ["nltk>=3.10.0"]
+override-dependencies = ["nltk>=3.10.3"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/ingestion/connectors/crm/hubspot/Dockerfile
+++ b/src/ingestion/connectors/crm/hubspot/Dockerfile
@@ -4,13 +4,13 @@ COPY . /airbyte/integration_code
 RUN pip install --no-cache-dir /airbyte/integration_code
 
 # airbyte-cdk pins nltk==3.9.1 (fixable CVE-2025-14009, CVE-2026-0846,
-# CVE-2026-33231, CVE-2026-54293) but only uses it in the file-based
-# unstructured parser, which this connector never loads; defusedxml is
+# CVE-2026-33231, CVE-2026-54293, CVE-2026-79675) but only uses it in the
+# file-based unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
 # tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
 # arrives with the base image's keyring stack (SecretStorage); its wheel
 # bundles OpenSSL, and 50.0.1 is the first built against 4.0.2 (CVE-2026-63072).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.1 \
+RUN pip install --no-cache-dir --no-deps nltk==3.10.3 defusedxml==0.7.1 cryptography==50.0.1 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/crm/hubspot/pyproject.toml
+++ b/src/ingestion/connectors/crm/hubspot/pyproject.toml
@@ -26,9 +26,9 @@ source-hubspot-insight = "source_hubspot.source:main"
 # Do not resolve a version published in the last week: a freshly pushed release is
 # where a compromised maintainer account shows up first.
 exclude-newer = "7 days"
-# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.3
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
-override-dependencies = ["nltk>=3.10.0"]
+override-dependencies = ["nltk>=3.10.3"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/ingestion/connectors/git/gitlab/Dockerfile
+++ b/src/ingestion/connectors/git/gitlab/Dockerfile
@@ -4,13 +4,13 @@ COPY . /airbyte/integration_code
 RUN pip install /airbyte/integration_code
 
 # airbyte-cdk pins nltk==3.9.1 (fixable CVE-2025-14009, CVE-2026-0846,
-# CVE-2026-33231, CVE-2026-54293) but only uses it in the file-based
-# unstructured parser, which this connector never loads; defusedxml is
+# CVE-2026-33231, CVE-2026-54293, CVE-2026-79675) but only uses it in the
+# file-based unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
 # tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
 # arrives with the base image's keyring stack (SecretStorage); its wheel
 # bundles OpenSSL, and 50.0.1 is the first built against 4.0.2 (CVE-2026-63072).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.1 \
+RUN pip install --no-cache-dir --no-deps nltk==3.10.3 defusedxml==0.7.1 cryptography==50.0.1 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/git/gitlab/pyproject.toml
+++ b/src/ingestion/connectors/git/gitlab/pyproject.toml
@@ -27,9 +27,9 @@ source-gitlab-insight = "source_gitlab.source:main"
 # Do not resolve a version published in the last week: a freshly pushed release is
 # where a compromised maintainer account shows up first.
 exclude-newer = "7 days"
-# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.3
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
-override-dependencies = ["nltk>=3.10.0"]
+override-dependencies = ["nltk>=3.10.3"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/ingestion/connectors/hr-directory/active-directory/Dockerfile
+++ b/src/ingestion/connectors/hr-directory/active-directory/Dockerfile
@@ -4,13 +4,13 @@ COPY . /airbyte/integration_code
 RUN pip install /airbyte/integration_code
 
 # airbyte-cdk pins nltk==3.9.1 (fixable CVE-2025-14009, CVE-2026-0846,
-# CVE-2026-33231, CVE-2026-54293) but only uses it in the file-based
-# unstructured parser, which this connector never loads; defusedxml is
+# CVE-2026-33231, CVE-2026-54293, CVE-2026-79675) but only uses it in the
+# file-based unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
 # tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
 # arrives with the base image's keyring stack (SecretStorage); its wheel
 # bundles OpenSSL, and 50.0.1 is the first built against 4.0.2 (CVE-2026-63072).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.1 \
+RUN pip install --no-cache-dir --no-deps nltk==3.10.3 defusedxml==0.7.1 cryptography==50.0.1 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/hr-directory/active-directory/pyproject.toml
+++ b/src/ingestion/connectors/hr-directory/active-directory/pyproject.toml
@@ -21,9 +21,9 @@ source-active-directory = "source_active_directory.source:main"
 # Do not resolve a version published in the last week: a freshly pushed release is
 # where a compromised maintainer account shows up first.
 exclude-newer = "7 days"
-# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.3
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
-override-dependencies = ["nltk>=3.10.0"]
+override-dependencies = ["nltk>=3.10.3"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/src/ingestion/connectors/hr-directory/bamboohr/Dockerfile
+++ b/src/ingestion/connectors/hr-directory/bamboohr/Dockerfile
@@ -4,13 +4,13 @@ COPY . /airbyte/integration_code
 RUN pip install /airbyte/integration_code
 
 # airbyte-cdk pins nltk==3.9.1 (fixable CVE-2025-14009, CVE-2026-0846,
-# CVE-2026-33231, CVE-2026-54293) but only uses it in the file-based
-# unstructured parser, which this connector never loads; defusedxml is
+# CVE-2026-33231, CVE-2026-54293, CVE-2026-79675) but only uses it in the
+# file-based unstructured parser, which this connector never loads; defusedxml is
 # nltk 3.10's added runtime dependency. poetry/dulwich are base-image build
 # tooling unused at runtime (CVE-2026-34591, CVE-2026-42305). cryptography
 # arrives with the base image's keyring stack (SecretStorage); its wheel
 # bundles OpenSSL, and 50.0.1 is the first built against 4.0.2 (CVE-2026-63072).
-RUN pip install --no-cache-dir --no-deps nltk==3.10.0 defusedxml==0.7.1 cryptography==50.0.1 \
+RUN pip install --no-cache-dir --no-deps nltk==3.10.3 defusedxml==0.7.1 cryptography==50.0.1 \
     && pip uninstall -y poetry dulwich
 
 RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user

--- a/src/ingestion/connectors/hr-directory/bamboohr/pyproject.toml
+++ b/src/ingestion/connectors/hr-directory/bamboohr/pyproject.toml
@@ -24,9 +24,9 @@ source-bamboohr = "source_bamboohr.source:main"
 # Do not resolve a version published in the last week: a freshly pushed release is
 # where a compromised maintainer account shows up first.
 exclude-newer = "7 days"
-# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.3
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
-override-dependencies = ["nltk>=3.10.0"]
+override-dependencies = ["nltk>=3.10.3"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
**Why.** Connector image publication is blocked because five images contain NLTK 3.10.0, affected by CVE-2026-79675.

**What changed.** Pin those images to NLTK 3.10.3 and raise their uv override floors to prevent vulnerable dependency resolution.

Five connector resolutions now select NLTK 3.10.3; zero NLTK 3.10.0 pins remain.

**Verified.** All five `uv lock --dry-run` checks and `git diff --check` passed.
