### PR TITLE
chore(git-cli-proxy): size default resources, staleness and heavy-ops cap to the post-long-poll serving regime

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -628,15 +628,17 @@ gitCliProxy:
     repository: ghcr.io/constructorfabric/insight-git-cli-proxy
     tag: ""
     pullPolicy: IfNotPresent
-  # The git subprocesses (clone, fetch, repack) run in this pod's cgroup and
-  # dominate its memory. The service caps git's own pack budgets so their
-  # peak cannot scale with the repository; this limit is the headroom above
-  # that ceiling rather than a figure derived from cache.maxRepoBytes. Lower
-  # cache.heavyOpsConcurrency before raising it — overlapping heavy
-  # operations are what push a correctly-capped pod over.
+  # The git subprocesses run in this pod's cgroup and dominate its memory,
+  # and page serves over blob-heavy windows legitimately run for minutes of
+  # CPU each — the CPU limit paces how long their buffers coexist, so it is
+  # sized to drain rather than to average load. Memory is the serve cap times
+  # the heaviest window plus headroom, and it must also fit the node's budget
+  # beside the warehouse and the platform pods — limits do not reserve, so a
+  # limit the node cannot honour under load takes the container runtime down
+  # with it. Lower cache.serveConcurrency before raising it.
   resources:
     requests: {cpu: 200m, memory: 1Gi}
-    limits: {cpu: "2", memory: 8Gi}
+    limits: {cpu: "4", memory: 8Gi}
   persistence:
     size: 50Gi
     storageClass: ""
@@ -645,8 +647,12 @@ gitCliProxy:
     # headroom absorbs transient packs and git temp files. Override with
     # diskBudgetBytes (must stay within 50-90% of the volume).
     maxRepoBytes: 10737418240
-    defaultMaxStalenessSeconds: 300
-    heavyOpsConcurrency: 4
+    # Under a daily sync cadence so every sync reads fresh refs, above any
+    # steady-state run length so no walk refetches mid-flight.
+    defaultMaxStalenessSeconds: 43200
+    # A fetch holds its entry's write lock while queued for a slot, so one
+    # slow clone must not convoy every other repository's refresh.
+    heavyOpsConcurrency: 2
     caCertPath: ""
   caCertSecret: ""
   # Bearer token the proxy requires on every /v1 request. Empty = generated on

--- a/src/backend/services/git-cli-proxy/helm/values.yaml
+++ b/src/backend/services/git-cli-proxy/helm/values.yaml
@@ -24,15 +24,16 @@ resources:
     cpu: 200m
     memory: 1Gi
   limits:
-    # git subprocesses (clone, repack) are the memory consumers here, and
-    # their transient peak on a large repository reaches multiple GiB. The
-    # service caps git's own pack budgets (pack.threads, pack.windowMemory,
-    # pack.deltaCacheSize) so that peak cannot scale with the repository —
-    # this limit is the headroom above that ceiling, not a bound derived from
-    # cache.maxRepoBytes. Lower cache.heavyOpsConcurrency before raising it:
-    # overlapping heavy operations, not one large repository, are what push a
-    # correctly-capped pod over.
-    cpu: "2"
+    # git subprocesses are the memory consumers here, and page serves over
+    # blob-heavy windows legitimately run for minutes of CPU each — the CPU
+    # limit is what paces how long their buffers coexist, so it is sized to
+    # drain rather than to average load. Memory is the serve cap times the
+    # heaviest window plus headroom, and it must also fit the NODE's budget
+    # beside the warehouse and the platform pods: limits do not reserve, so a
+    # limit the node cannot honour under load takes the container runtime
+    # down with it rather than the pod. Lower cache.serveConcurrency before
+    # raising it.
+    cpu: "4"
     memory: 8Gi
 
 # OpenTelemetry export. Off by default; the umbrella overrides these via
@@ -69,9 +70,14 @@ cache:
   maxRepoBytes: 10737418240
   # Freshness window in seconds: a repo fetched more recently is served
   # without contacting origin. Per-request override: X-Max-Staleness.
-  defaultMaxStalenessSeconds: 300
+  # Under a daily sync cadence so every sync reads fresh refs, above any
+  # steady-state run length so no walk refetches (and 409s) mid-flight.
+  defaultMaxStalenessSeconds: 43200
   # Concurrency cap for clone/fetch/repack.
-  heavyOpsConcurrency: 4
+  # Two, not more: admission reserves cache.maxRepoBytes per slot, and a
+  # fetch holds its entry's write lock while queued here — one slow clone
+  # must not convoy every other repository's refresh behind it.
+  heavyOpsConcurrency: 2
   # PEM bundle for self-hosted origins behind a private CA. Empty = system
   # trust store (correct for the public clouds).
   caCertPath: ""


### PR DESCRIPTION
**Why.** The chart defaults describe the pre-long-poll regime: a 2-CPU pod sized for serves that died in seconds, a 5-minute staleness that refetches mid-walk (generation bumps 409 in-flight continuations), and a heavy-ops cap of 4 whose per-slot disk reservations nearly exhaust the default budget while a fetch queued for a slot holds its entry write lock.

**What changed.** The CPU limit rises to 4 — serves are CPU-bound, and the limit paces how long their buffers coexist. `defaultMaxStalenessSeconds` becomes 43200: under a daily sync cadence so every sync reads fresh refs, above steady-state run lengths so no walk refetches mid-flight. `heavyOpsConcurrency` drops to 2 so one slow clone cannot convoy every other repository's refresh. Comments rewritten to the current rationale.

**The memory limit stays 8Gi — deliberately.** Limits do not reserve, so a limit larger than the node can honour under load takes the container runtime down rather than the pod; the bound that actually caps proxy memory is the serve-concurrency semaphore (#3032), not a bigger ceiling. The comments now say so.

**Verified.** Helm contract suite (27 passed), both values files parse. `helm lint` failures on the umbrella pre-exist on main (unbuilt chart dependencies) and are unchanged by this diff.
