### PR TITLE
fix(frontend): say how long a running sync has been going, not that it took no time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,12 +150,12 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - name: Install PyYAML
-        run: python3 -m pip install --quiet pyyaml
+      - name: Install PyYAML and pytest
+        run: python3 -m pip install --quiet pyyaml pytest
       - name: Connector wiring invariants
         run: python3 scripts/ci/connector_wiring.py
       - name: Reconcile renderer contract
-        run: python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests -p 'test_*.py'
+        run: python3 -m pytest src/ingestion/reconcile-connectors/tests -q
 
   # One unified job per Rust crate: fmt + clippy (when entry.lint) and coverage
   # (when entry.cover). Replaces the old standalone workspace rust-lint — fmt and

--- a/src/frontend/src/components/portal/connector-health.test.tsx
+++ b/src/frontend/src/components/portal/connector-health.test.tsx
@@ -152,6 +152,33 @@ describe("the pane prints what it was served", () => {
     expect(within(row).queryByText("0")).not.toBeInTheDocument();
   });
 
+  it("says how long a sync in flight has been going, not that it took no time", () => {
+    // The mover reports an unfinished job's duration as a running total, and
+    // ledger rows recorded before that stopped being stored still carry its
+    // zero. A row printing that zero hides the one state this page exists to
+    // surface: a sync that started and never came back.
+    mocks.summary.data = summary({
+      connectors: [
+        {
+          connector: "alpha",
+          configured: true,
+          last_sync: {
+            job_id: "1",
+            status: "running",
+            started_at: "2026-01-15T10:46:00.000Z",
+            duration_ms: 0,
+            records_reported: null,
+          },
+        },
+      ],
+    });
+    render(<ConnectorHealthPane />);
+
+    const row = rowFor("alpha");
+    expect(within(row).getByText("1h 14m so far")).toBeInTheDocument();
+    expect(within(row).queryByText("0 ms")).not.toBeInTheDocument();
+  });
+
   it("says a reported zero is a zero", () => {
     mocks.summary.data = summary({
       connectors: [

--- a/src/frontend/src/components/portal/connector-health.tsx
+++ b/src/frontend/src/components/portal/connector-health.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import type { SyncFact } from "@/api/connector-health-client";
+import type { ConnectorHealth, SyncFact } from "@/api/connector-health-client";
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { Badge } from "@/components/ui/badge";
@@ -15,9 +15,9 @@ import {
 import {
   UNMEASURED,
   describeConnector,
+  describeDuration,
   describeRecording,
   describeSync,
-  formatDuration,
   formatRecords,
   formatStarted,
   type ConnectorTone,
@@ -145,9 +145,7 @@ export function ConnectorHealthPane() {
                     <TableCell className="tabular-nums text-muted-foreground">
                       {formatStarted(row.last_sync?.started_at ?? null)}
                     </TableCell>
-                    <TableCell className="text-right tabular-nums text-muted-foreground">
-                      {formatDuration(row.last_sync?.duration_ms ?? null)}
-                    </TableCell>
+                    <DurationCell sync={row.last_sync} asOf={data.as_of} />
                     <TableCell className="text-right tabular-nums text-muted-foreground">
                       {formatRecords(row.last_sync?.records_reported ?? null)}
                     </TableCell>
@@ -155,7 +153,7 @@ export function ConnectorHealthPane() {
                   open ? (
                     <TableRow key={`syncs-${row.connector}`}>
                       <TableCell colSpan={COLUMNS} id={panelId} className="bg-muted/40">
-                        <RecentSyncs connector={row.connector} />
+                        <RecentSyncs connector={row.connector} asOf={data.as_of} />
                       </TableCell>
                     </TableRow>
                   ) : null,
@@ -169,7 +167,32 @@ export function ConnectorHealthPane() {
   );
 }
 
-function RecentSyncs({ connector }: { connector: string }) {
+/**
+ * A sync still in flight is not dimmed like a settled one: its number is the
+ * only thing on the row that keeps moving, and it is what an operator opened
+ * the page to see.
+ */
+function DurationCell({
+  sync,
+  asOf,
+}: {
+  sync: ConnectorHealth["last_sync"];
+  asOf: string;
+}) {
+  const duration = describeDuration(sync, asOf);
+  return (
+    <TableCell
+      className={cn(
+        "text-right tabular-nums",
+        duration.inFlight ? "text-foreground" : "text-muted-foreground",
+      )}
+    >
+      {duration.text}
+    </TableCell>
+  );
+}
+
+function RecentSyncs({ connector, asOf }: { connector: string; asOf: string }) {
   const { data, isPending, isError, refetch } = useConnectorSyncs(connector);
 
   if (isPending) return <CenteredSpinner className="min-h-24" />;
@@ -195,23 +218,29 @@ function RecentSyncs({ connector }: { connector: string }) {
       </p>
       <ul className="flex flex-col gap-1">
         {data.syncs.map((sync) => (
-          <SyncLine key={sync.job_id} sync={sync} />
+          <SyncLine key={sync.job_id} sync={sync} asOf={asOf} />
         ))}
       </ul>
     </div>
   );
 }
 
-function SyncLine({ sync }: { sync: SyncFact }) {
+function SyncLine({ sync, asOf }: { sync: SyncFact; asOf: string }) {
   const state = describeSync(sync);
+  const duration = describeDuration(sync, asOf);
   return (
     <li className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
       <Badge className={cn("font-medium", TONE_STYLE[state.tone])}>
         {state.label}
       </Badge>
       <span className="tabular-nums">{formatStarted(sync.started_at)}</span>
-      <span className="tabular-nums text-muted-foreground">
-        {formatDuration(sync.duration_ms)}
+      <span
+        className={cn(
+          "tabular-nums",
+          duration.inFlight ? "text-foreground" : "text-muted-foreground",
+        )}
+      >
+        {duration.text}
       </span>
       <span className="tabular-nums text-muted-foreground">
         {formatRecords(sync.records_reported)} records

--- a/src/frontend/src/lib/portal/connector-health.test.ts
+++ b/src/frontend/src/lib/portal/connector-health.test.ts
@@ -18,6 +18,7 @@ import {
   UNMEASURED,
   describeAge,
   describeConnector,
+  describeDuration,
   describeRecording,
   describeSync,
   formatDuration,
@@ -134,6 +135,73 @@ describe("what a row says", () => {
     for (const status of statuses) {
       expect(describeSync(sync({ status })).label.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("how long a sync has been going", () => {
+  const AS_OF = "2026-01-15T09:22:00.000Z";
+
+  it("a finished sync states what it took", () => {
+    const view = describeDuration(sync({ duration_ms: 142_000 }), AS_OF);
+    expect(view).toEqual({ text: "2m 22s", inFlight: false });
+  });
+
+  it("a running sync states how long it has been going, worded as unfinished", () => {
+    const view = describeDuration(
+      sync({ status: "running", started_at: "2026-01-15T09:00:00.000Z" }),
+      AS_OF,
+    );
+    expect(view).toEqual({ text: "22m 0s so far", inFlight: true });
+  });
+
+  it("a running sync ignores a recorded duration rather than printing it", () => {
+    // Rows written before the recorder stopped storing one still hold the
+    // mover's zero here, and printing it says a running sync took no time.
+    const view = describeDuration(
+      sync({
+        status: "running",
+        started_at: "2026-01-15T09:00:00.000Z",
+        duration_ms: 0,
+      }),
+      AS_OF,
+    );
+    expect(view.text).toBe("22m 0s so far");
+  });
+
+  it("a queued sync has no start to measure from, so it prints absence", () => {
+    // Not "0 s so far": nothing has begun, and a span from nothing is invented.
+    const view = describeDuration(
+      sync({ status: "pending", started_at: null, duration_ms: null }),
+      AS_OF,
+    );
+    expect(view).toEqual({ text: UNMEASURED, inFlight: false });
+  });
+
+  it("a start the page cannot date prints absence rather than an epoch span", () => {
+    const view = describeDuration(sync({ status: "running", started_at: "nonsense" }), AS_OF);
+    expect(view.text).toBe(UNMEASURED);
+  });
+
+  it("a start ahead of the answer's own clock prints absence", () => {
+    // Two clocks that disagree can date nothing, and "0 s so far" would be the
+    // page asserting a measurement neither of them supports.
+    const view = describeDuration(
+      sync({ status: "running", started_at: "2026-01-15T10:00:00.000Z" }),
+      AS_OF,
+    );
+    expect(view.text).toBe(UNMEASURED);
+  });
+
+  it("a status this build cannot read is not treated as running", () => {
+    // An unreadable word may well name a finished sync, and the measurement it
+    // carries is the only account of it there is.
+    const view = describeDuration(sync({ status: "borked", duration_ms: 142_000 }), AS_OF);
+    expect(view).toEqual({ text: "2m 22s", inFlight: false });
+  });
+
+  it("a connector that has never synced prints absence", () => {
+    expect(describeDuration(null, AS_OF)).toEqual({ text: UNMEASURED, inFlight: false });
+    expect(describeDuration(undefined, AS_OF)).toEqual({ text: UNMEASURED, inFlight: false });
   });
 });
 

--- a/src/frontend/src/lib/portal/connector-health.ts
+++ b/src/frontend/src/lib/portal/connector-health.ts
@@ -146,7 +146,7 @@ export function describeRecording(
     };
   }
 
-  const age = ageMs(summary.as_of, summary.checked_at);
+  const age = elapsedMs(summary.as_of, summary.checked_at);
   if (age === null) {
     return {
       state: "unreadable",
@@ -200,19 +200,24 @@ function staleAfter(interval: number | null | undefined): number | null {
 }
 
 /**
- * How long ago the mover was read, or null where the pair cannot say.
+ * How long ago something happened, by the answer's own clock, or null where the
+ * pair cannot say.
  *
- * A negative age is not clamped to zero: the two stamps come from clocks that
+ * Both spans this page states are measured here — how old the read is, and how
+ * long an unfinished sync has been going — because both are the same question
+ * asked of a different stamp, and both must refuse the same inputs.
+ *
+ * A negative span is not clamped to zero: the two stamps come from clocks that
  * are supposed to agree, and one ahead of the other means neither can date the
  * page. Reporting "just now" there would be the page asserting a freshness it
  * has no basis for.
  */
-function ageMs(asOf: string, checkedAt: string): number | null {
+function elapsedMs(asOf: string, since: string | null | undefined): number | null {
   const now = parseStamp(asOf);
-  const then = parseStamp(checkedAt);
+  const then = parseStamp(since);
   if (now === null || then === null) return null;
-  const age = now - then;
-  return age >= 0 ? age : null;
+  const span = now - then;
+  return span >= 0 ? span : null;
 }
 
 /**
@@ -272,6 +277,56 @@ export function formatDuration(durationMs: number | null | undefined): string {
   const seconds = totalSeconds % 60;
   if (totalMinutes < 60) return `${totalMinutes}m ${seconds}s`;
   return `${Math.floor(totalMinutes / 60)}h ${totalMinutes % 60}m`;
+}
+
+/**
+ * Which states mean the sync has not finished, so its span is still growing.
+ *
+ * Read off the state name rather than the raw status word, so the one place
+ * that maps the mover's vocabulary stays the only one — a second `=== "running"`
+ * here would silently stop agreeing with the badge beside it.
+ */
+const IN_FLIGHT: ReadonlySet<ConnectorStateName> = new Set(["queued", "syncing"]);
+
+export interface DurationView {
+  /** What the cell prints. */
+  text: string;
+  /** True where the number is time so far rather than a finished measurement. */
+  inFlight: boolean;
+}
+
+/**
+ * What the Duration cell says for one sync.
+ *
+ * A finished sync states what it took; one still in flight states how long it
+ * has been going — a different fact, so it is worded as one rather than left to
+ * be read as a completed measurement.
+ *
+ * INVARIANT: a recorded duration is ignored for an unfinished sync. The mover
+ * reports such a job's duration as a running total, and a zero where it has
+ * none; ledger rows written before the recorder stopped storing it still hold
+ * that zero, and printing it would tell an operator watching a stuck sync that
+ * it took no time at all.
+ *
+ * The span is measured against the answer's own `as_of` rather than the
+ * reader's clock, so it agrees with the "Last checked" line above it instead of
+ * drifting from it by whatever the two machines disagree about.
+ */
+export function describeDuration(
+  sync: Pick<SyncFact, "status" | "started_at" | "duration_ms"> | null | undefined,
+  asOf: string,
+): DurationView {
+  if (sync == null) return { text: UNMEASURED, inFlight: false };
+  if (!IN_FLIGHT.has(stateOf(sync.status).state)) {
+    return { text: formatDuration(sync.duration_ms), inFlight: false };
+  }
+
+  // A queued job has no start, and a job whose start cannot be dated is one
+  // this page cannot time — both print absence rather than a span from nothing.
+  const running = elapsedMs(asOf, sync.started_at);
+  if (running === null) return { text: UNMEASURED, inFlight: false };
+
+  return { text: `${formatDuration(running)} so far`, inFlight: true };
 }
 
 export function formatRecords(records: number | null | undefined): string {

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -1139,6 +1139,13 @@ function connectorHealthHandlers() {
       sync("8402", "succeeded", 24, 41_000, 903),
       sync("8388", "succeeded", 84, 39_100, 874),
     ],
+    // A sync still in flight carries no duration — the mover reports one only
+    // for a job it has finished — so the row states how long it has been going
+    // instead.
+    "example-inbox": [
+      sync("8420", "running", 37, null, null),
+      sync("8391", "succeeded", 97, 61_000, 2_140),
+    ],
     "example-warehouse": [],
     "example-retired": [sync("7801", "succeeded", 60 * 26, 90_000, 55)],
   };
@@ -1160,6 +1167,7 @@ function connectorHealthHandlers() {
           summaryRow("example-tracker", true),
           summaryRow("example-directory", true),
           summaryRow("example-messaging", true),
+          summaryRow("example-inbox", true),
           summaryRow("example-warehouse", true),
           summaryRow("example-retired", false),
         ],

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -1108,9 +1108,13 @@ function syntheticDays(count: number) {
  * visible in the mock too.
  */
 function connectorHealthHandlers() {
-  const now = new Date();
+  // The fixtures are anchored once, so a sync keeps the moment it started
+  // across requests. Only the answer's own clock is read per request — below,
+  // in the handler — because a fixed `as_of` would freeze the elapsed time the
+  // page derives from it and the running row would never advance while polling.
+  const anchor = new Date();
   const minutesAgo = (minutes: number) =>
-    new Date(now.getTime() - minutes * 60_000).toISOString();
+    new Date(anchor.getTime() - minutes * 60_000).toISOString();
 
   const sync = (
     job_id: string,
@@ -1157,10 +1161,11 @@ function connectorHealthHandlers() {
   });
 
   return [
-    http.get("/api/analytics/v1/connector-health", () =>
-      HttpResponse.json({
+    http.get("/api/analytics/v1/connector-health", () => {
+      const now = new Date();
+      return HttpResponse.json({
         as_of: now.toISOString(),
-        checked_at: minutesAgo(6),
+        checked_at: new Date(now.getTime() - 6 * 60_000).toISOString(),
         typical_read_interval_ms: 15 * 60_000,
         history_available: true,
         connectors: [
@@ -1171,8 +1176,8 @@ function connectorHealthHandlers() {
           summaryRow("example-warehouse", true),
           summaryRow("example-retired", false),
         ],
-      }),
-    ),
+      });
+    }),
     http.get("/api/analytics/v1/connector-health/:connector/syncs", ({ params }) => {
       const connector = String(params.connector);
       return HttpResponse.json({

--- a/src/ingestion/reconcile-connectors/python/sweep/plan.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/plan.py
@@ -250,15 +250,22 @@ def sync_row(
     if placed is None:
         return Skipped(job_id, "job carries no readable moment")
 
+    status = vocab.normalise(entry.get("status"))
+
     return {
         "tick_id": tick_id,
         "job_id": job_id,
         "connector": connector,
         "event": SYNC_COMPLETED,
-        "status": vocab.normalise(entry.get("status")),
+        "status": status,
         "started_at": moment(entry.get("startTime")),
         "job_updated_at": placed,
-        "duration_ms": duration_ms(entry.get("duration")),
+        # SAFETY: an unfinished job's reported duration is not what this column
+        # holds. Recorded as-is, the mover's zero reads as a sync that took no
+        # time; how long such a job has been going is derived from its start.
+        "duration_ms": (
+            None if vocab.is_in_flight(status) else duration_ms(entry.get("duration"))
+        ),
         "records_reported": records_reported(entry),
     }
 

--- a/src/ingestion/reconcile-connectors/python/sweep/status.py
+++ b/src/ingestion/reconcile-connectors/python/sweep/status.py
@@ -27,6 +27,14 @@ UNKNOWN = "unknown"
 #: can, at the cost of a duplicate row that resolves to the same answer.
 TERMINAL_STATUSES = frozenset({"succeeded", "failed", "cancelled", "incomplete"})
 
+#: A job carrying one of these has not finished, so nothing it reports about
+#: itself is a completed measurement.
+#:
+#: INVARIANT: `UNKNOWN` is absent here too, and for the opposite reason to its
+#: absence above. A word we could not read may well be a finished job, and
+#: treating it as in flight would discard the measurement it carries.
+IN_FLIGHT_STATUSES = frozenset({"pending", "running"})
+
 
 def normalise(raw: object) -> str:
     """Map the mover's reported status onto the closed set."""
@@ -39,3 +47,8 @@ def normalise(raw: object) -> str:
 def is_terminal(status: str) -> bool:
     """Whether a recorded status closes its job for coverage purposes."""
     return status in TERMINAL_STATUSES
+
+
+def is_in_flight(status: str) -> bool:
+    """Whether a recorded status describes a job that has not finished."""
+    return status in IN_FLIGHT_STATUSES

--- a/src/ingestion/reconcile-connectors/tests/test_render_cronworkflow.py
+++ b/src/ingestion/reconcile-connectors/tests/test_render_cronworkflow.py
@@ -4,7 +4,7 @@
 prints a list newline-separated and `render_cronworkflow.py` turns every line
 into one entry of the Argo >=3.5 `schedules:` array.
 
-Run: python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests
+Run: pytest src/ingestion/reconcile-connectors/tests
 """
 
 from __future__ import annotations
@@ -14,9 +14,9 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
-import unittest
 from pathlib import Path
+
+import pytest
 
 RECONCILE_DIR = Path(__file__).resolve().parents[1]
 RENDERER = RECONCILE_DIR / "python" / "render_cronworkflow.py"
@@ -93,33 +93,39 @@ def _rendered_name(document: str) -> str:
     raise AssertionError("the rendered document carries no `metadata.name`")
 
 
-class RendererTests(unittest.TestCase):
+class TestRenderer:
     def test_a_single_cron_renders_exactly_one_entry(self) -> None:
         result = _render("0 4 * * *")
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(_rendered_schedules(result.stdout), ["0 4 * * *"])
-        self.assertEqual(_rendered_name(result.stdout), "example-connector-example-sync")
+        assert result.returncode == 0, result.stderr
+        assert _rendered_schedules(result.stdout) == ["0 4 * * *"]
+        assert _rendered_name(result.stdout) == "example-connector-example-sync"
 
     def test_every_cron_line_renders_its_own_entry_in_order(self) -> None:
         result = _render("50 23 * * *\n0 9,15,21 28-31 * *")
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(_rendered_schedules(result.stdout), ["50 23 * * *", "0 9,15,21 28-31 * *"])
+        assert result.returncode == 0, result.stderr
+        assert _rendered_schedules(result.stdout) == [
+            "50 23 * * *",
+            "0 9,15,21 28-31 * *",
+        ]
 
     def test_a_schedule_carrying_no_cron_expression_is_rejected(self) -> None:
         result = _render("\n   \n")
 
-        self.assertEqual(result.returncode, 2, result.stderr)
-        self.assertIn("render_cronworkflow: --schedule carries no cron expression", result.stderr)
+        assert result.returncode == 2, result.stderr
+        expected = "render_cronworkflow: --schedule carries no cron expression"
+        assert expected in result.stderr
 
 
-class ArgoCronWorkflowTests(unittest.TestCase):
-    def setUp(self) -> None:
-        self.tmp = tempfile.TemporaryDirectory()
-        self.tmp_path = Path(self.tmp.name)
-        self.kubectl_log = self.tmp_path / "kubectl.log"
-        kubectl = self.tmp_path / "kubectl"
+class TestArgoCronWorkflow:
+    @pytest.fixture(autouse=True)
+    def _kubectl_on_path(self, tmp_path: Path) -> None:
+        """A fake `kubectl` earlier on PATH than the real one, and a log of what
+        the script asked it to do."""
+        self.tmp_path = tmp_path
+        self.kubectl_log = tmp_path / "kubectl.log"
+        kubectl = tmp_path / "kubectl"
         kubectl.write_text(
             """#!/usr/bin/env bash
 printf '%s\\n' \"$*\" >> \"${FAKE_KUBECTL_LOG}\"
@@ -139,9 +145,6 @@ printf 'ok\\n'
             "FAKE_KUBECTL_LOG": str(self.kubectl_log),
             "PATH": f"{self.tmp_path}{os.pathsep}{os.environ['PATH']}",
         }
-
-    def tearDown(self) -> None:
-        self.tmp.cleanup()
 
     def _run_argo(self, script: str, *args: str, **env: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
@@ -183,9 +186,9 @@ argo_apply_cronworkflow \"$@\"
         connector = "c" * 38
         result = self._run_argo('source "$ARGO_SCRIPT"\nargo_cron_workflow_name "$@"', connector, "tenantid")
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), f"{connector}-tenantid-sync")
-        self.assertEqual(len(result.stdout.strip()), 52)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == f"{connector}-tenantid-sync"
+        assert len(result.stdout.strip()) == 52
 
     def test_a_53_character_name_is_rejected_before_kubectl(self) -> None:
         result = self._run_argo(
@@ -199,53 +202,47 @@ argo_apply_cronworkflow \"$@\"
             "",
         )
 
-        self.assertEqual(result.returncode, 1, result.stderr)
-        self.assertIn("Argo accepts at most 52", result.stderr)
-        self.assertEqual(self._kubectl_calls(), [])
+        assert result.returncode == 1, result.stderr
+        assert "Argo accepts at most 52" in result.stderr
+        assert self._kubectl_calls() == []
 
     def test_apply_removes_the_legacy_full_tenant_name(self) -> None:
         tenant = "tenant-identifier"
         result = self._apply("example-connector", tenant)
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(
-            self._kubectl_calls(),
-            [
+        assert result.returncode == 0, result.stderr
+        assert self._kubectl_calls() == [
                 "apply -f -",
                 f"-n insight delete cronworkflow.argoproj.io/example-connector-{tenant}-sync --ignore-not-found",
-            ],
-        )
+            ]
 
     def test_apply_returns_2_when_legacy_cleanup_fails(self) -> None:
         tenant = "tenant-identifier"
         legacy_name = f"example-connector-{tenant}-sync"
         result = self._apply("example-connector", tenant, FAKE_KUBECTL_FAIL_DELETE_NAME=legacy_name)
 
-        self.assertEqual(result.returncode, 2, result.stderr)
-        self.assertIn(f"{legacy_name}: kubectl delete failed: delete rejected", result.stderr)
+        assert result.returncode == 2, result.stderr
+        assert f"{legacy_name}: kubectl delete failed: delete rejected" in result.stderr
 
     def test_apply_for_a_short_tenant_does_not_delete_the_same_name_twice(self) -> None:
         result = self._apply("example-connector", "short")
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(self._kubectl_calls(), ["apply -f -"])
+        assert result.returncode == 0, result.stderr
+        assert self._kubectl_calls() == ["apply -f -"]
 
     def test_delete_removes_full_tenant_and_bounded_names(self) -> None:
         tenant = "tenant-identifier"
         result = self._delete("example-connector", tenant)
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(
-            self._kubectl_calls(),
-            [
+        assert result.returncode == 0, result.stderr
+        assert self._kubectl_calls() == [
                 f"-n insight delete cronworkflow.argoproj.io/example-connector-{tenant}-sync --ignore-not-found",
                 "-n insight delete cronworkflow.argoproj.io/example-connector-tenant-i-sync --ignore-not-found",
-            ],
-        )
+            ]
 
 
-@unittest.skipUnless(HAS_PYYAML, "PyYAML unavailable")
-class DescriptorScheduleTests(unittest.TestCase):
+@pytest.mark.skipif(not HAS_PYYAML, reason="PyYAML unavailable")
+class TestDescriptorSchedule:
     """The descriptor -> parse_descriptor -> renderer path reconcile takes."""
 
     def test_the_whole_rendered_document_stays_valid_yaml(self) -> None:
@@ -253,38 +250,40 @@ class DescriptorScheduleTests(unittest.TestCase):
 
         rendered = _render("50 23 * * *\n0 9,15,21 28-31 * *")
 
-        self.assertEqual(rendered.returncode, 0, rendered.stderr)
+        assert rendered.returncode == 0, rendered.stderr
         document = yaml.safe_load(rendered.stdout)
-        self.assertEqual(document["kind"], "CronWorkflow")
-        self.assertEqual(document["spec"]["schedules"], ["50 23 * * *", "0 9,15,21 28-31 * *"])
+        assert document["kind"] == "CronWorkflow"
+        assert document["spec"]["schedules"] == ["50 23 * * *", "0 9,15,21 28-31 * *"]
 
     def _schedule_of(self, descriptor: Path) -> str:
         result = _run([sys.executable, str(PARSER), "--descriptor", str(descriptor), "--field", "schedule"])
 
-        self.assertEqual(result.returncode, 0, result.stderr)
+        assert result.returncode == 0, result.stderr
         return result.stdout
 
-    def test_a_descriptor_schedule_reaches_the_rendered_array(self) -> None:
-        for label, body, expected in DESCRIPTOR_CASES:
-            with self.subTest(descriptor=label), tempfile.TemporaryDirectory() as tmp:
-                descriptor = Path(tmp) / "descriptor.yaml"
-                descriptor.write_text(f'name: example-connector\nversion: "1.0.0"\n{body}', encoding="utf-8")
+    @pytest.mark.parametrize(("label", "body", "expected"), DESCRIPTOR_CASES)
+    def test_a_descriptor_schedule_reaches_the_rendered_array(
+        self, tmp_path: Path, label: str, body: str, expected: list[str]
+    ) -> None:
+        descriptor = tmp_path / "descriptor.yaml"
+        descriptor.write_text(
+            f'name: example-connector\nversion: "1.0.0"\n{body}', encoding="utf-8"
+        )
 
-                rendered = _render(self._schedule_of(descriptor))
+        rendered = _render(self._schedule_of(descriptor))
 
-                self.assertEqual(rendered.returncode, 0, rendered.stderr)
-                self.assertEqual(_rendered_schedules(rendered.stdout), expected, f"should render: {label}")
+        assert rendered.returncode == 0, rendered.stderr
+        assert _rendered_schedules(rendered.stdout) == expected, (
+            f"should render: {label}"
+        )
 
     def test_claude_team_reads_more_than_once_a_day_at_month_end(self) -> None:
         rendered = _render(self._schedule_of(CLAUDE_TEAM_DESCRIPTOR))
 
-        self.assertEqual(rendered.returncode, 0, rendered.stderr)
-        self.assertEqual(
-            _rendered_schedules(rendered.stdout),
-            ["50 23 * * *", "0 9,15,21 28-31 * *"],
-            "claude-team must keep the extra month-end readings its billing month depends on",
+        assert rendered.returncode == 0, rendered.stderr
+        assert _rendered_schedules(rendered.stdout) == [
+            "50 23 * * *",
+            "0 9,15,21 28-31 * *",
+        ], (
+            "claude-team must keep the extra month-end readings its billing month depends on"
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_against_clickhouse.py
@@ -13,9 +13,9 @@ Skipped unless a server is offered, so CI stays dependency-free:
     src/ingestion/scripts/lib/ch-exec.sh < the migration, then
     SWEEP_TEST_CH_URL=http://localhost:38310 \\
     SWEEP_TEST_CH_USER=insight SWEEP_TEST_CH_PASSWORD=insight \\
-        python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests
+        pytest src/ingestion/reconcile-connectors/tests
 
-Run: python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests
+Run: pytest src/ingestion/reconcile-connectors/tests
 """
 
 from __future__ import annotations
@@ -25,13 +25,14 @@ import json
 import os
 import sys
 import threading
-import unittest
 import urllib.parse
 import urllib.request
 from datetime import UTC, datetime, timedelta
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Self
+from typing import Any, ClassVar, Self
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
 
@@ -226,10 +227,19 @@ def _count(sql: str) -> int:
     return int(value)
 
 
-@unittest.skipUnless(CH_URL, "set SWEEP_TEST_CH_URL to run")
-class SweptRowsLandAndResolve(unittest.TestCase):
+@pytest.mark.skipif(not CH_URL, reason="set SWEEP_TEST_CH_URL to run")
+class TestSweptRowsLandAndResolve:
+    entry: ClassVar[Any]
+
+    @pytest.fixture(scope="class", autouse=True)
     @classmethod
-    def setUpClass(cls) -> None:
+    def _sweep_points_at_the_stubs(cls) -> None:
+        """The entry point, and the environment it reads its two endpoints from.
+
+        Imported here rather than at module scope: the import runs the package's
+        own wiring, which an install without a server offered must not pay for
+        only to skip every test that follows.
+        """
         from sweep import __main__ as entry
 
         cls.entry = entry
@@ -247,7 +257,9 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             }
         )
 
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def _empty_ledger(self) -> None:
+        """Each case states its own history, so it starts from no rows at all."""
         _query(f"TRUNCATE TABLE {TABLE}")
 
     def _tick(self, tick_id: str) -> int:
@@ -261,16 +273,15 @@ class SweptRowsLandAndResolve(unittest.TestCase):
 
     def test_a_first_sweep_lands_the_whole_retained_history(self) -> None:
         with _StubMover() as mover:
-            self.assertEqual(self._tick("tick-a"), 0)
-            self.assertIsNone(
-                mover.requests[0].get("updatedAtStart"),
-                "an empty ledger reads everything, unfiltered",
+            assert self._tick("tick-a") == 0
+            assert mover.requests[0].get("updatedAtStart") is None, (
+                "an empty ledger reads everything, unfiltered"
             )
 
         syncs = _rows(
             f"SELECT job_id FROM {TABLE} WHERE event = 'sync.completed' ORDER BY job_id"
         )
-        self.assertEqual(len(syncs), 8, "seven closed jobs plus the running one")
+        assert len(syncs) == 8, "seven closed jobs plus the running one"
 
     def test_a_later_tick_reads_from_the_watermark_not_from_the_start(self) -> None:
         with _StubMover() as mover:
@@ -279,11 +290,11 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             self._tick("tick-b")
 
             since = mover.requests[0].get("updatedAtStart")
-            self.assertIsNotNone(since, "a populated ledger must filter")
+            assert since is not None, "a populated ledger must filter"
             # Not merely "a stamp": one the listing can parse. The ledger's own
             # form differs by a space, and a listing handed that form filters on
             # nothing at all.
-            self.assertEqual(_parse_iso(since).tzinfo is None, False, since)
+            assert _parse_iso(since).tzinfo is not None, since
 
     def test_the_watermark_does_not_step_over_an_unfinished_job(self) -> None:
         """It stands on the oldest OPEN job, so that job is read again.
@@ -298,10 +309,8 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             self._tick("tick-b")
 
         since = mover.requests[0]["updatedAtStart"]
-        self.assertLessEqual(
-            _parse_iso(since),
-            _parse_iso(_stamp(8)),
-            "the still-running job must stay at or above the watermark",
+        assert _parse_iso(since) <= _parse_iso(_stamp(8)), (
+            "the still-running job must stay at or above the watermark"
         )
 
     def test_the_tick_seals_after_its_snapshot(self) -> None:
@@ -316,10 +325,8 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             f"SELECT toString(max(ts)) AS ts FROM {TABLE} "
             "WHERE event = 'connector.configured'"
         )
-        self.assertEqual(len(seal), 1)
-        self.assertGreaterEqual(
-            seal[0]["ts"], snapshot[0]["ts"], "the seal must be written last"
-        )
+        assert len(seal) == 1
+        assert seal[0]["ts"] >= snapshot[0]["ts"], "the seal must be written last"
 
     def test_a_second_tick_adds_no_row_for_a_closed_job(self) -> None:
         with _StubMover():
@@ -331,7 +338,7 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             "WHERE event = 'sync.completed' AND status = 'succeeded' "
             "GROUP BY job_id HAVING seen > 1"
         )
-        self.assertEqual(closed, [], "a job with a final account is left alone")
+        assert closed == [], "a job with a final account is left alone"
 
     def test_a_running_job_is_re_recorded_once_it_ends(self) -> None:
         """The one behaviour every other test here would pass without."""
@@ -345,11 +352,9 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             "WHERE event = 'sync.completed' AND job_id = '999' "
             "ORDER BY ts DESC LIMIT 1"
         )
-        self.assertEqual(resolved[0]["status"], "failed")
-        self.assertEqual(
-            int(resolved[0]["records_reported"]),
-            0,
-            "a reported zero is not an absence",
+        assert resolved[0]["status"] == "failed"
+        assert int(resolved[0]["records_reported"]) == 0, (
+            "a reported zero is not an absence"
         )
 
     def test_the_summary_resolves_to_the_newest_row_of_the_newest_job(self) -> None:
@@ -365,9 +370,9 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             "   ORDER BY job_id, ts DESC LIMIT 1 BY job_id"
             ") ORDER BY connector, job_updated_at DESC, job_id DESC LIMIT 1 BY connector"
         )
-        self.assertEqual(len(summary), 1)
-        self.assertEqual(summary[0]["job_id"], "999")
-        self.assertEqual(summary[0]["status"], "failed")
+        assert len(summary) == 1
+        assert summary[0]["job_id"] == "999"
+        assert summary[0]["status"] == "failed"
 
     def test_a_job_in_flight_is_recorded_and_placed_at_its_start(self) -> None:
         """The listing sends a running job with a start and no update stamp.
@@ -384,9 +389,9 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             f"toString(job_updated_at) AS placed FROM {TABLE} "
             "WHERE event = 'sync.completed' AND job_id = '999'"
         )
-        self.assertEqual(len(running), 1, "the job in flight must be recorded")
-        self.assertEqual(running[0]["status"], "running")
-        self.assertEqual(running[0]["placed"], running[0]["started"])
+        assert len(running) == 1, "the job in flight must be recorded"
+        assert running[0]["status"] == "running"
+        assert running[0]["placed"] == running[0]["started"]
 
     def test_no_connectors_records_nothing_at_all(self) -> None:
         """An empty configured set is indistinguishable from "all removed"."""
@@ -394,8 +399,8 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             code = self.entry.run(
                 io.StringIO(json.dumps({"tick_id": "tick-z", "connectors": []}))
             )
-        self.assertEqual(code, 1)
-        self.assertEqual(_count(f"SELECT count() AS n FROM {TABLE}"), 0)
+        assert code == 1
+        assert _count(f"SELECT count() AS n FROM {TABLE}") == 0
 
     def test_an_unreachable_mover_records_nothing_and_does_not_seal(self) -> None:
         """The seal dates the page, so an unread tick must not place one.
@@ -406,15 +411,11 @@ class SweptRowsLandAndResolve(unittest.TestCase):
         """
         # No stub server running: the listing call fails.
         code = self._tick("tick-y")
-        self.assertEqual(code, 1, "the caller learns the tick was incomplete")
+        assert code == 1, "the caller learns the tick was incomplete"
         for event in ("sync.completed", "connector.configured", "sweep.completed"):
-            self.assertEqual(
-                _count(
+            assert _count(
                     f"SELECT count() AS n FROM {TABLE} WHERE event = '{event}'"
-                ),
-                0,
-                f"an unread tick must write no {event} row",
-            )
+                ) == 0, f"an unread tick must write no {event} row"
 
     def test_a_listing_that_ignores_the_watermark_records_nothing(self) -> None:
         """An unapplied filter is a failed read, not a noisy one.
@@ -436,19 +437,13 @@ class SweptRowsLandAndResolve(unittest.TestCase):
         with _StubMover(honours_filter=False):
             code = self._tick("tick-b")
 
-        self.assertEqual(code, 1, "the caller learns the tick was incomplete")
-        self.assertEqual(
-            _count(f"SELECT count() AS n FROM {TABLE}"),
-            before,
-            "an unfiltered listing must not re-record the history it served",
+        assert code == 1, "the caller learns the tick was incomplete"
+        assert _count(f"SELECT count() AS n FROM {TABLE}") == before, (
+            "an unfiltered listing must not re-record the history it served"
         )
-        self.assertEqual(
-            _count(
+        assert _count(
                 f"SELECT count() AS n FROM {TABLE} WHERE event = 'sweep.completed'"
-            ),
-            seals,
-            "and must not seal, or the page reports itself freshly checked",
-        )
+            ) == seals, "and must not seal, or the page reports itself freshly checked"
 
     def test_a_connector_awaiting_its_first_connection_is_still_configured(self) -> None:
         """Configured is the first thing the page answers, and it does not
@@ -463,7 +458,7 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             }
         )
         with _StubMover():
-            self.assertEqual(self.entry.run(io.StringIO(work)), 0)
+            assert self.entry.run(io.StringIO(work)) == 0
 
         configured = {
             row["connector"]
@@ -471,7 +466,7 @@ class SweptRowsLandAndResolve(unittest.TestCase):
                 f"SELECT connector FROM {TABLE} WHERE event = 'connector.configured'"
             )
         }
-        self.assertEqual(configured, {CONNECTOR, "awaiting-connection"})
+        assert configured == {CONNECTOR, "awaiting-connection"}
 
     def test_a_job_that_fell_below_the_read_start_stops_reading_as_running(self) -> None:
         """The floor's own cost, paid honestly.
@@ -500,10 +495,8 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             f"SELECT status FROM {TABLE} WHERE event = 'sync.completed' "
             "AND job_id = 'stranded' ORDER BY ts DESC LIMIT 1"
         )
-        self.assertEqual(
-            resolved[0]["status"],
-            "unknown",
-            "a job the sweep can no longer see must not keep reading as running",
+        assert resolved[0]["status"] == "unknown", (
+            "a job the sweep can no longer see must not keep reading as running"
         )
 
     def test_a_stranded_job_is_marked_once_and_not_every_tick(self) -> None:
@@ -531,7 +524,7 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             f"SELECT count() AS n FROM {TABLE} WHERE job_id = 'stranded' "
             "AND status = 'unknown'"
         )
-        self.assertEqual(markers, 1, "the marker must settle, not repeat")
+        assert markers == 1, "the marker must settle, not repeat"
 
     def test_a_stuck_open_job_does_not_pin_the_watermark_for_ever(self) -> None:
         """One job that can never close would otherwise drag the read start back
@@ -550,12 +543,6 @@ class SweptRowsLandAndResolve(unittest.TestCase):
             self._tick("tick-b")
 
         since = _parse_iso(mover.requests[0]["updatedAtStart"])
-        self.assertGreater(
-            since,
-            _parse_iso(stale),
-            "the stuck job must not hold the read start at its own creation time",
+        assert since > _parse_iso(stale), (
+            "the stuck job must not hold the read start at its own creation time"
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_mover.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_mover.py
@@ -5,13 +5,12 @@ that land: whether a short page means the end of the listing, and whether the
 read ran out of time. Getting either wrong makes an incomplete tick report
 itself complete, which is the one thing that stops FR-12 from ever firing.
 
-Run: python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests
+Run: pytest src/ingestion/reconcile-connectors/tests
 """
 
 from __future__ import annotations
 
 import sys
-import unittest
 import urllib.parse
 from pathlib import Path
 
@@ -41,14 +40,14 @@ class _Listing(Mover):
         return [{"jobId": offset + n} for n in range(usable)], served
 
 
-class AShortPageEndsTheRead(unittest.TestCase):
+class TestAShortPageEndsTheRead:
     def test_a_page_shorter_than_the_size_is_the_end_of_the_listing(self) -> None:
         listing = _Listing([(mover_module.PAGE_SIZE, mover_module.PAGE_SIZE), (5, 5)])
         entries, truncated = listing.sync_jobs(None)
 
-        self.assertEqual(len(entries), mover_module.PAGE_SIZE + 5)
-        self.assertFalse(truncated)
-        self.assertEqual(len(listing.requested), 2)
+        assert len(entries) == mover_module.PAGE_SIZE + 5
+        assert not truncated
+        assert len(listing.requested) == 2
 
     def test_a_full_page_carrying_an_unusable_entry_is_not_a_short_page(self) -> None:
         """The end-of-listing test must read what the SERVER served.
@@ -62,14 +61,14 @@ class AShortPageEndsTheRead(unittest.TestCase):
         listing = _Listing([(full - 1, full), (3, 3)])
         entries, truncated = listing.sync_jobs(None)
 
-        self.assertEqual(
-            len(listing.requested), 2, "the read must continue past the filtered page"
+        assert len(listing.requested) == 2, (
+            "the read must continue past the filtered page"
         )
-        self.assertEqual(len(entries), full - 1 + 3)
-        self.assertFalse(truncated)
+        assert len(entries) == full - 1 + 3
+        assert not truncated
 
 
-class TheReadHasATimeBudget(unittest.TestCase):
+class TestTheReadHasATimeBudget:
     def test_an_exhausted_budget_stops_the_read_and_says_so(self) -> None:
         """The page cap alone bounds nothing in time.
 
@@ -86,29 +85,25 @@ class TheReadHasATimeBudget(unittest.TestCase):
         finally:
             mover_module.BUDGET_SECS = original
 
-        self.assertTrue(truncated, "a read that ran out of time is not a complete read")
-        self.assertEqual(len(listing.requested), 1, "it stops rather than finishing")
-        self.assertEqual(len(entries), full, "and keeps what it did read")
+        assert truncated, "a read that ran out of time is not a complete read"
+        assert len(listing.requested) == 1, "it stops rather than finishing"
+        assert len(entries) == full, "and keeps what it did read"
 
     def test_the_budget_leaves_room_under_the_ticks_own_deadline(self) -> None:
         # The workflow pod's deadline is 1800s; the sweep is its last layer and
         # still has the ledger writes and the seal to do afterwards.
-        self.assertLess(mover_module.BUDGET_SECS, 900)
+        assert mover_module.BUDGET_SECS < 900
 
     def test_the_page_cap_is_a_backstop_not_the_budget(self) -> None:
         full = mover_module.PAGE_SIZE
         listing = _Listing([(full, full)] * (mover_module.MAX_PAGES + 5))
         _, truncated = listing.sync_jobs(None)
 
-        self.assertTrue(truncated)
-        self.assertEqual(len(listing.requested), mover_module.MAX_PAGES)
+        assert truncated
+        assert len(listing.requested) == mover_module.MAX_PAGES
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
-class TheRequestNamesTheFieldItReadsBack(unittest.TestCase):
+class TestTheRequestNamesTheFieldItReadsBack:
     """The sort key, the filter and the field read off an entry are one stamp.
 
     The mover answers 200 and ignores a query parameter it does not recognise,
@@ -127,22 +122,22 @@ class TheRequestNamesTheFieldItReadsBack(unittest.TestCase):
                 return {"data": []}
 
         _Transport("http://mover.invalid", "token").sync_jobs(updated_at_start)
-        self.assertEqual(len(asked), 1)
+        assert len(asked) == 1
         query = urllib.parse.urlparse(asked[0]).query
         return dict(urllib.parse.parse_qsl(query))
 
     def test_the_listing_is_ordered_by_the_stamp_the_planner_records(self) -> None:
-        self.assertEqual(self._query(None)["orderBy"], "updatedAt|ASC")
+        assert self._query(None)["orderBy"] == "updatedAt|ASC"
 
     def test_the_watermark_is_sent_as_the_update_filter(self) -> None:
         query = self._query("2026-08-27T08:02:52Z")
 
-        self.assertEqual(query["updatedAtStart"], "2026-08-27T08:02:52Z")
-        self.assertNotIn("createdAtStart", query)
+        assert query["updatedAtStart"] == "2026-08-27T08:02:52Z"
+        assert "createdAtStart" not in query
 
     def test_a_first_sweep_sends_no_filter_at_all(self) -> None:
         """None is "read the whole retained history", not "read from now"."""
         query = self._query(None)
 
-        self.assertNotIn("updatedAtStart", query)
-        self.assertNotIn("createdAtStart", query)
+        assert "updatedAtStart" not in query
+        assert "createdAtStart" not in query

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
@@ -1,13 +1,14 @@
 """What a tick decides to write.
 
-Run: python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests
+Run: pytest src/ingestion/reconcile-connectors/tests
 """
 
 from __future__ import annotations
 
 import sys
-import unittest
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
 
@@ -71,63 +72,58 @@ def row(**overrides: object) -> dict[str, object]:
     return planned
 
 
-class StatusKeepsTheMoversWord(unittest.TestCase):
-    def test_documented_statuses_are_stored_verbatim(self) -> None:
-        for word in sorted(vocab.MOVER_STATUSES):
-            with self.subTest(word=word):
-                self.assertEqual(row(status=word)["status"], word)
+class TestStatusKeepsTheMoversWord:
+    @pytest.mark.parametrize("word", sorted(vocab.MOVER_STATUSES))
+    def test_documented_statuses_are_stored_verbatim(self, word: str) -> None:
+        assert row(status=word)["status"] == word
 
-    def test_an_undocumented_word_is_stored_as_unknown(self) -> None:
-        for word in ("SUCCEEDED_PARTIALLY", "", None, 7, "  "):
-            with self.subTest(word=word):
-                self.assertEqual(
-                    row(status=word)["status"],
-                    vocab.UNKNOWN,
-                    f"should not pass through: {word!r}",
-                )
+    @pytest.mark.parametrize("word", ["SUCCEEDED_PARTIALLY", "", None, 7, "  "])
+    def test_an_undocumented_word_is_stored_as_unknown(self, word: object) -> None:
+        assert row(status=word)["status"] == vocab.UNKNOWN, (
+            f"should not pass through: {word!r}"
+        )
 
     def test_case_and_padding_do_not_produce_an_unknown(self) -> None:
-        self.assertEqual(row(status=" Succeeded ")["status"], "succeeded")
+        assert row(status=" Succeeded ")["status"] == "succeeded"
 
     def test_unknown_does_not_close_a_job(self) -> None:
         """Coverage fails closed: a status we could not read is re-read."""
-        self.assertFalse(vocab.is_terminal(vocab.UNKNOWN))
+        assert not vocab.is_terminal(vocab.UNKNOWN)
 
-    def test_an_unfinished_status_does_not_close_a_job(self) -> None:
-        for word in ("pending", "running"):
-            with self.subTest(word=word):
-                self.assertFalse(vocab.is_terminal(word))
+    @pytest.mark.parametrize("word", ["pending", "running"])
+    def test_an_unfinished_status_does_not_close_a_job(self, word: str) -> None:
+        assert not vocab.is_terminal(word)
 
 
-class AJobMustBePlaceable(unittest.TestCase):
-    def test_a_job_with_neither_stamp_readable_is_refused(self) -> None:
+class TestAJobMustBePlaceable:
+    @pytest.mark.parametrize("absent", [None, 0, -1, "yesterday", True])
+    def test_a_job_with_neither_stamp_readable_is_refused(self, absent: object) -> None:
         """Both, because either one places the job. A case that blanks only the
         update stamp stops testing the refusal the moment a fallback exists."""
-        for absent in (None, 0, -1, "yesterday", True):
-            with self.subTest(absent=absent):
-                planned = plan.sync_row(
-                    entry(lastUpdatedAt=absent, startTime=absent), CONNECTORS, TICK
-                )
-                self.assertIsInstance(
-                    planned, plan.Skipped, f"should refuse both stamps = {absent!r}"
-                )
+        planned = plan.sync_row(
+            entry(lastUpdatedAt=absent, startTime=absent), CONNECTORS, TICK
+        )
+
+        assert isinstance(planned, plan.Skipped), (
+            f"should refuse both stamps = {absent!r}"
+        )
 
     def test_a_job_with_no_identity_is_refused(self) -> None:
         planned = plan.sync_row(entry(jobId=None), CONNECTORS, TICK)
-        self.assertIsInstance(planned, plan.Skipped)
+        assert isinstance(planned, plan.Skipped)
 
     def test_an_entry_with_no_job_is_refused(self) -> None:
         planned = plan.sync_row({"connectionId": CONNECTION}, CONNECTORS, TICK)
-        self.assertIsInstance(planned, plan.Skipped)
+        assert isinstance(planned, plan.Skipped)
 
     def test_a_refusal_carries_its_reason(self) -> None:
         planned = plan.sync_row(
             entry(lastUpdatedAt=None, startTime=None), CONNECTORS, TICK
         )
-        self.assertIn("moment", planned.reason)
+        assert "moment" in planned.reason
 
 
-class AbsenceIsNotZero(unittest.TestCase):
+class TestAbsenceIsNotZero:
     def test_a_job_not_started_has_no_start_and_no_duration(self) -> None:
         bare = {
             "jobId": 1,
@@ -136,55 +132,54 @@ class AbsenceIsNotZero(unittest.TestCase):
             "lastUpdatedAt": UPDATED,
         }
         planned = plan.sync_row(bare, CONNECTORS, TICK)
-        self.assertIsNone(planned["started_at"])
-        self.assertIsNone(planned["duration_ms"])
-        self.assertIsNone(planned["records_reported"])
+        assert planned["started_at"] is None
+        assert planned["duration_ms"] is None
+        assert planned["records_reported"] is None
 
     def test_a_reported_zero_survives_as_zero(self) -> None:
         """A sync that moved nothing is not a sync nobody counted."""
-        self.assertEqual(row(rowsSynced=0)["records_reported"], 0)
+        assert row(rowsSynced=0)["records_reported"] == 0
 
-    def test_no_reported_count_at_all_is_absent(self) -> None:
-        for absent in (None, "", "many", True):
-            with self.subTest(absent=absent):
-                self.assertIsNone(row(rowsSynced=absent)["records_reported"])
+    @pytest.mark.parametrize("absent", [None, "", "many", True])
+    def test_no_reported_count_at_all_is_absent(self, absent: object) -> None:
+        assert row(rowsSynced=absent)["records_reported"] is None
 
     def test_a_negative_count_is_absent_rather_than_recorded(self) -> None:
-        self.assertIsNone(row(rowsSynced=-1)["records_reported"])
+        assert row(rowsSynced=-1)["records_reported"] is None
 
-    def test_a_non_finite_number_is_absent_rather_than_an_exception(self) -> None:
+    @pytest.mark.parametrize("absent", [float("nan"), float("inf"), float("-inf")])
+    def test_a_non_finite_number_is_absent_rather_than_an_exception(
+        self, absent: float
+    ) -> None:
         """`int(inf)` raises, and one malformed field would cost the whole tick
         its seal — which stops the page's own clock."""
-        for absent in (float("nan"), float("inf"), float("-inf")):
-            with self.subTest(absent=absent):
-                self.assertIsNone(row(duration=absent)["duration_ms"])
-                self.assertIsNone(row(rowsSynced=absent)["records_reported"])
+        assert row(duration=absent)["duration_ms"] is None
+        assert row(rowsSynced=absent)["records_reported"] is None
 
-    def test_an_empty_job_identity_is_refused(self) -> None:
+    @pytest.mark.parametrize("empty", ["", "   "])
+    def test_an_empty_job_identity_is_refused(self, empty: str) -> None:
         """Several such jobs would share one key and replace each other during
         resolution, so the page would answer with whichever landed last."""
-        for empty in ("", "   "):
-            with self.subTest(empty=empty):
-                planned = plan.sync_row(entry(jobId=empty), CONNECTORS, TICK)
-                self.assertIsInstance(planned, plan.Skipped)
+        planned = plan.sync_row(entry(jobId=empty), CONNECTORS, TICK)
 
-    def test_a_duration_that_will_not_parse_is_absent(self) -> None:
+        assert isinstance(planned, plan.Skipped)
+
+    @pytest.mark.parametrize("absent", ["1m37s", "P", "", None, "PT", "garbage"])
+    def test_a_duration_that_will_not_parse_is_absent(self, absent: object) -> None:
         """Reading only some components would report a span shorter than the
         truth, which is worse than reporting none."""
-        for absent in ("1m37s", "P", "", None, "PT", "garbage"):
-            with self.subTest(absent=absent):
-                self.assertIsNone(row(duration=absent)["duration_ms"])
+        assert row(duration=absent)["duration_ms"] is None
 
 
-class WhatIsRead(unittest.TestCase):
+class TestWhatIsRead:
     def test_the_stamps_are_read_as_iso_8601(self) -> None:
         planned = row()
-        self.assertEqual(planned["job_updated_at"], "2026-08-27 08:02:52.000")
-        self.assertEqual(planned["started_at"], "2026-08-27 08:00:30.000")
+        assert planned["job_updated_at"] == "2026-08-27 08:02:52.000"
+        assert planned["started_at"] == "2026-08-27 08:00:30.000"
 
     def test_a_stamp_with_an_offset_is_normalised_to_utc(self) -> None:
         planned = row(lastUpdatedAt="2026-08-27T11:00:00+03:00")
-        self.assertEqual(planned["job_updated_at"], "2026-08-27 08:00:00.000")
+        assert planned["job_updated_at"] == "2026-08-27 08:00:00.000"
 
     def test_the_placing_stamp_is_the_last_update_not_the_start(self) -> None:
         """Two stamps arrive and only one places the job.
@@ -193,8 +188,8 @@ class WhatIsRead(unittest.TestCase):
         expected value catches a planner that took `startTime` for the axis the
         watermark moves along.
         """
-        self.assertEqual(row()["job_updated_at"], "2026-08-27 08:02:52.000")
-        self.assertNotEqual(row()["job_updated_at"], row()["started_at"])
+        assert row()["job_updated_at"] == "2026-08-27 08:02:52.000"
+        assert row()["job_updated_at"] != row()["started_at"]
 
     def test_an_epoch_number_is_not_a_stamp(self) -> None:
         """The listing sends strings. A number here would be a different
@@ -204,51 +199,54 @@ class WhatIsRead(unittest.TestCase):
             CONNECTORS,
             TICK,
         )
-        self.assertIsInstance(planned, plan.Skipped)
+        assert isinstance(planned, plan.Skipped)
 
-    def test_the_duration_is_read_as_an_iso_8601_duration(self) -> None:
-        cases = {
-            "PT1M37S": 97_000,
-            "PT2H3M4.5S": 7_384_500,
-            "P1DT1S": 86_401_000,
-            "PT0.25S": 250,
-        }
-        for text, expected in cases.items():
-            with self.subTest(duration=text):
-                self.assertEqual(row(duration=text)["duration_ms"], expected)
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("PT1M37S", 97_000),
+            ("PT2H3M4.5S", 7_384_500),
+            ("P1DT1S", 86_401_000),
+            ("PT0.25S", 250),
+        ],
+    )
+    def test_the_duration_is_read_as_an_iso_8601_duration(
+        self, text: str, expected: int
+    ) -> None:
+        assert row(duration=text)["duration_ms"] == expected
 
     def test_the_reported_count_is_read_from_the_entry(self) -> None:
-        self.assertEqual(row()["records_reported"], 12_400)
+        assert row()["records_reported"] == 12_400
 
 
-class AJobMustBelongToAManagedConnection(unittest.TestCase):
+class TestAJobMustBelongToAManagedConnection:
     def test_a_job_on_an_unmanaged_connection_is_refused(self) -> None:
         """The listing is instance-wide, so it carries jobs this install does
         not manage. Guessing a connector for one would file syncs on the wrong
         row."""
         planned = plan.sync_row(entry(connectionId="someone-else"), CONNECTORS, TICK)
-        self.assertIsInstance(planned, plan.Skipped)
-        self.assertIn("managed connection", planned.reason)
+        assert isinstance(planned, plan.Skipped)
+        assert "managed connection" in planned.reason
 
     def test_a_job_with_no_connection_is_refused(self) -> None:
         planned = plan.sync_row(entry(connectionId=None), CONNECTORS, TICK)
-        self.assertIsInstance(planned, plan.Skipped)
+        assert isinstance(planned, plan.Skipped)
 
     def test_the_connector_comes_from_the_map_not_the_name(self) -> None:
         planned = plan.sync_row(entry(), {CONNECTION: "renamed"}, TICK)
-        self.assertEqual(planned["connector"], "renamed")
+        assert planned["connector"] == "renamed"
 
 
-class CoverageSkipsWhatIsClosed(unittest.TestCase):
+class TestCoverageSkipsWhatIsClosed:
     def test_a_job_already_terminal_in_the_ledger_is_left_alone(self) -> None:
         planned = plan.plan_syncs(
             [entry()], CONNECTORS, TICK, frozenset({"8412"})
         )
-        self.assertEqual(planned.rows, [])
+        assert planned.rows == []
 
     def test_a_job_not_yet_closed_is_recorded_again(self) -> None:
         planned = plan.plan_syncs([entry()], CONNECTORS, TICK, frozenset())
-        self.assertEqual(len(planned.rows), 1)
+        assert len(planned.rows) == 1
 
     def test_refusals_are_reported_beside_the_rows(self) -> None:
         planned = plan.plan_syncs(
@@ -257,12 +255,12 @@ class CoverageSkipsWhatIsClosed(unittest.TestCase):
             TICK,
             frozenset(),
         )
-        self.assertEqual(len(planned.rows), 1)
-        self.assertEqual(len(planned.skipped), 1)
-        self.assertEqual(planned.skipped[0].job_id, "7")
+        assert len(planned.rows) == 1
+        assert len(planned.skipped) == 1
+        assert planned.skipped[0].job_id == "7"
 
 
-class EveryRowClassFillsEveryColumn(unittest.TestCase):
+class TestEveryRowClassFillsEveryColumn:
     """The insert names no columns, so a row missing one would silently take a
     DEFAULT — and a row carrying an extra one would be rejected outright."""
 
@@ -270,33 +268,29 @@ class EveryRowClassFillsEveryColumn(unittest.TestCase):
         sync = row()
         snapshot = plan.plan_snapshot([CONNECTOR], TICK)[0]
         seal = plan.plan_seal(TICK)
-        self.assertEqual(set(snapshot), set(sync))
-        self.assertEqual(set(seal), set(sync))
+        assert set(snapshot) == set(sync)
+        assert set(seal) == set(sync)
 
     def test_a_snapshot_row_names_its_connector_and_nothing_else(self) -> None:
         snapshot = plan.plan_snapshot([CONNECTOR], TICK)[0]
-        self.assertEqual(snapshot["connector"], CONNECTOR)
-        self.assertEqual(snapshot["event"], plan.CONNECTOR_CONFIGURED)
-        self.assertEqual(snapshot["job_id"], "")
-        self.assertEqual(snapshot["status"], "")
-        self.assertIsNone(snapshot["job_updated_at"])
+        assert snapshot["connector"] == CONNECTOR
+        assert snapshot["event"] == plan.CONNECTOR_CONFIGURED
+        assert snapshot["job_id"] == ""
+        assert snapshot["status"] == ""
+        assert snapshot["job_updated_at"] is None
 
     def test_the_seal_names_no_connector(self) -> None:
         seal = plan.plan_seal(TICK)
-        self.assertEqual(seal["event"], plan.SWEEP_COMPLETED)
-        self.assertEqual(seal["connector"], "")
-        self.assertEqual(seal["tick_id"], TICK)
+        assert seal["event"] == plan.SWEEP_COMPLETED
+        assert seal["connector"] == ""
+        assert seal["tick_id"] == TICK
 
     def test_a_snapshot_holds_each_connector_once(self) -> None:
         rows = plan.plan_snapshot([CONNECTOR, CONNECTOR, "other"], TICK)
-        self.assertEqual([r["connector"] for r in rows], ["example-tracker", "other"])
+        assert [r["connector"] for r in rows] == ["example-tracker", "other"]
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
-class TheListingsOwnShape(unittest.TestCase):
+class TestTheListingsOwnShape:
     """The fixture above is the mover's shape, not a convenient stand-in for it.
 
     A field the mover never sends refuses every real entry while every test
@@ -305,7 +299,7 @@ class TheListingsOwnShape(unittest.TestCase):
     """
 
     def test_the_fixture_carries_exactly_the_keys_the_listing_serves(self) -> None:
-        self.assertEqual(frozenset(entry()), SERVED_KEYS)
+        assert frozenset(entry()) == SERVED_KEYS
 
     def test_a_creation_stamp_does_not_place_a_job(self) -> None:
         """The listing filters on creation and reports none, so an entry
@@ -317,10 +311,10 @@ class TheListingsOwnShape(unittest.TestCase):
 
         planned = plan.sync_row(invented, CONNECTORS, TICK)
 
-        self.assertIsInstance(planned, plan.Skipped)
+        assert isinstance(planned, plan.Skipped)
 
 
-class AJobStillRunningIsPlaceable(unittest.TestCase):
+class TestAJobStillRunningIsPlaceable:
     """A running job can arrive with a start and no update stamp at all.
 
     Refusing it costs the one state the page most needs: the connector reads as
@@ -344,8 +338,8 @@ class AJobStillRunningIsPlaceable(unittest.TestCase):
     def test_it_is_recorded_rather_than_skipped(self) -> None:
         planned = plan.sync_row(self.RUNNING, CONNECTORS, TICK)
 
-        self.assertNotIsInstance(planned, plan.Skipped, planned)
-        self.assertEqual(planned["status"], "running")
+        assert not isinstance(planned, plan.Skipped), planned
+        assert planned["status"] == "running"
 
     def test_it_is_placed_at_its_start(self) -> None:
         """The listing places such an entry around its start — it serves the
@@ -354,11 +348,11 @@ class AJobStillRunningIsPlaceable(unittest.TestCase):
         and the filter part company."""
         planned = plan.sync_row(self.RUNNING, CONNECTORS, TICK)
 
-        self.assertEqual(planned["job_updated_at"], "2026-08-27 08:00:30.000")
+        assert planned["job_updated_at"] == "2026-08-27 08:00:30.000"
 
     def test_an_update_stamp_still_wins_when_there_is_one(self) -> None:
         """The fallback must not outrank the field it stands in for."""
-        self.assertEqual(row()["job_updated_at"], "2026-08-27 08:02:52.000")
+        assert row()["job_updated_at"] == "2026-08-27 08:02:52.000"
 
     def test_it_outranks_the_finished_job_it_follows(self) -> None:
         """A sync that started after the last one finished is the newer fact,
@@ -369,8 +363,8 @@ class AJobStillRunningIsPlaceable(unittest.TestCase):
         )
 
         placed = {r["job_id"]: r["job_updated_at"] for r in planned.rows}
-        self.assertEqual(len(placed), 2)
-        self.assertGreater(placed["9001"], placed["8900"])
+        assert len(placed) == 2
+        assert placed["9001"] > placed["8900"]
 
     def test_it_records_no_duration(self) -> None:
         """The mover reports an unfinished job's duration as a running total —
@@ -379,40 +373,37 @@ class AJobStillRunningIsPlaceable(unittest.TestCase):
         an operator watching a stuck sync must not be given."""
         planned = plan.sync_row(self.RUNNING, CONNECTORS, TICK)
 
-        self.assertIsNone(planned["duration_ms"])
+        assert planned["duration_ms"] is None
 
     def test_it_still_states_when_it_started(self) -> None:
         """The elapsed time the page reports is derived from this stamp, so
         withholding the duration must not withhold the start with it."""
         planned = plan.sync_row(self.RUNNING, CONNECTORS, TICK)
 
-        self.assertEqual(planned["started_at"], "2026-08-27 08:00:30.000")
+        assert planned["started_at"] == "2026-08-27 08:00:30.000"
 
 
-class OnlyAnUnfinishedJobLosesItsDuration(unittest.TestCase):
-    def test_every_in_flight_word_records_none(self) -> None:
-        for word in sorted(vocab.IN_FLIGHT_STATUSES):
-            with self.subTest(word=word):
-                self.assertIsNone(row(status=word, duration="PT1M37S")["duration_ms"])
+class TestOnlyAnUnfinishedJobLosesItsDuration:
+    @pytest.mark.parametrize("word", sorted(vocab.IN_FLIGHT_STATUSES))
+    def test_every_in_flight_word_records_none(self, word: str) -> None:
+        assert row(status=word, duration="PT1M37S")["duration_ms"] is None
 
-    def test_every_finished_word_keeps_what_it_reported(self) -> None:
-        for word in sorted(vocab.TERMINAL_STATUSES):
-            with self.subTest(word=word):
-                planned = row(status=word, duration="PT1M37S")
-                self.assertEqual(planned["duration_ms"], 97_000)
+    @pytest.mark.parametrize("word", sorted(vocab.TERMINAL_STATUSES))
+    def test_every_finished_word_keeps_what_it_reported(self, word: str) -> None:
+        assert row(status=word, duration="PT1M37S")["duration_ms"] == 97_000
 
     def test_a_word_that_could_not_be_read_keeps_its_duration(self) -> None:
         """An unreadable word may well name a finished job, and treating it as
         in flight would discard a measurement that was actually taken."""
-        self.assertEqual(row(status="borked", duration="PT1M37S")["duration_ms"], 97_000)
+        assert row(status="borked", duration="PT1M37S")["duration_ms"] == 97_000
 
     def test_a_finished_job_that_really_took_no_time_still_says_so(self) -> None:
         """Suppression is decided by the status, never by the value: a zero
         from a finished job is a measurement, not an absence."""
-        self.assertEqual(row(status="succeeded", duration="PT0S")["duration_ms"], 0)
+        assert row(status="succeeded", duration="PT0S")["duration_ms"] == 0
 
 
-class AnIgnoredFilterIsVisible(unittest.TestCase):
+class TestAnIgnoredFilterIsVisible:
     """The mover answers 200 and drops a parameter it does not recognise.
 
     So a filter renamed by a later release stops filtering rather than failing:
@@ -428,21 +419,17 @@ class AnIgnoredFilterIsVisible(unittest.TestCase):
         at_the_mark = entry(jobId=2, lastUpdatedAt="2026-08-27T08:00:00Z")
         newer = entry(jobId=3, lastUpdatedAt="2026-08-27T09:00:00Z")
 
-        self.assertEqual(
-            plan.unfiltered_count([older, at_the_mark, newer], self.WATERMARK), 1
-        )
+        assert plan.unfiltered_count([older, at_the_mark, newer], self.WATERMARK) == 1
 
     def test_a_filtered_listing_counts_nothing(self) -> None:
-        self.assertEqual(plan.unfiltered_count([entry()], self.WATERMARK), 0)
+        assert plan.unfiltered_count([entry()], self.WATERMARK) == 0
 
     def test_the_first_sweep_sent_no_watermark_so_nothing_is_out_of_place(self) -> None:
         older = entry(lastUpdatedAt="2020-01-01T00:00:00Z")
 
-        self.assertEqual(plan.unfiltered_count([older], None), 0)
+        assert plan.unfiltered_count([older], None) == 0
 
     def test_an_unplaceable_entry_is_not_evidence_of_an_ignored_filter(self) -> None:
         """It is refused for its own reason; counting it here would report a
         working filter as broken on every tick that meets one."""
-        self.assertEqual(
-            plan.unfiltered_count([entry(lastUpdatedAt=None)], self.WATERMARK), 0
-        )
+        assert plan.unfiltered_count([entry(lastUpdatedAt=None)], self.WATERMARK) == 0

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_plan.py
@@ -372,6 +372,45 @@ class AJobStillRunningIsPlaceable(unittest.TestCase):
         self.assertEqual(len(placed), 2)
         self.assertGreater(placed["9001"], placed["8900"])
 
+    def test_it_records_no_duration(self) -> None:
+        """The mover reports an unfinished job's duration as a running total —
+        a zero where it has none — and this column holds finished measurements.
+        Recorded as-is it says the sync took no time, which is the one reading
+        an operator watching a stuck sync must not be given."""
+        planned = plan.sync_row(self.RUNNING, CONNECTORS, TICK)
+
+        self.assertIsNone(planned["duration_ms"])
+
+    def test_it_still_states_when_it_started(self) -> None:
+        """The elapsed time the page reports is derived from this stamp, so
+        withholding the duration must not withhold the start with it."""
+        planned = plan.sync_row(self.RUNNING, CONNECTORS, TICK)
+
+        self.assertEqual(planned["started_at"], "2026-08-27 08:00:30.000")
+
+
+class OnlyAnUnfinishedJobLosesItsDuration(unittest.TestCase):
+    def test_every_in_flight_word_records_none(self) -> None:
+        for word in sorted(vocab.IN_FLIGHT_STATUSES):
+            with self.subTest(word=word):
+                self.assertIsNone(row(status=word, duration="PT1M37S")["duration_ms"])
+
+    def test_every_finished_word_keeps_what_it_reported(self) -> None:
+        for word in sorted(vocab.TERMINAL_STATUSES):
+            with self.subTest(word=word):
+                planned = row(status=word, duration="PT1M37S")
+                self.assertEqual(planned["duration_ms"], 97_000)
+
+    def test_a_word_that_could_not_be_read_keeps_its_duration(self) -> None:
+        """An unreadable word may well name a finished job, and treating it as
+        in flight would discard a measurement that was actually taken."""
+        self.assertEqual(row(status="borked", duration="PT1M37S")["duration_ms"], 97_000)
+
+    def test_a_finished_job_that_really_took_no_time_still_says_so(self) -> None:
+        """Suppression is decided by the status, never by the value: a zero
+        from a finished job is a measurement, not an absence."""
+        self.assertEqual(row(status="succeeded", duration="PT0S")["duration_ms"], 0)
+
 
 class AnIgnoredFilterIsVisible(unittest.TestCase):
     """The mover answers 200 and drops a parameter it does not recognise.

--- a/src/ingestion/reconcile-connectors/tests/test_sweep_work.py
+++ b/src/ingestion/reconcile-connectors/tests/test_sweep_work.py
@@ -8,14 +8,13 @@ have, too narrow and a configured one reads as removed.
 Drives the real bash rather than a transcription of it — the gate's three exit
 codes are the whole point, and a rewrite in Python would test the rewrite.
 
-Run: python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests
+Run: pytest src/ingestion/reconcile-connectors/tests
 """
 
 from __future__ import annotations
 
 import json
 import subprocess
-import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -61,26 +60,26 @@ def names(result: subprocess.CompletedProcess) -> list[str]:
     return [c["name"] for c in work["connectors"]]
 
 
-class ConfiguredMeansTheInstallHasIt(unittest.TestCase):
+class TestConfiguredMeansTheInstallHasIt:
     def test_a_descriptor_without_a_secret_is_not_configured(self) -> None:
         """Descriptors are every connector the product ships. Reporting them all
         fills the page with connectors this install never had — and reconcile
         agrees: without a Secret it deletes the source rather than driving it."""
         result = build_work('[[ "$1" == "charlie" ]] && return 0; return 1')
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(names(result), ["alpha", "bravo"])
+        assert result.returncode == 0, result.stderr
+        assert names(result) == ["alpha", "bravo"]
 
     def test_a_connector_with_a_secret_is_configured_even_with_no_connection(self) -> None:
         """A configured connector that never ran is a state the page must be
         able to show, so it is reported without a connection id, not dropped."""
         result = build_work("return 1")
 
-        self.assertEqual(result.returncode, 0, result.stderr)
+        assert result.returncode == 0, result.stderr
         work = json.loads(result.stdout)
         by_name = {c["name"]: c for c in work["connectors"]}
-        self.assertEqual(by_name["alpha"]["connection_id"], "conn-alpha")
-        self.assertNotIn("connection_id", by_name["charlie"])
+        assert by_name["alpha"]["connection_id"] == "conn-alpha"
+        assert "connection_id" not in by_name["charlie"]
 
     def test_a_failed_secret_lookup_records_nothing_at_all(self) -> None:
         """Exit 2 is "the API blipped", not "the Secret is gone". Dropping the
@@ -88,18 +87,14 @@ class ConfiguredMeansTheInstallHasIt(unittest.TestCase):
         which the read surface takes at face value — so no snapshot is built."""
         result = build_work('[[ "$1" == "bravo" ]] && return 2; return 1')
 
-        self.assertEqual(result.returncode, 1)
-        self.assertEqual(result.stdout.strip(), "")
-        self.assertIn("bravo", result.stderr)
+        assert result.returncode == 1
+        assert result.stdout.strip() == ""
+        assert "bravo" in result.stderr
 
     def test_no_descriptor_carries_a_secret_and_the_set_is_empty(self) -> None:
         """An empty set is not an error here. The caller refuses to seal it —
         an empty snapshot and "everything was removed" are the same rows."""
         result = build_work("return 0")
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(names(result), [])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert result.returncode == 0, result.stderr
+        assert names(result) == []


### PR DESCRIPTION
Closes #3036.

**Why.** A connector shown as `syncing` reported a Duration of `0 ms` however long ago it started, so a sync stuck for hours looked like the fastest row on the page.

**What changed.** The column read the mover's own reported duration for every row, and for a job it has not finished the mover reports a running total — a zero where it has none. The sweep now records no duration for a `pending` or `running` job, and the page derives the elapsed time for such a row from its start and the answer's own `as_of`.

**The page ignores a recorded duration for an in-flight row rather than trusting the writer.** Ledger rows written before this change still hold that zero, so the fix has to work without a backfill. Reversible on its own.

**Wording is "so far", not a bare duration.** Elapsed time and a finished measurement are different facts and share one column; the row says which it is instead of relying on the state badge beside it.

The `example-inbox` row, started 37 minutes before the page was dated, carrying the zero a ledger row written by the old sweep still holds:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/constructorfabric/insight/pr-3112-assets/before.png) | ![after](https://raw.githubusercontent.com/constructorfabric/insight/pr-3112-assets/after.png) |

**Verified.** `vitest run --project=unit` (2352 pass, 9 new), `tsc -b`, `eslint --max-warnings 0`, and `python3 -m unittest discover -s src/ingestion/reconcile-connectors/tests` (87 pass, 6 new). Screenshots are the msw mock stand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connector health now displays live elapsed time for pending and running syncs instead of misleading zero-duration values.
  * Completed syncs continue to display their reported durations, including genuine zero-duration jobs.
  * Unavailable or invalid timing information is shown as unmeasured rather than a fabricated duration.

* **Improvements**
  * Active syncs are clearly distinguished from completed syncs.
  * Running syncs appear in health history with their start time and current status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->