### PR TITLE
fix(identity): emit roster profile claims

### DIFF
--- a/src/ingestion/dbt/macros/identity_inputs_from_history.sql
+++ b/src/ingestion/dbt/macros/identity_inputs_from_history.sql
@@ -273,14 +273,14 @@ person_profile_events AS (
         insight_source_id,
         insight_source_type,
         source_account_id,
-        concat('person_', value_type) AS value_type,
+        concat('person_', profile.value_type) AS value_type,
         value,
         value_field_name,
         operation_type,
         _synced_at,
         _version
-    FROM identity_field_events
-    WHERE value_type IN (
+    FROM identity_field_events AS profile
+    WHERE profile.value_type IN (
         {% for profile_field in person_profile_fields %}
         '{{ profile_field }}'{{ ',' if not loop.last }}
         {% endfor %}

--- a/src/ingestion/tests/e2e/identity/test_github_directory_member_id_binding.py
+++ b/src/ingestion/tests/e2e/identity/test_github_directory_member_id_binding.py
@@ -271,6 +271,52 @@ def test_github_member_id_resolves_a_person_through_the_real_connector_pipeline(
     )
 
 
+def test_github_directory_emits_roster_profile_claims(
+    ch_seeder: CHSeeder,
+    dbt_runner: DbtRunner,
+    tracked_models: TrackedModels,
+    worker_ctx: WorkerContext,
+    compose_stack: SessionConfig,
+) -> None:
+    run_tag = uuid.uuid4().hex[:10]
+    member_id = _run_specific_member_id(run_tag)
+    login = f"profile-dev-{run_tag}"
+    email = f"profile.dev.{run_tag}@e2e.test"
+    display_name = "Profile Dev"
+
+    _run_connector_dbt_path(
+        ch_seeder,
+        dbt_runner,
+        tracked_models,
+        worker_ctx,
+        {
+            "bronze_github_directory.org_members": [
+                _org_member(
+                    run_tag=run_tag,
+                    login=login,
+                    member_id=member_id,
+                    email=email,
+                    display_name=display_name,
+                )
+            ]
+        },
+    )
+
+    rows = clickhouse.query(
+        compose_stack,
+        "SELECT value_type, value FROM identity.identity_inputs"
+        f" WHERE insight_source_type = 'github' AND source_account_id = '{member_id}'"
+        "   AND value_type IN ('person_email', 'person_username', 'person_display_name')"
+        "   AND operation_type = 'UPSERT' ORDER BY value_type",
+    )
+
+    assert rows == [
+        ["person_display_name", display_name],
+        ["person_email", email],
+        ["person_username", login],
+    ]
+
+
 def test_the_binding_is_the_member_id_never_the_login(
     identity_svc,
     ch_seeder: CHSeeder,

--- a/src/ingestion/tests/e2e/identity/test_persons_seed_org_chart_gaps.py
+++ b/src/ingestion/tests/e2e/identity/test_persons_seed_org_chart_gaps.py
@@ -284,6 +284,19 @@ def test_seed_org_chart_from_real_bamboohr_connector_pipeline(
         "not just untested"
     )
 
+    profile_rows = clickhouse.query(
+        compose_stack,
+        "SELECT value_type, value FROM identity.identity_inputs"
+        f" WHERE insight_source_type = 'bamboohr' AND source_account_id = 'rep-{run_tag}'"
+        "   AND value_type IN ('person_display_name', 'person_first_name', 'person_last_name')"
+        "   AND operation_type = 'UPSERT' ORDER BY value_type",
+    )
+    assert profile_rows == [
+        ["person_display_name", "Pipeline Report"],
+        ["person_first_name", "Pipeline"],
+        ["person_last_name", "Report"],
+    ]
+
     res = identity_svc.run_seed_cli(tenant=str(seed.SEED_TENANT), force=True)
     assert res.returncode == 0, f"rc={res.returncode}\n{res.stdout}\n{res.stderr}"
 


### PR DESCRIPTION
**Why.** Roster people can be created without profile fields because ClickHouse resolves an unqualified `value_type` filter against the generated output alias.

**What changed.** Qualify the source field before generating `person_*` types. Add connector-path regressions for GitHub and BambooHR profiles, including first and last names.

Synthetic ClickHouse reproduction: 0 projected rows before; 3 after.

**Verified.** `dbt parse`, Ruff, Python compilation, pytest collection, and synthetic ClickHouse query passed. Full E2E awaits CI because local prerequisite service images were unavailable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when generating person profile identity values from historical events.

* **Tests**
  * Added end-to-end coverage confirming GitHub directory members emit display name, email, and username identity claims.
  * Added validation that BambooHR org chart data correctly produces seeded person display, first-name, and last-name identity claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->