### PR TITLE
feat(identity): serve canonical people

### DIFF
--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -2001,6 +2001,110 @@
         "summary": "List current roster people"
       }
     },
+    "/v1/people/{person_id}": {
+      "get": {
+        "operationId": "identity_resolution.people.get",
+        "parameters": [
+          {
+            "description": "Canonical person id",
+            "in": "path",
+            "name": "person_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PeopleListItemResponse"
+                }
+              }
+            },
+            "description": "Current roster person visible to the caller"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get one current roster person"
+      }
+    },
     "/v1/person-roles": {
       "get": {
         "operationId": "identity_resolution.person_roles.list",

--- a/src/backend/services/identity-resolution/src/api/http_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/api/http_live_tests.rs
@@ -738,6 +738,52 @@ async fn people_lists_only_current_roster_people_visible_to_the_caller() -> Test
 }
 
 #[tokio::test]
+async fn people_detail_uses_the_roster_projection_not_later_identity_evidence() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = f.person("detail-caller@http-live.test").await?;
+    let report = f.person("detail-report@http-live.test").await?;
+    f.project_person(
+        report,
+        Some("roster@example.com"),
+        Some("roster-handle"),
+        Some("Roster Name"),
+        Some("Roster"),
+        Some("Name"),
+    )
+    .await?;
+    f.observed(report, "display_name", "Activity Name").await?;
+    f.reports_to(report, caller).await?;
+
+    let (status, body) = get(app(&f, caller), &format!("/v1/people/{report}")).await?;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["person_id"], report.to_string());
+    assert_eq!(body["display_name"], "Roster Name");
+    assert_eq!(body["first_name"], "Roster");
+    assert_eq!(body["last_name"], "Name");
+    assert_eq!(body["manager_person_id"], caller.to_string());
+    Ok(())
+}
+
+#[tokio::test]
+async fn people_detail_hides_a_roster_person_outside_the_callers_visible_set() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = f.person("detail-hidden-caller@http-live.test").await?;
+    let hidden = f.person("detail-hidden-person@http-live.test").await?;
+    f.project_person(hidden, None, None, Some("Hidden Person"), None, None)
+        .await?;
+
+    let (status, _) = get(app(&f, caller), &format!("/v1/people/{hidden}")).await?;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    Ok(())
+}
+
+#[tokio::test]
 async fn people_preserve_source_names_and_only_synthesize_a_missing_display_name() -> TestResult {
     let Some(f) = fixture_or_skip().await? else {
         return Ok(());

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -211,6 +211,21 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         .handler(people::list_people)
         .register(router, openapi);
 
+    let router = OperationBuilder::get("/v1/people/{person_id}")
+        .operation_id("identity_resolution.people.get")
+        .summary("Get one current roster person")
+        .authenticated()
+        .path_param("person_id", "Canonical person id")
+        .no_license_required()
+        .json_response_with_schema::<people::PeopleListItemResponse>(
+            openapi,
+            StatusCode::OK,
+            "Current roster person visible to the caller",
+        )
+        .standard_errors(openapi)
+        .handler(people::get_person)
+        .register(router, openapi);
+
     let router = OperationBuilder::get("/v1/persons")
         .operation_id("identity_resolution.persons.search")
         .summary("List the tenant's persons, narrowed by search terms (admin)")
@@ -745,6 +760,10 @@ mod openapi_tests {
         assert!(
             document.paths.paths.contains_key("/v1/people"),
             "the additive people listing must be described"
+        );
+        assert!(
+            document.paths.paths.contains_key("/v1/people/{person_id}"),
+            "the canonical person detail must be described"
         );
         assert!(
             document.paths.paths.contains_key("/v1/resolution/bind"),

--- a/src/backend/services/identity-resolution/src/api/people.rs
+++ b/src/backend/services/identity-resolution/src/api/people.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use axum::Json;
-use axum::extract::{Extension, Query};
+use axum::extract::{Extension, Path, Query};
 use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
 use toolkit_canonical_errors::CanonicalError;
@@ -75,6 +75,7 @@ pub struct PeopleListItemResponse {
     pub attributes: BTreeMap<String, String>,
     pub manager_person_id: Option<Uuid>,
 }
+impl toolkit::api::api_dto::ResponseApiDto for PeopleListItemResponse {}
 
 impl From<PersonListRow> for PeopleListItemResponse {
     fn from(person: PersonListRow) -> Self {
@@ -115,12 +116,10 @@ pub async fn list_people(
     let limit = listing::clamp_limit(params.limit, DEFAULT_LIMIT, MAX_LIMIT);
     let query = cursor_query(visibility, caller, &terms.join(" "));
     let resume = resume_from(params.cursor.as_deref(), tenant, &query)?;
-    let restrict = Restrict {
-        visible_to: (visibility == PeopleVisibility::Caller).then_some(VisibleTo {
-            viewer_person_id: caller,
-            org_source_type: &state.config.org_chart_source_type,
-            policy: state.config.visibility_policy,
-        }),
+    let restrict = if visibility == PeopleVisibility::Caller {
+        caller_restriction(&state, caller)
+    } else {
+        Restrict { visible_to: None }
     };
 
     let rows = if listing::person_terms_name_nobody(&terms, &named, &values) {
@@ -157,6 +156,47 @@ pub async fn list_people(
 
     let items = rows.into_iter().map(PeopleListItemResponse::from).collect();
     Ok(Json(PeopleListResponse { items, next_cursor }))
+}
+
+pub async fn get_person(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Path(person_id): Path<Uuid>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    let caller = require_caller(&ctx)?;
+    let tenant = ctx.subject_tenant_id();
+    let person_ids = [person_id];
+    let rows = people_listing::list_persons(
+        &state.db,
+        tenant,
+        ListQuery {
+            org_chart_source_type: &state.config.org_chart_source_type,
+            terms: &[],
+            person_ids: &person_ids,
+            restrict: caller_restriction(&state, caller),
+            after: None,
+            limit: 1,
+        },
+    )
+    .await
+    .map_err(|error| read_error(&error))?;
+
+    let person = rows.into_iter().next().ok_or_else(|| {
+        PersonSearchError::not_found("person not found or not visible")
+            .with_resource(person_id.to_string())
+            .create()
+    })?;
+    Ok(Json(PeopleListItemResponse::from(person)))
+}
+
+fn caller_restriction(state: &AppState, caller: Uuid) -> Restrict<'_> {
+    Restrict {
+        visible_to: Some(VisibleTo {
+            viewer_person_id: caller,
+            org_source_type: &state.config.org_chart_source_type,
+            policy: state.config.visibility_policy,
+        }),
+    }
 }
 
 fn search_terms(q: Option<&str>) -> Result<Vec<String>, CanonicalError> {

--- a/src/frontend/src/api/identity-client.test.ts
+++ b/src/frontend/src/api/identity-client.test.ts
@@ -65,6 +65,21 @@ describe("listPeople", () => {
     expect(page.next_cursor).toBe("next-page");
   });
 
+  it("requests a searchable tenant roster for an admin console", async () => {
+    mockFetch.mockResolvedValueOnce(response({ items: [] }));
+    const controller = new AbortController();
+
+    await listPeople(
+      { q: "ada example", visibility: "tenant", limit: 50 },
+      controller.signal,
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/identity/v1/people?visibility=tenant&q=ada+example&limit=50",
+      { signal: controller.signal },
+    );
+  });
+
   it("rejects a malformed roster response", async () => {
     mockFetch.mockResolvedValueOnce(response({ items: null }));
 

--- a/src/frontend/src/api/identity-client.test.ts
+++ b/src/frontend/src/api/identity-client.test.ts
@@ -20,7 +20,10 @@ import {
 
 const mockFetch = fetchWithAuth as unknown as ReturnType<typeof vi.fn>;
 
-function response(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+function response(
+  body: unknown,
+  init?: { ok?: boolean; status?: number }
+): Response {
   return {
     ok: init?.ok ?? true,
     status: init?.status ?? 200,
@@ -49,13 +52,13 @@ describe("listPeople", () => {
           },
         ],
         next_cursor: "next-page",
-      }),
+      })
     );
 
     const page = await listPeople({ cursor: "current-page", limit: 250 });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/identity/v1/people?cursor=current-page&limit=250",
+      "/api/identity/v1/people?cursor=current-page&limit=250"
     );
     expect(page.items[0]).toMatchObject({
       person_id: "019e27bc-dec0-7626-81a9-c5524662a6a9",
@@ -71,12 +74,12 @@ describe("listPeople", () => {
 
     await listPeople(
       { q: "ada example", visibility: "tenant", limit: 50 },
-      controller.signal,
+      controller.signal
     );
 
     expect(mockFetch).toHaveBeenCalledWith(
       "/api/identity/v1/people?visibility=tenant&q=ada+example&limit=50",
-      { signal: controller.signal },
+      { signal: controller.signal }
     );
   });
 
@@ -90,89 +93,47 @@ describe("listPeople", () => {
 });
 
 describe("getPerson", () => {
-  it("POSTs /profiles with a person_id body and maps the profile", async () => {
+  it("GETs canonical person detail and maps roster attributes", async () => {
     mockFetch.mockResolvedValueOnce(
       response({
         person_id: "019e27bc-dec0-7626-81a9-c5524662a6a9",
-        insight_tenant_id: "t-1",
         email: "bob.park@example.com",
         display_name: "Bob Park",
-        job_title: "Lead",
-        supervisor_email: "ceo@example.com",
-      }),
+        first_name: "Bob",
+        last_name: "Park",
+        username: "bpark",
+        attributes: {
+          department: "Engineering",
+          job_title: "Lead",
+        },
+        manager_person_id: "019e27bc-dec0-7626-81a9-c5524662a6aa",
+      })
     );
 
     const person = await getPerson("019e27bc-dec0-7626-81a9-c5524662a6a9");
 
-    const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toBe("/api/identity/v1/profiles");
-    expect(init).toMatchObject({ method: "POST" });
-    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
-      value_type: "person_id",
-      value: "019e27bc-dec0-7626-81a9-c5524662a6a9",
-    });
-
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/identity/v1/people/019e27bc-dec0-7626-81a9-c5524662a6a9"
+    );
     expect(person.person_id).toBe("019e27bc-dec0-7626-81a9-c5524662a6a9");
     expect(person.email).toBe("bob.park@example.com");
+    expect(person.first_name).toBe("Bob");
     expect(person.job_title).toBe("Lead");
-    expect(person.supervisor_email).toBe("ceo@example.com");
-    // Omitted optional strings default to ""; omitted parent fields stay null.
-    expect(person.department).toBe("");
-    expect(person.parent_id).toBeNull();
-    expect(person.parent_email).toBeNull();
-  });
-
-  it("keeps subordinates without an email — person_id is the key now", async () => {
-    mockFetch.mockResolvedValueOnce(
-      response({
-        person_id: "019e27bc-dec0-7626-81a9-c5524662a6aa",
-        insight_tenant_id: "t-1",
-        email: "lead@example.com",
-        subordinates: [
-          { person_id: "019e27bc-dec0-7626-81a9-c5524662a6ab", insight_tenant_id: "t-1", email: "ic1@example.com" },
-          // No email is legitimate: identity serves persons whose log carries
-          // none, and links/keys read person_id.
-          { person_id: "019e27bc-dec0-7626-81a9-c5524662a6a9", insight_tenant_id: "t-1" },
-        ],
-      }),
+    expect(person.department).toBe("Engineering");
+    expect(person.parent_person_id).toBe(
+      "019e27bc-dec0-7626-81a9-c5524662a6aa"
     );
-
-    const person = await getPerson("019e27bc-dec0-7626-81a9-c5524662a6aa");
-
-    expect(person.subordinates.map((s) => s.person_id)).toEqual([
-      "019e27bc-dec0-7626-81a9-c5524662a6ab",
-      "019e27bc-dec0-7626-81a9-c5524662a6a9",
-    ]);
-    expect(person.subordinates.map((s) => s.email)).toEqual([
-      "ic1@example.com",
-      "",
-    ]);
-  });
-
-  it("drops a subordinate without a person_id — a keyless node breaks links and React keys", async () => {
-    mockFetch.mockResolvedValueOnce(
-      response({
-        person_id: "019e27bc-dec0-7626-81a9-c5524662a6aa",
-        insight_tenant_id: "t-1",
-        subordinates: [
-          { person_id: "019e27bc-dec0-7626-81a9-c5524662a6ab", insight_tenant_id: "t-1" },
-          { insight_tenant_id: "t-1", email: "keyless@example.com" },
-          { person_id: "  ", insight_tenant_id: "t-1" },
-        ],
-      } as never),
-    );
-
-    const person = await getPerson("019e27bc-dec0-7626-81a9-c5524662a6aa");
-
-    expect(person.subordinates.map((s) => s.person_id)).toEqual(["019e27bc-dec0-7626-81a9-c5524662a6ab"]);
+    expect(person.subordinates).toEqual([]);
   });
 
   it("throws IdentityApiError with the status + body on a non-ok response", async () => {
     mockFetch.mockResolvedValueOnce(
-      response({ error: "not_found" }, { ok: false, status: 404 }),
+      response({ error: "not_found" }, { ok: false, status: 404 })
     );
 
-    await expect(getPerson("ghost@example.com")).rejects.toMatchObject({
+    await expect(
+      getPerson("019e27bc-dec0-7626-81a9-c5524662a6a9")
+    ).rejects.toMatchObject({
       name: "IdentityApiError",
       status: 404,
       body: { error: "not_found" },
@@ -188,24 +149,25 @@ describe("getPerson", () => {
       },
     } as unknown as Response);
 
-    await expect(getPerson("bob@example.com")).rejects.toMatchObject({
+    await expect(
+      getPerson("019e27bc-dec0-7626-81a9-c5524662a6a9")
+    ).rejects.toMatchObject({
       status: 200,
       body: { error: "invalid_json" },
     });
   });
 
-  it("rejects a profile missing the required person_id", async () => {
-    mockFetch.mockResolvedValueOnce(
-      response({ insight_tenant_id: "t-1", email: "bob@example.com" } as never),
-    );
+  it("rejects person detail missing the required person id", async () => {
+    mockFetch.mockResolvedValueOnce(response({ attributes: {} } as never));
 
-    const err = await getPerson("019e27bc-dec0-7626-81a9-c5524662a6a9").catch((e: unknown) => e);
+    const err = await getPerson("019e27bc-dec0-7626-81a9-c5524662a6a9").catch(
+      (e: unknown) => e
+    );
     expect(err).toBeInstanceOf(IdentityApiError);
     expect((err as IdentityApiError).body).toEqual({
-      error: "missing_person_id",
+      error: "malformed_person",
     });
   });
-
 });
 
 describe("getMe", () => {
@@ -217,7 +179,7 @@ describe("getMe", () => {
         roles: [
           { role_id: "a4d11000-0000-4000-8000-000000000001", name: "admin" },
         ],
-      }),
+      })
     );
 
     const me = await getMe();
@@ -230,7 +192,7 @@ describe("getMe", () => {
 
   it("keeps an empty roles list as a valid 'not an admin' answer", async () => {
     mockFetch.mockResolvedValueOnce(
-      response({ person_id: "p-1", insight_tenant_id: "t-1", roles: [] }),
+      response({ person_id: "p-1", insight_tenant_id: "t-1", roles: [] })
     );
 
     await expect(getMe()).resolves.toMatchObject({ roles: [] });
@@ -238,7 +200,7 @@ describe("getMe", () => {
 
   it("throws on an HTTP failure instead of pretending to an empty grant", async () => {
     mockFetch.mockResolvedValueOnce(
-      response({ title: "unauthenticated" }, { ok: false, status: 401 }),
+      response({ title: "unauthenticated" }, { ok: false, status: 401 })
     );
 
     await expect(getMe()).rejects.toMatchObject({ status: 401 });
@@ -246,7 +208,7 @@ describe("getMe", () => {
 
   it("rejects a malformed body rather than reading it as 'no roles'", async () => {
     mockFetch.mockResolvedValueOnce(
-      response({ person_id: "p-1", insight_tenant_id: "t-1" } as never),
+      response({ person_id: "p-1", insight_tenant_id: "t-1" } as never)
     );
 
     await expect(getMe()).rejects.toMatchObject({
@@ -264,7 +226,7 @@ describe("getMe", () => {
     ["a member whose role_id is blank", [{ role_id: "  ", name: "admin" }]],
   ])("rejects a roles array with %s", async (_name, roles) => {
     mockFetch.mockResolvedValueOnce(
-      response({ person_id: "p-1", insight_tenant_id: "t-1", roles } as never),
+      response({ person_id: "p-1", insight_tenant_id: "t-1", roles } as never)
     );
 
     await expect(getMe()).rejects.toMatchObject({
@@ -288,14 +250,21 @@ describe("getAttention", () => {
             candidates: [],
           },
         ],
-        rates: { persons: 1, observed: 1, bound: 0, pending: 1, no_evidence: 0, excluded: 0 },
-      }),
+        rates: {
+          persons: 1,
+          observed: 1,
+          bound: 0,
+          pending: 1,
+          no_evidence: 0,
+          excluded: 0,
+        },
+      })
     );
 
     const queue = await getAttention(50);
 
     expect(mockFetch.mock.calls[0][0]).toBe(
-      "/api/identity/v1/resolution/attention?limit=50",
+      "/api/identity/v1/resolution/attention?limit=50"
     );
     expect(queue.items).toHaveLength(1);
     expect(queue.rates.pending).toBe(1);
@@ -311,7 +280,7 @@ describe("getAttention", () => {
 
   it("throws on an HTTP failure (a revoked role must not look like zero work)", async () => {
     mockFetch.mockResolvedValueOnce(
-      response({ title: "forbidden" }, { ok: false, status: 403 }),
+      response({ title: "forbidden" }, { ok: false, status: 403 })
     );
 
     await expect(getAttention()).rejects.toMatchObject({ status: 403 });
@@ -321,13 +290,22 @@ describe("getAttention", () => {
 describe("getAccountBinding", () => {
   it("URI-encodes every path segment — an account_id with slashes cannot escape", async () => {
     mockFetch.mockResolvedValueOnce(
-      response({ source: "github", source_id: "s", account_id: "a/b c", history: [] }),
+      response({
+        source: "github",
+        source_id: "s",
+        account_id: "a/b c",
+        history: [],
+      })
     );
 
-    await getAccountBinding({ source: "github", source_id: "s", account_id: "a/b c" });
+    await getAccountBinding({
+      source: "github",
+      source_id: "s",
+      account_id: "a/b c",
+    });
 
     expect(mockFetch.mock.calls[0][0]).toBe(
-      "/api/identity/v1/resolution/accounts/github/s/a%2Fb%20c",
+      "/api/identity/v1/resolution/accounts/github/s/a%2Fb%20c"
     );
   });
 
@@ -335,7 +313,7 @@ describe("getAccountBinding", () => {
     mockFetch.mockResolvedValueOnce(response({ source: "github" } as never));
 
     await expect(
-      getAccountBinding({ source: "github", source_id: "s", account_id: "a" }),
+      getAccountBinding({ source: "github", source_id: "s", account_id: "a" })
     ).rejects.toMatchObject({ body: { error: "malformed_binding" } });
   });
 });
@@ -380,7 +358,7 @@ describe("correction verbs", () => {
 
   it("detach returns the freshly minted person", async () => {
     mockFetch.mockResolvedValueOnce(
-      response({ ...OK, new_person_id: "p-new" }),
+      response({ ...OK, new_person_id: "p-new" })
     );
 
     const outcome = await detachAccount({ account: ACCOUNT });
@@ -391,7 +369,9 @@ describe("correction verbs", () => {
   it("a refusal body without items is malformed, not silently empty", async () => {
     mockFetch.mockResolvedValueOnce(response({ applied: 0 } as never));
 
-    await expect(bindAccount({ account: ACCOUNT, person_id: "p-1" })).rejects.toMatchObject({
+    await expect(
+      bindAccount({ account: ACCOUNT, person_id: "p-1" })
+    ).rejects.toMatchObject({
       body: { error: "malformed_correction" },
     });
   });
@@ -404,7 +384,7 @@ describe("searchPersons", () => {
     await searchPersons("iva example.com");
 
     expect(mockFetch.mock.calls[0][0]).toBe(
-      "/api/identity/v1/persons?q=iva%20example.com",
+      "/api/identity/v1/persons?q=iva%20example.com"
     );
   });
 
@@ -450,22 +430,28 @@ describe("getPersonAccounts", () => {
 
     await expect(getPersonAccounts(OWNED.person_id)).resolves.toEqual(OWNED);
     expect(mockFetch.mock.calls[0][0]).toBe(
-      `/api/identity/v1/resolution/persons/${OWNED.person_id}/accounts`,
+      `/api/identity/v1/resolution/persons/${OWNED.person_id}/accounts`
     );
   });
 
   it("keeps an empty account list a valid answer", async () => {
-    mockFetch.mockResolvedValueOnce(response({ person_id: "p-1", accounts: [] }));
+    mockFetch.mockResolvedValueOnce(
+      response({ person_id: "p-1", accounts: [] })
+    );
 
-    await expect(getPersonAccounts("p-1")).resolves.toMatchObject({ accounts: [] });
+    await expect(getPersonAccounts("p-1")).resolves.toMatchObject({
+      accounts: [],
+    });
   });
 
   it("throws on an HTTP failure instead of reporting nothing to move", async () => {
     mockFetch.mockResolvedValueOnce(
-      response({ title: "forbidden" }, { ok: false, status: 403 }),
+      response({ title: "forbidden" }, { ok: false, status: 403 })
     );
 
-    await expect(getPersonAccounts("p-1")).rejects.toMatchObject({ status: 403 });
+    await expect(getPersonAccounts("p-1")).rejects.toMatchObject({
+      status: 403,
+    });
   });
 
   // The merge preview counts this list, so a malformed body must not read as

--- a/src/frontend/src/api/identity-client.test.ts
+++ b/src/frontend/src/api/identity-client.test.ts
@@ -13,6 +13,7 @@ import {
   getPerson,
   getPersonAccounts,
   IdentityApiError,
+  listPeople,
   mergePersons,
   searchPersons,
 } from "./identity-client";
@@ -29,6 +30,48 @@ function response(body: unknown, init?: { ok?: boolean; status?: number }): Resp
 
 beforeEach(() => {
   mockFetch.mockReset();
+});
+
+describe("listPeople", () => {
+  it("GETs one caller-visible roster page from /people", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({
+        items: [
+          {
+            person_id: "019e27bc-dec0-7626-81a9-c5524662a6a9",
+            display_name: null,
+            first_name: null,
+            last_name: null,
+            username: "example-user",
+            email: null,
+            attributes: { department: "Engineering" },
+            manager_person_id: null,
+          },
+        ],
+        next_cursor: "next-page",
+      }),
+    );
+
+    const page = await listPeople({ cursor: "current-page", limit: 250 });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/identity/v1/people?cursor=current-page&limit=250",
+    );
+    expect(page.items[0]).toMatchObject({
+      person_id: "019e27bc-dec0-7626-81a9-c5524662a6a9",
+      username: "example-user",
+      attributes: { department: "Engineering" },
+    });
+    expect(page.next_cursor).toBe("next-page");
+  });
+
+  it("rejects a malformed roster response", async () => {
+    mockFetch.mockResolvedValueOnce(response({ items: null }));
+
+    await expect(listPeople()).rejects.toMatchObject({
+      body: { error: "malformed_roster" },
+    });
+  });
 });
 
 describe("getPerson", () => {

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -476,6 +476,11 @@ export interface PageRequest {
   limit?: number;
 }
 
+export interface PeopleListRequest extends PageRequest {
+  q?: string;
+  visibility?: "caller" | "tenant";
+}
+
 function pageParams(page: PageRequest): string {
   const params = new URLSearchParams();
   if (page.cursor) params.set("cursor", page.cursor);
@@ -486,13 +491,19 @@ function pageParams(page: PageRequest): string {
 
 /** One caller-authorized page of the canonical roster. */
 export async function listPeople(
-  page: PageRequest = {},
+  page: PeopleListRequest = {},
+  signal?: AbortSignal,
 ): Promise<PeopleListResponse> {
   const params = new URLSearchParams();
+  if (page.visibility) params.set("visibility", page.visibility);
+  if (page.q) params.set("q", page.q);
   if (page.cursor) params.set("cursor", page.cursor);
   if (page.limit != null) params.set("limit", String(page.limit));
   const query = params.toString();
-  const res = await fetchWithAuth(`${BASE}/people${query ? `?${query}` : ""}`);
+  const url = `${BASE}/people${query ? `?${query}` : ""}`;
+  const res = signal
+    ? await fetchWithAuth(url, { signal })
+    : await fetchWithAuth(url);
   if (!res.ok) {
     const body = await res.json().catch(() => null);
     throw new IdentityApiError(res.status, body);

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -1,15 +1,3 @@
-/**
- * `subordinates` is empty until the backend `expand_subordinates` flag is on.
- * When mocks are off and the endpoint fails the caller surfaces the failure to
- * the UI — never silently falls back to seeded data.
- *
- * The legacy `GET /persons/{email}` lookup (RFC 8594 deprecated) is replaced by
- * `POST /profiles` with a `{ value_type, value }` body. In the wire shape
- * (`ProfileResponse`) nearly every field is optional; we normalize it back into
- * the required-string `IdentityPerson` projection the UI already consumes so
- * callers and the org-tree sidebar are unchanged.
- */
-
 import { fetchWithAuth } from "@/api/fetch-with-auth";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import type { IdentityPerson } from "@/types/insight";
@@ -17,28 +5,6 @@ import type { IdentityPerson } from "@/types/insight";
 const BASE =
   (import.meta.env.VITE_IDENTITY_BASE as string | undefined) ??
   "/api/identity/v1";
-
-/** Wire shape of `POST /profiles` (snake_case; optional fields omitted). */
-interface ProfileResponse {
-  person_id: string;
-  insight_tenant_id: string;
-  email?: string;
-  display_name?: string;
-  first_name?: string;
-  last_name?: string;
-  department?: string;
-  division?: string;
-  job_title?: string;
-  status?: string;
-  username?: string;
-  employee_id?: string;
-  supervisor_email?: string;
-  supervisor_name?: string;
-  parent_email?: string;
-  parent_person_id?: string;
-  subordinates?: ProfileResponse[];
-  ids?: unknown[];
-}
 
 /** One active role assignment of the caller, as `GET /me` reports it. */
 export interface MeRole {
@@ -88,7 +54,11 @@ export async function getMe(): Promise<MeResponse> {
   // diagnosable where a silent [] is not. The entries are checked too: the
   // gate reads `role_id` off each one, so a `[null]` would throw during
   // render rather than fail closed.
-  if (!me.person_id?.trim() || !Array.isArray(me.roles) || !me.roles.every(isMeRole)) {
+  if (
+    !me.person_id?.trim() ||
+    !Array.isArray(me.roles) ||
+    !me.roles.every(isMeRole)
+  ) {
     throw new IdentityApiError(res.status, { error: "malformed_me" });
   }
   return me;
@@ -183,9 +153,11 @@ export const QUEUE_MAX_ITEMS = 1000;
  * read, so asking for more of it is a larger `limit`, not a next page.
  */
 export async function getAttention(
-  limit: number = QUEUE_FIRST_PAGE,
+  limit: number = QUEUE_FIRST_PAGE
 ): Promise<AttentionResponse> {
-  const res = await fetchWithAuth(`${BASE}/resolution/attention?limit=${limit}`);
+  const res = await fetchWithAuth(
+    `${BASE}/resolution/attention?limit=${limit}`
+  );
   if (!res.ok) {
     const body = await res.json().catch(() => null);
     throw new IdentityApiError(res.status, body);
@@ -235,11 +207,11 @@ export interface AccountSearchResponse {
 export async function searchAccounts(
   q: string,
   page: PageRequest = {},
-  signal?: AbortSignal,
+  signal?: AbortSignal
 ): Promise<AccountSearchResponse> {
   const res = await fetchWithAuth(
     `${BASE}/resolution/accounts?q=${encodeURIComponent(q)}${pageParams(page)}`,
-    { signal },
+    { signal }
   );
   if (!res.ok) {
     const body = await res.json().catch(() => null);
@@ -353,7 +325,7 @@ export interface CorrectionResponse {
 
 async function postCorrection(
   path: string,
-  body: unknown,
+  body: unknown
 ): Promise<CorrectionResponse> {
   const res = await fetchWithAuth(`${BASE}/resolution/${path}`, {
     method: "POST",
@@ -470,6 +442,31 @@ export interface PeopleListResponse {
   next_cursor?: string | null;
 }
 
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isPeopleListItem(value: unknown): value is PeopleListItem {
+  if (typeof value !== "object" || value === null) return false;
+  const person = value as Record<string, unknown>;
+  const attributes = person.attributes;
+  return (
+    typeof person.person_id === "string" &&
+    isNullableString(person.display_name) &&
+    isNullableString(person.first_name) &&
+    isNullableString(person.last_name) &&
+    isNullableString(person.username) &&
+    isNullableString(person.email) &&
+    typeof attributes === "object" &&
+    attributes !== null &&
+    !Array.isArray(attributes) &&
+    Object.values(attributes).every(
+      (attribute) => typeof attribute === "string"
+    ) &&
+    isNullableString(person.manager_person_id)
+  );
+}
+
 /** One page of a listing: where to resume and how many rows to ask for. */
 export interface PageRequest {
   cursor?: string;
@@ -492,7 +489,7 @@ function pageParams(page: PageRequest): string {
 /** One caller-authorized page of the canonical roster. */
 export async function listPeople(
   page: PeopleListRequest = {},
-  signal?: AbortSignal,
+  signal?: AbortSignal
 ): Promise<PeopleListResponse> {
   const params = new URLSearchParams();
   if (page.visibility) params.set("visibility", page.visibility);
@@ -514,7 +511,7 @@ export async function listPeople(
   } catch {
     throw new IdentityApiError(res.status, { error: "invalid_json" });
   }
-  if (!Array.isArray(listed.items)) {
+  if (!Array.isArray(listed.items) || !listed.items.every(isPeopleListItem)) {
     throw new IdentityApiError(res.status, { error: "malformed_roster" });
   }
   return listed;
@@ -528,11 +525,11 @@ export async function listPeople(
 export async function searchPersons(
   q: string,
   page: PageRequest = {},
-  signal?: AbortSignal,
+  signal?: AbortSignal
 ): Promise<PersonSearchResponse> {
   const res = await fetchWithAuth(
     `${BASE}/persons?q=${encodeURIComponent(q)}${pageParams(page)}`,
-    { signal },
+    { signal }
   );
   if (!res.ok) {
     const body = await res.json().catch(() => null);
@@ -556,7 +553,7 @@ export async function searchPersons(
  * their own visible set, so it needs no admin role.
  */
 export async function listVisiblePersons(
-  page: PageRequest & { q?: string } = {},
+  page: PageRequest & { q?: string } = {}
 ): Promise<PersonSearchResponse> {
   const params = new URLSearchParams();
   if (page.q) params.set("q", page.q);
@@ -564,7 +561,7 @@ export async function listVisiblePersons(
   if (page.limit != null) params.set("limit", String(page.limit));
   const query = params.toString();
   const res = await fetchWithAuth(
-    `${BASE}/visible-persons${query ? `?${query}` : ""}`,
+    `${BASE}/visible-persons${query ? `?${query}` : ""}`
   );
   if (!res.ok) {
     const body = await res.json().catch(() => null);
@@ -593,10 +590,10 @@ export interface PersonAccountEntry {
 
 /** Every account currently bound to a person — the merge preview's substance. */
 export async function getPersonAccounts(
-  personId: string,
+  personId: string
 ): Promise<{ person_id: string; accounts: PersonAccountEntry[] }> {
   const res = await fetchWithAuth(
-    `${BASE}/resolution/persons/${encodeURIComponent(personId)}/accounts`,
+    `${BASE}/resolution/persons/${encodeURIComponent(personId)}/accounts`
   );
   if (!res.ok) {
     const body = await res.json().catch(() => null);
@@ -626,80 +623,49 @@ export class IdentityApiError extends Error {
   }
 }
 
-/**
- * Normalize a `ProfileResponse` into the FE `IdentityPerson`. `person_id` is the
- * UI identity (route links + React keys), so the top-level profile is guaranteed
- * to carry one by `getPerson`; subordinates the wire returns without one are
- * dropped rather than projected to `""` — a keyless node would make broken links
- * and collide as duplicate React keys across siblings. `email` is display-only
- * now and may legitimately be absent. Other optional strings default to `""`;
- * omitted parent/supervisor fields stay `null`.
- */
-function toIdentityPerson(p: ProfileResponse): IdentityPerson {
+function toIdentityPerson(p: PeopleListItem): IdentityPerson {
   return {
     person_id: p.person_id,
     email: p.email ?? "",
     display_name: p.display_name ?? "",
     first_name: p.first_name ?? "",
     last_name: p.last_name ?? "",
-    department: p.department ?? "",
-    division: p.division ?? "",
-    job_title: p.job_title ?? "",
-    status: p.status ?? "",
+    department: p.attributes.department ?? "",
+    division: p.attributes.division ?? "",
+    job_title: p.attributes.job_title ?? "",
+    status: p.attributes.status ?? "",
     username: p.username ?? "",
-    parent_email: p.parent_email ?? null,
-    // `parent_id` has no ProfileResponse source; preserve the prior default.
+    parent_email: null,
     parent_id: null,
-    parent_person_id: p.parent_person_id ?? null,
-    supervisor_email: p.supervisor_email ?? null,
-    supervisor_name: p.supervisor_name ?? null,
-    subordinates: (p.subordinates ?? [])
-      .filter((s) => Boolean(s.person_id?.trim()))
-      .map(toIdentityPerson),
+    parent_person_id: p.manager_person_id,
+    supervisor_email: null,
+    supervisor_name: null,
+    subordinates: [],
   };
 }
 
-/**
- * Resolve one profile by canonical person id — the key the SPA routes on and
- * the metrics API filters by since the identity cutover. Identity applies the
- * caller's visible set here, so a person's name and their metrics answer to
- * one permission: an id outside it is a 404, not a nameless dashboard.
- */
-export async function getPerson(personId: string): Promise<IdentityPerson> {
-  // Normalized on the way out, matching the query key: one spelling of an id
-  // must not become two requests, or two cache entries for one person.
-  return resolveProfile({
-    value_type: "person_id",
-    value: normalizePersonId(personId),
-  });
-}
-
-async function resolveProfile(body: {
-  value_type: "person_id";
-  value: string;
-}): Promise<IdentityPerson> {
-  const url = `${BASE}/profiles`;
-  const res = await fetchWithAuth(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+/** One caller-visible canonical roster person. */
+export async function getPerson(
+  personId: string,
+  signal?: AbortSignal
+): Promise<IdentityPerson> {
+  const id = normalizePersonId(personId);
+  const url = `${BASE}/people/${encodeURIComponent(id)}`;
+  const res = signal
+    ? await fetchWithAuth(url, { signal })
+    : await fetchWithAuth(url);
   if (!res.ok) {
     const body = await res.json().catch(() => null);
     throw new IdentityApiError(res.status, body);
   }
-  let profile: ProfileResponse;
+  let person: unknown;
   try {
-    profile = (await res.json()) as ProfileResponse;
+    person = await res.json();
   } catch {
     throw new IdentityApiError(res.status, { error: "invalid_json" });
   }
-  // `person_id` is the queried identity + the UI's key; a profile without it
-  // is unusable, so surface it rather than projecting a keyless person. The
-  // email is NOT required — identity resolves persons whose observation log
-  // carries no current email, and nothing keys on it any more.
-  if (!profile.person_id?.trim()) {
-    throw new IdentityApiError(res.status, { error: "missing_person_id" });
+  if (!isPeopleListItem(person)) {
+    throw new IdentityApiError(res.status, { error: "malformed_person" });
   }
-  return toIdentityPerson(profile);
+  return toIdentityPerson(person);
 }

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -453,6 +453,23 @@ export interface PersonSearchResponse {
   next_cursor?: string | null;
 }
 
+/** One canonical roster person returned by `GET /people`. */
+export interface PeopleListItem {
+  person_id: string;
+  display_name: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  username: string | null;
+  email: string | null;
+  attributes: Record<string, string>;
+  manager_person_id: string | null;
+}
+
+export interface PeopleListResponse {
+  items: PeopleListItem[];
+  next_cursor?: string | null;
+}
+
 /** One page of a listing: where to resume and how many rows to ask for. */
 export interface PageRequest {
   cursor?: string;
@@ -465,6 +482,31 @@ function pageParams(page: PageRequest): string {
   if (page.limit != null) params.set("limit", String(page.limit));
   const query = params.toString();
   return query ? `&${query}` : "";
+}
+
+/** One caller-authorized page of the canonical roster. */
+export async function listPeople(
+  page: PageRequest = {},
+): Promise<PeopleListResponse> {
+  const params = new URLSearchParams();
+  if (page.cursor) params.set("cursor", page.cursor);
+  if (page.limit != null) params.set("limit", String(page.limit));
+  const query = params.toString();
+  const res = await fetchWithAuth(`${BASE}/people${query ? `?${query}` : ""}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new IdentityApiError(res.status, body);
+  }
+  let listed: PeopleListResponse;
+  try {
+    listed = (await res.json()) as PeopleListResponse;
+  } catch {
+    throw new IdentityApiError(res.status, { error: "invalid_json" });
+  }
+  if (!Array.isArray(listed.items)) {
+    throw new IdentityApiError(res.status, { error: "malformed_roster" });
+  }
+  return listed;
 }
 
 /**

--- a/src/frontend/src/components/app-sidebar.test.tsx
+++ b/src/frontend/src/components/app-sidebar.test.tsx
@@ -57,7 +57,6 @@ vi.mock("@/queries/identity-me", () => ({
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
     roster: rosterData,
-    truncated: false,
     isPending: false,
     isError: false,
     retry: () => {},

--- a/src/frontend/src/components/app-sidebar.test.tsx
+++ b/src/frontend/src/components/app-sidebar.test.tsx
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import "@/i18n";
 
+import type { PeopleListItem } from "@/api/identity-client";
 import type { IdentityPerson } from "@/types/insight";
 
 let currentPath = "/";
 let viewerEmail: string | null = "alice@x.io";
 let viewerPersonId: string | null = null;
 let viewerData: IdentityPerson | undefined;
+let rosterData: PeopleListItem[] = [];
 
 vi.mock("@tanstack/react-router", () => ({
   Link: ({
@@ -44,6 +46,27 @@ vi.mock("@/lib/portal/portal-store", () => ({
 
 vi.mock("@/queries/ic-dashboard", () => ({
   useIcPerson: () => ({ data: viewerData }),
+}));
+vi.mock("@/queries/identity-me", () => ({
+  useVisibilityPolicy: () => ({
+    policy: "org_chart",
+    isFlat: false,
+    isPending: false,
+  }),
+}));
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster: rosterData,
+    truncated: false,
+    isPending: false,
+    isError: false,
+    retry: () => {},
+  }),
+}));
+vi.mock("@/lib/portal/portal-nav", () => ({
+  usePortalNavActions: () => ({ setScope: vi.fn() }),
+  usePortalItem: () => null,
+  usePortalZone: () => null,
 }));
 
 
@@ -119,6 +142,28 @@ function person(
   } as IdentityPerson;
 }
 
+function rosterRows(
+  root: IdentityPerson,
+  managerPersonId: string | null = null,
+): PeopleListItem[] {
+  const row: PeopleListItem = {
+    person_id: root.person_id,
+    display_name: root.display_name || null,
+    first_name: root.first_name ?? null,
+    last_name: root.last_name ?? null,
+    username: root.username ?? null,
+    email: root.email || null,
+    attributes: {},
+    manager_person_id: managerPersonId,
+  };
+  return [
+    row,
+    ...root.subordinates.flatMap((report) =>
+      rosterRows(report, root.person_id),
+    ),
+  ];
+}
+
 // Alice manages Bob (who manages Carol) and Erin.
 const tree = person(PERSON_IDS.alice, "alice@x.io", "Alice", [
   person(PERSON_IDS.bob, "bob@x.io", "Bob", [
@@ -139,6 +184,7 @@ beforeEach(() => {
   viewerEmail = "alice@x.io";
   viewerPersonId = PERSON_IDS.alice;
   viewerData = tree;
+  rosterData = rosterRows(tree);
 });
 
 describe("AppSidebar", () => {
@@ -173,6 +219,7 @@ describe("AppSidebar", () => {
 
   it("renders no tree while the viewer query has no data and no footer user without an email", () => {
     viewerData = undefined;
+    rosterData = [];
     viewerEmail = null;
     viewerPersonId = null;
     render(<AppSidebar />);
@@ -192,6 +239,7 @@ describe("AppSidebar", () => {
 
   it("falls back to the bare email (no secondary line) when identity is not loaded", () => {
     viewerData = undefined;
+    rosterData = [];
     render(<AppSidebar />);
 
     const footer = screen.getByTestId("footer");
@@ -230,6 +278,7 @@ describe("AppSidebar", () => {
 
   it("falls back to the email as the node label when display_name is empty", () => {
     viewerData = person(PERSON_IDS.alice, "alice@x.io", "");
+    rosterData = rosterRows(viewerData);
     render(<AppSidebar />);
 
     expect(buttonFor("alice@x.io")).toBeInTheDocument();
@@ -239,6 +288,7 @@ describe("AppSidebar", () => {
     // The identity contract admits both being absent; an empty node would be an
     // unclickable sliver.
     viewerData = person(PERSON_IDS.alice, "", "");
+    rosterData = rosterRows(viewerData);
     render(<AppSidebar />);
 
     expect(buttonFor("Unnamed person")).toBeInTheDocument();

--- a/src/frontend/src/components/app-sidebar.tsx
+++ b/src/frontend/src/components/app-sidebar.tsx
@@ -1,15 +1,7 @@
-import { Link, useRouterState } from "@tanstack/react-router";
-import {
-  ChevronDown,
-  ChevronRight,
-  User,
-  Users,
-} from "lucide-react";
-import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useViewer } from "@/auth";
 import { AppSidebarFooter } from "@/components/app-sidebar-footer";
+import { OrgTree } from "@/components/org-tree";
 import {
   Sidebar,
   SidebarContent,
@@ -17,102 +9,10 @@ import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarHeader,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { personName } from "@/lib/identities/person-display";
-import { personIdFromPath } from "@/lib/metrics/entity";
-import { useIcPerson } from "@/queries/ic-dashboard";
-import type { IdentityPerson } from "@/types/insight";
-
-// The identity contract admits people with no email and no display name (a
-// person whose log carries neither). Their node still has to be clickable.
-const UNNAMED_PERSON = "Unnamed person";
-
-function personIdEq(a: string, b: string): boolean {
-  return a.toLowerCase() === b.toLowerCase();
-}
-
-function containsPerson(node: IdentityPerson, personId: string): boolean {
-  if (personIdEq(node.person_id, personId)) return true;
-  return node.subordinates.some((s) => containsPerson(s, personId));
-}
-
-function PersonNode({
-  node,
-  depth,
-  activePersonId,
-}: {
-  node: IdentityPerson;
-  depth: number;
-  activePersonId: string | null;
-}) {
-  const hasReports = node.subordinates.length > 0;
-  const isActive = activePersonId
-    ? personIdEq(activePersonId, node.person_id)
-    : false;
-  const hasActiveDescendant =
-    hasReports && activePersonId
-      ? node.subordinates.some((s) => containsPerson(s, activePersonId))
-      : false;
-  const open = depth === 0 || isActive || hasActiveDescendant;
-  return (
-    <>
-      <SidebarMenuItem>
-        <SidebarMenuButton
-          isActive={isActive}
-          render={
-            <Link
-              to="/ic/$person/personal"
-              params={{ person: node.person_id }}
-            />
-          }
-          style={{ paddingLeft: `${0.5 + depth * 0.875}rem` }}
-        >
-          {hasReports ? (
-            open ? (
-              <ChevronDown />
-            ) : (
-              <ChevronRight />
-            )
-          ) : (
-            <span className="w-4 shrink-0" />
-          )}
-          {hasReports ? <Users /> : <User />}
-          <span className="truncate">
-            {personName(node) ?? UNNAMED_PERSON}
-          </span>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
-      {hasReports && open
-        ? node.subordinates.map((sub) => (
-            <PersonNode
-              key={sub.person_id}
-              node={sub}
-              depth={depth + 1}
-              activePersonId={activePersonId}
-            />
-          ))
-        : null}
-    </>
-  );
-}
 
 export function AppSidebar() {
   const { t } = useTranslation();
-  const { personId: viewerPersonId } = useViewer();
-  const viewerQ = useIcPerson(viewerPersonId ?? "");
-  const viewer = viewerQ.data ?? null;
-  const pathname = useRouterState({ select: (s) => s.location.pathname });
-  // The URL segment is the person id since the identity cutover; a legacy
-  // email URL simply highlights nothing for the moment its redirect takes.
-  const activePersonId = useMemo(() => {
-    const fromPath = personIdFromPath(pathname);
-    if (fromPath) return fromPath;
-    if (pathname === "/" && viewerPersonId) return viewerPersonId;
-    return null;
-  }, [pathname, viewerPersonId]);
 
   return (
     <Sidebar>
@@ -129,11 +29,7 @@ export function AppSidebar() {
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupContent>
-            {viewer ? (
-              <SidebarMenu>
-                <PersonNode node={viewer} depth={0} activePersonId={activePersonId} />
-              </SidebarMenu>
-            ) : null}
+            <OrgTree />
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>

--- a/src/frontend/src/components/org-tree.test.tsx
+++ b/src/frontend/src/components/org-tree.test.tsx
@@ -1,18 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { PeopleListItem } from "@/api/identity-client";
 import { OrgTree } from "@/components/org-tree";
 import type { IdentityPerson } from "@/types/insight";
 
 const mocks = vi.hoisted(() => ({
   viewer: null as IdentityPerson | null,
   isFlat: false,
-  roster: [] as {
-    person_id: string;
-    display_name?: string | null;
-    email?: string | null;
-    username?: string | null;
-  }[],
+  roster: [] as PeopleListItem[],
 }));
 
 vi.mock("@/auth", () => ({ useViewer: () => ({ personId: "root" }) }));
@@ -70,12 +66,40 @@ function person(
   };
 }
 
+function rosterPerson(
+  personId: string,
+  displayName: string | null,
+  managerPersonId: string | null,
+  username: string | null = null,
+): PeopleListItem {
+  return {
+    person_id: personId,
+    display_name: displayName,
+    first_name: null,
+    last_name: null,
+    username,
+    email: null,
+    attributes: {},
+    manager_person_id: managerPersonId,
+  };
+}
+
 mocks.viewer = person("root", "Root Person", [
   person("lead", "Lead Person", [
     person("deep", "Deep Person"),
     person("other", "Other Person"),
   ]),
 ]);
+
+beforeEach(() => {
+  mocks.isFlat = false;
+  mocks.roster = [
+    rosterPerson("root", "Root Person", null),
+    rosterPerson("lead", "Lead Person", "root"),
+    rosterPerson("deep", "Deep Person", "lead"),
+    rosterPerson("other", "Other Person", "lead"),
+  ];
+});
 
 describe("OrgTree", () => {
   it("shows only the root's own level until something opens it", () => {
@@ -115,9 +139,9 @@ describe("OrgTree on an organisation with no reporting lines", () => {
     // this pane showing one name beside a full Employees table.
     mocks.viewer = { person_id: "root", display_name: "Me", email: "me@x", subordinates: [] } as IdentityPerson;
     mocks.roster = [
-      { person_id: "root", display_name: "Me", email: "me@x" },
-      { person_id: "p-ann", display_name: "Ann Dev", email: "ann@x" },
-      { person_id: "p-bot", display_name: null, email: null, username: "octo-bot" },
+      rosterPerson("root", "Me", null),
+      rosterPerson("p-ann", "Ann Dev", null),
+      rosterPerson("p-bot", null, null, "octo-bot"),
     ];
   });
 

--- a/src/frontend/src/components/org-tree.test.tsx
+++ b/src/frontend/src/components/org-tree.test.tsx
@@ -25,7 +25,6 @@ vi.mock("@/queries/identity-me", () => ({
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
     roster: mocks.roster,
-    truncated: false,
     isPending: false,
     isError: false,
     retry: () => {},

--- a/src/frontend/src/components/org-tree.tsx
+++ b/src/frontend/src/components/org-tree.tsx
@@ -2,23 +2,26 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import { ChevronDown, ChevronRight, User, Users } from "lucide-react";
 import { useMemo } from "react";
 
+import type { PeopleListItem } from "@/api/identity-client";
 import { useViewer } from "@/auth";
 import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { personDisplayName } from "@/lib/identities/person-display";
+import { personName } from "@/lib/identities/person-display";
 import { usePortalNavActions } from "@/lib/portal/portal-nav";
 import { personIdFromPath } from "@/lib/metrics/entity";
 import {
   filterOrgTree,
   type OrgTreeFilter,
 } from "@/lib/portal/org-tree-filter";
-import { useIcPerson } from "@/queries/ic-dashboard";
+import { rosterTree } from "@/lib/insight/identity-tree";
 import { useVisibilityPolicy } from "@/queries/identity-me";
 import { useVisibleRoster } from "@/queries/visible-roster";
 import type { IdentityPerson } from "@/types/insight";
+
+const UNNAMED_PERSON = "Unnamed person";
 
 // Person ids, not emails: the identity cutover made the id the key the route
 // segment, `?scope=` and the metric entity ids all carry.
@@ -90,7 +93,7 @@ function PersonNode({
             <span className="w-4 shrink-0" />
           )}
           {hasReports ? <Users /> : <User />}
-          <span className="truncate">{personDisplayName(node)}</span>
+          <span className="truncate">{personName(node) ?? UNNAMED_PERSON}</span>
         </SidebarMenuButton>
       </SidebarMenuItem>
       {hasReports && open
@@ -114,9 +117,14 @@ function PersonNode({
  * list, in label order, scrolling in the pane exactly as the chart does. There
  * is no chart to draw and no depth to indent, so a row carries no chevron.
  */
-function RosterList({ query }: { query: string }) {
+function RosterList({
+  query,
+  roster,
+}: {
+  query: string;
+  roster: readonly PeopleListItem[];
+}) {
   const { personId: viewerPersonId } = useViewer();
-  const { roster } = useVisibleRoster(true);
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const activePersonId = useMemo(() => {
     const fromPath = personIdFromPath(pathname);
@@ -128,7 +136,10 @@ function RosterList({ query }: { query: string }) {
   const listed = useMemo(() => {
     const term = query.trim().toLowerCase();
     const rows = roster
-      .map((person) => ({ person, label: personDisplayName(person) }))
+      .map((person) => ({
+        person,
+        label: personName(person) ?? UNNAMED_PERSON,
+      }))
       .sort((left, right) => left.label.localeCompare(right.label));
     return term
       ? rows.filter((row) => row.label.toLowerCase().includes(term))
@@ -183,8 +194,11 @@ export function OrgTree({
 }: { leadsToTeam?: boolean; query?: string } = {}) {
   const { isFlat } = useVisibilityPolicy();
   const { personId: viewerPersonId } = useViewer();
-  const viewerQ = useIcPerson(viewerPersonId ?? "");
-  const viewer = viewerQ.data ?? null;
+  const { roster } = useVisibleRoster(true);
+  const viewer = useMemo(
+    () => (viewerPersonId ? rosterTree(roster, viewerPersonId) : null),
+    [roster, viewerPersonId],
+  );
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const activePersonId = useMemo(() => {
     const fromPath = personIdFromPath(pathname);
@@ -194,7 +208,7 @@ export function OrgTree({
   }, [pathname, viewerPersonId]);
   const filter = useMemo(() => filterOrgTree(viewer, query), [viewer, query]);
 
-  if (isFlat) return <RosterList query={query} />;
+  if (isFlat) return <RosterList query={query} roster={roster} />;
   if (!viewer) return null;
   if (filter && filter.visible.size === 0) {
     return (

--- a/src/frontend/src/components/portal/ai-cost-view.test.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.test.tsx
@@ -17,12 +17,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
 import { setPortalShowPlanned } from "@/lib/portal/portal-store";
-import { identityPerson, pid } from "@/test/identity";
+import {
+  identityPerson,
+  peopleFromIdentityTree,
+  pid,
+} from "@/test/identity";
 import type { IdentityPerson, TeamMember } from "@/types/insight";
 
 const mocks = vi.hoisted(() => ({
   personId: null as string | null,
   tree: undefined as IdentityPerson | undefined,
+  roster: [] as import("@/api/identity-client").PeopleListItem[],
   members: [] as TeamMember[],
   grid: {
     byKey: new Map<string, NormalizedMetricResult>(),
@@ -62,7 +67,7 @@ vi.mock("@/queries/identity-me", () => ({
 }));
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
-    roster: [],
+    roster: mocks.roster,
     truncated: false,
     isPending: false,
     isError: false,
@@ -132,6 +137,7 @@ const IDS = LABELS.map(pid);
 beforeEach(() => {
   mocks.personId = pid("boss");
   mocks.tree = person("boss", {}, LABELS.map((l) => person(l)));
+  mocks.roster = peopleFromIdentityTree(mocks.tree);
   mocks.members = IDS.map(member);
   mocks.grid.isPending = false;
   mocks.grid.isError = false;
@@ -297,6 +303,7 @@ describe("AiCostView", () => {
       person("c", { division: "Sales" } as never),
       person("d", { division: "Sales" } as never),
     ]);
+    mocks.roster = peopleFromIdentityTree(mocks.tree);
     act(() => portalRouter.set({ slice: "division" }));
     render(<AiCostView item="by-unit-role" />);
     expect(screen.getByText("R&D")).toBeInTheDocument();
@@ -331,6 +338,7 @@ describe("AiCostView", () => {
       person("c", { division: "Sales" } as never),
       person("d", { division: "Sales" } as never),
     ]);
+    mocks.roster = peopleFromIdentityTree(mocks.tree);
     act(() => portalRouter.set({ slice: "division" }));
     render(<AiCostView item="by-unit-role" />);
     const cells = screen.getByText("Sales").closest("tr")?.querySelectorAll("td");
@@ -340,6 +348,7 @@ describe("AiCostView", () => {
   it("gates on an empty scope instead of rendering zero KPIs", () => {
     mocks.members = [];
     mocks.tree = person("boss");
+    mocks.roster = peopleFromIdentityTree(mocks.tree);
     render(<AiCostView item={null} />);
     expect(screen.getByText(/No people in the current scope/)).toBeInTheDocument();
     expect(screen.queryByText("AI potential usage cost")).not.toBeInTheDocument();

--- a/src/frontend/src/components/portal/ai-cost-view.test.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.test.tsx
@@ -68,7 +68,6 @@ vi.mock("@/queries/identity-me", () => ({
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
     roster: mocks.roster,
-    truncated: false,
     isPending: false,
     isError: false,
     retry: () => {},

--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -85,7 +85,6 @@ vi.mock("@/queries/identity-me", () => ({
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
     roster: mocks.roster,
-    truncated: false,
     isPending: false,
     isError: false,
     retry: () => {},

--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -21,7 +21,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GROUPS } from "@/lib/insight/groups";
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
 import { setPortalShowPlanned } from "@/lib/portal/portal-store";
-import { identityPerson, pid } from "@/test/identity";
+import {
+  identityPerson,
+  peopleFromIdentityTree,
+  pid,
+} from "@/test/identity";
 import type { IdentityPerson } from "@/types/insight";
 
 /* ── module mocks ────────────────────────────────────────────────────── */
@@ -29,6 +33,7 @@ import type { IdentityPerson } from "@/types/insight";
 const mocks = vi.hoisted(() => ({
   personId: null as string | null,
   tree: undefined as IdentityPerson | undefined,
+  roster: [] as import("@/api/identity-client").PeopleListItem[],
   grid: {
     byKey: new Map<string, NormalizedMetricResult>(),
     previousByKey: new Map<string, NormalizedMetricResult>(),
@@ -79,7 +84,7 @@ vi.mock("@/queries/identity-me", () => ({
 }));
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
-    roster: [],
+    roster: mocks.roster,
     truncated: false,
     isPending: false,
     isError: false,
@@ -198,6 +203,7 @@ const IDS = LABELS.map(pid);
 function seedHappyOrg() {
   mocks.personId = pid("boss");
   mocks.tree = person("boss", {}, LABELS.map((l) => person(l)));
+  mocks.roster = peopleFromIdentityTree(mocks.tree);
   // 4 members, 10+20+30+40 = 100 commits; everyone active.
   mocks.grid.byKey = new Map([
     ["t.commits", metric("t.commits", [[pid("a"), 10], [pid("b"), 20], [pid("c"), 30], [pid("d"), 40]], { short_label: "Commits", unit: "commits" })],
@@ -338,6 +344,7 @@ describe("rule 6: honest not-ingested gate", () => {
 describe("org-scope gates", () => {
   it("shows the empty-roster label instead of a fabricated dashboard", () => {
     mocks.tree = person("boss");
+    mocks.roster = peopleFromIdentityTree(mocks.tree);
     render(<DomainLensView config={HEADLINE_CONFIG} />);
     expect(screen.getByText(/No people in the current scope/)).toBeInTheDocument();
   });
@@ -895,6 +902,7 @@ describe("by-unit auto-section (rule 7: slice cohorts inside scope)", () => {
     mocks.tree = person("boss", {}, labels.map((l) =>
       person(l, { division: l.startsWith("a") ? "R&D" : "Sales" } as never),
     ));
+    mocks.roster = peopleFromIdentityTree(mocks.tree);
     mocks.grid.byKey = new Map([
       ["t.commits", metric("t.commits", labels.map((l) => [pid(l), l.startsWith("a") ? 10 : 30]), { short_label: "Commits" })],
     ]);
@@ -929,6 +937,7 @@ describe("direction-cards / attention sections", () => {
     // 7 healthy + 1 collapsed member
     const labels = ["m1", "m2", "m3", "m4", "m5", "m6", "m7", "z"];
     mocks.tree = person("boss", {}, labels.map((l) => person(l)));
+    mocks.roster = peopleFromIdentityTree(mocks.tree);
     mocks.grid.byKey = new Map([
       ["t.commits", metric("t.commits", labels.map((l) => [pid(l), l === "z" ? 0 : 10]), { label: "Commits" })],
     ]);
@@ -986,6 +995,7 @@ describe("coverage section (#2408)", () => {
 
   it("opens a level into exactly the people at it, and why each is thin", async () => {
     mocks.tree = person("boss", {}, [person("a"), person("b"), person("c")]);
+    mocks.roster = peopleFromIdentityTree(mocks.tree);
     coverageWorld(["a"]);
     render(
       <DomainLensView
@@ -1005,6 +1015,7 @@ describe("coverage section (#2408)", () => {
 
   it("does not open a level nobody is at", async () => {
     mocks.tree = person("boss", {}, [person("a")]);
+    mocks.roster = peopleFromIdentityTree(mocks.tree);
     coverageWorld([]);
     render(
       <DomainLensView

--- a/src/frontend/src/components/portal/employees-view.test.tsx
+++ b/src/frontend/src/components/portal/employees-view.test.tsx
@@ -12,6 +12,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { PeopleListItem } from "@/api/identity-client";
 import { identityPerson, pid } from "@/test/identity";
 import type { IdentityPerson } from "@/types/insight";
 
@@ -19,7 +20,7 @@ const mocks = vi.hoisted(() => ({
   personId: null as string | null,
   isFlat: false,
   roster: {
-    roster: [] as { person_id: string; display_name?: string | null; username?: string | null; job_title?: string | null; status?: string | null; provisional?: boolean }[],
+    roster: [] as PeopleListItem[],
     truncated: false,
     isPending: false,
     isError: false,
@@ -56,11 +57,35 @@ const person = (
   subs: IdentityPerson[] = [],
 ): IdentityPerson => identityPerson(label, over, subs);
 
+function rosterPerson(
+  label: string,
+  managerPersonId: string | null = null,
+  attributes: Record<string, string> = {},
+): PeopleListItem {
+  return {
+    person_id: pid(label),
+    display_name: `${label[0]!.toUpperCase()}${label.slice(1)}`,
+    first_name: null,
+    last_name: null,
+    username: null,
+    email: `${label}@example.com`,
+    attributes,
+    manager_person_id: managerPersonId,
+  };
+}
+
 beforeEach(() => {
   mocks.ic.refetch.mockClear();
   mocks.personId = pid("boss");
   mocks.isFlat = false;
-  mocks.roster.roster = [];
+  mocks.roster.roster = [
+    rosterPerson("boss", null, { job_title: "Director" }),
+    rosterPerson("zoe", pid("boss"), {
+      job_title: "QA Engineer",
+      department: "Quality",
+    }),
+    rosterPerson("adam", pid("boss"), { job_title: "Backend Dev" }),
+  ];
   mocks.roster.isPending = false;
   mocks.roster.isError = false;
   mocks.ic.isPending = false;
@@ -98,11 +123,11 @@ describe("EmployeesView", () => {
   });
 
   it("surfaces an identity failure as a retryable error", async () => {
-    mocks.ic.data = undefined;
-    mocks.ic.isError = true;
+    mocks.roster.roster = [];
+    mocks.roster.isError = true;
     render(<EmployeesView />);
     await userEvent.click(screen.getByRole("button", { name: /retry/i }));
-    expect(mocks.ic.refetch).toHaveBeenCalledOnce();
+    expect(mocks.roster.retry).toHaveBeenCalledOnce();
   });
 });
 
@@ -113,9 +138,13 @@ describe("EmployeesView on an organisation with no reporting lines", () => {
     // directory with a single row.
     mocks.ic.data = person("boss");
     mocks.roster.roster = [
-      { person_id: pid("boss"), display_name: "Boss Person", job_title: "Lead" },
-      { person_id: pid("ann"), display_name: "Ann Dev", job_title: "Engineer" },
-      { person_id: pid("bob"), username: "bobby", provisional: true },
+      { ...rosterPerson("boss"), display_name: "Boss Person" },
+      { ...rosterPerson("ann"), display_name: "Ann Dev" },
+      {
+        ...rosterPerson("bob"),
+        display_name: null,
+        username: "bobby",
+      },
     ];
   });
 

--- a/src/frontend/src/components/portal/employees-view.test.tsx
+++ b/src/frontend/src/components/portal/employees-view.test.tsx
@@ -21,7 +21,6 @@ const mocks = vi.hoisted(() => ({
   isFlat: false,
   roster: {
     roster: [] as PeopleListItem[],
-    truncated: false,
     isPending: false,
     isError: false,
     retry: vi.fn(),

--- a/src/frontend/src/components/portal/employees-view.tsx
+++ b/src/frontend/src/components/portal/employees-view.tsx
@@ -2,8 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { Search } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import type { PersonSummary } from "@/api/identity-client";
-import { useViewer } from "@/auth";
+import type { PeopleListItem } from "@/api/identity-client";
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { Badge } from "@/components/ui/badge";
@@ -16,14 +15,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  usePortalNavActions,
-} from "@/lib/portal/portal-nav";
-import { useIcPerson } from "@/queries/ic-dashboard";
+import { personName } from "@/lib/identities/person-display";
+import { usePortalNavActions } from "@/lib/portal/portal-nav";
 import { useVisibilityPolicy } from "@/queries/identity-me";
 import { useVisibleRoster } from "@/queries/visible-roster";
-import type { IdentityPerson } from "@/types/insight";
-import { personName } from "@/lib/identities/person-display";
 import { cn } from "@/lib/utils";
 
 // Mirrors the rail: a person with neither display name nor email is still a row.
@@ -39,77 +34,38 @@ interface EmployeeRow {
   status: string;
 }
 
-/** Flatten the org tree (root + every descendant) into a de-duplicated roster. */
-function collectEmployees(root: IdentityPerson): EmployeeRow[] {
-  // Keyed by person id, not email: the identity contract admits people with no
-  // email, and their row still has to be listed and clickable.
-  const byId = new Map<string, EmployeeRow>();
-  const walk = (node: IdentityPerson) => {
-    if (node.person_id) {
-      const key = node.person_id.toLowerCase();
-      if (!byId.has(key)) {
-        byId.set(key, {
-          personId: node.person_id,
-          displayName: personName(node) ?? UNNAMED_PERSON,
-          jobTitle: node.job_title ?? "",
-          department: node.department ?? "",
-          division: node.division ?? "",
-          supervisorName: node.supervisor_name ?? "",
-          status: node.status ?? "",
-        });
-      }
-    }
-    node.subordinates.forEach(walk);
-  };
-  walk(root);
-  return [...byId.values()].sort((a, b) =>
-    a.displayName.localeCompare(b.displayName),
+function rosterEmployees(roster: readonly PeopleListItem[]): EmployeeRow[] {
+  const byId = new Map(
+    roster.map((person) => [person.person_id.toLowerCase(), person]),
   );
-}
-
-/**
- * Rows for an organisation with no reporting lines: the roster as identity
- * serves it. Named through `personName` so the precedence has one definition,
- * with its own last resort — `person-display` stops at the id on purpose, and a
- * raw id in this column is a row nobody can tell apart.
- */
-function rosterEmployees(roster: readonly PersonSummary[]): EmployeeRow[] {
   return roster
     .map((person) => ({
       personId: person.person_id,
       displayName: personName(person) ?? UNNAMED_PERSON,
-      jobTitle: person.job_title ?? "",
-      // No reporting lines, and `PersonSummary` carries no org attributes.
-      department: "",
-      division: "",
-      supervisorName: "",
-      status: person.status ?? "",
+      jobTitle: person.attributes.job_title ?? "",
+      department: person.attributes.department ?? "",
+      division: person.attributes.division ?? "",
+      supervisorName: person.manager_person_id
+        ? personName(byId.get(person.manager_person_id.toLowerCase()) ?? {}) ?? ""
+        : "",
+      status: person.attributes.status ?? "",
     }))
     .sort((a, b) => a.displayName.localeCompare(b.displayName));
 }
 
 /**
- * Employees directory — every person in the viewer's org (flattened org tree),
- * searchable, each row linking into their Person view. Sourced entirely from
- * the identity profile tree (`getPerson` recurses), so no metric queries and no
- * new endpoint: it's a live people index, not a scaffold.
+ * Employees directory — every canonical person visible to the viewer,
+ * searchable and linked to their Person view.
  */
 export function EmployeesView() {
   const { setZone } = usePortalNavActions();
-  const { personId: viewerPersonId } = useViewer();
-  const { data, isPending, isError, refetch } = useIcPerson(viewerPersonId ?? "");
   const { isFlat } = useVisibilityPolicy();
-  const flatRoster = useVisibleRoster(isFlat);
+  const visibleRoster = useVisibleRoster(true);
   const [query, setQuery] = useState("");
 
   const employees = useMemo(
-    () =>
-      isFlat
-        ? rosterEmployees(flatRoster.roster)
-        : data
-          ? collectEmployees(data)
-          : [],
-    [isFlat, flatRoster.roster, data],
+    () => rosterEmployees(visibleRoster.roster),
+    [visibleRoster.roster],
   );
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -122,8 +78,8 @@ export function EmployeesView() {
     );
   }, [employees, query]);
 
-  const loading = isFlat ? flatRoster.isPending : isPending;
-  const failed = isFlat ? flatRoster.isError : isError || !data;
+  const loading = visibleRoster.isPending;
+  const failed = visibleRoster.isError;
   if (loading) return <CenteredSpinner className="min-h-[60vh]" />;
   if (failed)
     return (
@@ -131,7 +87,7 @@ export function EmployeesView() {
         <ComingSoon
           variant="card"
           state="error"
-          onRetry={isFlat ? flatRoster.retry : refetch}
+          onRetry={visibleRoster.retry}
         />
       </div>
     );

--- a/src/frontend/src/components/portal/person-accounts-view.test.tsx
+++ b/src/frontend/src/components/portal/person-accounts-view.test.tsx
@@ -29,6 +29,7 @@ const hooks = vi.hoisted(() => {
     error: null as unknown,
   });
   return {
+  personSource: "identities" as "identities" | "roster",
   accounts: {
     data: undefined as
       | { person_id: string; accounts: PersonAccountEntry[] }
@@ -62,7 +63,14 @@ const hooks = vi.hoisted(() => {
 vi.mock("@/queries/identity-resolution", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/queries/identity-resolution")>()),
   usePersonAccounts: () => hooks.accounts,
-  usePersonList: () => hooks.search,
+  usePersonList: (
+    _q: string,
+    _intent: "browse" | "match",
+    source: "identities" | "roster" = "identities",
+  ) => {
+    hooks.personSource = source;
+    return hooks.search;
+  },
   useAccountList: () => hooks.accountSearch,
   // The verbs belong to person-dialog.test; stubbed so the window can render
   // them without this suite standing up a query client.
@@ -102,6 +110,7 @@ function roster() {
 }
 
 beforeEach(() => {
+  hooks.personSource = "identities";
   hooks.accounts.data = undefined;
   hooks.accounts.isLoading = false;
   hooks.accounts.isError = false;
@@ -139,6 +148,7 @@ describe("PersonAccountsView", () => {
 
     expect(screen.getByText("Ann Lee")).toBeInTheDocument();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(hooks.personSource).toBe("roster");
   });
 
   it("puts the chosen person in the URL, so the view is a link", async () => {

--- a/src/frontend/src/components/portal/person-accounts-view.tsx
+++ b/src/frontend/src/components/portal/person-accounts-view.tsx
@@ -36,6 +36,7 @@ export function PersonAccountsView() {
       <PersonPicker
         browseWhenEmpty
         asSurface
+        source="roster"
         // The roster's terms live in the URL: a reader who comes back to this
         // mode should not have to find the same person twice. `replace`,
         // because typing is not a place to go back to.

--- a/src/frontend/src/components/portal/person-header.test.tsx
+++ b/src/frontend/src/components/portal/person-header.test.tsx
@@ -16,12 +16,19 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { identityPerson, pid } from "@/test/identity";
+import type { PeopleListItem } from "@/api/identity-client";
 import type { IdentityPerson } from "@/types/insight";
 
 const mocks = vi.hoisted(() => ({
   person: undefined as IdentityPerson | undefined,
-  managerNodes: [] as Array<{ person_id: string; name: string; depth: number; teamSize: number }>,
+  managerNodes: [] as Array<{
+    person_id: string;
+    name: string;
+    depth: number;
+    teamSize: number;
+  }>,
   icCalls: [] as string[],
+  roster: [] as PeopleListItem[],
 }));
 
 vi.mock("@/queries/ic-dashboard", () => ({
@@ -33,15 +40,36 @@ vi.mock("@/queries/ic-dashboard", () => ({
 vi.mock("@/lib/portal/use-org-scope", () => ({
   useOrgScope: () => ({ managerNodes: mocks.managerNodes }),
 }));
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({ roster: mocks.roster }),
+}));
 
 import { PersonHeader } from "./person-header";
 
 const LEAD = pid("lead");
 const BOSS = pid("boss");
 
+function rosterPerson(
+  personId: string,
+  displayName: string,
+  managerPersonId: string | null
+): PeopleListItem {
+  return {
+    person_id: personId,
+    display_name: displayName,
+    first_name: null,
+    last_name: null,
+    username: null,
+    email: null,
+    attributes: {},
+    manager_person_id: managerPersonId,
+  };
+}
+
 beforeEach(() => {
   mocks.icCalls = [];
   mocks.managerNodes = [];
+  mocks.roster = [rosterPerson(LEAD, "Lead", BOSS)];
   mocks.person = identityPerson("lead", {
     person_id: LEAD,
     display_name: "Lead",
@@ -68,8 +96,27 @@ describe("PersonHeader", () => {
     mocks.managerNodes = [
       { person_id: BOSS, name: "Boss", depth: 0, teamSize: 4 },
     ];
+    mocks.roster.push(rosterPerson(BOSS, "Boss", null));
     render(<PersonHeader person={LEAD} />);
     expect(screen.getByText("Boss")).toBeInTheDocument();
+  });
+
+  it("uses the canonical roster name instead of the profile supervisor label", () => {
+    mocks.person = identityPerson("lead", {
+      person_id: LEAD,
+      display_name: "Lead",
+      parent_person_id: BOSS,
+      supervisor_name: "Activity Name",
+    });
+    mocks.managerNodes = [
+      { person_id: BOSS, name: "Roster Boss", depth: 0, teamSize: 4 },
+    ];
+    mocks.roster.push(rosterPerson(BOSS, "Roster Boss", null));
+
+    render(<PersonHeader person={LEAD} />);
+
+    expect(screen.getByText("Roster Boss")).toBeInTheDocument();
+    expect(screen.queryByText("Activity Name")).toBeNull();
   });
 });
 
@@ -80,6 +127,7 @@ describe("PersonHeader on an organisation with no reporting lines", () => {
     // zones are how a flat organisation navigates — a button here that scoped to
     // an empty org would read as a broken link rather than an absent one.
     mocks.managerNodes = [];
+    mocks.roster = [rosterPerson(pid("solo"), "Solo", null)];
     mocks.person = identityPerson("solo", {
       person_id: pid("solo"),
       display_name: "Solo",

--- a/src/frontend/src/components/portal/person-header.tsx
+++ b/src/frontend/src/components/portal/person-header.tsx
@@ -12,11 +12,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useIcPerson } from "@/queries/ic-dashboard";
-import {
-  usePortalNavActions,
-} from "@/lib/portal/portal-nav";
+import { usePortalNavActions } from "@/lib/portal/portal-nav";
 import { useOrgScope } from "@/lib/portal/use-org-scope";
-import { personDisplayName } from "@/lib/identities/person-display";
+import { personDisplayName, personName } from "@/lib/identities/person-display";
+import { useVisibleRoster } from "@/queries/visible-roster";
 import { cn } from "@/lib/utils";
 
 /**
@@ -27,13 +26,14 @@ import { cn } from "@/lib/utils";
  * to People — scoped to the person's own reports if they're a manager, else to
  * their manager's team — and that jump also sets the global org scope, so it only
  * renders when the target is a node the scope can actually reach. Everything is
- * route-driven (clears the pinned zone) and sourced from the identity profile;
+ * route-driven (clears the pinned zone) and sourced from canonical people;
  * absent fields render nothing.
  */
 export function PersonHeader({ person }: { person: string }) {
   const { setScope, setZone } = usePortalNavActions();
   const navigate = useNavigate();
   const { data } = useIcPerson(person);
+  const { roster } = useVisibleRoster(true);
   // Ids, not emails, since the identity cutover: the same key the route
   // segment, `?scope=` and the metric entity ids carry.
   const supervisorPersonId = data?.parent_person_id ?? null;
@@ -42,7 +42,7 @@ export function PersonHeader({ person }: { person: string }) {
   const { managerNodes } = useOrgScope();
   const scopeRoots = useMemo(
     () => new Set(managerNodes.map((n) => n.person_id.toLowerCase())),
-    [managerNodes],
+    [managerNodes]
   );
   // A person ABOVE the viewer is not theirs to open. Identity's visibility rule
   // serves a viewer their own subtree, and offering a link out of it invites a
@@ -52,10 +52,15 @@ export function PersonHeader({ person }: { person: string }) {
   const canSeeSupervisor = supervisorPersonId
     ? scopeRoots.has(supervisorPersonId.toLowerCase())
     : false;
-  // Siblings come from the manager's own record, so the same rule gates the
-  // fetch: no manager, no query. It self-disables on "".
-  const { data: manager } = useIcPerson(
-    canSeeSupervisor && supervisorPersonId ? supervisorPersonId : "",
+  const manager = supervisorPersonId
+    ? roster.find(
+        (candidate) =>
+          candidate.person_id.toLowerCase() === supervisorPersonId.toLowerCase()
+      )
+    : undefined;
+  const reports = roster.filter(
+    (candidate) =>
+      candidate.manager_person_id?.toLowerCase() === person.toLowerCase()
   );
 
   if (!data) return null;
@@ -63,8 +68,8 @@ export function PersonHeader({ person }: { person: string }) {
   const subtitle = [data.job_title, data.department]
     .filter((s) => s && s.trim())
     .join(" · ");
-  const supervisorName = data.supervisor_name ?? null;
-  const isManager = data.subordinates.length > 0;
+  const supervisorName = manager ? personName(manager) : null;
+  const isManager = reports.length > 0;
   // Manager → their own team; IC → their manager's team (peers).
   const teamTarget = isManager ? data.person_id : supervisorPersonId;
   // An IC viewer's own supervisor sits ABOVE them, outside the subtree identity
@@ -75,11 +80,14 @@ export function PersonHeader({ person }: { person: string }) {
     ? scopeRoots.has(teamTarget.toLowerCase())
     : false;
 
-  const peers = [...(manager?.subordinates ?? [])]
-    .filter((p) => p.person_id)
-    .sort((a, b) =>
-      personDisplayName(a).localeCompare(personDisplayName(b)),
-    );
+  const peers = roster
+    .filter(
+      (candidate) =>
+        supervisorPersonId !== null &&
+        candidate.manager_person_id?.toLowerCase() ===
+          supervisorPersonId.toLowerCase()
+    )
+    .sort((a, b) => personDisplayName(a).localeCompare(personDisplayName(b)));
   const hasPeers = peers.length > 1;
 
   function goPerson(personId: string) {
@@ -137,12 +145,10 @@ export function PersonHeader({ person }: { person: string }) {
                       <Check
                         className={cn(
                           "size-4",
-                          active ? "opacity-100" : "opacity-0",
+                          active ? "opacity-100" : "opacity-0"
                         )}
                       />
-                      <span className="truncate">
-                        {personDisplayName(p)}
-                      </span>
+                      <span className="truncate">{personDisplayName(p)}</span>
                     </DropdownMenuItem>
                   );
                 })}

--- a/src/frontend/src/components/portal/person-picker.tsx
+++ b/src/frontend/src/components/portal/person-picker.tsx
@@ -32,6 +32,7 @@ import {
   listsAnyone,
   MAX_SEARCH_CHARS,
   MIN_SEARCH_CHARS,
+  type PersonListSource,
   SEARCH_DEBOUNCE_MS,
   usePersonList,
 } from "@/queries/identity-resolution";
@@ -52,6 +53,7 @@ export function PersonPicker({
   asSurface = false,
   initialQuery = "",
   onSettled,
+  source = "identities",
 }: {
   onPick: (person: PersonSummary) => void;
   excludeIds?: string[];
@@ -66,6 +68,7 @@ export function PersonPicker({
    *  keystroke: a caller that stores them in the URL would otherwise navigate
    *  on every letter. */
   onSettled?: (query: string) => void;
+  source?: PersonListSource;
 }) {
   const { t } = useTranslation();
   const [query, setQuery] = useState(initialQuery);
@@ -82,7 +85,7 @@ export function PersonPicker({
 
   const intent = browseWhenEmpty ? "browse" : "match";
   const asked = listsAnyone(debounced, intent);
-  const list = usePersonList(debounced, intent);
+  const list = usePersonList(debounced, intent, source);
 
   const excluded = new Set(excludeIds);
   const results = asked

--- a/src/frontend/src/components/portal/portal-topbar.test.tsx
+++ b/src/frontend/src/components/portal/portal-topbar.test.tsx
@@ -20,7 +20,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { MetricDefinitionListResponse } from "@/api/metric-definitions-client";
 import { setPortalShowPlanned } from "@/lib/portal/portal-store";
-import { identityPerson, pid } from "@/test/identity";
+import { identityPerson, peopleFromIdentityTree, pid } from "@/test/identity";
+
+const roster = peopleFromIdentityTree(
+  identityPerson("boss", {
+    person_id: pid("boss"),
+    division: "Alpha",
+    subordinates: [
+      identityPerson("one", { person_id: pid("one"), division: "Alpha" }),
+      identityPerson("two", { person_id: pid("two"), division: "Beta" }),
+    ],
+  }),
+);
 
 const mocks = vi.hoisted(() => ({
   definitions: { metrics: [] } as MetricDefinitionListResponse,
@@ -37,7 +48,7 @@ vi.mock("@/queries/identity-me", () => ({
 }));
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
-    roster: [],
+    roster,
     truncated: false,
     isPending: false,
     isError: false,

--- a/src/frontend/src/components/portal/portal-topbar.test.tsx
+++ b/src/frontend/src/components/portal/portal-topbar.test.tsx
@@ -49,7 +49,6 @@ vi.mock("@/queries/identity-me", () => ({
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
     roster,
-    truncated: false,
     isPending: false,
     isError: false,
     retry: () => {},

--- a/src/frontend/src/components/portal/shell-layout.test.tsx
+++ b/src/frontend/src/components/portal/shell-layout.test.tsx
@@ -64,7 +64,6 @@ vi.mock("@/queries/ic-dashboard", () => ({
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
     roster: [],
-    truncated: false,
     isPending: false,
     isError: false,
     retry: () => {},

--- a/src/frontend/src/components/portal/shell-layout.test.tsx
+++ b/src/frontend/src/components/portal/shell-layout.test.tsx
@@ -61,6 +61,15 @@ vi.mock("@/components/widgets/period-selector-bar", () => ({
 vi.mock("@/queries/ic-dashboard", () => ({
   useIcPerson: () => ({ data: null }),
 }));
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster: [],
+    truncated: false,
+    isPending: false,
+    isError: false,
+    retry: () => {},
+  }),
+}));
 // The topbar asks the catalog which attributes a comparison may use; this
 // test is about the shell's layout, not about that answer.
 vi.mock("@/queries/metric-definitions", () => ({

--- a/src/frontend/src/components/portal/team-state-view.test.tsx
+++ b/src/frontend/src/components/portal/team-state-view.test.tsx
@@ -16,12 +16,14 @@ import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
-import { identityPerson, pid } from "@/test/identity";
+import type { PeopleListItem } from "@/api/identity-client";
+import { identityPerson, peopleFromIdentityTree, pid } from "@/test/identity";
 import type { IdentityPerson } from "@/types/insight";
 
 const mocks = vi.hoisted(() => ({
   personId: null as string | null,
   tree: undefined as IdentityPerson | undefined,
+  roster: [] as PeopleListItem[],
   grid: {
     byKey: new Map<string, NormalizedMetricResult>(),
     previousByKey: new Map<string, NormalizedMetricResult>(),
@@ -52,7 +54,7 @@ vi.mock("@/queries/identity-me", () => ({
 }));
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
-    roster: [],
+    roster: mocks.roster,
     truncated: false,
     isPending: false,
     isError: false,
@@ -96,6 +98,7 @@ const IDS = LABELS.map(pid);
 beforeEach(() => {
   mocks.personId = pid("boss");
   mocks.tree = person("boss", LABELS.map((l) => person(l)));
+  mocks.roster = peopleFromIdentityTree(mocks.tree);
   mocks.grid.isPending = false;
   mocks.grid.isError = false;
   // git.commits is a real headline key (GROUPS card.preview) — the view
@@ -151,6 +154,7 @@ describe("TeamStateView", () => {
 
   it("gates on the empty roster with the People-specific label", () => {
     mocks.tree = person("boss"); // a manager with nobody under them
+    mocks.roster = peopleFromIdentityTree(mocks.tree);
     render(<TeamStateView />);
     expect(
       screen.getByText(

--- a/src/frontend/src/components/portal/team-state-view.test.tsx
+++ b/src/frontend/src/components/portal/team-state-view.test.tsx
@@ -55,7 +55,6 @@ vi.mock("@/queries/identity-me", () => ({
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
     roster: mocks.roster,
-    truncated: false,
     isPending: false,
     isError: false,
     retry: () => {},

--- a/src/frontend/src/lib/insight/identity-tree.test.ts
+++ b/src/frontend/src/lib/insight/identity-tree.test.ts
@@ -13,14 +13,73 @@
 import { describe, expect, it } from "vitest";
 
 import type { IdentityPerson } from "@/types/insight";
+import type { PeopleListItem } from "@/api/identity-client";
 import { isPersonId } from "@/lib/metrics/entity";
 import {
   findIdentityNode,
   flattenSubordinates,
   hasIndirectReports,
+  rosterTree,
   scopeRosterToDirectReports,
   type RosterEntry,
 } from "./identity-tree";
+
+function rosterPerson(
+  personId: string,
+  displayName: string | null,
+  managerPersonId: string | null,
+  attributes: Record<string, string> = {},
+): PeopleListItem {
+  return {
+    person_id: personId,
+    display_name: displayName,
+    first_name: null,
+    last_name: null,
+    username: null,
+    email: null,
+    attributes,
+    manager_person_id: managerPersonId,
+  };
+}
+
+describe("rosterTree", () => {
+  it("builds the viewer hierarchy from canonical roster rows", () => {
+    const tree = rosterTree(
+      [
+        rosterPerson("viewer", "Viewer", null),
+        rosterPerson("lead", "Lead", "viewer"),
+        rosterPerson("report", "Report", "lead", {
+          department: "Engineering",
+          job_title: "Developer",
+        }),
+      ],
+      "viewer",
+    );
+
+    expect(tree?.subordinates[0]?.person_id).toBe("lead");
+    expect(tree?.subordinates[0]?.subordinates[0]).toMatchObject({
+      person_id: "report",
+      department: "Engineering",
+      job_title: "Developer",
+      supervisor_name: "Lead",
+    });
+  });
+
+  it("contains only rows returned by the roster endpoint", () => {
+    const tree = rosterTree(
+      [rosterPerson("viewer", "Viewer", null)],
+      "viewer",
+    );
+
+    expect(tree?.subordinates).toEqual([]);
+  });
+
+  it("returns no hierarchy when the viewer is not in the roster", () => {
+    expect(
+      rosterTree([rosterPerson("member", "Member", null)], "viewer"),
+    ).toBeNull();
+  });
+});
 
 // One UUID per persona, derived from the local part so a failure names the
 // person. person_id is deliberately NOT the email: keying them the same would

--- a/src/frontend/src/lib/insight/identity-tree.test.ts
+++ b/src/frontend/src/lib/insight/identity-tree.test.ts
@@ -79,6 +79,23 @@ describe("rosterTree", () => {
       rosterTree([rosterPerson("member", "Member", null)], "viewer"),
     ).toBeNull();
   });
+
+  it("uses the manager username when their display name is blank", () => {
+    const manager = rosterPerson("lead", "  ", "viewer");
+    manager.username = "lead-handle";
+    const tree = rosterTree(
+      [
+        rosterPerson("viewer", "Viewer", null),
+        manager,
+        rosterPerson("report", "Report", "lead"),
+      ],
+      "viewer",
+    );
+
+    expect(tree?.subordinates[0]?.subordinates[0]?.supervisor_name).toBe(
+      "lead-handle",
+    );
+  });
 });
 
 // One UUID per persona, derived from the local part so a failure names the

--- a/src/frontend/src/lib/insight/identity-tree.ts
+++ b/src/frontend/src/lib/insight/identity-tree.ts
@@ -1,6 +1,58 @@
+import type { PeopleListItem } from "@/api/identity-client";
 import type { IdentityPerson } from "@/types/insight";
 
 const toLower = (s: string | undefined | null) => (s ?? "").toLowerCase();
+
+export function rosterTree(
+  roster: readonly PeopleListItem[],
+  viewerPersonId: string,
+): IdentityPerson | null {
+  const byId = new Map(
+    roster.map((person) => [toLower(person.person_id), person]),
+  );
+  const children = new Map<string, PeopleListItem[]>();
+
+  for (const person of roster) {
+    const managerId = toLower(person.manager_person_id);
+    if (!managerId || !byId.has(managerId)) continue;
+    const reports = children.get(managerId) ?? [];
+    reports.push(person);
+    children.set(managerId, reports);
+  }
+
+  const build = (
+    person: PeopleListItem,
+    ancestors: ReadonlySet<string>,
+  ): IdentityPerson => {
+    const personId = toLower(person.person_id);
+    const nextAncestors = new Set(ancestors).add(personId);
+    const manager = person.manager_person_id
+      ? byId.get(toLower(person.manager_person_id))
+      : undefined;
+    const reports = (children.get(personId) ?? []).filter(
+      (report) => !nextAncestors.has(toLower(report.person_id)),
+    );
+
+    return {
+      person_id: person.person_id,
+      email: person.email ?? "",
+      display_name: person.display_name ?? "",
+      first_name: person.first_name ?? undefined,
+      last_name: person.last_name ?? undefined,
+      username: person.username ?? undefined,
+      department: person.attributes.department,
+      division: person.attributes.division,
+      job_title: person.attributes.job_title,
+      status: person.attributes.status,
+      parent_person_id: person.manager_person_id,
+      supervisor_name: manager?.display_name ?? manager?.username ?? null,
+      subordinates: reports.map((report) => build(report, nextAncestors)),
+    };
+  };
+
+  const viewer = byId.get(toLower(viewerPersonId));
+  return viewer ? build(viewer, new Set()) : null;
+}
 
 export function findIdentityNode(
   tree: IdentityPerson | null | undefined,

--- a/src/frontend/src/lib/insight/identity-tree.ts
+++ b/src/frontend/src/lib/insight/identity-tree.ts
@@ -45,7 +45,8 @@ export function rosterTree(
       job_title: person.attributes.job_title,
       status: person.attributes.status,
       parent_person_id: person.manager_person_id,
-      supervisor_name: manager?.display_name ?? manager?.username ?? null,
+      supervisor_name:
+        manager?.display_name?.trim() || manager?.username?.trim() || null,
       subordinates: reports.map((report) => build(report, nextAncestors)),
     };
   };

--- a/src/frontend/src/lib/insight/slices.test.ts
+++ b/src/frontend/src/lib/insight/slices.test.ts
@@ -1,13 +1,32 @@
 import { describe, expect, it } from "vitest";
 
+import type { PeopleListItem } from "@/api/identity-client";
 import type { IdentityPerson } from "@/types/insight";
 import {
   availableSlices,
   cohortKey,
+  collectPeopleAttrs,
   collectRosterAttrs,
   personAttributes,
   type SliceAttr,
 } from "./slices";
+
+function rosterPerson(
+  personId: string,
+  attributes: Record<string, string>,
+  managerPersonId: string | null = null,
+): PeopleListItem {
+  return {
+    person_id: personId,
+    display_name: null,
+    first_name: null,
+    last_name: null,
+    username: null,
+    email: null,
+    attributes,
+    manager_person_id: managerPersonId,
+  };
+}
 
 function person(over: Partial<IdentityPerson>): IdentityPerson {
   return {
@@ -97,6 +116,36 @@ describe("collectRosterAttrs", () => {
 
   it("returns an empty map for a null root", () => {
     expect(collectRosterAttrs(null, (e) => e).size).toBe(0);
+  });
+});
+
+describe("collectPeopleAttrs", () => {
+  it("reads generic roster attributes and normalizes the title key", () => {
+    const result = collectPeopleAttrs(
+      [
+        rosterPerson(
+          "PERSON-A",
+          { division: "R&D", job_title: "Developer", customTeam: "Core" },
+          "PERSON-MANAGER",
+        ),
+      ],
+      (id) => id.toLowerCase(),
+    );
+
+    expect(result.get("person-a")).toEqual({
+      division: { key: "division", label: "Division", value: "R&D" },
+      title: { key: "title", label: "Title", value: "Developer" },
+      customTeam: {
+        key: "customTeam",
+        label: "customTeam",
+        value: "Core",
+      },
+      manager: {
+        key: "manager",
+        label: "Manager",
+        value: "PERSON-MANAGER",
+      },
+    });
   });
 });
 

--- a/src/frontend/src/lib/insight/slices.ts
+++ b/src/frontend/src/lib/insight/slices.ts
@@ -1,13 +1,12 @@
+import type { PeopleListItem } from "@/api/identity-client";
 import type { IdentityPerson } from "@/types/insight";
 
 /**
  * Slices — grouping a roster and defining peer cohorts by a person attribute.
  * The machinery is **attribute-agnostic**: it works over a generic
- * `{ key → {label, value} }` map, so new identity attributes become sliceable
- * with no change here or downstream. The ONE place attribute names live is
- * `ATTR_FIELDS` below — the interim adapter from the fixed `IdentityPerson`
- * shape. Once identity exposes attributes generically (see constructorfabric/
- * insight#1881), `personAttributes` reads that list and `ATTR_FIELDS` disappears.
+ * `{ key → {label, value} }` map, so canonical people attributes become
+ * sliceable with no change here or downstream. `ATTR_FIELDS` adapts legacy
+ * profile responses still consumed by person-detail surfaces.
  *
  * There is no slice catalog in the analytics API yet, so `availableSlices()`
  * discovers dimensions from the data itself and gates them by presence and
@@ -37,8 +36,7 @@ const MAX_DISTINCT = 60;
 const MAX_UNIQUE_RATIO = 0.9;
 
 /**
- * Interim identity→attributes adapter — the only code that names attributes.
- * Replace its body with the profile's generic `attributes[]` when #1881 lands.
+ * Legacy profile-to-attributes adapter.
  */
 const ATTR_FIELDS: readonly {
   key: string;
@@ -122,6 +120,45 @@ export function collectRosterAttrs(
   };
   if (root) walk(root);
   return m;
+}
+
+const ROSTER_ATTRIBUTE_ALIASES: Readonly<
+  Record<string, { key: string; label: string }>
+> = {
+  department: { key: "department", label: "Department" },
+  division: { key: "division", label: "Division" },
+  job_title: { key: "title", label: "Title" },
+  status: { key: "status", label: "Status" },
+};
+
+export function collectPeopleAttrs(
+  roster: readonly PeopleListItem[],
+  keyOf: (personId: string) => string,
+): Map<string, Record<string, SliceAttr>> {
+  const byPerson = new Map<string, Record<string, SliceAttr>>();
+
+  for (const person of roster) {
+    const attributes: Record<string, SliceAttr> = {};
+    for (const [sourceKey, rawValue] of Object.entries(person.attributes)) {
+      const value = rawValue.trim();
+      if (!value) continue;
+      const descriptor = ROSTER_ATTRIBUTE_ALIASES[sourceKey] ?? {
+        key: sourceKey,
+        label: sourceKey,
+      };
+      attributes[descriptor.key] = { ...descriptor, value };
+    }
+    if (person.manager_person_id) {
+      attributes.manager = {
+        key: "manager",
+        label: "Manager",
+        value: person.manager_person_id,
+      };
+    }
+    byPerson.set(keyOf(person.person_id), attributes);
+  }
+
+  return byPerson;
 }
 
 /**

--- a/src/frontend/src/lib/portal/portal-hooks.test.tsx
+++ b/src/frontend/src/lib/portal/portal-hooks.test.tsx
@@ -37,7 +37,6 @@ const mocks = vi.hoisted(() => ({
   },
   roster: {
     roster: [] as import("@/api/identity-client").PeopleListItem[],
-    truncated: false,
     isPending: false,
     isError: false,
     retry: vi.fn(),

--- a/src/frontend/src/lib/portal/portal-hooks.test.tsx
+++ b/src/frontend/src/lib/portal/portal-hooks.test.tsx
@@ -35,6 +35,13 @@ const mocks = vi.hoisted(() => ({
     isError: false,
     refetch: vi.fn(),
   },
+  roster: {
+    roster: [] as import("@/api/identity-client").PeopleListItem[],
+    truncated: false,
+    isPending: false,
+    isError: false,
+    retry: vi.fn(),
+  },
 }));
 
 vi.mock("@/auth", () => ({
@@ -51,13 +58,7 @@ vi.mock("@/queries/identity-me", () => ({
   }),
 }));
 vi.mock("@/queries/visible-roster", () => ({
-  useVisibleRoster: () => ({
-    roster: [],
-    truncated: false,
-    isPending: false,
-    isError: false,
-    retry: () => {},
-  }),
+  useVisibleRoster: () => mocks.roster,
 }));
 // Only the request is stubbed; `useMetricDefinitionsResponse` itself runs, so
 // a cohort built from an attribute the catalog does not offer fails here.
@@ -96,6 +97,32 @@ const TREE = person(BOSS, "boss", { division: "R&D" }, [
   person(C, "c", { division: "R&D" }),
 ]);
 
+function rosterRows(
+  root: IdentityPerson,
+  managerPersonId: string | null = null,
+): import("@/api/identity-client").PeopleListItem[] {
+  return [
+    {
+      person_id: root.person_id,
+      display_name: root.display_name,
+      first_name: root.first_name ?? null,
+      last_name: root.last_name ?? null,
+      username: root.username ?? null,
+      email: root.email,
+      attributes: {
+        ...(root.department ? { department: root.department } : {}),
+        ...(root.division ? { division: root.division } : {}),
+        ...(root.job_title ? { job_title: root.job_title } : {}),
+        ...(root.status ? { status: root.status } : {}),
+      },
+      manager_person_id: managerPersonId,
+    },
+    ...root.subordinates.flatMap((report) =>
+      rosterRows(report, root.person_id),
+    ),
+  ];
+}
+
 beforeEach(() => {
   mocks.personId = BOSS;
   mocks.definitions = { metrics: [] };
@@ -104,6 +131,9 @@ beforeEach(() => {
   mocks.ic.isPending = false;
   mocks.ic.isLoading = false;
   mocks.ic.isError = false;
+  mocks.roster.roster = rosterRows(TREE);
+  mocks.roster.isPending = false;
+  mocks.roster.isError = false;
   act(() => {
     portalRouter.reset();
     setPortalShowPlanned(true);
@@ -172,7 +202,7 @@ describe("useActiveZone", () => {
 });
 
 describe("useViewerIsManager", () => {
-  it("is a manager when the viewer's node has subordinates", () => {
+  it("is a manager when a roster person reports to the viewer", () => {
     expect(renderHook(() => useViewerIsManager()).result.current).toEqual({
       isManager: true,
       isPending: false,
@@ -187,8 +217,8 @@ describe("useViewerIsManager", () => {
   });
 
   it("reports pending while identity resolves (callers assume manager)", () => {
-    mocks.ic.data = undefined;
-    mocks.ic.isPending = true;
+    mocks.roster.roster = [];
+    mocks.roster.isPending = true;
     const { result } = renderHook(() => useViewerIsManager());
     expect(result.current).toEqual({ isManager: false, isPending: true });
   });
@@ -268,12 +298,12 @@ describe("useOrgScope", () => {
   });
 
   it("surfaces identity errors and delegates refetch", () => {
-    mocks.ic.data = undefined;
-    mocks.ic.isError = true;
+    mocks.roster.roster = [];
+    mocks.roster.isError = true;
     const { result } = renderHook(() => useOrgScope());
     expect(result.current.isError).toBe(true);
     expect(result.current.pivot).toBeNull();
     result.current.refetch();
-    expect(mocks.ic.refetch).toHaveBeenCalledOnce();
+    expect(mocks.roster.retry).toHaveBeenCalledOnce();
   });
 });

--- a/src/frontend/src/lib/portal/use-cohort-label.test.tsx
+++ b/src/frontend/src/lib/portal/use-cohort-label.test.tsx
@@ -33,7 +33,6 @@ vi.mock("@/queries/ic-dashboard", () => ({
 vi.mock("@/queries/visible-roster", () => ({
   useVisibleRoster: () => ({
     roster: mocks.roster,
-    truncated: false,
     isPending: false,
     isError: false,
     retry: () => {},

--- a/src/frontend/src/lib/portal/use-cohort-label.test.tsx
+++ b/src/frontend/src/lib/portal/use-cohort-label.test.tsx
@@ -21,6 +21,7 @@ import type { IdentityPerson } from "@/types/insight";
 const mocks = vi.hoisted(() => ({
   tree: undefined as IdentityPerson | undefined,
   isFlat: false,
+  roster: [] as import("@/api/identity-client").PeopleListItem[],
 }));
 
 vi.mock("@/auth", () => ({
@@ -28,6 +29,15 @@ vi.mock("@/auth", () => ({
 }));
 vi.mock("@/queries/ic-dashboard", () => ({
   useIcPerson: () => ({ data: mocks.tree }),
+}));
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster: mocks.roster,
+    truncated: false,
+    isPending: false,
+    isError: false,
+    retry: () => {},
+  }),
 }));
 vi.mock("@/queries/identity-me", () => ({
   useVisibilityPolicy: () => ({
@@ -57,6 +67,32 @@ beforeEach(() => {
     person("b", { division: "Sales", job_title: "Rep" }),
     person("c", { division: "R&D", job_title: "Engineer" }),
   ]);
+  mocks.roster = [
+    {
+      person_id: pid("boss"),
+      display_name: "Boss",
+      first_name: null,
+      last_name: null,
+      username: null,
+      email: "boss@example.com",
+      attributes: {},
+      manager_person_id: null,
+    },
+    ...[
+      ["a", "R&D", "Engineer"],
+      ["b", "Sales", "Rep"],
+      ["c", "R&D", "Engineer"],
+    ].map(([label, division, jobTitle]) => ({
+      person_id: pid(label!),
+      display_name: label!,
+      first_name: null,
+      last_name: null,
+      username: null,
+      email: `${label}@example.com`,
+      attributes: { division: division!, job_title: jobTitle! },
+      manager_person_id: pid("boss"),
+    })),
+  ];
 });
 
 describe("useCohortLabel", () => {

--- a/src/frontend/src/lib/portal/use-cohort-label.ts
+++ b/src/frontend/src/lib/portal/use-cohort-label.ts
@@ -1,11 +1,10 @@
 import { useMemo } from "react";
 
-import { useViewer } from "@/auth";
-import { availableSlices, collectRosterAttrs } from "@/lib/insight/slices";
+import { availableSlices, collectPeopleAttrs } from "@/lib/insight/slices";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import { usePortalSlice } from "@/lib/portal/portal-nav";
-import { useIcPerson } from "@/queries/ic-dashboard";
 import { useVisibilityPolicy } from "@/queries/identity-me";
+import { useVisibleRoster } from "@/queries/visible-roster";
 
 /**
  * The label reads mid-sentence ("above the division median"), so a plain
@@ -28,11 +27,10 @@ export function peerPopulationLabel(
 export function useCohortLabel(): string {
   const slice = usePortalSlice();
   const { isFlat } = useVisibilityPolicy();
-  const { personId } = useViewer();
-  const tree = useIcPerson(personId ?? "").data ?? null;
+  const roster = useVisibleRoster(true).roster;
   const dims = useMemo(
-    () => availableSlices(collectRosterAttrs(tree, normalizePersonId).values()),
-    [tree]
+    () => availableSlices(collectPeopleAttrs(roster, normalizePersonId).values()),
+    [roster],
   );
   const sliceLabel = slice
     ? (dims.find((dimension) => dimension.key === slice)?.label ?? "cohort")

--- a/src/frontend/src/lib/portal/use-cohort-options.ts
+++ b/src/frontend/src/lib/portal/use-cohort-options.ts
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 
-import { useViewer } from "@/auth";
-import { collectRosterAttrs } from "@/lib/insight/slices";
+import { collectPeopleAttrs } from "@/lib/insight/slices";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import {
   catalogAttributes,
@@ -9,8 +8,8 @@ import {
   type CohortOptions,
 } from "@/lib/portal/cohort-options";
 import { usePortalSlice } from "@/lib/portal/portal-nav";
-import { useIcPerson } from "@/queries/ic-dashboard";
 import { useMetricDefinitionsResponse } from "@/queries/metric-definitions";
+import { useVisibleRoster } from "@/queries/visible-roster";
 
 export interface CohortOptionsState extends CohortOptions {
   /** True until both sources have answered — nothing may be dropped before. */
@@ -35,21 +34,20 @@ export interface CohortOptionsState extends CohortOptions {
  * `cohortOptions` for why the catalog outranks the roster.
  */
 export function useCohortOptions(): CohortOptionsState {
-  const { personId } = useViewer();
   const stored = usePortalSlice();
   const definitions = useMetricDefinitionsResponse();
-  const tree = useIcPerson(personId ?? "");
+  const roster = useVisibleRoster(true);
 
   const options = useMemo(
     () =>
       cohortOptions(
         catalogAttributes(definitions.data),
-        collectRosterAttrs(tree.data ?? null, normalizePersonId).values()
+        collectPeopleAttrs(roster.roster, normalizePersonId).values(),
       ),
-    [definitions.data, tree.data]
+    [definitions.data, roster.roster],
   );
 
-  const isPending = definitions.isPending || tree.isPending;
+  const isPending = definitions.isPending || roster.isPending;
   return {
     ...options,
     isPending,

--- a/src/frontend/src/lib/portal/use-org-scope.test.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { PeopleListItem } from "@/api/identity-client";
 import type { IdentityPerson } from "@/types/insight";
 import { flatOrgScope, resolveScopeRoster } from "./use-org-scope";
 
@@ -17,6 +18,22 @@ const person = (
     display_name: name,
     subordinates,
   }) as unknown as IdentityPerson;
+
+const rosterPerson = (
+  personId: string,
+  displayName: string,
+  over: Partial<PeopleListItem> = {},
+): PeopleListItem => ({
+  person_id: personId,
+  display_name: displayName,
+  first_name: null,
+  last_name: null,
+  username: null,
+  email: null,
+  attributes: {},
+  manager_person_id: null,
+  ...over,
+});
 
 //        ao
 //   ┌────┴─────┐
@@ -104,9 +121,9 @@ describe("resolveScopeRoster", () => {
 
 describe("flatOrgScope", () => {
   const roster = [
-    { person_id: "p-me", display_name: "Me" },
-    { person_id: "p-b", display_name: "Bea" },
-    { person_id: "p-c", display_name: "Cyd" },
+    rosterPerson("p-me", "Me"),
+    rosterPerson("p-b", "Bea"),
+    rosterPerson("p-c", "Cyd"),
   ];
 
   it("counts everyone the viewer may see, the viewer included", () => {
@@ -136,7 +153,7 @@ describe("flatOrgScope", () => {
     // The roster entry is what the zones label people by; dropping username
     // here would blank every person the org chart never named.
     const scope = flatOrgScope([
-      { person_id: "p-h", display_name: "", username: "handle", email: "" },
+      rosterPerson("p-h", "", { username: "handle", email: "" }),
     ]);
 
     expect(scope.roster).toEqual([
@@ -153,13 +170,10 @@ describe("flatOrgScope", () => {
 
   it("carries visible people without creating a report-specific profile", () => {
     const scope = flatOrgScope([
-      {
-        person_id: "p-h",
-        display_name: "Handle",
+      rosterPerson("p-h", "Handle", {
         email: "handle@example.com",
-        job_title: "Engineer",
-        status: "active",
-      },
+        attributes: { job_title: "Engineer", status: "active" },
+      }),
     ]);
 
     expect(scope.roster?.map((person) => person.person_id)).toEqual(["p-h"]);

--- a/src/frontend/src/lib/portal/use-org-scope.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.ts
@@ -5,18 +5,14 @@ import {
   findIdentityNode,
   flattenSubordinates,
   hasIndirectReports,
+  rosterTree,
   scopeRosterToDirectReports,
   type RosterEntry,
 } from "@/lib/insight/identity-tree";
-import {
-  type OrgScope,
-} from "@/lib/portal/portal-store";
-import {
-  usePortalScope,
-} from "@/lib/portal/portal-nav";
-import type { PersonSummary } from "@/api/identity-client";
+import { usePortalScope } from "@/lib/portal/portal-nav";
+import type { OrgScope } from "@/lib/portal/portal-store";
+import type { PeopleListItem } from "@/api/identity-client";
 import { personDisplayName } from "@/lib/identities/person-display";
-import { useIcPerson } from "@/queries/ic-dashboard";
 import { useVisibilityPolicy } from "@/queries/identity-me";
 import { useVisibleRoster } from "@/queries/visible-roster";
 import type { IdentityPerson } from "@/types/insight";
@@ -56,7 +52,7 @@ export const WHOLE_ORG_LABEL = "Whole organisation";
  * is looking disagrees with the roster listed right beside it (#2724).
  */
 export function flatOrgScope(
-  roster: readonly PersonSummary[] | null,
+  roster: readonly PeopleListItem[] | null,
 ): ResolvedScope {
   if (!roster) {
     return {
@@ -163,26 +159,30 @@ export function useOrgScope(): ResolvedScope & {
   pivotPersonId: string;
 } {
   const { personId } = useViewer();
-  const viewerQ = useIcPerson(personId ?? "");
   const scope = usePortalScope();
   const { isFlat } = useVisibilityPolicy();
-  const flatRoster = useVisibleRoster(isFlat);
+  const visibleRoster = useVisibleRoster(true);
+  const tree = useMemo(
+    () =>
+      visibleRoster.isPending || !personId
+        ? null
+        : rosterTree(visibleRoster.roster, personId),
+    [visibleRoster.isPending, visibleRoster.roster, personId],
+  );
 
   const resolved = useMemo(
     () =>
       isFlat
-        ? flatOrgScope(flatRoster.isPending ? null : flatRoster.roster)
-        : resolveScopeRoster(viewerQ.data ?? null, personId, scope),
-    [isFlat, flatRoster.isPending, flatRoster.roster, viewerQ.data, personId, scope],
+        ? flatOrgScope(visibleRoster.isPending ? null : visibleRoster.roster)
+        : resolveScopeRoster(tree, personId, scope),
+    [isFlat, visibleRoster.isPending, visibleRoster.roster, tree, personId, scope],
   );
 
-  // Under a flat policy the roster IS the org zones' subject, so its failure is
-  // theirs; the identity tree still answers who the viewer is.
   return {
     ...resolved,
-    isLoading: isFlat ? flatRoster.isPending : viewerQ.isLoading,
-    isError: isFlat ? flatRoster.isError : viewerQ.isError,
-    refetch: () => (isFlat ? flatRoster.retry() : void viewerQ.refetch()),
+    isLoading: visibleRoster.isPending,
+    isError: visibleRoster.isError,
+    refetch: visibleRoster.retry,
     pivotPersonId: resolved.pivot?.person_id ?? personId ?? "",
   };
 }

--- a/src/frontend/src/lib/portal/use-person-cohort.ts
+++ b/src/frontend/src/lib/portal/use-person-cohort.ts
@@ -1,10 +1,9 @@
 import { useMemo } from "react";
 
-import { useViewer } from "@/auth";
-import { cohortKey, collectRosterAttrs } from "@/lib/insight/slices";
+import { cohortKey, collectPeopleAttrs } from "@/lib/insight/slices";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import { useCohortOptions } from "@/lib/portal/use-cohort-options";
-import { useIcPerson } from "@/queries/ic-dashboard";
+import { useVisibleRoster } from "@/queries/visible-roster";
 
 /**
  * The entity ids of a person's slice cohort — everyone in the viewer's org who
@@ -18,11 +17,10 @@ export function usePersonCohort(entityId: string): string[] {
   // catalog has since dropped would otherwise keep building cohorts while the
   // control shows "Team (all)".
   const { slice } = useCohortOptions();
-  const { personId } = useViewer();
-  const tree = useIcPerson(personId ?? "").data ?? null;
+  const roster = useVisibleRoster(true).roster;
   const attrByEntity = useMemo(
-    () => collectRosterAttrs(tree, normalizePersonId),
-    [tree]
+    () => collectPeopleAttrs(roster, normalizePersonId),
+    [roster],
   );
   return useMemo(() => {
     if (!slice) return [];

--- a/src/frontend/src/lib/portal/use-viewer-is-manager.ts
+++ b/src/frontend/src/lib/portal/use-viewer-is-manager.ts
@@ -1,8 +1,5 @@
-import { useMemo } from "react";
-
 import { useViewer } from "@/auth";
-import { findIdentityNode } from "@/lib/insight/identity-tree";
-import { useIcPerson } from "@/queries/ic-dashboard";
+import { useVisibleRoster } from "@/queries/visible-roster";
 
 /**
  * Whether the current viewer manages anyone. The portal's org zones (Overview,
@@ -11,22 +8,18 @@ import { useIcPerson } from "@/queries/ic-dashboard";
  * so those zones would be empty — the shell collapses to their Person page
  * instead (see LensRail / PortalLayout).
  *
- * `isPending` is true only until the viewer's own identity resolves; callers
- * should treat pending as "assume manager" to avoid hiding zones on a flash.
+ * `isPending` remains true until the canonical roster resolves; callers should
+ * treat pending as "assume manager" to avoid hiding zones on a flash.
  */
 export function useViewerIsManager(): { isManager: boolean; isPending: boolean } {
   const { personId } = useViewer();
-  const q = useIcPerson(personId ?? "");
+  const roster = useVisibleRoster(true);
+  const viewerId = personId?.toLowerCase();
+  const isManager = viewerId
+    ? roster.roster.some(
+        (person) => person.manager_person_id?.toLowerCase() === viewerId,
+      )
+    : false;
 
-  const isManager = useMemo(() => {
-    const tree = q.data ?? null;
-    if (!tree || !personId) return false;
-    const node = findIdentityNode(tree, personId) ?? tree;
-    return (node.subordinates?.length ?? 0) > 0;
-  }, [q.data, personId]);
-
-  // `q.data == null` covers the error case too: with no tree we do not know,
-  // and callers treat unresolved as "assume manager" so the org zone can show
-  // the identity failure instead of the shell quietly demoting the viewer.
-  return { isManager, isPending: q.isPending || q.data == null };
+  return { isManager, isPending: roster.isPending || roster.isError };
 }

--- a/src/frontend/src/lib/portal/use-viewer-reach.test.ts
+++ b/src/frontend/src/lib/portal/use-viewer-reach.test.ts
@@ -7,18 +7,22 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import type { IdentityPerson } from "@/types/insight";
+import type { PeopleListItem } from "@/api/identity-client";
 
 const mocks = vi.hoisted(() => ({
-  viewer: null as IdentityPerson | null,
+  roster: [] as PeopleListItem[],
   isFlat: false,
   policyPending: false,
-  treePending: false,
+  rosterPending: false,
 }));
 
 vi.mock("@/auth", () => ({ useViewer: () => ({ personId: "me" }) }));
-vi.mock("@/queries/ic-dashboard", () => ({
-  useIcPerson: () => ({ data: mocks.viewer, isPending: mocks.treePending }),
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster: mocks.roster,
+    isPending: mocks.rosterPending,
+    isError: false,
+  }),
 }));
 vi.mock("@/queries/identity-me", () => ({
   useVisibilityPolicy: () => ({
@@ -30,21 +34,25 @@ vi.mock("@/queries/identity-me", () => ({
 
 import { useViewerReach } from "./use-viewer-reach";
 
-function person(id: string, subordinates: IdentityPerson[] = []): IdentityPerson {
+function person(id: string, managerPersonId: string | null = null): PeopleListItem {
   return {
     person_id: id,
     email: `${id}@example.com`,
     display_name: id,
-    subordinates,
-  } as IdentityPerson;
+    first_name: null,
+    last_name: null,
+    username: null,
+    attributes: {},
+    manager_person_id: managerPersonId,
+  };
 }
 
 describe("useViewerReach", () => {
   it("opens the org zones for a lead on a hierarchical install", () => {
-    mocks.viewer = person("me", [person("report")]);
+    mocks.roster = [person("me"), person("report", "me")];
     mocks.isFlat = false;
     mocks.policyPending = false;
-    mocks.treePending = false;
+    mocks.rosterPending = false;
 
     const { result } = renderHook(() => useViewerReach());
 
@@ -53,7 +61,7 @@ describe("useViewerReach", () => {
   });
 
   it("keeps them shut for a leaf IC on a hierarchical install", () => {
-    mocks.viewer = person("me");
+    mocks.roster = [person("me")];
     mocks.isFlat = false;
 
     const { result } = renderHook(() => useViewerReach());
@@ -64,7 +72,7 @@ describe("useViewerReach", () => {
 
   it("opens them under a flat policy even with nobody to manage", () => {
     // The whole point: no reports, and still the organisation to look at.
-    mocks.viewer = person("me");
+    mocks.roster = [person("me")];
     mocks.isFlat = true;
 
     const { result } = renderHook(() => useViewerReach());
@@ -74,9 +82,9 @@ describe("useViewerReach", () => {
   });
 
   it("waits rather than deciding while either answer is in flight", () => {
-    mocks.viewer = null;
+    mocks.roster = [];
     mocks.isFlat = false;
-    mocks.treePending = true;
+    mocks.rosterPending = true;
     mocks.policyPending = true;
 
     const { result } = renderHook(() => useViewerReach());

--- a/src/frontend/src/mocks/handlers.test.ts
+++ b/src/frontend/src/mocks/handlers.test.ts
@@ -58,3 +58,16 @@ it("refuses a feedback message past the budget", async () => {
 
   expect(response.status).toBe(400);
 });
+
+it("filters the canonical people mock before paging", async () => {
+  const response = await fetch(
+    new URL("/api/identity/v1/people?q=carol", window.location.href),
+  );
+  const body = (await response.json()) as {
+    items: Array<{ display_name: string }>;
+  };
+
+  expect(body.items.map((person) => person.display_name)).toEqual([
+    "Carol Chen",
+  ]);
+});

--- a/src/frontend/src/mocks/handlers.test.ts
+++ b/src/frontend/src/mocks/handlers.test.ts
@@ -21,7 +21,7 @@ it("rejects unsupported metric result entity types", async () => {
         period: { from: "2026-01-01", to: "2026-01-31" },
         metrics: [],
       }),
-    },
+    }
   );
 
   expect(response.status).toBe(400);
@@ -37,7 +37,7 @@ it("takes a feedback message the service takes: the budget counts characters", a
         message: "🙂".repeat(FEEDBACK_MESSAGE_MAX),
         path: "/portal/overview",
       }),
-    },
+    }
   );
 
   expect(response.status).toBe(204);
@@ -53,7 +53,7 @@ it("refuses a feedback message past the budget", async () => {
         message: "x".repeat(FEEDBACK_MESSAGE_MAX + 1),
         path: "/portal/overview",
       }),
-    },
+    }
   );
 
   expect(response.status).toBe(400);
@@ -61,7 +61,7 @@ it("refuses a feedback message past the budget", async () => {
 
 it("filters the canonical people mock before paging", async () => {
   const response = await fetch(
-    new URL("/api/identity/v1/people?q=carol", window.location.href),
+    new URL("/api/identity/v1/people?q=carol", window.location.href)
   );
   const body = (await response.json()) as {
     items: Array<{ display_name: string }>;
@@ -70,4 +70,22 @@ it("filters the canonical people mock before paging", async () => {
   expect(body.items.map((person) => person.display_name)).toEqual([
     "Carol Chen",
   ]);
+});
+
+it("returns canonical person detail from the people mock", async () => {
+  const response = await fetch(
+    new URL(
+      "/api/identity/v1/people/e8a33e91-2658-58dc-8175-ebf473d8be5c",
+      window.location.href
+    )
+  );
+  const body = (await response.json()) as {
+    person_id: string;
+    display_name: string;
+  };
+
+  expect(body).toMatchObject({
+    person_id: "e8a33e91-2658-58dc-8175-ebf473d8be5c",
+    display_name: "Carol Chen",
+  });
 });

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -3,10 +3,7 @@ import { http, HttpResponse } from "msw";
 import { FEEDBACK_MESSAGE_MAX } from "@/api/feedback-client";
 import type { MetricDrilldownRequest } from "@/api/metric-drilldown-client";
 import type { MetricResultsRequest } from "@/api/metric-results-client";
-import type {
-  CustomMetric,
-  CustomMetricGraph,
-} from "@/api/metrics-client";
+import type { CustomMetric, CustomMetricGraph } from "@/api/metrics-client";
 import { isPersonId } from "@/lib/metrics/entity";
 
 import { buildMetricDefinitions } from "./metric-definitions-factory";
@@ -19,6 +16,25 @@ import { buildIngestionIntensity } from "./ingestion-factory";
 import { buildIdentityTree, PEOPLE, PEOPLE_BY_EMAIL } from "./registry";
 
 const defaultPerson = PEOPLE[0];
+
+function peopleItem(person: (typeof PEOPLE)[number]) {
+  const [firstName, ...lastName] = person.name.split(" ");
+  return {
+    person_id: person.person_id,
+    display_name: person.name,
+    first_name: firstName ?? null,
+    last_name: lastName.join(" ") || null,
+    username: null,
+    email: person.email,
+    attributes: {
+      department: person.department,
+      division: person.department,
+      job_title: person.role,
+      status: "Active",
+    },
+    manager_person_id: person.supervisor_person_id,
+  };
+}
 
 /**
  * A mock page holds far fewer rows than a real one. The synthetic roster is
@@ -71,7 +87,6 @@ function mockSessionTiming(): { expires_at: number; refresh_at: number } {
   return { expires_at: now + 600, refresh_at: now + 510 };
 }
 
-
 // ── Saved queries (`/v1/queries`) ────────────────────────────
 // A tiny in-memory store so the console's CRUD + run round-trip in mock,
 // Storybook, and `VITE_ENABLE_MOCKS=true` dev runs. Synthetic data only.
@@ -113,7 +128,7 @@ function savedQueryHandlers() {
           name: q.name,
           description: q.description,
         })),
-      }),
+      })
     ),
     http.post(QUERIES_BASE, async ({ request }) => {
       const body = (await request.json().catch(() => null)) as {
@@ -122,7 +137,10 @@ function savedQueryHandlers() {
         sql?: string;
       } | null;
       if (!body?.name || !body?.sql) {
-        return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
+        return HttpResponse.json(
+          { error: "invalid_argument" },
+          { status: 400 }
+        );
       }
       const now = new Date().toISOString();
       const created: MockSavedQuery = {
@@ -242,7 +260,9 @@ function stripOrigin(metric: CustomMetric): CustomMetricGraph {
 /** A graph is well-formed enough to persist: identity, source, SQL, at least
  *  one measure, and the input wiring its computation requires. Mirrors the
  *  backend's create/update validation so FE tests exercise real behavior. */
-function isValidGraph(graph: CustomMetricGraph | null): graph is CustomMetricGraph {
+function isValidGraph(
+  graph: CustomMetricGraph | null
+): graph is CustomMetricGraph {
   if (
     !graph?.metric_key ||
     !graph.label ||
@@ -282,14 +302,17 @@ function customMetricHandlers() {
     http.get(METRICS_BASE, () =>
       HttpResponse.json({
         items: [...customMetricStore.values()].map(toSummary),
-      }),
+      })
     ),
     http.post(METRICS_BASE, async ({ request }) => {
       const body = (await request
         .json()
         .catch(() => null)) as CustomMetricGraph | null;
       if (!isValidGraph(body)) {
-        return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
+        return HttpResponse.json(
+          { error: "invalid_argument" },
+          { status: 400 }
+        );
       }
       // A duplicate key is a conflict, not an overwrite — leave the store
       // untouched and mirror the backend's 409.
@@ -297,7 +320,10 @@ function customMetricHandlers() {
         return HttpResponse.json({ error: "already_exists" }, { status: 409 });
       }
       if (sourceKeyTakenByOther(body.source_key, body.metric_key)) {
-        return HttpResponse.json({ error: "source_key_conflict" }, { status: 409 });
+        return HttpResponse.json(
+          { error: "source_key_conflict" },
+          { status: 409 }
+        );
       }
       const created: CustomMetric = { ...body, origin: "custom" };
       customMetricStore.set(created.metric_key, created);
@@ -308,7 +334,7 @@ function customMetricHandlers() {
     http.get(`${METRICS_BASE}/export`, () =>
       HttpResponse.json({
         metrics: [...customMetricStore.values()].map(stripOrigin),
-      }),
+      })
     ),
     http.post(`${METRICS_BASE}/import`, async ({ request }) => {
       const body = (await request.json().catch(() => null)) as {
@@ -318,7 +344,10 @@ function customMetricHandlers() {
       // nothing if any member is malformed. Only after the batch is known good
       // do we apply it, skipping keys that already exist.
       if (!Array.isArray(body?.metrics) || !body.metrics.every(isValidGraph)) {
-        return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
+        return HttpResponse.json(
+          { error: "invalid_argument" },
+          { status: 400 }
+        );
       }
       const skipped: string[] = [];
       let imported = 0;
@@ -349,12 +378,18 @@ function customMetricHandlers() {
       const candidate = body ? { ...body, metric_key: key } : null;
       // Reject an incomplete/invalid graph instead of persisting it.
       if (!isValidGraph(candidate)) {
-        return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
+        return HttpResponse.json(
+          { error: "invalid_argument" },
+          { status: 400 }
+        );
       }
       // A source_key already claimed by a different metric is a 409, matching
       // the backend's new collision check.
       if (sourceKeyTakenByOther(candidate.source_key, key)) {
-        return HttpResponse.json({ error: "source_key_conflict" }, { status: 409 });
+        return HttpResponse.json(
+          { error: "source_key_conflict" },
+          { status: 409 }
+        );
       }
       const updated: CustomMetric = { ...candidate, origin: "custom" };
       customMetricStore.set(key, updated);
@@ -366,7 +401,6 @@ function customMetricHandlers() {
     }),
   ];
 }
-
 
 // Assembled last: the sections above declare module-level stores/consts the
 // handler factories close over, and the factories are CALLED right here —
@@ -396,7 +430,13 @@ const DEFAULT_SYSTEM_PROMPT = [
 
 const mockContext = new Map<
   string,
-  { id: string; scope: "tenant" | "person"; title: string; body: string; updated_at: string }
+  {
+    id: string;
+    scope: "tenant" | "person";
+    title: string;
+    body: string;
+    updated_at: string;
+  }
 >([
   [
     "ctx-org-1",
@@ -422,7 +462,7 @@ const mockContext = new Map<
 
 export const handlers = [
   http.get("/auth/me", () =>
-    HttpResponse.json({ ...MOCK_SESSION, ...mockSessionTiming() }),
+    HttpResponse.json({ ...MOCK_SESSION, ...mockSessionTiming() })
   ),
   http.post("/auth/refresh", () => HttpResponse.json(mockSessionTiming())),
   http.post("/auth/logout", () => HttpResponse.json({ rp_logout_url: null })),
@@ -430,11 +470,7 @@ export const handlers = [
     const body = (await request
       .json()
       .catch(() => null)) as MetricResultsRequest | null;
-    if (
-      !body ||
-      !body.entity ||
-      !Array.isArray(body.metrics)
-    ) {
+    if (!body || !body.entity || !Array.isArray(body.metrics)) {
       return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
     }
 
@@ -442,7 +478,7 @@ export const handlers = [
     if (entityType !== "person" && entityType !== "tenant") {
       return HttpResponse.json(
         { error: "invalid_argument", field: "entity.type" },
-        { status: 400 },
+        { status: 400 }
       );
     }
 
@@ -453,22 +489,24 @@ export const handlers = [
     if (
       body.entity.type === "person" &&
       (!Array.isArray(body.entity.ids) ||
-        !body.entity.ids.every((id) => typeof id === "string" && isPersonId(id)))
+        !body.entity.ids.every(
+          (id) => typeof id === "string" && isPersonId(id)
+        ))
     ) {
       return HttpResponse.json(
         { error: "invalid_argument", field: "entity.ids" },
-        { status: 400 },
+        { status: 400 }
       );
     }
     if (
       body.entity.type === "tenant" &&
       body.metrics.some((metric) =>
-        metric.views.some((view) => view.view === "peer"),
+        metric.views.some((view) => view.view === "peer")
       )
     ) {
       return HttpResponse.json(
         { error: "invalid_argument", field: "metrics.views" },
-        { status: 400 },
+        { status: 400 }
       );
     }
     return HttpResponse.json(buildMetricResultsResponse(body));
@@ -492,7 +530,10 @@ export const handlers = [
         .json()
         .catch(() => null)) as MetricDrilldownRequest | null;
       if (!body?.metric_key || !body.entity || !body.period) {
-        return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
+        return HttpResponse.json(
+          { error: "invalid_argument" },
+          { status: 400 }
+        );
       }
       return new HttpResponse(buildMetricDrilldownCsv(body), {
         headers: {
@@ -500,14 +541,15 @@ export const handlers = [
           "Content-Disposition": `attachment; filename="${body.metric_key}.csv"`,
         },
       });
-    },
+    }
   ),
   // The demo viewer is an identity admin, so mock mode exercises the admin
   // surfaces (Manage → Identities). The role id is the backend's seeded
   // `roles_repo::ADMIN_ROLE_ID` migration constant.
   http.get("/api/identity/v1/me", () =>
     HttpResponse.json({
-      person_id: defaultPerson?.person_id ?? "00000000-0000-0000-0000-0000000000bb",
+      person_id:
+        defaultPerson?.person_id ?? "00000000-0000-0000-0000-0000000000bb",
       insight_tenant_id: "00000000-0000-4000-8000-00000000c0de",
       roles: [
         {
@@ -518,13 +560,13 @@ export const handlers = [
       // Mock mode demos the reporting-line product; the flat roster below is
       // served anyway, so switching this to "flat" exercises that shell.
       visibility_policy: "org_chart",
-    }),
+    })
   ),
   // Minimal, honest empty catalog: without this handler the request falls
   // through to the network, and in a proxy-configured dev run the resulting
   // 401 bounces the whole mock session to the real IdP.
   http.get("/api/analytics/v1/metric-definitions", () =>
-    HttpResponse.json({ metrics: buildMetricDefinitions() }),
+    HttpResponse.json({ metrics: buildMetricDefinitions() })
   ),
   // One account's binding + decision trail. dev-42 carries a small history so
   // the panel has something to show; any other account answers 200 with no
@@ -657,14 +699,15 @@ export const handlers = [
                   job_title: carol.role,
                 }
               : null,
-            comment: "Checked with HR — same person, the chat handle is theirs.",
+            comment:
+              "Checked with HR — same person, the chat handle is theirs.",
             accounts_touched: 3,
             outcome: "applied",
             recorded_at: "2026-08-01T10:15:00.000000",
           },
         ],
       });
-    },
+    }
   ),
   // The person listing: a blank query is the whole roster, terms narrow it,
   // and both are paged the way the service pages them.
@@ -678,8 +721,10 @@ export const handlers = [
       terms.every((term) =>
         isPersonId(term)
           ? p.person_id.toLowerCase() === term
-          : [p.name, p.email, p.role].some((v) => v.toLowerCase().includes(term)),
-      ),
+          : [p.name, p.email, p.role].some((v) =>
+              v.toLowerCase().includes(term)
+            )
+      )
     )
       .map((p) => ({
         person_id: p.person_id,
@@ -690,7 +735,7 @@ export const handlers = [
         status: "active",
       }))
       .sort((left, right) =>
-        (left.display_name ?? "").localeCompare(right.display_name ?? ""),
+        (left.display_name ?? "").localeCompare(right.display_name ?? "")
       );
     return HttpResponse.json(pageOf(items, params, q));
   }),
@@ -702,8 +747,7 @@ export const handlers = [
     const q = params.get("q")?.trim().toLowerCase() ?? "";
     const items = PEOPLE.filter(
       (p) =>
-        !q ||
-        [p.name, p.email, p.role].some((v) => v.toLowerCase().includes(q)),
+        !q || [p.name, p.email, p.role].some((v) => v.toLowerCase().includes(q))
     )
       .map((p) => ({
         person_id: p.person_id,
@@ -714,7 +758,7 @@ export const handlers = [
         status: "active",
       }))
       .sort((left, right) =>
-        (left.display_name ?? "").localeCompare(right.display_name ?? ""),
+        (left.display_name ?? "").localeCompare(right.display_name ?? "")
       );
     return HttpResponse.json(pageOf(items, params, q));
   }),
@@ -725,32 +769,27 @@ export const handlers = [
     const items = PEOPLE.filter((person) =>
       terms.every((term) =>
         [person.name, person.email, person.role, person.department].some(
-          (value) => value.toLowerCase().includes(term),
-        ),
-      ),
+          (value) => value.toLowerCase().includes(term)
+        )
+      )
     )
-      .map((person) => {
-        const [firstName, ...lastName] = person.name.split(" ");
-        return {
-          person_id: person.person_id,
-          display_name: person.name,
-          first_name: firstName ?? null,
-          last_name: lastName.join(" ") || null,
-          username: null,
-          email: person.email,
-          attributes: {
-            department: person.department,
-            division: person.department,
-            job_title: person.role,
-            status: "Active",
-          },
-          manager_person_id: person.supervisor_person_id,
-        };
-      })
+      .map(peopleItem)
       .sort((left, right) =>
-        left.display_name.localeCompare(right.display_name),
+        left.display_name.localeCompare(right.display_name)
       );
     return HttpResponse.json(pageOf(items, params, q));
+  }),
+  http.get("/api/identity/v1/people/:personId", ({ params }) => {
+    const personId = String(params.personId).toLowerCase();
+    const person = PEOPLE.find(
+      (candidate) => candidate.person_id.toLowerCase() === personId
+    );
+    return person
+      ? HttpResponse.json(peopleItem(person))
+      : HttpResponse.json(
+          { type: "urn:insight:error:person_not_found" },
+          { status: 404 }
+        );
   }),
   // The account listing: the same roster seen as accounts; blank lists them all.
   http.get("/api/identity/v1/resolution/accounts", ({ request }) => {
@@ -758,7 +797,9 @@ export const handlers = [
     const q = params.get("q")?.trim() ?? "";
     const needle = q.toLowerCase();
     const items = PEOPLE.filter(
-      (p) => !needle || [p.name, p.email].some((v) => v.toLowerCase().includes(needle)),
+      (p) =>
+        !needle ||
+        [p.name, p.email].some((v) => v.toLowerCase().includes(needle))
     ).map((p, index) => ({
       source: index % 2 === 0 ? "github" : "gitlab",
       source_id: "01900000-0000-7000-8000-00000000aa01",
@@ -777,7 +818,9 @@ export const handlers = [
     // The service orders by the label each row shows; the mock mirrors it so a
     // mock run does not demonstrate an order the real listing never produces.
     items.sort((left, right) =>
-      (left.email ?? left.account_id).localeCompare(right.email ?? right.account_id),
+      (left.email ?? left.account_id).localeCompare(
+        right.email ?? right.account_id
+      )
     );
     return HttpResponse.json(pageOf(items, params, q));
   }),
@@ -805,7 +848,7 @@ export const handlers = [
             bound_by_operator: true,
           },
         ],
-      }),
+      })
   ),
   // The four correction verbs: happy-path outcomes, no state kept — the queue
   // mock is static, so the demo shows the flow rather than a simulation.
@@ -825,8 +868,8 @@ export const handlers = [
         ...(verb === "detach"
           ? { new_person_id: "01900000-0000-7000-8000-00000000dead" }
           : {}),
-      }),
-    ),
+      })
+    )
   ),
   // The review queue, exercising all three kinds. Candidates reuse the seeded
   // roster so names/emails stay consistent with every other mock surface.
@@ -935,54 +978,59 @@ export const handlers = [
           candidates: [],
         },
       ],
-      rates: { observed: 60, bound: 55, pending: 3, no_source_id: 0, no_evidence: 2, excluded: 1 },
+      rates: {
+        observed: 60,
+        bound: 55,
+        pending: 3,
+        no_source_id: 0,
+        no_evidence: 2,
+        excluded: 1,
+      },
       truncated: false,
       items_truncated: false,
     });
   }),
-  http.post(
-    "/api/identity/v1/profiles",
-    async ({ request }) => {
-      const body = (await request.json().catch(() => null)) as
-        | { value_type?: string; value?: string }
-        | null;
-      const value = (body?.value ?? "").trim();
-      // The service resolves `person_id` (the SPA's key) and `email` (legacy
-      // URL migration only); anything else is a client error.
-      if (body?.value_type !== "email" && body?.value_type !== "person_id") {
-        return HttpResponse.json(
-          { type: "urn:insight:error:invalid_argument" },
-          { status: 400 },
-        );
-      }
-      // A malformed person_id is a 400, not a 404 — matching the service, where
-      // "does not parse" and "resolves to nobody" are different answers.
-      if (body.value_type === "person_id" && !isPersonId(value)) {
-        return HttpResponse.json(
-          { type: "urn:insight:error:invalid_argument" },
-          { status: 400 },
-        );
-      }
-      const personId =
-        body.value_type === "email"
-          ? PEOPLE_BY_EMAIL[value.toLowerCase()]?.person_id
-          : value.toLowerCase();
-      if (!personId) {
-        return HttpResponse.json(
-          { type: "urn:insight:error:person_not_found" },
-          { status: 404 },
-        );
-      }
-      const tree = buildIdentityTree(personId);
-      if (!tree) {
-        return HttpResponse.json(
-          { type: "urn:insight:error:person_not_found" },
-          { status: 404 },
-        );
-      }
-      return HttpResponse.json(tree);
-    },
-  ),
+  http.post("/api/identity/v1/profiles", async ({ request }) => {
+    const body = (await request.json().catch(() => null)) as {
+      value_type?: string;
+      value?: string;
+    } | null;
+    const value = (body?.value ?? "").trim();
+    // The service resolves `person_id` (the SPA's key) and `email` (legacy
+    // URL migration only); anything else is a client error.
+    if (body?.value_type !== "email" && body?.value_type !== "person_id") {
+      return HttpResponse.json(
+        { type: "urn:insight:error:invalid_argument" },
+        { status: 400 }
+      );
+    }
+    // A malformed person_id is a 400, not a 404 — matching the service, where
+    // "does not parse" and "resolves to nobody" are different answers.
+    if (body.value_type === "person_id" && !isPersonId(value)) {
+      return HttpResponse.json(
+        { type: "urn:insight:error:invalid_argument" },
+        { status: 400 }
+      );
+    }
+    const personId =
+      body.value_type === "email"
+        ? PEOPLE_BY_EMAIL[value.toLowerCase()]?.person_id
+        : value.toLowerCase();
+    if (!personId) {
+      return HttpResponse.json(
+        { type: "urn:insight:error:person_not_found" },
+        { status: 404 }
+      );
+    }
+    const tree = buildIdentityTree(personId);
+    if (!tree) {
+      return HttpResponse.json(
+        { type: "urn:insight:error:person_not_found" },
+        { status: 404 }
+      );
+    }
+    return HttpResponse.json(tree);
+  }),
   ...savedQueryHandlers(),
   ...customMetricHandlers(),
   ...connectorHealthHandlers(),
@@ -1018,8 +1066,12 @@ function ingestionHandlers() {
         (scope !== null && scope !== "" && !BRONZE_SLUG.test(scope));
       if (bad) {
         return HttpResponse.json(
-          { status: 400, title: "Bad Request", detail: "unsupported ingestion parameter" },
-          { status: 400 },
+          {
+            status: 400,
+            title: "Bad Request",
+            detail: "unsupported ingestion parameter",
+          },
+          { status: 400 }
         );
       }
 
@@ -1030,7 +1082,7 @@ function ingestionHandlers() {
           scope,
           from: params.get("from"),
           to: params.get("to"),
-        }),
+        })
       );
     }),
   ];
@@ -1087,7 +1139,10 @@ function feedbackHandlers() {
       } | null;
       const message = body?.message?.trim();
       if (!message || [...message].length > FEEDBACK_MESSAGE_MAX) {
-        return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
+        return HttpResponse.json(
+          { error: "invalid_argument" },
+          { status: 400 }
+        );
       }
       feedbackStore.unshift({
         feedback_id: `mock-${feedbackStore.length + 1}`,
@@ -1155,11 +1210,12 @@ function connectorHealthHandlers() {
     status: string,
     startedMinutesAgo: number | null,
     duration_ms: number | null,
-    records_reported: number | null,
+    records_reported: number | null
   ) => ({
     job_id,
     status,
-    started_at: startedMinutesAgo === null ? null : minutesAgo(startedMinutesAgo),
+    started_at:
+      startedMinutesAgo === null ? null : minutesAgo(startedMinutesAgo),
     duration_ms,
     records_reported,
   });
@@ -1226,10 +1282,11 @@ function connectorHealthHandlers() {
 function usageHandlers() {
   return [
     http.get("/api/analytics/v1/usage/config", () =>
-      HttpResponse.json({ enabled: true }),
+      HttpResponse.json({ enabled: true })
     ),
-    http.post("/api/analytics/v1/usage/events", () =>
-      new HttpResponse(null, { status: 204 }),
+    http.post(
+      "/api/analytics/v1/usage/events",
+      () => new HttpResponse(null, { status: 204 })
     ),
     http.get("/api/analytics/v1/usage/summary", () => {
       const by_day = syntheticDays(30);
@@ -1269,7 +1326,12 @@ function usageHandlers() {
           },
         ],
         by_event: [
-          { event_name: "drill", target: "pr_cycle_time", opens: 34, people: 3 },
+          {
+            event_name: "drill",
+            target: "pr_cycle_time",
+            opens: 34,
+            people: 3,
+          },
           { event_name: "drill", target: "review_load", opens: 21, people: 3 },
           { event_name: "drill", target: "ai_share", opens: 12, people: 2 },
           { event_name: "session_start", target: "", opens: 57, people: 4 },
@@ -1371,8 +1433,12 @@ function aiAssistHandlers() {
           "Worth checking before concluding anything: the window holds fewer working days than a full month.",
         ].join("\n\n"),
         model: "claude-sonnet-5",
-        tenant_context_entries: [...mockContext.values()].filter((e) => e.scope === "tenant").length,
-        person_context_entries: [...mockContext.values()].filter((e) => e.scope === "person").length,
+        tenant_context_entries: [...mockContext.values()].filter(
+          (e) => e.scope === "tenant"
+        ).length,
+        person_context_entries: [...mockContext.values()].filter(
+          (e) => e.scope === "person"
+        ).length,
       });
     }),
   ];

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -720,25 +720,37 @@ export const handlers = [
   }),
   http.get("/api/identity/v1/people", ({ request }) => {
     const params = new URL(request.url).searchParams;
-    const items = PEOPLE.map((person) => {
-      const [firstName, ...lastName] = person.name.split(" ");
-      return {
-        person_id: person.person_id,
-        display_name: person.name,
-        first_name: firstName ?? null,
-        last_name: lastName.join(" ") || null,
-        username: null,
-        email: person.email,
-        attributes: {
-          department: person.department,
-          division: person.department,
-          job_title: person.role,
-          status: "Active",
-        },
-        manager_person_id: person.supervisor_person_id,
-      };
-    }).sort((left, right) => left.display_name.localeCompare(right.display_name));
-    return HttpResponse.json(pageOf(items, params, ""));
+    const q = params.get("q")?.trim().toLowerCase() ?? "";
+    const terms = q ? q.split(/\s+/) : [];
+    const items = PEOPLE.filter((person) =>
+      terms.every((term) =>
+        [person.name, person.email, person.role, person.department].some(
+          (value) => value.toLowerCase().includes(term),
+        ),
+      ),
+    )
+      .map((person) => {
+        const [firstName, ...lastName] = person.name.split(" ");
+        return {
+          person_id: person.person_id,
+          display_name: person.name,
+          first_name: firstName ?? null,
+          last_name: lastName.join(" ") || null,
+          username: null,
+          email: person.email,
+          attributes: {
+            department: person.department,
+            division: person.department,
+            job_title: person.role,
+            status: "Active",
+          },
+          manager_person_id: person.supervisor_person_id,
+        };
+      })
+      .sort((left, right) =>
+        left.display_name.localeCompare(right.display_name),
+      );
+    return HttpResponse.json(pageOf(items, params, q));
   }),
   // The account listing: the same roster seen as accounts; blank lists them all.
   http.get("/api/identity/v1/resolution/accounts", ({ request }) => {

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -718,6 +718,28 @@ export const handlers = [
       );
     return HttpResponse.json(pageOf(items, params, q));
   }),
+  http.get("/api/identity/v1/people", ({ request }) => {
+    const params = new URL(request.url).searchParams;
+    const items = PEOPLE.map((person) => {
+      const [firstName, ...lastName] = person.name.split(" ");
+      return {
+        person_id: person.person_id,
+        display_name: person.name,
+        first_name: firstName ?? null,
+        last_name: lastName.join(" ") || null,
+        username: null,
+        email: person.email,
+        attributes: {
+          department: person.department,
+          division: person.department,
+          job_title: person.role,
+          status: "Active",
+        },
+        manager_person_id: person.supervisor_person_id,
+      };
+    }).sort((left, right) => left.display_name.localeCompare(right.display_name));
+    return HttpResponse.json(pageOf(items, params, ""));
+  }),
   // The account listing: the same roster seen as accounts; blank lists them all.
   http.get("/api/identity/v1/resolution/accounts", ({ request }) => {
     const params = new URL(request.url).searchParams;

--- a/src/frontend/src/queries/ic-dashboard.test.ts
+++ b/src/frontend/src/queries/ic-dashboard.test.ts
@@ -35,7 +35,8 @@ describe("useIcPerson", () => {
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBe(person);
-    expect(mockGetPerson).toHaveBeenCalledWith("Alice@X.com");
+    expect(mockGetPerson.mock.calls[0]?.[0]).toBe("Alice@X.com");
+    expect(mockGetPerson.mock.calls[0]?.[1]).toBeInstanceOf(AbortSignal);
   });
 
   it("stays disabled for an empty person id", async () => {

--- a/src/frontend/src/queries/ic-dashboard.ts
+++ b/src/frontend/src/queries/ic-dashboard.ts
@@ -1,32 +1,14 @@
-import { useQuery, useQueryClient, type UseQueryResult } from "@tanstack/react-query";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
 import { getPerson } from "@/api/identity-client";
-import { getViewerPersonId } from "@/auth";
-import { findIdentityNode } from "@/lib/insight/identity-tree";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import type { IdentityPerson } from "@/types/insight";
 
 export function useIcPerson(personId: string): UseQueryResult<IdentityPerson> {
-  const queryClient = useQueryClient();
   const key = normalizePersonId(personId);
   return useQuery({
     queryKey: ["identity", "person", key],
-    queryFn: () => getPerson(personId),
+    queryFn: ({ signal }) => getPerson(personId, signal),
     enabled: Boolean(personId),
-    // A subordinate's identity (name, title, own subtree) already rides the
-    // viewer's cached org tree — surface it immediately instead of waiting
-    // for the canonical per-person fetch, which still runs and replaces it.
-    placeholderData: () => {
-      const viewerKey = normalizePersonId(getViewerPersonId() ?? "");
-      if (!viewerKey || viewerKey === key) return undefined;
-      const viewerTree = queryClient.getQueryData<IdentityPerson>([
-        "identity",
-        "person",
-        viewerKey,
-      ]);
-      return viewerTree
-        ? (findIdentityNode(viewerTree, personId) ?? undefined)
-        : undefined;
-    },
   });
 }

--- a/src/frontend/src/queries/identity-resolution.test.tsx
+++ b/src/frontend/src/queries/identity-resolution.test.tsx
@@ -34,6 +34,7 @@ import {
 } from "./identity-resolution";
 
 const searchPersons = vi.mocked(identityClient.searchPersons);
+const listPeople = vi.mocked(identityClient.listPeople);
 
 const bindAccount = vi.mocked(identityClient.bindAccount);
 
@@ -149,6 +150,7 @@ describe("useBindAccount cache behavior", () => {
     const keys = invalidate.mock.calls.map((c) => c[0]?.queryKey);
     expect(keys).toContainEqual(["identity", "resolution"]);
     expect(keys).toContainEqual(["identity", "persons", "search"]);
+    expect(keys).toContainEqual(["identity", "people", "search"]);
   });
 });
 
@@ -158,6 +160,41 @@ describe("usePersonList", () => {
   function roster(): identityClient.PersonSearchResponse {
     return { items: [{ person_id: "01900000-0000-7000-8000-0000000000b0" }] };
   }
+
+  it("uses the tenant canonical roster for roster people", async () => {
+    const { wrapper } = harness();
+    listPeople.mockResolvedValue({
+      items: [
+        {
+          person_id: "01900000-0000-7000-8000-0000000000b0",
+          display_name: "Example Person",
+          first_name: "Example",
+          last_name: "Person",
+          username: "example-person",
+          email: "person@example.com",
+          attributes: { job_title: "Engineer", status: "active" },
+          manager_person_id: null,
+        },
+      ],
+    });
+
+    const { result } = renderHook(
+      () => usePersonList("example", "browse", "roster"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(listPeople).toHaveBeenCalledWith(
+      { q: "example", visibility: "tenant", limit: 50, cursor: undefined },
+      expect.any(AbortSignal),
+    );
+    expect(searchPersons).not.toHaveBeenCalled();
+    expect(result.current.data?.pages[0]?.items[0]).toMatchObject({
+      display_name: "Example Person",
+      job_title: "Engineer",
+      status: "active",
+    });
+  });
 
   it.each([
     ["browse", true],

--- a/src/frontend/src/queries/identity-resolution.ts
+++ b/src/frontend/src/queries/identity-resolution.ts
@@ -26,6 +26,7 @@ import {
   getAccountBinding,
   getAttention,
   getPersonAccounts,
+  listPeople,
   mergePersons,
   QUEUE_FIRST_PAGE,
   searchAccounts,
@@ -100,6 +101,7 @@ const RESOLUTION_KEY = ["identity", "resolution"] as const;
  *  changes its answers too: a merge absorbs a person the cache would keep
  *  offering, and binding to them recreates the split the operator just fixed. */
 const PERSON_SEARCH_KEY = ["identity", "persons", "search"] as const;
+const PEOPLE_SEARCH_KEY = ["identity", "people", "search"] as const;
 
 type Verb<TArgs> = UseMutationResult<CorrectionResponse, unknown, TArgs>;
 
@@ -125,6 +127,7 @@ function useCorrection<TArgs>(
       );
       void client.invalidateQueries({ queryKey: RESOLUTION_KEY });
       void client.invalidateQueries({ queryKey: PERSON_SEARCH_KEY });
+      void client.invalidateQueries({ queryKey: PEOPLE_SEARCH_KEY });
     },
   });
 }
@@ -149,6 +152,7 @@ const PAGE_SIZE = 50;
  */
 /** What a blank query means to a caller of {@link usePersonList}. */
 export type PersonListIntent = "browse" | "match";
+export type PersonListSource = "identities" | "roster";
 
 /**
  * The same for {@link useAccountList}. The accounts mode browses — reviewing
@@ -172,9 +176,9 @@ export type AccountListIntent = "browse" | "match";
 export const MIN_SEARCH_CHARS = 2;
 
 /**
- * The ceiling both identity search surfaces are checked against server-side —
- * `listing::MAX_QUERY_CHARS` on `/v1/persons` and `/v1/visible-persons`, and
- * the same value on `/v1/resolution/accounts`. Declared here so a field can
+ * The ceiling the identity search surfaces check server-side —
+ * `listing::MAX_QUERY_CHARS` on `/v1/persons`, `/v1/visible-persons`,
+ * `/v1/people`, and `/v1/resolution/accounts`. Declared here so a field can
  * stop at the limit rather than let the operator type past it and receive a
  * refusal they cannot read as "too long".
  */
@@ -270,17 +274,49 @@ export function usePersonList(
    *  stops a request and not a cache read, so one shared key would render the
    *  roster that browse mode cached inside the dialog. */
   intent: PersonListIntent = "browse",
+  source: PersonListSource = "identities",
 ): UseInfiniteQueryResult<InfiniteData<PersonSearchResponse>> {
   const { session } = useAuth();
   const sessionScope = sessionAuthorizationScope(session);
   const trimmed = q.trim();
   return useInfiniteQuery({
-    queryKey: ["identity", "persons", "search", sessionScope, intent, trimmed],
+    queryKey:
+      source === "roster"
+        ? [...PEOPLE_SEARCH_KEY, sessionScope, intent, trimmed]
+        : [...PERSON_SEARCH_KEY, sessionScope, intent, trimmed],
     // The signal is the point, not hygiene: a search-as-you-type field
-    // supersedes its own request, and each one costs the service a scan of the
-    // person journal. Dropped on the client, they would all still be answered.
-    queryFn: ({ pageParam, signal }) =>
-      searchPersons(trimmed, { cursor: pageParam, limit: PAGE_SIZE }, signal),
+    // supersedes its own request. Dropped on the client, every stale listing
+    // would still be answered.
+    queryFn: async ({ pageParam, signal }) => {
+      if (source === "identities") {
+        return searchPersons(
+          trimmed,
+          { cursor: pageParam, limit: PAGE_SIZE },
+          signal,
+        );
+      }
+
+      const page = await listPeople(
+        {
+          q: trimmed,
+          visibility: "tenant",
+          cursor: pageParam,
+          limit: PAGE_SIZE,
+        },
+        signal,
+      );
+      return {
+        items: page.items.map((person) => ({
+          person_id: person.person_id,
+          display_name: person.display_name,
+          email: person.email,
+          username: person.username,
+          job_title: person.attributes.job_title,
+          status: person.attributes.status,
+        })),
+        next_cursor: page.next_cursor,
+      };
+    },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (page) => page.next_cursor ?? undefined,
     staleTime: ATTENTION_STALE_TIME,

--- a/src/frontend/src/queries/visible-roster.test.tsx
+++ b/src/frontend/src/queries/visible-roster.test.tsx
@@ -25,7 +25,7 @@ vi.mock("@/auth/session-scope", () => ({
 
 import { MAX_ROSTER_PAGES, useVisibleRoster } from "./visible-roster";
 
-const listVisiblePersons = vi.mocked(identityClient.listVisiblePersons);
+const listPeople = vi.mocked(identityClient.listPeople);
 
 function harness() {
   const queryClient = new QueryClient({
@@ -36,8 +36,17 @@ function harness() {
   return { wrapper };
 }
 
-function person(id: string): identityClient.PersonSummary {
-  return { person_id: id, display_name: `Person ${id}` };
+function person(id: string): identityClient.PeopleListItem {
+  return {
+    person_id: id,
+    display_name: `Person ${id}`,
+    first_name: null,
+    last_name: null,
+    username: null,
+    email: null,
+    attributes: {},
+    manager_person_id: null,
+  };
 }
 
 beforeEach(() => {
@@ -46,7 +55,7 @@ beforeEach(() => {
 
 describe("useVisibleRoster", () => {
   it("collects every page, not the first", async () => {
-    listVisiblePersons
+    listPeople
       .mockResolvedValueOnce({ items: [person("a")], next_cursor: "c1" })
       .mockResolvedValueOnce({ items: [person("b")], next_cursor: "c2" })
       .mockResolvedValueOnce({ items: [person("c")], next_cursor: null });
@@ -60,7 +69,7 @@ describe("useVisibleRoster", () => {
 
   it("stops at the ceiling rather than following a cursor forever", async () => {
     // A service that always returns a cursor must not spin the browser.
-    listVisiblePersons.mockResolvedValue({
+    listPeople.mockResolvedValue({
       items: [person("x")],
       next_cursor: "always-more",
     });
@@ -68,11 +77,11 @@ describe("useVisibleRoster", () => {
     const { result } = renderHook(() => useVisibleRoster(true), harness());
 
     await waitFor(() => expect(result.current.truncated).toBe(true));
-    expect(listVisiblePersons).toHaveBeenCalledTimes(MAX_ROSTER_PAGES);
+    expect(listPeople).toHaveBeenCalledTimes(MAX_ROSTER_PAGES);
   });
 
   it("surfaces a refusal instead of an empty roster", async () => {
-    listVisiblePersons.mockRejectedValue(new Error("refused"));
+    listPeople.mockRejectedValue(new Error("refused"));
 
     const { result } = renderHook(() => useVisibleRoster(true), harness());
 
@@ -83,6 +92,6 @@ describe("useVisibleRoster", () => {
   it("asks for nothing until the caller says the policy needs it", () => {
     renderHook(() => useVisibleRoster(false), harness());
 
-    expect(listVisiblePersons).not.toHaveBeenCalled();
+    expect(listPeople).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/src/queries/visible-roster.test.tsx
+++ b/src/frontend/src/queries/visible-roster.test.tsx
@@ -1,7 +1,7 @@
 /**
  * The roster every flat-org zone counts. What matters: the walk collects every
- * page rather than the first, it stops at a ceiling instead of following a
- * cursor forever, and a refusal surfaces as an error — an empty roster would
+ * page rather than the first, rejects a cursor cycle instead of looping, and a
+ * refusal surfaces as an error — an empty roster would
  * read to every zone as "this person can see nobody", which is a different
  * fact.
  */
@@ -23,7 +23,7 @@ vi.mock("@/auth/session-scope", () => ({
     s == null ? null : (s as { scope: string }).scope,
 }));
 
-import { MAX_ROSTER_PAGES, useVisibleRoster } from "./visible-roster";
+import { useVisibleRoster } from "./visible-roster";
 
 const listPeople = vi.mocked(identityClient.listPeople);
 
@@ -54,21 +54,27 @@ beforeEach(() => {
 });
 
 describe("useVisibleRoster", () => {
-  it("collects every page, not the first", async () => {
+  it("collects every page until the service ends the cursor walk", async () => {
     listPeople
       .mockResolvedValueOnce({ items: [person("a")], next_cursor: "c1" })
       .mockResolvedValueOnce({ items: [person("b")], next_cursor: "c2" })
-      .mockResolvedValueOnce({ items: [person("c")], next_cursor: null });
+      .mockResolvedValueOnce({ items: [person("c")], next_cursor: "c3" })
+      .mockResolvedValueOnce({ items: [person("d")], next_cursor: "c4" })
+      .mockResolvedValueOnce({ items: [person("e")], next_cursor: null });
 
     const { result } = renderHook(() => useVisibleRoster(true), harness());
 
-    await waitFor(() => expect(result.current.roster).toHaveLength(3));
-    expect(result.current.roster.map((p) => p.person_id)).toEqual(["a", "b", "c"]);
-    expect(result.current.truncated).toBe(false);
+    await waitFor(() => expect(result.current.roster).toHaveLength(5));
+    expect(result.current.roster.map((p) => p.person_id)).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+    ]);
   });
 
-  it("stops at the ceiling rather than following a cursor forever", async () => {
-    // A service that always returns a cursor must not spin the browser.
+  it("rejects a repeated cursor rather than following it forever", async () => {
     listPeople.mockResolvedValue({
       items: [person("x")],
       next_cursor: "always-more",
@@ -76,8 +82,17 @@ describe("useVisibleRoster", () => {
 
     const { result } = renderHook(() => useVisibleRoster(true), harness());
 
-    await waitFor(() => expect(result.current.truncated).toBe(true));
-    expect(listPeople).toHaveBeenCalledTimes(MAX_ROSTER_PAGES);
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(listPeople).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards query cancellation to every people request", async () => {
+    listPeople.mockResolvedValue({ items: [], next_cursor: null });
+
+    const { result } = renderHook(() => useVisibleRoster(true), harness());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(listPeople.mock.calls[0]?.[1]).toBeInstanceOf(AbortSignal);
   });
 
   it("surfaces a refusal instead of an empty roster", async () => {

--- a/src/frontend/src/queries/visible-roster.ts
+++ b/src/frontend/src/queries/visible-roster.ts
@@ -10,20 +10,7 @@ import {
 import { useAuth } from "@/auth/use-auth";
 import { sessionAuthorizationScope } from "@/auth/session-scope";
 
-/** Rows per request — the endpoint's own default, and its cap is 500. */
 const ROSTER_PAGE_SIZE = 500;
-
-/**
- * How many pages the walk will follow.
- *
- * The whole roster is collected up front because every zone wants a head-count
- * and a member list at once, and an organisation with no reporting lines is
- * small by construction. That does not scale: past this ceiling the roster is
- * cut and `truncated` says so, rather than the browser walking a cursor for a
- * tenant this design never suited. Revisit with a paged member list — and note
- * `metric-results` refuses more than 1000 ids in one request either way.
- */
-export const MAX_ROSTER_PAGES = 4;
 
 /** Grants and roster changes land on a seed cadence, not per interaction. */
 const ROSTER_STALE_TIME = 60 * 1000;
@@ -31,30 +18,35 @@ const ROSTER_STALE_TIME = 60 * 1000;
 export interface VisibleRoster {
   /** Every person the caller may see, the viewer included. */
   roster: PeopleListItem[];
-  /** The walk hit {@link MAX_ROSTER_PAGES} — the roster is a prefix. */
-  truncated: boolean;
   isPending: boolean;
   isError: boolean;
   retry: () => void;
 }
 
-async function collectRoster(): Promise<{
-  roster: PeopleListItem[];
-  truncated: boolean;
-}> {
+async function collectRoster(signal: AbortSignal): Promise<PeopleListItem[]> {
   const roster: PeopleListItem[] = [];
+  const cursors = new Set<string>();
   let cursor: string | undefined;
 
-  for (let page = 0; page < MAX_ROSTER_PAGES; page += 1) {
-    const answered = await listPeople({
-      cursor,
-      limit: ROSTER_PAGE_SIZE,
-    });
+  while (true) {
+    const answered = await listPeople(
+      {
+        cursor,
+        limit: ROSTER_PAGE_SIZE,
+      },
+      signal,
+    );
     roster.push(...answered.items);
-    cursor = answered.next_cursor ?? undefined;
-    if (!cursor) return { roster, truncated: false };
+
+    const nextCursor = answered.next_cursor ?? undefined;
+    if (!nextCursor) return roster;
+    if (cursors.has(nextCursor)) {
+      throw new Error("People listing returned a repeated cursor");
+    }
+
+    cursors.add(nextCursor);
+    cursor = nextCursor;
   }
-  return { roster, truncated: true };
 }
 
 /**
@@ -65,14 +57,13 @@ export function useVisibleRoster(enabled: boolean): VisibleRoster {
   const sessionScope = sessionAuthorizationScope(session);
   const query = useQuery({
     queryKey: ["identity", "visible-roster", sessionScope],
-    queryFn: collectRoster,
+    queryFn: ({ signal }) => collectRoster(signal),
     staleTime: ROSTER_STALE_TIME,
     enabled: enabled && sessionScope != null,
   });
 
   return {
-    roster: query.data?.roster ?? [],
-    truncated: query.data?.truncated ?? false,
+    roster: query.data ?? [],
     isPending: query.isPending,
     isError: query.isError,
     retry: () => void query.refetch(),

--- a/src/frontend/src/queries/visible-roster.ts
+++ b/src/frontend/src/queries/visible-roster.ts
@@ -1,16 +1,11 @@
 /**
- * The roster a flat organisation counts as its single cohort.
- *
- * Every org zone reads its people from `useOrgScope`, which walks the viewer's
- * `subordinates` — a walk that yields nobody when the organisation has no
- * reporting lines. This hook is the other source: the persons the caller may
- * see, straight from identity.
+ * The canonical people roster the caller is authorized to see.
  */
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  listVisiblePersons,
-  type PersonSummary,
+  listPeople,
+  type PeopleListItem,
 } from "@/api/identity-client";
 import { useAuth } from "@/auth/use-auth";
 import { sessionAuthorizationScope } from "@/auth/session-scope";
@@ -35,7 +30,7 @@ const ROSTER_STALE_TIME = 60 * 1000;
 
 export interface VisibleRoster {
   /** Every person the caller may see, the viewer included. */
-  roster: PersonSummary[];
+  roster: PeopleListItem[];
   /** The walk hit {@link MAX_ROSTER_PAGES} — the roster is a prefix. */
   truncated: boolean;
   isPending: boolean;
@@ -44,14 +39,14 @@ export interface VisibleRoster {
 }
 
 async function collectRoster(): Promise<{
-  roster: PersonSummary[];
+  roster: PeopleListItem[];
   truncated: boolean;
 }> {
-  const roster: PersonSummary[] = [];
+  const roster: PeopleListItem[] = [];
   let cursor: string | undefined;
 
   for (let page = 0; page < MAX_ROSTER_PAGES; page += 1) {
-    const answered = await listVisiblePersons({
+    const answered = await listPeople({
       cursor,
       limit: ROSTER_PAGE_SIZE,
     });
@@ -63,9 +58,7 @@ async function collectRoster(): Promise<{
 }
 
 /**
- * The caller's whole visible roster. `enabled` is the policy question — a
- * hierarchical deployment reads its people from the tree and must not spend a
- * request here.
+ * The caller's whole visible roster.
  */
 export function useVisibleRoster(enabled: boolean): VisibleRoster {
   const { session } = useAuth();

--- a/src/frontend/src/routes/-__root.test.tsx
+++ b/src/frontend/src/routes/-__root.test.tsx
@@ -58,7 +58,7 @@ describe("prefetchViewerIdentity", () => {
   it("resolves the viewer by person_id and caches it under the normalized key", async () => {
     await prefetchViewerIdentity();
 
-    expect(resolve).toHaveBeenCalledWith(PERSON_ID);
+    expect(resolve).toHaveBeenCalledWith(PERSON_ID, expect.any(AbortSignal));
     // Lowercased: this is the key `useIcPerson` computes, so the shell mounts
     // with the tree already cached instead of re-fetching it.
     expect(

--- a/src/frontend/src/routes/__root.tsx
+++ b/src/frontend/src/routes/__root.tsx
@@ -1,4 +1,8 @@
-import { Outlet, createRootRoute, useRouterState } from "@tanstack/react-router";
+import {
+  Outlet,
+  createRootRoute,
+  useRouterState,
+} from "@tanstack/react-router";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { getPerson } from "@/api/identity-client";
@@ -19,14 +23,13 @@ import { FeedbackDialogProvider } from "@/components/feedback-dialog-provider";
 import { MetricEvidenceDialogProvider } from "@/components/metric-evidence-dialog-provider";
 
 // Warms the exact key `useIcPerson` reads, so the shell mounts with the
-// viewer's tree already cached. Keyed by person_id since the identity cutover:
-// an email here would both miss that key and make identity answer 400.
+// viewer's canonical person already cached.
 export async function prefetchViewerIdentity(): Promise<void> {
   const personId = getViewerPersonId();
   if (!personId) return;
   await queryClient.prefetchQuery({
     queryKey: ["identity", "person", normalizePersonId(personId)],
-    queryFn: () => getPerson(personId),
+    queryFn: ({ signal }) => getPerson(personId, signal),
   });
 }
 

--- a/src/frontend/src/screens/dashboard.test.tsx
+++ b/src/frontend/src/screens/dashboard.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GROUPS, KPI_ROW } from "@/lib/insight/groups";
+import type { PeopleListItem } from "@/api/identity-client";
 
 const METRIC_KEYS = [...KPI_ROW];
 const GROUP_IDS = GROUPS.map((def) => def.id);
@@ -15,6 +16,7 @@ const kpiState = {
 };
 let personData: { display_name?: string } | undefined;
 let personError: unknown;
+let roster: PeopleListItem[] = [];
 let tilesReturn: Array<{ key: string }> = [];
 let attentionPerGroup: Array<{ key: string }> = [];
 let omitGroupId: string | null = null;
@@ -27,6 +29,15 @@ vi.mock("@/queries/ic-dashboard", () => ({
     error: personError,
     isError: personError !== undefined,
     refetch: personRefetch,
+  }),
+}));
+
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster,
+    isPending: false,
+    isError: false,
+    retry: vi.fn(),
   }),
 }));
 
@@ -79,8 +90,16 @@ vi.mock("@/queries/metric-results", () => ({
 }));
 
 vi.mock("@/components/widgets/dashboard/dashboard-header", () => ({
-  DashboardHeader: ({ title }: { title: string }) => (
-    <div data-testid="header">{title}</div>
+  DashboardHeader: ({
+    title,
+    hasReports,
+  }: {
+    title: string;
+    hasReports: boolean;
+  }) => (
+    <div data-testid="header" data-has-reports={String(hasReports)}>
+      {title}
+    </div>
   ),
 }));
 
@@ -153,6 +172,7 @@ beforeEach(() => {
   omitGroupId = null;
   personData = undefined;
   personError = undefined;
+  roster = [];
   personRefetch.mockReset();
 });
 
@@ -209,6 +229,39 @@ describe("DashboardScreen", () => {
         .getAllByTestId("drilldown")
         .every((el) => el.dataset.open === "false")
     ).toBe(true);
+  });
+
+  it("derives the team affordance from canonical roster relationships", () => {
+    personData = { display_name: "Lead" };
+    roster = [
+      {
+        person_id: "lead",
+        display_name: "Lead",
+        first_name: null,
+        last_name: null,
+        username: null,
+        email: null,
+        attributes: {},
+        manager_person_id: null,
+      },
+      {
+        person_id: "report",
+        display_name: "Report",
+        first_name: null,
+        last_name: null,
+        username: null,
+        email: null,
+        attributes: {},
+        manager_person_id: "lead",
+      },
+    ];
+
+    render(<DashboardScreen personId="lead" />);
+
+    expect(screen.getByTestId("header")).toHaveAttribute(
+      "data-has-reports",
+      "true"
+    );
   });
 
   it("shows ONE retryable error for the row when the collection errored", async () => {

--- a/src/frontend/src/screens/dashboard.tsx
+++ b/src/frontend/src/screens/dashboard.tsx
@@ -27,6 +27,7 @@ import {
 import { IdentityApiError } from "@/api/identity-client";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import { useIcPerson } from "@/queries/ic-dashboard";
+import { useVisibleRoster } from "@/queries/visible-roster";
 import {
   collectionSetPending,
   useMetricCollection,
@@ -53,6 +54,7 @@ export interface DashboardScreenProps {
 export function DashboardScreen({ personId }: DashboardScreenProps) {
   const personQ = useIcPerson(personId);
   const person = personQ.data ?? null;
+  const visibleRoster = useVisibleRoster(true);
   const { period, dateRange } = usePeriod();
   const { focusMode } = useSettings();
   const entityId = normalizePersonId(personId);
@@ -103,6 +105,10 @@ export function DashboardScreen({ personId }: DashboardScreenProps) {
   // cached tree resolves in a beat; the title stays blank until then.
   const displayName = person ? (personName(person) ?? "") : "";
   const role = person?.job_title;
+  const hasReports = visibleRoster.roster.some(
+    (candidate) =>
+      candidate.manager_person_id?.toLowerCase() === personId.toLowerCase()
+  );
 
   // The one loading gate: a single page spinner while any of the screen's
   // queries has no data. A period change mints new query keys, so the same
@@ -112,8 +118,7 @@ export function DashboardScreen({ personId }: DashboardScreenProps) {
   // standing, so a pending one is still loading. Left out, the block would
   // paint before it could say anything — and an empty attention block reads as
   // "nothing to see" rather than "not compared yet".
-  const isLoading =
-    kpiData.isPending || collectionSetPending(groupData);
+  const isLoading = kpiData.isPending || collectionSetPending(groupData);
   // Identity failing is not a metric failure: with no person there is no name,
   // no reports, and the metrics below are unauthorized anyway. A 404 means the
   // id is gone or outside the viewer's visible set — say so, rather than paint
@@ -159,7 +164,7 @@ export function DashboardScreen({ personId }: DashboardScreenProps) {
         title={displayName}
         subtitle={role}
         person={personId}
-        hasReports={(person?.subordinates?.length ?? 0) > 0}
+        hasReports={hasReports}
       />
       <main className="flex flex-1 flex-col gap-8 p-4 md:p-6">
         {personQ.isError ? (

--- a/src/frontend/src/screens/team-view.test.tsx
+++ b/src/frontend/src/screens/team-view.test.tsx
@@ -23,6 +23,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { PeopleListItem } from "@/api/identity-client";
+import { peopleFromIdentityTree } from "@/test/identity";
 import type { IdentityPerson, TeamMember } from "@/types/insight";
 
 vi.mock("@/components/ic-view-toggle", () => ({
@@ -71,8 +73,7 @@ vi.mock("@/queries/member-grid", () => ({
 /** Entity ids the scoped roster sent to the heatmap fetch. */
 function heatmapFetchedIds(): string[] {
   const entity = useMemberGridData.mock.lastCall?.[1] as
-    | { ids: string[] }
-    | undefined;
+    { ids: string[] } | undefined;
   return entity?.ids ?? [];
 }
 
@@ -97,7 +98,7 @@ function person(
   personId: string,
   email: string,
   name: string,
-  subordinates: IdentityPerson[] = [],
+  subordinates: IdentityPerson[] = []
 ): IdentityPerson {
   return {
     person_id: personId,
@@ -128,33 +129,27 @@ const grantedTree = person(PERSON_IDS.grace, "grace@x.io", "Grace", [
   person(PERSON_IDS.hana, "hana@x.io", "Hana"),
 ]);
 
-// Identity answers per person id: the screen asks for the PIVOT's profile, not
-// the viewer's tree, so a request keyed by anyone else must not resolve here.
-let trees: Record<string, IdentityPerson> = {};
+let roster: PeopleListItem[] = [];
+let rosterError = false;
+const rosterRetry = vi.fn();
 
-let pivotError: unknown;
-const pivotRefetch = vi.fn();
-
-vi.mock("@/queries/ic-dashboard", () => ({
-  useIcPerson: (personId: string) => ({
-    ...queryState,
-    data: pivotError === undefined ? trees[personId] : undefined,
-    error: pivotError,
-    isError: pivotError !== undefined,
-    refetch: pivotRefetch,
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster,
+    isPending: false,
+    isError: rosterError,
+    retry: rosterRetry,
   }),
 }));
 
 import { TeamViewScreen } from "./team-view";
 
 beforeEach(() => {
-  pivotError = undefined;
-  pivotRefetch.mockReset();
-  trees = {
-    [PERSON_IDS.alice]: viewerTree,
-    [PERSON_IDS.dave]: flatTree,
-    [PERSON_IDS.grace]: grantedTree,
-  };
+  rosterError = false;
+  rosterRetry.mockReset();
+  roster = [viewerTree, flatTree, grantedTree].flatMap((root) =>
+    peopleFromIdentityTree(root)
+  );
 });
 
 function renderScreen(teamId: string = PERSON_IDS.alice) {
@@ -163,26 +158,24 @@ function renderScreen(teamId: string = PERSON_IDS.alice) {
 
 describe("TeamViewScreen identity failures", () => {
   it("says the person is unavailable instead of showing an empty team", async () => {
-    // A 404 pivot is not a team with no members: rendering the empty state
-    // over it would report a broken lookup as an empty org.
-    const { IdentityApiError } = await import("@/api/identity-client");
-    pivotError = new IdentityApiError(404, {});
+    roster = roster.filter((person) => person.person_id !== PERSON_IDS.alice);
 
     renderScreen();
 
-    expect(screen.getByText("This person is not available")).toBeInTheDocument();
+    expect(
+      screen.getByText("This person is not available")
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("heatmap")).not.toBeInTheDocument();
   });
 
   it("offers a retry when identity itself failed, not the lookup", async () => {
-    const { IdentityApiError } = await import("@/api/identity-client");
-    pivotError = new IdentityApiError(500, {});
+    rosterError = true;
 
     renderScreen();
 
     expect(screen.getByText("Unable to load this person")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Retry" }));
-    expect(pivotRefetch).toHaveBeenCalled();
+    expect(rosterRetry).toHaveBeenCalled();
   });
 });
 
@@ -191,7 +184,7 @@ describe("TeamViewScreen direct-reports scoping", () => {
     renderScreen();
 
     expect(
-      screen.getByText("Direct reports of Alice · 2 members"),
+      screen.getByText("Direct reports of Alice · 2 members")
     ).toBeInTheDocument();
     expect(screen.getByText("Direct reports only")).toBeInTheDocument();
     expect(screen.getByText("(2/3)")).toBeInTheDocument();
@@ -207,7 +200,7 @@ describe("TeamViewScreen direct-reports scoping", () => {
     await user.click(screen.getByRole("switch"));
 
     expect(
-      screen.getByText("Alice's department · 3 members"),
+      screen.getByText("Alice's department · 3 members")
     ).toBeInTheDocument();
     expect(screen.getByText("(3/3)")).toBeInTheDocument();
     expect(screen.getByTestId("heatmap")).toHaveTextContent("Bob,Carol,Erin");
@@ -238,7 +231,7 @@ describe("TeamViewScreen direct-reports scoping", () => {
     // is just the member count, and the full roster reaches the queries.
     expect(screen.getByText("2 members")).toBeInTheDocument();
     expect(
-      screen.queryByText(/Direct reports of|department/),
+      screen.queryByText(/Direct reports of|department/)
     ).not.toBeInTheDocument();
     expect(screen.getByTestId("heatmap")).toHaveTextContent("Fay,Gil");
 
@@ -248,18 +241,18 @@ describe("TeamViewScreen direct-reports scoping", () => {
 
 describe("TeamViewScreen member labels", () => {
   it("labels a member with no display name by username, then e-mail (#2711)", () => {
-    trees[PERSON_IDS.alice] = person(PERSON_IDS.alice, "alice@x.io", "Alice", [
-      {
-        ...person(PERSON_IDS.bob, "42+bee@noreply.x.io", ""),
-        username: "bee",
-      },
-      person(PERSON_IDS.erin, "erin@x.io", ""),
-    ]);
+    roster = peopleFromIdentityTree(
+      person(PERSON_IDS.alice, "alice@x.io", "Alice", [
+        {
+          ...person(PERSON_IDS.bob, "42+bee@noreply.x.io", ""),
+          username: "bee",
+        },
+        person(PERSON_IDS.erin, "erin@x.io", ""),
+      ])
+    );
 
     renderScreen();
 
-    expect(screen.getByTestId("heatmap")).toHaveTextContent(
-      "bee,erin@x.io",
-    );
+    expect(screen.getByTestId("heatmap")).toHaveTextContent("bee,erin@x.io");
   });
 });

--- a/src/frontend/src/screens/team-view.tsx
+++ b/src/frontend/src/screens/team-view.tsx
@@ -1,10 +1,6 @@
 import { useMemo, useState } from "react";
 
-import { IdentityApiError } from "@/api/identity-client";
-import {
-  personDisplayName,
-  personName,
-} from "@/lib/identities/person-display";
+import { personDisplayName, personName } from "@/lib/identities/person-display";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { DashboardEmptyState } from "@/components/widgets/dashboard/dashboard-empty-state";
 import { DashboardHeader } from "@/components/widgets/dashboard/dashboard-header";
@@ -19,25 +15,22 @@ import { usePeriod } from "@/hooks/use-period";
 import {
   flattenSubordinates,
   hasIndirectReports,
+  rosterTree,
   scopeRosterToDirectReports,
 } from "@/lib/insight/identity-tree";
-import {
-  GROUPS,
-  HEATMAP_COLLECTION,
-  type GroupId,
-} from "@/lib/insight/groups";
+import { GROUPS, HEATMAP_COLLECTION, type GroupId } from "@/lib/insight/groups";
 import {
   memberMetricEntries,
   metricBelowCounts,
 } from "@/lib/insight/team-metrics";
 import { projectViews } from "@/lib/metrics/collection";
 import { normalizePersonId } from "@/lib/metrics/entity";
-import { useIcPerson } from "@/queries/ic-dashboard";
 import {
   collectionSetPending,
   useMetricCollectionSet,
 } from "@/queries/metric-results";
 import { useMemberGridData } from "@/queries/member-grid";
+import { useVisibleRoster } from "@/queries/visible-roster";
 import type { TeamMember } from "@/types/insight";
 
 // Team surfaces request period + peer only: a per-member timeseries over a
@@ -71,17 +64,15 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
     setOpenGroup(null);
   }
 
-  // The pivot is resolved by identity, NOT looked up in the viewer's tree:
-  // visibility also comes from explicit and wildcard grants, so a person the
-  // viewer may legitimately see can sit outside their reporting line. A tree
-  // lookup would render that team empty. The hook still serves the viewer's
-  // cached tree as placeholder data, so the common case paints immediately.
-  const pivotQ = useIcPerson(teamId);
-  const pivot = pivotQ.data ?? null;
+  const visibleRoster = useVisibleRoster(true);
+  const pivot = useMemo(
+    () => rosterTree(visibleRoster.roster, teamId),
+    [teamId, visibleRoster.roster]
+  );
 
   const fullRoster = useMemo(
     () => (pivot ? flattenSubordinates(pivot) : null),
-    [pivot],
+    [pivot]
   );
   // With no indirect reports, direct reports == the whole team, so the
   // toggle could never change the roster — hide it (#1756).
@@ -92,12 +83,11 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
     () =>
       scopeRosterToDirectReports(
         fullRoster,
-        canScopeToDirectReports && directReportsOnly,
+        canScopeToDirectReports && directReportsOnly
       ),
-    [fullRoster, canScopeToDirectReports, directReportsOnly],
+    [fullRoster, canScopeToDirectReports, directReportsOnly]
   );
-  // Never fall back to the raw id (a UUID) — the shell prefetches the viewer
-  // tree, so the pivot resolves synchronously in practice.
+  // Never fall back to the raw id (a UUID).
   const teamName = pivot ? (personName(pivot) ?? "") : "";
 
   // The roster IS the member list: identity owns who is on the team, and
@@ -109,7 +99,7 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
         person_id: entry.person_id,
         name: personDisplayName(entry),
       })),
-    [roster],
+    [roster]
   );
   const memberEntityIds = members.map((m) => normalizePersonId(m.person_id));
   const memberRefs: TeamMemberRef[] = members.map((m) => ({
@@ -120,13 +110,13 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
     HEATMAP_COLLECTION,
     { type: "person", ids: memberEntityIds },
     dateRange,
-    period,
+    period
   );
 
   const metricGroupData = useMetricCollectionSet(
     TEAM_METRIC_COLLECTIONS,
     { type: "person", ids: memberEntityIds },
-    dateRange,
+    dateRange
   );
 
   const metricBelowByMember = new Map<string, number>();
@@ -136,11 +126,11 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
     for (const [memberId, count] of metricBelowCounts(
       def,
       byKey,
-      memberEntityIds,
+      memberEntityIds
     )) {
       metricBelowByMember.set(
         memberId,
-        (metricBelowByMember.get(memberId) ?? 0) + count,
+        (metricBelowByMember.get(memberId) ?? 0) + count
       );
     }
   }
@@ -149,27 +139,21 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
   const metricEntriesByPerson = memberMetricEntries(
     GROUPS,
     (id) => metricGroupData.get(id)?.byKey,
-    memberEntityIds,
+    memberEntityIds
   );
 
   // The one loading gate: a single page spinner while ANY of the screen's
   // queries has no data. A period or scope change mints new query keys, so
   // the same gate re-trips — no per-widget loaders, no partial paints. The
-  // roster query (the pivot's own profile) comes first: every other query
-  // derives its entity ids from it.
+  // roster query comes first: every other query derives its entity ids from it.
   const isLoading =
-    pivotQ.isPending ||
+    visibleRoster.isPending ||
     heatmapQ.isPending ||
     collectionSetPending(metricGroupData);
   const hasMembers = members.length > 0;
   const isAllEmpty = !isLoading && !hasMembers;
-  // Identity failing is not an empty team: without the pivot there is no
-  // roster at all, and rendering the empty state over a 404 or a down service
-  // would read as "this team has no members". Same split as the personal
-  // dashboard: a 404 (gone, renamed, or outside the visible set) has nothing
-  // to retry; anything else offers one.
   const pivotMissing =
-    pivotQ.error instanceof IdentityApiError && pivotQ.error.status === 404;
+    !visibleRoster.isPending && !visibleRoster.isError && pivot === null;
 
   const memberCountLabel = `${members.length} member${members.length === 1 ? "" : "s"}`;
   const scopeLabel = directReportsOnly
@@ -189,13 +173,13 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
         hasReports
         actions={
           canScopeToDirectReports && fullRoster ? (
-            <label className="text-foreground flex cursor-pointer items-center gap-2 text-sm select-none">
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-foreground select-none">
               <Switch
                 checked={directReportsOnly}
                 onCheckedChange={setDirectReportsOnly}
               />
               <span>Direct reports only</span>
-              <span className="text-muted-foreground text-xs">
+              <span className="text-xs text-muted-foreground">
                 ({roster?.length ?? 0}/{fullRoster.length})
               </span>
             </label>
@@ -203,7 +187,7 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
         }
       />
       <main className="flex flex-1 flex-col gap-8 p-4 md:p-6">
-        {pivotQ.isError ? (
+        {visibleRoster.isError || pivotMissing ? (
           <ComingSoon
             variant="card"
             state="error"
@@ -212,7 +196,7 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
                 ? "This person is not available"
                 : "Unable to load this person"
             }
-            onRetry={pivotMissing ? undefined : () => void pivotQ.refetch()}
+            onRetry={pivotMissing ? undefined : visibleRoster.retry}
           />
         ) : isLoading ? (
           <CenteredSpinner className="min-h-[70vh]" />
@@ -243,7 +227,7 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
             )}
 
             <section className="flex flex-col gap-3">
-              <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
                 Sections
               </p>
               <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">

--- a/src/frontend/src/test/identity.ts
+++ b/src/frontend/src/test/identity.ts
@@ -1,3 +1,4 @@
+import type { PeopleListItem } from "@/api/identity-client";
 import type { IdentityPerson } from "@/types/insight";
 
 /**
@@ -43,4 +44,30 @@ export function identityPerson(
     subordinates,
     ...over,
   } as unknown as IdentityPerson;
+}
+
+export function peopleFromIdentityTree(
+  root: IdentityPerson,
+  managerPersonId: string | null = null,
+): PeopleListItem[] {
+  return [
+    {
+      person_id: root.person_id,
+      display_name: root.display_name,
+      first_name: root.first_name ?? null,
+      last_name: root.last_name ?? null,
+      username: root.username ?? null,
+      email: root.email,
+      attributes: {
+        ...(root.department ? { department: root.department } : {}),
+        ...(root.division ? { division: root.division } : {}),
+        ...(root.job_title ? { job_title: root.job_title } : {}),
+        ...(root.status ? { status: root.status } : {}),
+      },
+      manager_person_id: managerPersonId,
+    },
+    ...root.subordinates.flatMap((report) =>
+      peopleFromIdentityTree(report, root.person_id),
+    ),
+  ];
 }

--- a/src/ingestion/tests/e2e/identity/test_github_directory_member_id_binding.py
+++ b/src/ingestion/tests/e2e/identity/test_github_directory_member_id_binding.py
@@ -311,9 +311,9 @@ def test_github_directory_emits_roster_profile_claims(
     )
 
     assert rows == [
-        ["person_display_name", display_name],
-        ["person_email", email],
-        ["person_username", login],
+        ("person_display_name", display_name),
+        ("person_email", email),
+        ("person_username", login),
     ]
 
 

--- a/src/ingestion/tests/e2e/identity/test_persons_seed_org_chart_gaps.py
+++ b/src/ingestion/tests/e2e/identity/test_persons_seed_org_chart_gaps.py
@@ -292,9 +292,9 @@ def test_seed_org_chart_from_real_bamboohr_connector_pipeline(
         "   AND operation_type = 'UPSERT' ORDER BY value_type",
     )
     assert profile_rows == [
-        ["person_display_name", "Pipeline Report"],
-        ["person_first_name", "Pipeline"],
-        ["person_last_name", "Report"],
+        ("person_display_name", "Pipeline Report"),
+        ("person_first_name", "Pipeline"),
+        ("person_last_name", "Report"),
     ]
 
     res = identity_svc.run_seed_cli(tenant=str(seed.SEED_TENANT), force=True)

--- a/src/ingestion/tools/seed/insight_seed/identity.py
+++ b/src/ingestion/tools/seed/insight_seed/identity.py
@@ -1,5 +1,5 @@
 """
-MariaDB identity seed: persons, org_chart, person_roles.
+MariaDB identity seed: people, persons, org_chart, person_roles.
 
 All UUIDs are stored as BINARY(16) in RFC 4122 big-endian — the
 convention the identity-resolution service's schema uses.
@@ -297,6 +297,34 @@ def seed_person_names(
     return inserted
 
 
+def seed_people(
+    cur: pymysql.cursors.Cursor,
+    tenant_uuid: str,
+    roster: Iterable[Person],
+) -> int:
+    sql = """
+        INSERT IGNORE INTO people (
+            insight_tenant_id, person_id, email, username,
+            display_name, first_name, last_name, attributes, valid_from
+        ) VALUES (
+            %s, %s, %s, NULL, %s, %s, %s, JSON_OBJECT(), '2000-01-01 00:00:00'
+        )
+    """
+    rows = [
+        (
+            _bin(tenant_uuid),
+            _bin(person.uuid),
+            person.email,
+            person.display_name,
+            person.first_name,
+            person.last_name,
+        )
+        for person in roster
+    ]
+    cur.executemany(sql, rows)
+    return cur.rowcount
+
+
 def seed_org_chart(
     cur: pymysql.cursors.Cursor,
     tenant_uuid: str,
@@ -428,6 +456,7 @@ def run() -> None:
         n_persons = seed_persons(cur, tenant, roster)
         n_login_id = seed_login_ids(cur, tenant, roster)
         n_names = seed_person_names(cur, tenant, roster)
+        n_people = seed_people(cur, tenant, roster)
         n_org = seed_org_chart(cur, tenant, roster)
         n_roles = seed_person_roles(cur, tenant, roster)
 
@@ -440,11 +469,12 @@ def run() -> None:
             n_names += seed_person_names(cur, TENANT_OTHER, other_roster)
 
     LOG.info(
-        "DONE: persons=%d (new), login_id=%d (new), names=%d (new), "
+        "DONE: persons=%d (new), login_id=%d (new), names=%d (new), people=%d (new), "
         "org_chart=%d (new), person_roles=%d (new)",
         n_persons,
         n_login_id,
         n_names,
+        n_people,
         n_org,
         n_roles,
     )

--- a/src/ingestion/tools/seed/tests/test_identity.py
+++ b/src/ingestion/tools/seed/tests/test_identity.py
@@ -195,3 +195,46 @@ class SeedPersonsIdempotencyTests(unittest.TestCase):
         self.assertGreater(first, 0, "names are written on the first run")
         self.assertEqual(second, 0, "a re-run must be a no-op, not a duplicate observation")
         self.assertEqual(cur.insert_count, first)
+
+
+class _PeopleCursor:
+    def __init__(self) -> None:
+        self.rowcount = 0
+        self.rows: list[tuple[Any, ...]] = []
+        self._current: set[tuple[Any, Any]] = set()
+
+    def executemany(self, sql: str, rows: list[tuple[Any, ...]]) -> None:
+        self.assert_people_insert(sql)
+        inserted = 0
+        for row in rows:
+            key = (row[0], row[1])
+            if key in self._current:
+                continue
+            self._current.add(key)
+            self.rows.append(row)
+            inserted += 1
+        self.rowcount = inserted
+
+    @staticmethod
+    def assert_people_insert(sql: str) -> None:
+        if "INSERT IGNORE INTO people" not in sql:
+            raise AssertionError(f"unexpected SQL: {sql}")
+
+
+class SeedPeopleTests(unittest.TestCase):
+    def test_whole_roster_is_projected_once_with_its_profile(self) -> None:
+        cur = _PeopleCursor()
+        roster = _roster()
+
+        first = identity.seed_people(cur, _TENANT, roster)  # type: ignore[arg-type]
+        second = identity.seed_people(cur, _TENANT, roster)  # type: ignore[arg-type]
+
+        self.assertEqual(first, len(roster))
+        self.assertEqual(second, 0)
+        self.assertEqual(
+            [(row[2], row[3], row[4], row[5]) for row in cur.rows],
+            [
+                ("dev@company.nonpresent", "Dev Lead", "Dev", "Lead"),
+                ("sales-lead@company.nonpresent", "Sales Lead", "Sales", "Lead"),
+            ],
+        )

--- a/tests/stand/api/identity/test_people.py
+++ b/tests/stand/api/identity/test_people.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+from insight_stand import Manifest, PersonaSession, identity_path
+
+from ..schemas.identity import PeopleListItemResponse, PeopleListResponse
+
+PEOPLE = identity_path("/v1/people")
+
+
+@pytest.mark.requires_seed("dev_lead", "development_ic", "sales_ic")
+@pytest.mark.security
+def test_people_lists_only_the_callers_visible_roster(
+    lead_session: PersonaSession, stand_manifest: Manifest
+) -> None:
+    report = stand_manifest.fixture("development_ic")
+    outsider = stand_manifest.fixture("sales_ic")
+
+    response = lead_session.client.get(PEOPLE, params={"limit": 500})
+
+    assert (
+        response.status_code == 200
+    ), f"status={response.status_code} {response.text[:300]}"
+    people = response.parse(PeopleListResponse).items
+    by_id = {str(person.person_id): person for person in people}
+    assert lead_session.person.uuid in by_id
+    assert report.uuid in by_id
+    assert outsider.uuid not in by_id
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.security
+def test_people_detail_returns_the_visible_roster_profile(
+    lead_session: PersonaSession, stand_manifest: Manifest
+) -> None:
+    expected = stand_manifest.fixture("dev_lead")
+
+    response = lead_session.client.get(f"{PEOPLE}/{expected.uuid}")
+
+    assert (
+        response.status_code == 200
+    ), f"status={response.status_code} {response.text[:300]}"
+    person = response.parse(PeopleListItemResponse)
+    assert str(person.person_id) == expected.uuid
+    assert person.email == expected.email
+    assert person.display_name == expected.display_name

--- a/tests/stand/api/operations.py
+++ b/tests/stand/api/operations.py
@@ -148,13 +148,15 @@ ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("GET", f"/v1/connector-health/{SOME_CONNECTOR}/syncs"),
 )
 
-#: identity-resolution — 29 operations. `/health` and `/healthz` are the host
+#: identity-resolution — 31 operations. `/health` and `/healthz` are the host
 #: router's, not the product API, and are deliberately absent: the real probes
 #: address the pod directly rather than passing the gateway.
 IDENTITY_OPERATIONS: Final[tuple[Operation, ...]] = (
     _i("POST", "/v1/profiles"),
     _i("POST", "/v1/profiles/batch"),
     _i("GET", "/v1/me"),
+    _i("GET", "/v1/people"),
+    _i("GET", f"/v1/people/{SOME_ID}"),
     _i("GET", "/v1/persons"),
     # The operator correction surface. `source` stays the literal `github` in
     # the accounts read: it is a connector type, not an id, and the tests


### PR DESCRIPTION
**Why.** Roster surfaces derived membership, hierarchy, and person presentation from different identity endpoints. Profile responses could mix canonical roster data with unrelated identity observations, while flat and hierarchical installations followed different data paths.

**What changed.** Add caller-authorized `GET /api/identity/v1/people/{person_id}` for one current canonical roster person. Load roster collections from `GET /api/identity/v1/people`, follow cursor pages to completion, and build reporting relationships from `manager_person_id`. Person dashboards, headers, the sidebar footer, team views, the People view, org scopes, manager detection, and cohort helpers now use the canonical people endpoints. The identity console lists tenant-wide roster people while observed account search and resolution operations retain their existing endpoints.

**Verified.** `cargo test -p identity-resolution` (422 tests), `cargo clippy -p identity-resolution --all-targets -- -D warnings`, `cargo fmt --all -- --check`, generated OpenAPI drift check, `pnpm test` (2,378 tests), `pnpm typecheck`, `pnpm lint`, and `pnpm build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a canonical people roster with caller- and tenant-wide visibility options, search, pagination, and cancellation support.
  - Added roster-based people selection for account management.
  - Updated employee, organization tree, sidebar, cohort, and manager views to use authorized roster data.
  - Preserved reporting relationships, person attributes, department details, job titles, and statuses across roster-driven views.

- **Bug Fixes**
  - Improved handling of malformed roster responses and roster loading, error, and retry states.
  - Added safeguards against cyclic reporting relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
