### PR TITLE
docs(product): personas across two visibility modes, scenarios as per-persona classes

### DIFF
--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -74,7 +74,7 @@ persona in that function.
 
 - **Who:** any signed-in person when the installation runs flat
 - **Mode:** flat
-- **Lands on:** the organization roll-up, the same landing as a manager
+- **Lands on:** the organization roll-up
 - **Asks:** "How are we doing, and where do I stand among my peers?"
 - **Sees:** the whole organization, everyone by name, themselves included
 - **May compare:** anyone with anyone; the organization is the only cohort
@@ -113,7 +113,10 @@ a customer does not arrive for it.
   the promise, *Today*.
 - A *boundary* is observable: the thing is absent from every response the persona can obtain, or it
   is withheld with a stated reason. A cell says *and says why* where the reason must be shown.
-- A `—` in *Boundaries* means nothing beyond [Configuration and access](#s-9--configuration-and-access) — that boundary holds in every scenario.
+- A `—` reads by column. In *User scenarios*: the persona brings no question of their own here. In
+  *Can see and do*: nothing. In *Boundaries*: nothing beyond
+  [Configuration and access](#s-9--configuration-and-access) — that boundary holds in every
+  scenario. In the grid below: the persona has no row in that scenario.
 - In *User scenarios*, *a … lead* in any function is LEAD, and *everyone* is every persona.
 
 **Who appears in which scenario**
@@ -124,8 +127,8 @@ a customer does not arrive for it.
 | [S-2](#s-2--analysis-and-diagnosis) Analysis and diagnosis | ✓ | ✓ | not an audience | ✓ | see [Sources and evidence coverage](#s-7--sources-and-evidence-coverage) |
 | [S-3](#s-3--conclusions-recommendation-and-validation) Conclusions | ✓ | ✓ | never the subject | undecided | ✓ |
 | [S-4](#s-4--dashboards-views-and-exploration) Dashboards and exploration | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [S-5](#s-5--sharing-and-reuse) Sharing and reuse | ✓ | ✓ | — | — | ✓ |
-| [S-6](#s-6--external-comparison) External comparison | ✓ | — | — | — | ✓ |
+| [S-5](#s-5--sharing-and-reuse) Sharing and reuse | ✓ | ✓ | — | ✓ | ✓ |
+| [S-6](#s-6--external-comparison) External comparison | ✓ | — | — | ✓ | ✓ |
 | [S-7](#s-7--sources-and-evidence-coverage) Sources and evidence coverage | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [S-8](#s-8--identity-roles-and-organization-model) Identity and organization model | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [S-9](#s-9--configuration-and-access) Configuration and access | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -148,11 +151,14 @@ week by default.
 | **EXEC** | Where are we improving, and where just getting busier? · What falls apart if a specific person drops out? — with the person-level grant · How much does AI cost, who spends it, in what form? — from finance | organization, function and team over time · coverage counted from people who have data, never by treating missing data as zero | a default view that ranks people · a number without its coverage |
 | **LEAD** | What changed for my team over the period? · Where is work stalling? · What falls apart if a specific person drops out? — with the person-level grant · How much goes into coordination instead of work? | their team at any depth, people by name · group figures recalculated for the team on screen · concentration read with its domain's meaning, and the surface says which | a team they do not manage · a group figure for fewer than four people · a team figure equal to the organization's when the team's own data would give another |
 | **IC** | What is visible about me, and what is in my way? | their own activity, flow and AI usage against the department or cohort median — shown only when five or more people have data | another person's activity · any team metric beyond that median · their own rank |
-| **PEER** | How are we doing, and where do I stand among my peers? | the whole organization as one scope, everyone named · their own page against the organization median | a peer comparison with fewer than five people who have data |
+| **PEER** | How are we doing, and where do I stand among my peers? | the whole organization as one scope, everyone named · their own page against the organization median | a peer comparison with fewer than five people who have data · their own rank — whether the band that places them against the median is one is undecided |
 | **ADMIN** | — | nothing by default | — |
 
 **Not this:** no single "value of AI" number — seat and usage cost are never summed, and unattributed
 cost stays its own line.
+
+**Today:** the four-person floor on a group figure is a promise, not yet enforced; the five-person
+floor on a peer comparison is ([rule 10](#6-rules-that-hold-in-every-scenario)).
 
 ### S-2 · Analysis and diagnosis
 
@@ -163,11 +169,11 @@ what to commit to, from the organization's own delivery history.
 
 | Who | User scenarios | Can see and do | Boundaries |
 |---|---|---|---|
-| **EXEC** | Did throughput rise where AI was adopted, and what did it cost? · Activity rose — did the deals move? · Development got cheaper — did the cost move somewhere else? — from finance · Is it feasible, what will it cost, how long, what risks? — from product · Where is the effect larger for less effort? — from product | the same as LEAD at organization level · cost and outcome followed to the function, team, product or service as far as the trail goes · ranked opportunities where the effect is larger for less effort | attribution stronger than the lineage supports · a causal claim where the evidence supports a correlation · a forecast presented as a guarantee |
+| **EXEC** | Did throughput rise where AI was adopted, and what did it cost? · Activity rose — did the deals move? · Development got cheaper — did the cost move somewhere else? — from finance · Is it feasible, what will it cost, how long, what risks? — from product · Where is the effect larger for less effort? — from product | a conclusion for the organization, a function or a team, with the evidence behind it · cost and outcome followed to the function, team, product or service as far as the trail goes · ranked opportunities where the effect is larger for less effort | attribution stronger than the lineage supports · a causal claim where the evidence supports a correlation · a forecast presented as a guarantee |
 | **LEAD** | Did throughput rise where AI was adopted, and what did it cost? · Is speed limited by writing code or by reviewing it? · Speed went up — did quality hold? — an engineering or product lead · Is this ticket spike caused by what we shipped? — a support or product lead · Activity rose — did the deals move? — a sales lead · Is it feasible, what will it cost, how long, what risks? — a product lead | a conclusion for their team or cohort, with the evidence behind it · where the chain of evidence breaks in their area, and what would repair it · feasibility, cost, duration and risk of proposed work from the organization's own history | a verdict about a named individual · a comparative conclusion with fewer than eight people on each side — withheld, and says why · a conclusion built on a metric known to be defective — excluded by name, and says why |
 | **IC** | — | not an audience for diagnosis | a named example inside one |
-| **PEER** | any of EXEC's or LEAD's questions, at organization level | the same as EXEC, with one cohort: the comparison is against the organization's own history | records, cost or recommendations without their own grant · a causal claim where the evidence supports a correlation |
-| **ADMIN** | — | not here — what limits a conclusion is their view in [Sources and evidence coverage](#s-7--sources-and-evidence-coverage) | — |
+| **PEER** | Did throughput rise where AI was adopted, and what did it cost? · Is speed limited by writing code or by reviewing it? · Where is the effect larger for less effort? | a conclusion for the whole organization, with the evidence behind it · comparison against the organization's own history, since there is no second group to compare with | records, cost or recommendations without their own grant · a causal claim where the evidence supports a correlation |
+| **ADMIN** | — | what limits a conclusion — a missing source, two windows that do not overlap, a metric under a known defect — shown as evidence coverage, not as a conclusion | — |
 
 **Not this:** "AI sped up development by X%" is not a claim Insight makes; what it can say is that a
 cohort with high usage differs from one with low usage in stated ways, correlationally — with the word
@@ -178,17 +184,17 @@ traced is shown as an evidence gap, never converted into a confident claim.
 ### S-3 · Conclusions: recommendation and validation
 
 A recommendation is one lever from a fixed set, with a named owner, the evidence and confidence behind
-it, what should move as a result, which guardrail must not slip, and a four-week window — counted from
-the day it is issued — after which the product reads the outcome from the measured system; its origin
-is declared, evidence-derived from the customer's own data or heuristic.
+it, what should move as a result, which guardrail must not slip, and a validation window — four weeks
+by default, counted from the day it is issued — after which the product reads the outcome from the
+measured system; its origin is declared, evidence-derived from the customer's own data or heuristic.
 
 | Who | User scenarios | Can see and do | Boundaries |
 |---|---|---|---|
-| **EXEC** | Was it applied? Did it help? | one of four answers: the lever moved and the outcome moved · the lever moved and the outcome did not · the lever did not move · not enough data — when either side has fewer than eight people · read four weeks before against four weeks after, against a control: a group in the same size band that received no recommendation | a result assembled from metrics chosen after the fact — they are fixed when the recommendation is issued · a detector hunting for a shift, which on a team of ten finds noise |
-| **LEAD** | I can see the problem — what do I do? · Was it applied? Did it help? · We had a reorg that month — how do I say so? | one lever they can own, with how it is measured, what should move, the guardrail, and the check date | a recommendation that judges a named individual rather than a process, team or cohort — an owner is named, a subject is not · a recommendation whose origin is unstated |
+| **EXEC** | Was it applied? Did it help? | one of four answers: the lever moved and the outcome moved · the lever moved and the outcome did not · the lever did not move · not enough data — when either side has fewer than eight people with data · read the window before against the window after, against a control: a group in the same size band that received no recommendation | a result assembled from metrics chosen after the fact — the lever's measure, the outcome and the guardrail are fixed when the recommendation is issued · a shift reported on any other metric — a detector hunting for one on a team of ten finds noise |
+| **LEAD** | I can see the problem — what do I do? · Was it applied? Did it help? · We had a reorg that month — how do I say so? | one lever they can own, with how it is measured, what should move, the guardrail, and the check date · the four answers, for their own team · a note on the window — a reorg, a hiring wave, an outage — carried beside the outcome, never fed into it | a recommendation that judges a named individual rather than a process, team or cohort — an owner is named, a subject is not · a recommendation whose origin is unstated |
 | **IC** | — | — | being the subject of a recommendation |
-| **PEER** | — | undecided — a recommendation names an owner, and a flat organization has no lead (see [Open points](#7-open-points)) | — |
-| **ADMIN** | — | which recommendation families are enabled, who owns them, and how validation windows are defined | — |
+| **PEER** | — | a recommendation names an owner, and a flat organization has no lead — undecided | — |
+| **ADMIN** | — | which levers are enabled, who owns each, and the validation window | — |
 
 **Not this:** no surveys, and no self-reporting of any kind as an input — a validation that depends on
 people filling in a form does not run. Insight recommends; it does not execute ([rule 7](#6-rules-that-hold-in-every-scenario)).
@@ -212,13 +218,13 @@ Boundaries are those of [Configuration and access](#s-9--configuration-and-acces
 
 | Who | User scenarios | Can see and do | Boundaries |
 |---|---|---|---|
-| **EXEC** | How does group A differ from group B in the same scope? · How does the same figure split by one attribute? | the same as LEAD, at organization and function level | a follow-back from a figure that reaches underlying records without that grant |
+| **EXEC** | How does group A differ from group B in the same scope? · How does the same figure split by one attribute? | compose from the catalog · slice by attribute · define cohorts and comparison groups across the organization and its functions · follow any figure back to how it was calculated | a follow-back from a figure that reaches underlying records without that grant |
 | **LEAD** | How does group A differ from group B in the same scope? · How does the same figure split by one attribute? | compose from the catalog · slice by attribute · define cohorts and comparison groups · follow any figure back to how it was calculated · groups recalculated for what is on screen | an exploration path that reaches outside their own team · a group figure for fewer than four people · a follow-back that reaches underlying records without that grant |
 | **IC** | — | their own context only | a follow-back that reaches underlying records without that grant |
-| **PEER** | the same as LEAD, over the whole organization | views over the whole organization; the same as EXEC | a follow-back that reaches underlying records without that grant |
-| **ADMIN** | — | which metrics and thresholds exist, which cohorts are valid, who may publish a shared view | — |
+| **PEER** | How does group A differ from group B? · How does the same figure split by one attribute? | compose from the catalog · slice by attribute · define cohorts across the whole organization · follow any figure back to how it was calculated | a follow-back that reaches underlying records without that grant |
+| **ADMIN** | — | which metrics and thresholds exist, and which cohorts are valid | — |
 
-**Not this:** a saved or shared view (see [Open points](#7-open-points)).
+**Not this:** a saved or shared view — undecided (see [Open points](#7-open-points)).
 
 ### S-5 · Sharing and reuse
 
@@ -231,6 +237,7 @@ Boundaries are those of [Configuration and access](#s-9--configuration-and-acces
 |---|---|---|---|
 | **ADMIN** | How do we pull this into our BI, a report, or a bot? | API and governed data access, under the access rules that apply inside the product | a number stripped of its definition and confidence — outside the product it becomes a fact without caveats |
 | **LEAD, EXEC** | How do we pull this into our BI, a report, or a bot? | a conclusion in their own report or review, upward or outward | — |
+| **PEER** | How do we pull this into our BI, a report, or a bot? | a conclusion in their own report or review, over the whole organization | — |
 
 **Not this:** none.
 
@@ -244,7 +251,7 @@ Boundaries are those of [Configuration and access](#s-9--configuration-and-acces
 
 | Who | User scenarios | Can see and do | Boundaries |
 |---|---|---|---|
-| **EXEC** | Our three-day cycle — is that bad? | own history first, which requires sharing nothing · peer comparison only where the customer has opted in | — |
+| **EXEC, PEER** | Our three-day cycle — is that bad? | own history first, which requires sharing nothing · peer comparison only where the customer has opted in | — |
 | **ADMIN** | — | participation on and off; it is revocable | — |
 
 **Not this:** raw customer data leaving the customer boundary — only anonymized aggregates at cohort,
@@ -273,7 +280,7 @@ Boundaries are those of [Configuration and access](#s-9--configuration-and-acces
 |---|---|---|---|
 | **ADMIN** | Which questions can I already ask, and which not? · Why is this empty, and what would make it not empty? · Is this an event in the business, or a break in the data? | all eight evidence categories as connected, partly connected or absent — people, work, communication, delivery, support, sales, cost, AI — and which metrics each unlocks · what each source declares about itself: fields, window, freshness, blind spots, and the level it supports · which links between systems are weak or broken, and what would repair them | being left to guess why a screen is empty |
 | **LEAD, EXEC** | Why is this empty, and what would make it not empty? · Is this an event in the business, or a break in the data? | the cause named directly — which source is missing, which identities are unresolved, which link is broken — plus the minimal fix | a comparison across two periods whose source windows do not overlap, rendered as a plain number — it is withheld, and the source is named |
-| **IC, PEER** | — | the same guarantee, on their own context or on the whole organization | — |
+| **IC, PEER** | — | an empty section on their own page, or on the organization roll-up, names the missing source and the smallest fix | — |
 
 **Not this:** a zero in place of missing data, or a "rough estimate for now" — the honest answer to a
 missing source is what is missing ([rule 1](#6-rules-that-hold-in-every-scenario)).
@@ -288,8 +295,8 @@ not valid at the time.
 | Who | User scenarios | Can see and do | Boundaries |
 |---|---|---|---|
 | **ADMIN** | Which identity links did the system make, where is it unsure, where wrong? · How do I tell the product who is supposed to do what here? · Someone is listed in one role and does another — error or reality? | what was matched automatically, where the system is unsure, and where it got it wrong · merges and splits, reversibly · roles, several per person, and role history | losing a manual correction to the next sync |
-| **LEAD, EXEC** | Someone is listed in one role and does another — error or reality? | a tree they can trust to roll up into, with team membership kept per period | a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it |
-| **IC, PEER** | — | being one person, not four | their work attributed to a duplicate of themselves |
+| **LEAD, EXEC** | Someone is listed in one role and does another — error or reality? | the configured role beside the observed activity, for anyone in their reach · a tree they can trust to roll up into, with team membership kept per period | a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it |
+| **IC, PEER** | — | recognised as one person across code, tickets, chat and the HR system, with a stated confidence | their work attributed to a duplicate of themselves |
 
 **Not this:** where observed work does not match the configured role model, Insight recommends
 changing the configuration — not the person.
@@ -302,7 +309,7 @@ every surface.
 
 | Who | User scenarios | Can see and do | Boundaries |
 |---|---|---|---|
-| **ADMIN** | How do I give a lead their team and nothing more? · How do I tell the product who is supposed to do what here? | grants the five kinds of data one by one · adapts roles, metrics and thresholds without engineering · sets language, date, number, currency and timezone rules | holding all five kinds implicitly · a refusal only hidden on screen rather than enforced by the system · data visibility from the admin role alone |
+| **ADMIN** | How do I give a lead their team and nothing more? | grants the five kinds of data one by one · adapts roles, metrics and thresholds without engineering · sets language, date, number, currency and timezone rules | holding all five kinds implicitly · a refusal only hidden on screen rather than enforced by the system · data visibility from the admin role alone |
 | **LEAD** | — | their own team, in full, at every depth | one level up, or sideways — the limit is structural, not a filter on a screen |
 | **EXEC** | — | aggregates for the whole organization, and people where person-level access is granted | raw access as a privilege of rank — it is one of the five grants |
 | **PEER** | — | everyone by name — person-level sight is what the mode grants | records, cost or recommendations without their own grant |
@@ -354,11 +361,12 @@ From the vision, stated once here instead of repeated in each scenario.
    are shared, opt-in and revocable.
 9. **Role and activity are separate axes** — expected role model and observed activity are
    compared, never conflated; history is kept under the model valid at the time.
-10. **Three group sizes, and they differ** — a group figure is not shown below **four**
-    people, and a comparative conclusion is not drawn below **eight** on each side. The first keeps an
-    individual unidentifiable behind a number; the second keeps a claim from resting on a handful. The
-    one threshold the product enforces today sits between them: a peer comparison — the median and
-    quartiles behind a person's position — is not computed below **five** observed people.
+10. **Three group sizes, and they differ** — each counts people who have data in the period in
+    view, never headcount. A group figure is not shown below **four**, and a comparative conclusion
+    is not drawn below **eight** on each side; both are withheld, and say why. The first keeps an
+    individual unidentifiable behind a number; the second keeps a claim from resting on a handful.
+    The one threshold the product enforces today sits between them: a peer comparison — the median
+    and quartiles behind a person's position — is not computed below **five**.
 11. **A metric with a known defect says so on the metric itself** — and where a conclusion would rest
     on it, the metric is excluded by name rather than quietly included.
 12. **A group figure is computed for the group in view** — never inherited from a wider scope. This is
@@ -389,10 +397,13 @@ and what it blocks.
 - **Saved and shared views.** *Question:* if a view can be shared, is what each viewer sees
   re-evaluated for that viewer? *Why now:* far cheaper to decide before the feature than after.
   *Blocks:* sharing in [Dashboards, views and exploration](#s-4--dashboards-views-and-exploration).
-- **An identity correction surviving the next sync.** *Question:* is a manual merge or split undone by
-  re-resolution? *Why now:* a correction that does not survive is not a correction. *Blocks:* ADMIN's
-  promise in [Identity, roles and organization model](#s-8--identity-roles-and-organization-model).
-- **The group-size thresholds.** *Question:* are four (a group figure) and eight per side (a comparative
-  conclusion) product rules, and may a customer configure them? *Why now:* only five (a peer
-  comparison) is enforced today ([rule 10](#6-rules-that-hold-in-every-scenario)). *Blocks:* LEAD's cells in [Metrics review](#s-1--metrics-review) and
-  [Analysis and diagnosis](#s-2--analysis-and-diagnosis).
+- **A manual correction against new evidence.** *Question:* when a later sync brings evidence that
+  contradicts a manual merge or split, does the correction still win silently, or is the administrator
+  shown the conflict and asked? *Why now:*
+  [Identity, roles and organization model](#s-8--identity-roles-and-organization-model) promises
+  the correction survives; it does not say what the administrator learns when the sources disagree.
+  *Blocks:* ADMIN's row there.
+- **The group-size thresholds.** *Question:* may a customer change four (a group figure) and eight per
+  side (a comparative conclusion), or are they fixed? *Why now:* the scenarios already use both as
+  boundaries, but only five (a peer comparison) is enforced today
+  ([rule 10](#6-rules-that-hold-in-every-scenario)). *Blocks:* every cell that names the number.

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -16,9 +16,9 @@ no commitment.
 
 | Tier | What it is | Scenarios |
 |---|---|---|
-| **Main** | Review metrics, analyse them, reach conclusions — and, looking forward, estimate work not yet started. This is what the product is for. | S-1, S-2, S-3 |
-| **Secondary** | Build new views, explore, take the output elsewhere, compare with the outside world. | S-4, S-5, S-6 |
-| **Service** | Set the product up, keep it configured, keep it running. | S-7, S-8, S-9, S-10 |
+| **Main** | Review metrics, analyse them, reach conclusions — and, looking forward, estimate work not yet started. This is what the product is for. | [S-1](#s-1--metrics-review--main), [S-2](#s-2--analysis-and-diagnosis--main), [S-3](#s-3--conclusions-recommendation-and-validation--main) |
+| **Secondary** | Build new views, explore, take the output elsewhere, compare with the outside world. | [S-4](#s-4--dashboards-views-and-exploration--secondary), [S-5](#s-5--sharing-and-reuse--secondary), [S-6](#s-6--external-comparison--secondary) |
+| **Service** | Set the product up, keep it configured, keep it running. | [S-7](#s-7--sources-and-evidence-coverage--service), [S-8](#s-8--identity-roles-and-organization-model--service), [S-9](#s-9--configuration-and-access--service), [S-10](#s-10--deployment-upgrade-and-migration--service) |
 
 The order is by importance to the reader, not by build order. Technically the service tier comes
 first — sources and identity have to be right before a metric can be — but a customer does not buy
@@ -63,7 +63,7 @@ chosen per installation by the identity service's `visibility_policy`.
 The mode belongs to the installation, not to a person, and the identity service reports it to every
 client (`GET /v1/me`) — a leaf IC and a PEER are served the same empty `subordinates`, and the policy
 is what tells them apart. Grants keep their meaning under either mode: underlying records, aggregates,
-person-level data, cost and recommendations are still granted one by one (S-9).
+person-level data, cost and recommendations are still granted one by one ([S-9](#s-9--configuration-and-access--service)).
 
 **ADMIN is orthogonal to both.** Administration is a role, not a reach. An administrator is also an
 IC, LEAD, EXEC or PEER underneath, and the role adds no visibility of its own — the identity
@@ -183,7 +183,7 @@ what to commit to, from the organization's own delivery history.
 | **IC** | not an audience for diagnosis | a named example inside one |
 
 What limits a conclusion — which sources are missing, which windows do not overlap, which metric is
-under a known defect — is an administrator's view, and it lives in S-7.
+under a known defect — is an administrator's view, and it lives in [S-7](#s-7--sources-and-evidence-coverage--service).
 
 **Not this:** "AI sped up development by X%" is not a claim Insight makes; what it can say is that a
 cohort with high usage differs from one with low usage in stated ways, correlationally — with the word
@@ -207,7 +207,7 @@ used to check it. Its origin is declared — evidence-derived from the customer'
 |---|---|---|
 | **LEAD** | one lever they can own, from a fixed set rather than composed freely — three in the first version: reduce change size, spread review load, raise AI adoption where it is low at comparable load — with how the lever is measured, what should move, which guardrail must not slip, and when it is checked: four weeks, computed automatically | a recommendation that passes judgement on a named individual rather than a process, team or cohort — a named *owner* is expected, a named *subject* is not · a recommendation whose origin is unstated |
 | **EXEC** | whether the lever moved, whether the outcome moved, and the honest fourth answer: not enough data; read over a fixed window, four weeks before against four weeks after, and against a control — a comparable group that received no recommendation | a result assembled from metrics chosen after the fact — they are fixed when the recommendation is issued · a detector hunting for a shift, which on a team of ten finds noise |
-| **PEER** | undecided — a recommendation names an owner, and a flat organization has no lead to own a lever (§6) | — |
+| **PEER** | undecided — a recommendation names an owner, and a flat organization has no lead to own a lever (see [Open points](#6-open-points)) | — |
 | **ADMIN** | which recommendation families are enabled, who owns them, and how validation windows are defined | — |
 | **IC** | — | being the subject of a recommendation |
 
@@ -229,7 +229,7 @@ calculated. Exploration moves the question, never the boundary.
 
 **User scenarios in this class**
 - How does group A differ from group B in the same scope? — LEAD, EXEC
-- The slicing side of every S-1 question — who asks it there asks it here
+- The slicing side of every [S-1](#s-1--metrics-review--main) question — who asks it there asks it here
 
 | Who | Does here | Must never meet |
 |---|---|---|
@@ -240,7 +240,7 @@ calculated. Exploration moves the question, never the boundary.
 | **ADMIN** | which metrics and thresholds exist, which cohorts are valid, who may publish a shared view | — |
 
 **Not this:** a view carries the definitions and coverage of the metrics in it, never bare numbers.
-Saving a composed view and sharing it are proposals rather than restatements (§6): if a view
+Saving a composed view and sharing it are proposals rather than restatements (see [Open points](#6-open-points)): if a view
 can be shared, what a viewer sees has to be re-evaluated for that viewer, so a shared dashboard cannot
 become a way around access rules — which is why it needs deciding before view sharing is built.
 
@@ -281,8 +281,8 @@ cohort, team or organization level are shared — never individual data, never s
 None of this is why anyone buys the product, and all of it has to work before the rest does.
 
 **These four are also a sequence.** A new customer walks them roughly in order — connect the sources
-(S-7), resolve who is who (S-8), configure roles, metrics and access (S-9), with the installation
-itself underneath (S-10) — and only then does the main tier hold anything. The vision states the
+([S-7](#s-7--sources-and-evidence-coverage--service)), resolve who is who ([S-8](#s-8--identity-roles-and-organization-model--service)), configure roles, metrics and access ([S-9](#s-9--configuration-and-access--service)), with the installation
+itself underneath ([S-10](#s-10--deployment-upgrade-and-migration--service)) — and only then does the main tier hold anything. The vision states the
 same adoption path: connect, configure, run readiness, start with directional insight, improve
 evidence, validate. Listed last by importance; met first in time.
 
@@ -413,7 +413,7 @@ Several claims in this document go beyond what VISION.md and the scenario draft 
 as requirements because the alternative is to leave them undecided, but each needs a decision rather
 than a nod.
 
-- **Administrative rights and data visibility** — settled. §1 asserts that ADMIN gains no data
+- **Administrative rights and data visibility** — settled. [Personas](#1-personas) asserts that ADMIN gains no data
   visibility implicitly, and the access model agrees: the identity service computes an
   administrator's visible set without the role, under either visibility mode.
 - **An executive is a manager with a larger subtree.** The product tells EXEC from LEAD only by how
@@ -424,19 +424,19 @@ than a nod.
   default view that ranks named individuals; a flat organization has opted into seeing everyone.
   Which of the two this is has to be decided before the mode is sold as a feature — and if the bands
   are a ranking, whether flat mode suppresses them or the customer accepts them.
-- **Saved and shared views** (S-4). Composing a view is in the vision; *saving* it and *sharing* it are
+- **Saved and shared views** ([S-4](#s-4--dashboards-views-and-exploration--secondary)). Composing a view is in the vision; *saving* it and *sharing* it are
   not. If sharing exists, the access rule has to come with it — what each viewer sees, re-evaluated for
   them — and that is far cheaper to decide before the feature than after.
-- **An identity correction surviving the next sync** (S-8). The draft says merges and splits are
+- **An identity correction surviving the next sync** ([S-8](#s-8--identity-roles-and-organization-model--service)). The draft says merges and splits are
   reversible; neither document says a correction is not undone by re-resolution. Stated here as a
   requirement, because a correction that does not survive is not a correction.
-- **The group-size thresholds** (rule 10). The four for a group figure and the eight per side for a
+- **The group-size thresholds** ([rule 10](#5-rules-that-hold-in-every-scenario)). The four for a group figure and the eight per side for a
   comparative conclusion come from the scenario draft rather than from the vision, and are worth
   confirming as product rules — including whether a customer may configure them. The five for a peer
   comparison is the product's own, and is the only one of the three confirmed to be enforced.
-- **Recommendation ownership in a flat organization.** S-3 expects a named owner for every lever. A
+- **Recommendation ownership in a flat organization.** [S-3](#s-3--conclusions-recommendation-and-validation--main) expects a named owner for every lever. A
   flat organization has no lead, so either the owner is chosen some other way, or recommendations are
   not offered under `flat` — and the mode should say which.
 - **IC has the narrowest surface and the tightest boundary.** Everything an IC sees is their own or a
   median — the combination that is easiest to get wrong quietly.
-- **S-6 has no surface yet.** Listed so the capability stays planned for, not to imply it exists.
+- **[S-6](#s-6--external-comparison--secondary) has no surface yet.** Listed so the capability stays planned for, not to imply it exists.

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -6,7 +6,7 @@ The vision says what Insight is and what it can do. This document says **who is 
 it, what they are there to do, and how far each of them may reach**. It adds no capability and changes
 no commitment.
 
-- **Personas** — the target user groups of VISION §6.1, as five *reach* personas across the two
+- **Personas** — the vision's target user groups, as five *reach* personas across the two
   visibility modes the product ships, plus the administrator role, which is a role and not a reach.
 - **Scenarios** — ten, in three tiers, ordered by what the product is for. Each one is a class of
   user scenarios: the concrete questions people bring, and what each persona does and must never meet
@@ -66,11 +66,12 @@ is what tells them apart. Grants keep their meaning under either mode: underlyin
 person-level data, cost and recommendations are still granted one by one (S-9).
 
 **ADMIN is orthogonal to both.** Administration is a role, not a reach. An administrator is also an
-IC, LEAD, EXEC or PEER underneath, and the role adds no visibility of its own — the visible-set
-predicate in the identity service has no role term (ADR-0015).
+IC, LEAD, EXEC or PEER underneath, and the role adds no visibility of its own — the identity
+service's own design records that an administrator's visible set is computed without the role.
 
 **Function is the second axis.** Reach says how far a person may see; function says what they are
-looking at. VISION §6.2 lists nine — Engineering / R&D, Product Management, Design / UX, DevOps / SRE,
+looking at. The vision lists nine functions — Engineering / R&D, Product Management, Design / UX,
+DevOps / SRE,
 QA, Support, Sales, Marketing, Finance / FinOps — and a function is applied per user scenario, never
 per persona: a line reads `LEAD · Sales` or `EXEC · Finance`. Finance and product management are
 therefore not personas; their questions are carried by a reach persona in that function.
@@ -129,12 +130,12 @@ most customers these are different people; in the product they are one role
 
 # 2. Main — review, analysis, conclusions
 
-The loop the product exists for: measure → diagnose → recommend → validate (VISION §1).
+The loop the product exists for: measure → diagnose → recommend → validate.
 
 ## S-1 · Metrics review · Main
 
 Every number carries a governed definition, unit, granularity, confidence and stated limitations, and
-is worked out the same way for every persona and every scope (VISION §8.4).
+is worked out the same way for every persona and every scope.
 
 **User scenarios in this class**
 - What is visible about me, and what is in my way? — IC
@@ -155,17 +156,14 @@ is worked out the same way for every persona and every scope (VISION §8.4).
 | **ADMIN** | nothing by default | data visibility from the role alone |
 
 **Not this:** no single "value of AI" number — seat-based and usage-based cost are never summed into
-one figure, and unattributed cost stays its own line rather than being spread across the rest
-(VISION §6.2.9, §11.4).
+one figure, and unattributed cost stays its own line rather than being spread across the rest.
 
 ## S-2 · Analysis and diagnosis · Main
 
 The product stops showing shape and starts asserting a relationship — bottlenecks, risks, anomalies,
 cost drivers, quality issues, role and activity mismatches — and says which kind of claim it is making,
-with confidence and limitations (VISION §8.5). It rests on lineage, and lineage comes before
-attribution (VISION §7.3): what cannot be traced is shown as an evidence gap, never converted into a
-confident claim. Looking forward is the same scenario in the other direction — deciding what to commit
-to, from the organization's own delivery history rather than generic assumptions (VISION §1).
+with confidence and limitations. Looking forward is the same scenario in the other direction: deciding
+what to commit to, from the organization's own delivery history.
 
 **User scenarios in this class**
 - Did throughput rise where AI was adopted, and what did it cost? — LEAD, EXEC
@@ -190,11 +188,12 @@ under a known defect — is an administrator's view, and it lives in S-7.
 **Not this:** "AI sped up development by X%" is not a claim Insight makes; what it can say is that a
 cohort with high usage differs from one with low usage in stated ways, correlationally — with the word
 said on the surface, not in a footnote. Attribution reaches person × day × tool and no further, so
-"this change was written by AI" and "this change cost $N" are not claims Insight makes either.
+"this change was written by AI" and "this change cost $N" are not claims Insight makes either. And
+work that cannot be traced is shown as an evidence gap, never converted into a confident claim.
 
 ## S-3 · Conclusions: recommendation and validation · Main
 
-A recommendation is a structured improvement object (VISION §1): observed problem, affected area,
+A recommendation is a structured improvement object: observed problem, affected area,
 evidence and confidence, recommended action, owner, expected metric movement, and the follow-up window
 used to check it. Its origin is declared — evidence-derived from the customer's own data, or heuristic
 — and afterwards the product reads the outcome from the measured system.
@@ -208,13 +207,13 @@ used to check it. Its origin is declared — evidence-derived from the customer'
 |---|---|---|
 | **LEAD** | one lever they can own, from a fixed set rather than composed freely — three in the first version: reduce change size, spread review load, raise AI adoption where it is low at comparable load — with how the lever is measured, what should move, which guardrail must not slip, and when it is checked: four weeks, computed automatically | a recommendation that passes judgement on a named individual rather than a process, team or cohort — a named *owner* is expected, a named *subject* is not · a recommendation whose origin is unstated |
 | **EXEC** | whether the lever moved, whether the outcome moved, and the honest fourth answer: not enough data; read over a fixed window, four weeks before against four weeks after, and against a control — a comparable group that received no recommendation | a result assembled from metrics chosen after the fact — they are fixed when the recommendation is issued · a detector hunting for a shift, which on a team of ten finds noise |
-| **PEER** | undecided — a recommendation names an owner, and a flat organization has no lead to own a lever (Appendix C) | — |
-| **ADMIN** | which recommendation families are enabled, who owns them, and how validation windows are defined (VISION §9) | — |
+| **PEER** | undecided — a recommendation names an owner, and a flat organization has no lead to own a lever (§6) | — |
+| **ADMIN** | which recommendation families are enabled, who owns them, and how validation windows are defined | — |
 | **IC** | — | being the subject of a recommendation |
 
 **Not this:** no surveys, and no self-reporting of any kind as an input — not because opinions do not
 matter, but because a validation that depends on people filling in a form does not run. Validation is
-read from the measured system. Insight recommends; it does not execute (VISION §13.3).
+read from the measured system. Insight recommends; it does not execute.
 
 ---
 
@@ -225,10 +224,8 @@ Everything here extends the main loop. None of it is where a customer starts.
 ## S-4 · Dashboards, views and exploration · Secondary
 
 Someone builds a view rather than reading one: composing dashboards from the metric and recommendation
-catalog (VISION §8.7, §9), slicing by an attribute, defining a cohort, and following a figure back to
-how it was calculated (VISION §2). Exploration moves the question, never the boundary. Here a cohort is
-something a person builds — the attribute, the comparison group, the scope — where in S-1 it is the
-fixed backdrop a person is placed against; the machinery is shared, the activity is not.
+catalog, slicing by an attribute, defining a cohort, and following a figure back to how it was
+calculated. Exploration moves the question, never the boundary.
 
 **User scenarios in this class**
 - How does group A differ from group B in the same scope? — LEAD, EXEC
@@ -240,17 +237,17 @@ fixed backdrop a person is placed against; the machinery is shared, the activity
 | **EXEC** | the same, at organization and function level | — |
 | **PEER** | views over the whole organization; the same as EXEC | — |
 | **IC** | their own context only | — |
-| **ADMIN** | which metrics and thresholds exist, which cohorts are valid, who may publish a shared view (VISION §9) | — |
+| **ADMIN** | which metrics and thresholds exist, which cohorts are valid, who may publish a shared view | — |
 
 **Not this:** a view carries the definitions and coverage of the metrics in it, never bare numbers.
-Saving a composed view and sharing it are proposals rather than restatements (Appendix C): if a view
+Saving a composed view and sharing it are proposals rather than restatements (§6): if a view
 can be shared, what a viewer sees has to be re-evaluated for that viewer, so a shared dashboard cannot
 become a way around access rules — which is why it needs deciding before view sharing is built.
 
 ## S-5 · Sharing and reuse · Secondary
 
 A number keeps its meaning when it leaves the product — views, summaries, APIs and governed data access
-carry the definition, coverage and confidence with the number (VISION §8.8).
+carry the definition, coverage and confidence with the number.
 
 **User scenarios in this class**
 - How do we pull this into our BI, a report, or a bot? — ADMIN, LEAD
@@ -264,7 +261,7 @@ carry the definition, coverage and confidence with the number (VISION §8.8).
 
 Comparison against the organization's own history by default; opt-in comparison against peers and
 public data where enabled. Every benchmark declares its source, cohort definition, coverage and
-confidence (VISION §8.9, §12).
+confidence.
 
 **User scenarios in this class**
 - Our three-day cycle — is that bad? — EXEC
@@ -272,11 +269,10 @@ confidence (VISION §8.9, §12).
 | Who | Does here | Must never meet |
 |---|---|---|
 | **EXEC** | own history first, which requires sharing nothing; peer comparison only where the customer has opted in | — |
-| **ADMIN** | participation on and off; it is revocable (VISION §12) | — |
+| **ADMIN** | participation on and off; it is revocable | — |
 
 **Not this:** raw customer data never leaves the customer boundary. Only anonymized aggregates at
-cohort, team or organization level are shared — never individual data, never stack ranking
-(VISION §3, §12.2).
+cohort, team or organization level are shared — never individual data, never stack ranking.
 
 ---
 
@@ -286,7 +282,7 @@ None of this is why anyone buys the product, and all of it has to work before th
 
 **These four are also a sequence.** A new customer walks them roughly in order — connect the sources
 (S-7), resolve who is who (S-8), configure roles, metrics and access (S-9), with the installation
-itself underneath (S-10) — and only then does the main tier hold anything. VISION §14.1 states the
+itself underneath (S-10) — and only then does the main tier hold anything. The vision states the
 same adoption path: connect, configure, run readiness, start with directional insight, improve
 evidence, validate. Listed last by importance; met first in time.
 
@@ -294,7 +290,7 @@ evidence, validate. Listed last by importance; met first in time.
 
 Whatever the wiring state, the product says so plainly: what is connected, what that unlocks, and —
 where an answer is not possible — the cause and the smallest set of fixes with the largest gain in
-confidence (readiness mode, VISION §7.5).
+confidence.
 
 **User scenarios in this class**
 - Which questions can I already ask, and which not? — ADMIN
@@ -303,7 +299,7 @@ confidence (readiness mode, VISION §7.5).
 
 | Who | Does here | Must never meet |
 |---|---|---|
-| **ADMIN** | all eight evidence categories as connected, partly connected or absent — people, work, communication, delivery, support, sales, cost, AI — and which metrics each unlocks; what each source declares about itself: fields, window, freshness, blind spots, and which level it supports — measurement, diagnosis, recommendation or validation (VISION §10.10); which links between systems are weak or broken, and what would repair them | being left to guess why a screen is empty |
+| **ADMIN** | all eight evidence categories as connected, partly connected or absent — people, work, communication, delivery, support, sales, cost, AI — and which metrics each unlocks; what each source declares about itself: fields, window, freshness, blind spots, and which level it supports — measurement, diagnosis, recommendation or validation; which links between systems are weak or broken, and what would repair them | being left to guess why a screen is empty |
 | **LEAD, EXEC** | the cause named directly — which source is missing, which identities are unresolved, which link is broken — plus the minimal fix | a comparison across two periods whose source windows do not overlap |
 | **IC** | the same guarantee on their own context | — |
 | **PEER** | the same guarantee, on the whole organization at once | — |
@@ -316,7 +312,7 @@ alarm. And no "rough estimate for now": the honest answer to a missing source is
 Someone who appears separately in code, tickets, chat and the HR system is recognised as one person,
 with a stated confidence. The customer can correct the result, the correction survives the next sync,
 and role and team history is preserved so past periods are not recalculated under a model that was not
-valid at the time (VISION §8.2, §7.2).
+valid at the time.
 
 **User scenarios in this class**
 - Which identity links did the system make, where is it unsure, where wrong? — ADMIN
@@ -326,21 +322,17 @@ valid at the time (VISION §8.2, §7.2).
 | Who | Does here | Must never meet |
 |---|---|---|
 | **ADMIN** | what was matched automatically, where the system is unsure, and where it got it wrong; merges and splits, reversibly; roles, several per person, and role history | losing a manual correction to the next sync |
-| **LEAD, EXEC** | a tree they can trust to roll up into (VISION §7.2 — temporal team membership) | a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it |
+| **LEAD, EXEC** | a tree they can trust to roll up into, with team membership kept per period | a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it |
 | **IC, PEER** | being one person, not four | their work attributed to a duplicate of themselves |
 
 **Not this:** where observed work does not match the configured role model, Insight recommends
-changing the configuration — not the person (VISION §9).
+changing the configuration — not the person.
 
 ## S-9 · Configuration and access · Service
 
-The customer configures roles, activities, sources, metrics, thresholds, cohorts, dashboards,
-localization and access rules (VISION §9). Access to raw, people-level, aggregate, cost and
-recommendation data is role-based and policy-controlled, and the boundary holds on every surface. Where
-a setting cannot yet be honoured, the gap is shown rather than implied — timezone is the live example:
-dates are bucketed in UTC while a period is chosen in the viewer's own zone, so an event near local
-midnight can land a day either side, and until sources carry people's timezones the divergence is
-labelled on the surface.
+The customer configures roles, sources, metrics, thresholds, cohorts, dashboards, localization and
+access rules. Each of the five kinds of data is granted separately, and the boundary holds on every
+surface.
 
 **User scenarios in this class**
 - How do I give a lead their team and nothing more? — ADMIN
@@ -349,21 +341,20 @@ labelled on the surface.
 
 | Who | Does here | Must never meet |
 |---|---|---|
-| **ADMIN** | grants the five kinds of data one by one; adapts roles, metrics and thresholds without engineering involvement; sets language, date, number, currency and timezone rules | holding all five kinds implicitly · a refusal only hidden on screen rather than enforced by the system |
+| **ADMIN** | grants the five kinds of data one by one; adapts roles, metrics and thresholds without engineering involvement; sets language, date, number, currency and timezone rules; where a setting cannot yet be honoured, the gap is labelled on the surface — timezone today, with dates bucketed in UTC while the period is chosen in the viewer's own zone | holding all five kinds implicitly · a refusal only hidden on screen rather than enforced by the system |
 | **LEAD** | their own team, in full, at every depth | one level up, or sideways — the limit is structural, not a filter on a screen |
 | **EXEC** | the organization as a whole: aggregates, and people where person-level access is granted; the underlying records only where granted | raw access as a privilege of rank — it is one of the five grants |
 | **PEER** | the organization as a whole, everyone by name — person-level sight is what the mode grants | records, cost or recommendations without their own grant |
 | **IC** | themselves — named to their own management chain and to anyone else granted person-level access for their part of the organization | being named to anyone outside it |
 
 **Not this:** Insight is read-only towards connected systems: it writes its own configuration and
-annotations, nothing else (VISION §13.3).
+annotations, nothing else.
 
 ## S-10 · Deployment, upgrade and migration · Service
 
 The product is installed, updated, upgraded and — where it replaces something — migrated into, without
-losing what already worked. Deployment models differ (Constructor-hosted, customer cloud, private
-cloud, customer-operated), and in all of them customer data stays under customer control (VISION §1,
-§14.1, §15.2).
+losing what already worked. Deployment models differ — Constructor-hosted, customer cloud, private
+cloud, customer-operated — and in all of them customer data stays under customer control.
 
 **User scenarios in this class**
 - How do we replace what we have without losing history? — ADMIN, EXEC
@@ -372,10 +363,10 @@ cloud, customer-operated), and in all of them customer data stays under customer
 |---|---|---|
 | **ADMIN** | install, configure, update and upgrade a customer-operated deployment; inventory what exists first, then keep, rename, replace or retire; import history where retention allows, and check parity over an agreed period | losing a surface that worked before an upgrade — what was live before it is checked after it |
 | **EXEC** | the previous system replaced with confidence — parity stated openly, including what could not be reproduced | a parity claim that quietly omits what could not be reproduced |
-| **LEAD, IC, PEER** | their history kept across the change (VISION §7.2) | a past period silently recalculated under a new model |
+| **LEAD, IC, PEER** | their history kept across the change | a past period silently recalculated under a new model |
 
 **Not this:** Insight does not require Constructor to have default access to customer data in order
-to operate (VISION §1).
+to operate.
 
 ---
 
@@ -383,23 +374,23 @@ to operate (VISION §1).
 
 From the vision, stated once here instead of repeated in each scenario.
 
-1. **Evidence gaps are shown, not hidden** (§3, §7.5) — never a zero for missing data, never an
+1. **Evidence gaps are shown, not hidden** — never a zero for missing data, never an
    approximate estimate in place of an answer.
-2. **Confidence and limitations travel with every conclusion** (§3) — a strong finding, a directional
+2. **Confidence and limitations travel with every conclusion** — a strong finding, a directional
    signal and an instrumentation problem stay distinguishable.
-3. **Lineage before attribution** (§7.3) — untraceable work is a gap, not a quiet claim.
-4. **No default ranking of named individuals, and no unexplained productivity scores** (§3) — people
+3. **Lineage before attribution** — untraceable work is a gap, not a quiet claim.
+4. **No default ranking of named individuals, and no unexplained productivity scores** — people
    are named where person-level access has been granted; the ranking is what is ruled out.
-5. **People-level access is role-based and policy-controlled** (§3, §9) — five kinds of data, granted
+5. **People-level access is role-based and policy-controlled** — five kinds of data, granted
    separately. The scope boundary holds by construction, not as a filter a screen applies: a viewer is
    handed their own part of the organization and cannot ask for more.
-6. **Cost movement is preserved, not folded away** (§11.4) — a local saving that shifts cost, risk or
+6. **Cost movement is preserved, not folded away** — a local saving that shifts cost, risk or
    effort downstream is shown as a shift; seat-based and usage-based cost are never one figure.
-7. **Insight observes and advises; people act** (§13.3) — it writes its own configuration and
+7. **Insight observes and advises; people act** — it writes its own configuration and
    annotations, nothing else.
-8. **Clean room** (§12.2) — raw data stays inside the customer boundary; only anonymized aggregates
+8. **Clean room** — raw data stays inside the customer boundary; only anonymized aggregates
    are shared, opt-in and revocable.
-9. **Role and activity are separate axes** (§7.2) — expected role model and observed activity are
+9. **Role and activity are separate axes** — expected role model and observed activity are
    compared, never conflated; history is kept under the model valid at the time.
 10. **Two group-size thresholds, and they are different** — a group figure is not shown below **four**
     people, and a comparative conclusion is not drawn below **eight** on each side. The first keeps an
@@ -416,43 +407,20 @@ From the vision, stated once here instead of repeated in each scenario.
 
 ---
 
-## Appendix B · Scenarios against VISION §8
-
-The vision lists nine product capabilities. The scenarios above are organised by what a person is
-doing rather than by capability, so the mapping is not one-to-one: configuration splits in two, and
-deployment comes from elsewhere in the vision.
-
-| VISION §8 capability | Scenario |
-|---|---|
-| 8.1 Source connection and evidence coverage | S-7 |
-| 8.2 Identity, role and organization model | S-8 |
-| 8.3 Work, outcome and cost lineage | No scenario of its own — nobody opens lineage. It is the rule S-2 and S-3 rest on (§5, rule 3), and repairing it is ADMIN work in S-7 |
-| 8.4 Measurement and metric definitions | S-1 |
-| 8.5 Analysis, diagnosis and forecasting | S-2 |
-| 8.6 Recommendation and validation | S-3 |
-| 8.7 Customer configuration | S-9 governs it — which metrics, cohorts and views may exist, and who may publish them; S-4 is where people exercise it |
-| 8.8 Exposure and consumption | S-5 |
-| 8.9 Benchmarks and shared intelligence | S-6 |
-| §1, §14.1, §15.2 — deployment models, adoption, migration | S-10 |
-
----
-
----
-
-## Appendix C · Open points
+## 6. Open points
 
 Several claims in this document go beyond what VISION.md and the scenario draft state. They are written
 as requirements because the alternative is to leave them undecided, but each needs a decision rather
 than a nod.
 
 - **Administrative rights and data visibility** — settled. §1 asserts that ADMIN gains no data
-  visibility implicitly, and the access model agrees: the identity service's visible-set predicate
-  carries no role term (ADR-0015), under either visibility mode.
+  visibility implicitly, and the access model agrees: the identity service computes an
+  administrator's visible set without the role, under either visibility mode.
 - **An executive is a manager with a larger subtree.** The product tells EXEC from LEAD only by how
   much of the organization reports to them, so anything this document gives EXEC and withholds from
   LEAD holds by scope, not by rule. An EXEC-only rule cannot be enforced until the product knows a
   title.
-- **Ranking in flat mode.** A PEER sees every other member's position band. VISION §3 rules out a
+- **Ranking in flat mode.** A PEER sees every other member's position band. The vision rules out a
   default view that ranks named individuals; a flat organization has opted into seeing everyone.
   Which of the two this is has to be decided before the mode is sold as a feature — and if the bands
   are a ranking, whether flat mode suppresses them or the customer accepts them.
@@ -462,7 +430,7 @@ than a nod.
 - **An identity correction surviving the next sync** (S-8). The draft says merges and splits are
   reversible; neither document says a correction is not undone by re-resolution. Stated here as a
   requirement, because a correction that does not survive is not a correction.
-- **The group-size thresholds** (§5, rule 10). The four for a group figure and the eight per side for a
+- **The group-size thresholds** (rule 10). The four for a group figure and the eight per side for a
   comparative conclusion come from the scenario draft rather than from the vision, and are worth
   confirming as product rules — including whether a customer may configure them. The five for a peer
   comparison is the product's own, and is the only one of the three confirmed to be enforced.

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -6,7 +6,8 @@ The vision says what Insight is and what it can do. This document says **who is 
 it, what they are there to do, and how far each of them may reach**. It adds no capability and changes
 no commitment.
 
-- **Personas** — the four target user groups of VISION §6.1.
+- **Personas** — the target user groups of VISION §6.1, as five *reach* personas across the two
+  visibility modes the product ships, plus the administrator role, which is a role and not a reach.
 - **Scenarios** — ten, in three tiers, ordered by what the product is for.
 - **Underneath** — the detailed user scenarios (Appendix A): thirty concrete questions, one person
   asking one thing at one moment, each traced to the scenario it belongs to.
@@ -26,13 +27,15 @@ product. **Secondary and service do not mean low priority on a roadmap**; they m
 not arrive for them.
 
 **Why split by persona.** A capability is not one scenario. "Review metrics" is a single tier, but it
-means three different things:
+means four different things:
 
 - an **individual contributor** sees their own work against a department or cohort median, and no team
   metrics at all;
 - a **team manager** sees their team, the people in it by name, and groups recalculated for that team
   rather than carried over from the organization;
-- an **executive** sees the whole organization.
+- an **executive** sees the whole organization;
+- a **member** of a flat organization sees everyone, because there is no tree to bound them — the
+  customer chose that mode, and the boundary is the organization itself.
 
 The activity is shared. The boundary is not, and the boundary is the part that gets lost in
 implementation. That is why it is written down as a statement rather than left implied.
@@ -52,39 +55,76 @@ implementation. That is why it is written down as a statement rather than left i
 
 ## 1. Personas
 
-The four target user groups of VISION §6.1, with the short codes used throughout.
+A persona here is a **reach** — how far someone may see — and reach comes from one of two sources,
+chosen per installation by the identity service's `visibility_policy`.
 
-| Code | Group (VISION §6.1) | Arrives asking |
+| Mode | Where reach comes from | Reach personas |
 |---|---|---|
-| **EXEC** | Executives and portfolio leaders | "Did it get better, or did we just get busier?" |
-| **LEAD** | Functional leaders and team managers | "Where exactly is work blocked, and what can I do?" |
-| **IC** | Functional teams and individual contributors | "How does my own work look, and what is in my way?" |
-| **ADMIN** | Data stewards and administrators | "Which of these numbers can be trusted, and who may see them?" |
+| `org_chart` | Reporting lines. A viewer sees themselves, the people who report to them, and whatever they have been granted on top. | EXEC · LEAD · IC |
+| `flat` | The organization. Every viewer sees everyone and the organization roll-up — the mode for a roster that carries no reporting lines. | MEMBER |
 
-Finance and product management are not separate personas here. Their questions are carried by these
-four: cost by EXEC, forward-looking planning by EXEC and LEAD. VISION §6.2 lists nine functions —
-engineering, product, design, DevOps, QA, support, sales, marketing, finance — and a functional lead
-in any of them is a LEAD.
+The mode belongs to the installation, not to a person, and the identity service reports it to every
+client (`GET /v1/me`), so a surface never infers it from an empty list of reports — a leaf IC and a
+MEMBER are served the same empty `subordinates`, and the policy is what tells them apart. Grants keep
+their meaning under either mode: underlying records, person-level data, cost and recommendations are
+still granted one by one (S-9).
+
+**ADMIN is orthogonal to both.** Administration is a role, not a reach. An administrator is also an
+IC, LEAD, EXEC or MEMBER underneath, and the role adds no visibility of its own — the visible-set
+predicate in the identity service has no role term (ADR-0015).
+
+| Code | Group (VISION §6.1) | Mode | Arrives asking | What a failure costs them | How the product knows it is them |
+|---|---|---|---|---|---|
+| **EXEC** | Executives and portfolio leaders | `org_chart` | "Did it get better, or did we just get busier?" | A board-level number that is wrong or unexplained | A manager whose subtree is the whole organization |
+| **LEAD** | Functional leaders and team managers | `org_chart` | "Where exactly is work blocked, and what can I do?" | Acting on a jam that is a data artefact | A manager whose subtree is smaller than the organization |
+| **IC** | Functional teams and individual contributors | `org_chart` | "How does my own work look, and what is in my way?" | Seeing a colleague's activity, or their own work misattributed | Nobody reports to them |
+| **MEMBER** | Functional teams and individual contributors, in a flat organization | `flat` | "How are we doing, and where do I stand?" | A comparison shown to the whole company that was never meant as a ranking | Any viewer, when the policy is `flat` |
+| **ADMIN** | Data stewards and administrators | both | "Which of these numbers can be trusted, and who may see them?" | Shipping a customer that silently proves nothing | Holds the admin role, whatever their reach |
+
+**EXEC and LEAD are one code path.** The product knows a manager and the size of their subtree; it
+does not know a title. Whatever §1.1 gives EXEC and withholds from LEAD — comparison across functions,
+organization-wide cost — holds because the subtree happens to be the whole organization, not because a
+rule enforces it. An EXEC-only rule cannot be enforced today, and a scenario that needs one should say
+so.
+
+**ADMIN carries two jobs, and the persona says so rather than splitting.** The steward's — who is who
+(S-8), who may see what (S-9), which recommendation families are on (S-3) — and the operator's —
+install, upgrade, migrate (S-10), wire sources (S-7). At most customers these are different people;
+in the product they are one role, and the persona keeps them together until the product can tell them
+apart.
 
 ### 1.1 Reach
 
 The boundary each persona carries into every scenario below.
 
-| | EXEC | LEAD | IC | ADMIN |
-|---|---|---|---|---|
-| **How far they see** | The whole organization | Their own team, and no further | Themselves | Settings, not people's data |
-| **How far they zoom** | Organization, function, team, person | Team, sub-team, group, their own reports | Themselves, with the department or cohort as a median | n/a |
-| **People by name** | Anyone, where person-level access is granted | The people reporting to them — that is what a team view is for | Themselves | Only while resolving who is who |
-| **Comparison** | Between functions, teams and people | Between groups inside their own team, and between their own reports | Against a median, never against a named colleague | n/a |
-| **Cost figures** | Where granted | Where granted | No | Where granted |
-| **Conclusions and advice** | Reads conclusions | Reads conclusions, receives recommendations | Neither | Neither |
-| **Never** | A default view that ranks people against one another · a number with no statement of coverage and confidence | Anything outside their own team · a default view that ranks their reports · group figures carried over from the organization instead of recalculated for the team | Any other person's activity · any team metric beyond the median they are placed against · their own place in a ranking | Administrative rights do **not** carry the right to see data — each kind is granted separately (VISION §9) |
+| | EXEC | LEAD | IC | MEMBER | ADMIN |
+|---|---|---|---|---|---|
+| **How far they see** | The whole organization | Their own team, and no further | Themselves | The whole organization — the same as EXEC | Settings, not people's data |
+| **How far they zoom** | Organization, function, team, person | Team, sub-team, group, their own reports | Themselves, with the department or cohort as a median | Organization, group, person | n/a |
+| **People by name** | Anyone, where person-level access is granted | The people reporting to them — that is what a team view is for | Themselves | Anyone in the roster | Only while resolving who is who |
+| **Comparison** | Between functions, teams and people | Between groups inside their own team, and between their own reports | Against a median, never against a named colleague | Between anyone, themselves included, against named colleagues | n/a |
+| **Cost figures** | Where granted | Where granted | No | Where granted | Where granted |
+| **Conclusions and advice** | Reads conclusions | Reads conclusions, receives recommendations | Neither | Where granted | Neither |
+| **Never** | A default view that ranks people against one another · a number with no statement of coverage and confidence | Anything outside their own team · a default view that ranks their reports · group figures carried over from the organization instead of recalculated for the team | Any other person's activity · any team metric beyond the median they are placed against · their own place in a ranking | A group figure below four people · a number with no statement of coverage and confidence · the IC boundary is **not** on this list — a flat organization has chosen transparency over it, and the surface says so instead of implying the median-only rule still holds | Administrative rights do **not** carry the right to see data — each kind is granted separately (VISION §9) |
 
 **Naming and ranking are different things, and only one is restricted.** People are named wherever
 person-level access has been granted: a manager's team view names their reports, and that is the point
 of it. What VISION §3 rules out is a *default* view that ranks named individuals against one another,
 or an unexplained productivity score. The line is the default surface and the granted scope — not the
 name.
+
+**Flat mode is where that line needs an explicit answer.** A MEMBER sees every other member's position
+band on the same screen. Whether that is a comparison the customer opted into by choosing the mode, or
+the default ranking §3 rules out, is undecided (Appendix C) — and it has to be decided in the document,
+not discovered in a demo.
+
+### 1.2 Function — the second axis
+
+Reach says how far a person may see. Function says what they are looking at. VISION §6.2 lists nine:
+Engineering / R&D, Product Management, Design / UX, DevOps / SRE, QA, Support, Sales, Marketing,
+Finance / FinOps. A function is applied per scenario, never per persona — a line reads `LEAD · Sales`
+or `EXEC · Finance`. Finance and product management are therefore not personas: their questions are
+carried by a reach persona in that function, and Appendix A names which.
 
 ---
 
@@ -470,16 +510,16 @@ per customer, since the connected source set differs.
 | B3 | Where is work stalling? | LEAD | S-1 |
 | B4 | What falls apart if a specific person drops out? | LEAD, EXEC | S-1 |
 | B5 | Where are we improving, and where just getting busier? | EXEC | S-1 |
-| B6 | How much does AI cost, who spends it, in what form? | EXEC † | S-1 |
+| B6 | How much does AI cost, who spends it, in what form? | EXEC · Finance | S-1 |
 | B8 | How much goes into coordination instead of work? | LEAD | S-1 |
 | C1 | Did throughput rise where AI was adopted, and what did it cost? | LEAD, EXEC | S-2 |
 | C2 | Is speed limited by writing code or by reviewing it? | LEAD | S-2 |
-| C3 | Speed went up — did quality hold? | LEAD † | S-2 |
-| C4 | Is this ticket spike caused by what we shipped? | LEAD † | S-2 |
+| C3 | Speed went up — did quality hold? | LEAD · Product | S-2 |
+| C4 | Is this ticket spike caused by what we shipped? | LEAD · Support | S-2 |
 | C5 | Activity rose — did the deals move? | LEAD, EXEC | S-2 |
-| C6 | Development got cheaper — did the cost move somewhere else? | EXEC † | S-2 |
-| E1 | Is it feasible, what will it cost, how long, what risks? | EXEC, LEAD † | S-2 |
-| E2 | Where is the effect larger for less effort? | EXEC † | S-2 |
+| C6 | Development got cheaper — did the cost move somewhere else? | EXEC · Finance | S-2 |
+| E1 | Is it feasible, what will it cost, how long, what risks? | EXEC, LEAD · Product | S-2 |
+| E2 | Where is the effect larger for less effort? | EXEC · Product | S-2 |
 | D1 | I can see the problem — what do I do? | LEAD | S-3 |
 | D2 | Was it applied? Did it help? | LEAD, EXEC | S-3 |
 | D3 | We had a reorg that month — how do I say so? | LEAD | S-3 |
@@ -498,9 +538,10 @@ per customer, since the connected source set differs.
 
 All thirty map to a scenario. S-6 is the only scenario with no concrete question behind it yet.
 
-**†** The source draft tags this question with a persona this document does not keep separate —
-product management or finance. The row shows the persona carrying it here (§1). Six such rows: B6 and
-C6 were finance, C3, C4, E1 and E2 were product management.
+Six questions arrive from a function rather than a reach — finance (B6, C6) and product management
+(C3, C4, E1, E2). Each is carried by a reach persona in that function (§1.2). In a `flat`
+installation, MEMBER may ask any question listed for EXEC, LEAD or IC; the reach personas name the
+`org_chart` case.
 
 ---
 
@@ -527,12 +568,17 @@ deployment comes from elsewhere in the vision.
 
 ## Appendix C · Open points
 
-Four claims in this document go beyond what VISION.md and the scenario draft state. They are written
+Several claims in this document go beyond what VISION.md and the scenario draft state. They are written
 as requirements because the alternative is to leave them undecided, but each needs a decision rather
 than a nod.
 
-- **Administrative rights and data visibility.** §1.1 asserts that ADMIN gains no data visibility
-  implicitly. Worth confirming against the access model rather than the interface.
+- **Administrative rights and data visibility** — settled. §1.1 asserts that ADMIN gains no data
+  visibility implicitly, and the access model agrees: the identity service's visible-set predicate
+  carries no role term (ADR-0015), under either visibility mode.
+- **Ranking in flat mode.** A MEMBER sees every other member's position band. VISION §3 rules out a
+  default view that ranks named individuals; a flat organization has opted into seeing everyone.
+  Which of the two this is has to be decided before the mode is sold as a feature — and if the bands
+  are a ranking, whether flat mode suppresses them or the customer accepts them.
 - **Saved and shared views** (S-4). Composing a view is in the vision; *saving* it and *sharing* it are
   not. If sharing exists, the access rule has to come with it — what each viewer sees, re-evaluated for
   them — and that is far cheaper to decide before the feature than after.

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -6,68 +6,33 @@ The vision says what Insight is and what it can do. This document says **who is 
 it, what they are there to do, and how far each of them may reach**. It adds no capability and changes
 no commitment.
 
-- **Personas** — the vision's target user groups, as five *reach* personas across the two
-  visibility modes the product ships, plus the administrator role, which is a role and not a reach.
+- **Personas** — the vision's target user groups, as four *reach* personas across the two visibility
+  modes the product ships, plus the administrator role, which is a role and not a reach.
 - **Scenarios** — ten, in three tiers, ordered by what the product is for. Each one is a class of
-  user scenarios: the concrete questions people bring, and what each persona does and must never meet
-  while answering them.
-
-## The three tiers
-
-| Tier | What it is | Scenarios |
-|---|---|---|
-| **Main** | Review metrics, analyse them, reach conclusions — and, looking forward, estimate work not yet started. This is what the product is for. | [S-1](#s-1--metrics-review--main), [S-2](#s-2--analysis-and-diagnosis--main), [S-3](#s-3--conclusions-recommendation-and-validation--main) |
-| **Secondary** | Build new views, explore, take the output elsewhere, compare with the outside world. | [S-4](#s-4--dashboards-views-and-exploration--secondary), [S-5](#s-5--sharing-and-reuse--secondary), [S-6](#s-6--external-comparison--secondary) |
-| **Service** | Set the product up, keep it configured, keep it running. | [S-7](#s-7--sources-and-evidence-coverage--service), [S-8](#s-8--identity-roles-and-organization-model--service), [S-9](#s-9--configuration-and-access--service), [S-10](#s-10--deployment-upgrade-and-migration--service) |
-
-The order is by importance to the reader, not by build order. Technically the service tier comes
-first — sources and identity have to be right before a metric can be — but a customer does not buy
-setup, and a scenario list that opens with configuration describes an installation rather than a
-product. **Secondary and service do not mean low priority on a roadmap**; they mean a customer does
-not arrive for them.
-
-**Why split by persona.** A capability is not one scenario. "Review metrics" is a single tier, but it
-means four different things:
-
-- an **individual contributor** sees their own work against a department or cohort median, and no team
-  metrics at all;
-- a **team manager** sees their team, the people in it by name, and groups recalculated for that team
-  rather than carried over from the organization;
-- an **executive** sees the whole organization;
-- a **peer** in a flat organization sees everyone, because there is no tree to bound them — the
-  customer chose that mode, and the boundary is the organization itself.
-
-The activity is shared. The boundary is not, and the boundary is the part that gets lost in
-implementation. That is why it is written down as a statement rather than left implied.
-
-**How to read this document**
-
-- A **persona block** has fixed labels in a fixed order, so the same label answers the same question
-  for every persona.
-- A **scenario block** is a title, one sentence that holds for everyone, the user scenarios in the
-  class with who asks each, a table of what each persona does here and what they must never meet, and
-  *Not this* — what the scenario deliberately does not do, so it is not promised in a demo.
+  user scenarios: per persona, the questions they bring, what they can see and do, and their
+  boundaries.
 
 ---
 
 ## 1. Personas
 
+Each persona block has the same labels in the same order, so one label answers one question for
+every persona. The block is the one home of *how far they see*; the scenarios say what is done
+with that reach.
+
 A persona here is a **reach** — how far someone may see — and reach comes from one of two sources,
-chosen per installation by the identity service's `visibility_policy`.
+chosen per installation.
 
 | Mode | Where reach comes from | Reach personas |
 |---|---|---|
-| `org_chart` | Reporting lines. A viewer sees themselves, the people who report to them, and whatever they have been granted on top. | EXEC · LEAD · IC |
-| `flat` | The organization. Every viewer sees everyone and the organization roll-up — the mode for a roster that carries no reporting lines. | PEER |
+| **Reporting lines** (`org_chart`) | A viewer sees themselves, the people who report to them, and whatever they have been granted on top. | EXEC · LEAD · IC |
+| **Flat** (`flat`) | Every viewer sees everyone and the organization roll-up — the mode for a roster that carries no reporting lines. | PEER |
 
-The mode belongs to the installation, not to a person, and the identity service reports it to every
-client (`GET /v1/me`) — a leaf IC and a PEER are served the same empty `subordinates`, and the policy
-is what tells them apart. Grants keep their meaning under either mode: underlying records, aggregates,
-person-level data, cost and recommendations are still granted one by one ([S-9](#s-9--configuration-and-access--service)).
+The mode is set once per installation, never per person. Each kind of data is still granted
+separately under either mode ([rule 5](#6-rules-that-hold-in-every-scenario)).
 
 **ADMIN is orthogonal to both.** Administration is a role, not a reach. An administrator is also an
-IC, LEAD, EXEC or PEER underneath, and the role adds no visibility of its own — the identity
-service's own design records that an administrator's visible set is computed without the role.
+IC, LEAD, EXEC or PEER underneath, and the role adds no visibility of its own.
 
 **Function is the second axis.** Reach says how far a person may see; function says what they are
 looking at. The vision lists nine functions — Engineering / R&D, Product Management, Design / UX,
@@ -76,46 +41,45 @@ scenario, never per persona: a question is asked by *a sales lead*, or by *EXEC,
 Finance and product management are therefore not personas; their questions are carried by a reach
 persona in that function.
 
-#### EXEC · an executive or portfolio leader
+### EXEC · an executive or portfolio leader
 
 - **Who:** a manager whose subtree is the whole organization — the product tells an executive from a
   manager only by how much of the organization reports to them, never by a title
-- **Mode:** org_chart
+- **Mode:** reporting lines
 - **Lands on:** the organization roll-up
 - **Asks:** "Did it get better, or did we just get busier?"
 - **Sees:** the whole organization; anyone by name where person-level access is granted
 - **May compare:** functions, teams and people with one another
 
-#### LEAD · a functional leader or team manager
+### LEAD · a functional leader or team manager
 
 - **Who:** a manager whose subtree is smaller than the organization
-- **Mode:** org_chart
+- **Mode:** reporting lines
 - **Lands on:** their team's roll-up
 - **Asks:** "Where exactly is work blocked, and what can I do?"
-- **Sees:** their own team at any depth, the people in it by name, and no further
+- **Sees:** their own team at any depth, and the people in it by name
 - **May compare:** groups inside their own team, and their own reports with one another
 
-#### IC · an individual contributor in a hierarchy
+### IC · an individual contributor in a hierarchy
 
 - **Who:** nobody reports to them
-- **Mode:** org_chart
+- **Mode:** reporting lines
 - **Lands on:** their own page
 - **Asks:** "How does my own work look, and what is in my way?"
-- **Sees:** themselves, with the department or cohort as a median; no cost figures, and no conclusions
-  or advice
+- **Sees:** themselves, with the department or cohort as a median
 - **May compare:** nothing — they are placed against a department or cohort median, never against a
   named colleague
 
-#### PEER · a member of a flat organization
+### PEER · a member of a flat organization
 
-- **Who:** any signed-in person when the visibility policy is `flat`
+- **Who:** any signed-in person when the installation runs flat
 - **Mode:** flat
 - **Lands on:** the organization roll-up, the same landing as a manager
 - **Asks:** "How are we doing, and where do I stand among my peers?"
 - **Sees:** the whole organization, everyone by name, themselves included
 - **May compare:** anyone with anyone; the organization is the only cohort
 
-#### ADMIN · a data steward or administrator
+### ADMIN · a data steward or administrator
 
 - **Who:** holds the admin role, whatever their reach. Two jobs in one persona — the *steward* decides
   who is who and who may see what; the *operator* installs, upgrades, migrates and wires sources. At
@@ -123,254 +87,252 @@ persona in that function.
 - **Mode:** both
 - **Lands on:** Manage
 - **Asks:** "Which of these numbers can be trusted, and who may see them?"
-- **Sees:** settings, not people's data — the role adds no visibility of its own
-- **May compare:** nothing — the role sees settings, not people
+- **Sees:** settings, not people's data
+- **May compare:** nothing
 
 ---
 
-# 2. Main — review, analysis, conclusions
+## 2. Scenarios
+
+Ten, in three tiers, ordered by what the product is for.
+
+| Tier | What it is | Scenarios |
+|---|---|---|
+| **Main** | Review metrics, analyse them, reach conclusions — and, looking forward, estimate work not yet started. This is what the product is for. | [S-1](#s-1--metrics-review), [S-2](#s-2--analysis-and-diagnosis), [S-3](#s-3--conclusions-recommendation-and-validation) |
+| **Secondary** | Build new views, explore, take the output elsewhere, compare with the outside world. | [S-4](#s-4--dashboards-views-and-exploration), [S-5](#s-5--sharing-and-reuse), [S-6](#s-6--external-comparison) |
+| **Service** | Set the product up, keep it configured, keep it running. | [S-7](#s-7--sources-and-evidence-coverage), [S-8](#s-8--identity-roles-and-organization-model), [S-9](#s-9--configuration-and-access), [S-10](#s-10--deployment-upgrade-and-migration) |
+
+The order is by importance to the reader, not by build order: the service tier has to work first, but
+a customer does not arrive for it.
+
+**How to read a scenario**
+
+- A **scenario block** is a title, one sentence that holds for everyone, and a table with one row per
+  persona: their *user scenarios* here, what they *can see and do*, and their *boundaries* — then
+  *Not this*, what the scenario deliberately does not do, and where the current state differs from
+  the promise, *Today*.
+- A *boundary* is observable: the thing is absent from every response the persona can obtain, or it
+  is withheld with a stated reason. A cell says *and says why* where the reason must be shown.
+- A `—` in *Boundaries* means nothing beyond [Configuration and access](#s-9--configuration-and-access) — that boundary holds in every scenario.
+- In *User scenarios*, *a … lead* in any function is LEAD, and *everyone* is every persona.
+
+**Who appears in which scenario**
+
+| | EXEC | LEAD | IC | PEER | ADMIN |
+|---|---|---|---|---|---|
+| [S-1](#s-1--metrics-review) Metrics review | ✓ | ✓ | ✓ | ✓ | nothing by default |
+| [S-2](#s-2--analysis-and-diagnosis) Analysis and diagnosis | ✓ | ✓ | not an audience | ✓ | see [Sources and evidence coverage](#s-7--sources-and-evidence-coverage) |
+| [S-3](#s-3--conclusions-recommendation-and-validation) Conclusions | ✓ | ✓ | never the subject | undecided | ✓ |
+| [S-4](#s-4--dashboards-views-and-exploration) Dashboards and exploration | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [S-5](#s-5--sharing-and-reuse) Sharing and reuse | ✓ | ✓ | — | — | ✓ |
+| [S-6](#s-6--external-comparison) External comparison | ✓ | — | — | — | ✓ |
+| [S-7](#s-7--sources-and-evidence-coverage) Sources and evidence coverage | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [S-8](#s-8--identity-roles-and-organization-model) Identity and organization model | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [S-9](#s-9--configuration-and-access) Configuration and access | ✓ | ✓ | ✓ | ✓ | ✓ |
+| [S-10](#s-10--deployment-upgrade-and-migration) Deployment and migration | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+---
+
+## 3. Main — review, analysis, conclusions
 
 The loop the product exists for: measure → diagnose → recommend → validate.
 
-## S-1 · Metrics review · Main
+### S-1 · Metrics review
 
-Every number carries a governed definition, unit, granularity, confidence and stated limitations, and
-is worked out the same way for every persona and every scope.
+Every number carries a governed definition, unit, granularity, confidence and stated limitations, is
+worked out the same way for every persona and scope, and covers the period the viewer chooses — a
+week by default.
 
-**User scenarios in this class**
-- What is visible about me, and what is in my way? — IC
-- What changed for my team over the period? — LEAD
-- Where is work stalling? — LEAD
-- What falls apart if a specific person drops out? — LEAD, EXEC
-- Where are we improving, and where just getting busier? — EXEC
-- How much does AI cost, who spends it, in what form? — EXEC, from finance
-- How much goes into coordination instead of work? — LEAD
-- How are we doing, and where do I stand among my peers? — PEER
+| Who | User scenarios | Can see and do | Boundaries |
+|---|---|---|---|
+| **EXEC** | Where are we improving, and where just getting busier? · What falls apart if a specific person drops out? — with the person-level grant · How much does AI cost, who spends it, in what form? — from finance | organization, function and team over time · coverage counted from people who have data, never by treating missing data as zero | a default view that ranks people · a number without its coverage |
+| **LEAD** | What changed for my team over the period? · Where is work stalling? · What falls apart if a specific person drops out? — with the person-level grant · How much goes into coordination instead of work? | their team at any depth, people by name · group figures recalculated for the team on screen · concentration read with its domain's meaning, and the surface says which | a team they do not manage · a group figure for fewer than four people · a team figure equal to the organization's when the team's own data would give another |
+| **IC** | What is visible about me, and what is in my way? | their own activity, flow and AI usage against the department or cohort median — shown only when five or more people have data | another person's activity · any team metric beyond that median · their own rank |
+| **PEER** | How are we doing, and where do I stand among my peers? | the whole organization as one scope, everyone named · their own page against the organization median | a peer comparison with fewer than five people who have data |
+| **ADMIN** | — | nothing by default | — |
 
-| Who | Does here | Must never meet |
-|---|---|---|
-| **EXEC** | organization, function and team, with change over time; coverage counted from people who actually have data, never by treating missing data as zero | a default view that ranks people against one another · a number without its coverage |
-| **LEAD** | their own team at any depth, the people in it by name; groups recalculated for the team in view; concentration read with the meaning of its domain — in code and documentation a high top-decile share is a bus-factor risk, in communication a load imbalance, and the surface says which | a team they do not manage · a group figure below four people · a group figure carried over from the organization |
-| **IC** | their own activity, flow and AI usage, with the department or cohort as a median | another person's activity · any team metric beyond that median · their own rank |
-| **PEER** | the whole organization as one scope, themselves included, every member named; their own page against the organization as the median | a peer comparison below five people |
-| **ADMIN** | nothing by default | data visibility from the role alone |
+**Not this:** no single "value of AI" number — seat and usage cost are never summed, and unattributed
+cost stays its own line.
 
-**Not this:** no single "value of AI" number — seat-based and usage-based cost are never summed into
-one figure, and unattributed cost stays its own line rather than being spread across the rest.
-
-## S-2 · Analysis and diagnosis · Main
+### S-2 · Analysis and diagnosis
 
 The product stops showing shape and starts asserting a relationship — bottlenecks, risks, anomalies,
 cost drivers, quality issues, role and activity mismatches — and says which kind of claim it is making,
 with confidence and limitations. Looking forward is the same scenario in the other direction: deciding
 what to commit to, from the organization's own delivery history.
 
-**User scenarios in this class**
-- Did throughput rise where AI was adopted, and what did it cost? — LEAD, EXEC
-- Is speed limited by writing code or by reviewing it? — LEAD
-- Speed went up — did quality hold? — an engineering or product lead
-- Is this ticket spike caused by what we shipped? — a support or product lead
-- Activity rose — did the deals move? — a sales lead, or EXEC
-- Development got cheaper — did the cost move somewhere else? — EXEC, from finance
-- Is it feasible, what will it cost, how long, what risks? — a product lead, or EXEC
-- Where is the effect larger for less effort? — EXEC, or a product lead
-
-| Who | Does here | Must never meet |
-|---|---|---|
-| **LEAD** | a conclusion for their team or cohort, with the evidence behind it; where the chain of evidence breaks in their own area, and what would repair it; for proposed work, feasibility, cost, duration and risk from the organization's own history | a verdict about a named individual · a comparative conclusion with fewer than eight people on each side — the surface does not render it, and says why · a conclusion built on a metric known to be defective; it is excluded by name, and the exclusion is stated |
-| **EXEC** | the same at organization level; cost and outcome followed to the function, team, product or service as far as the trail goes; ranked opportunities where the expected effect is larger for less effort | attribution stronger than the lineage supports · a causal claim where the evidence supports a correlation · a forecast presented as a guarantee — it is an extrapolation that strengthens as history and lineage improve |
-| **PEER** | the same as EXEC at organization level, with one cohort: the comparison is against the organization's own history, because there is no second group to compare with | the same as EXEC |
-| **IC** | not an audience for diagnosis | a named example inside one |
-
-What limits a conclusion — which sources are missing, which windows do not overlap, which metric is
-under a known defect — is an administrator's view, and it lives in [S-7](#s-7--sources-and-evidence-coverage--service).
+| Who | User scenarios | Can see and do | Boundaries |
+|---|---|---|---|
+| **EXEC** | Did throughput rise where AI was adopted, and what did it cost? · Activity rose — did the deals move? · Development got cheaper — did the cost move somewhere else? — from finance · Is it feasible, what will it cost, how long, what risks? — from product · Where is the effect larger for less effort? — from product | the same as LEAD at organization level · cost and outcome followed to the function, team, product or service as far as the trail goes · ranked opportunities where the effect is larger for less effort | attribution stronger than the lineage supports · a causal claim where the evidence supports a correlation · a forecast presented as a guarantee |
+| **LEAD** | Did throughput rise where AI was adopted, and what did it cost? · Is speed limited by writing code or by reviewing it? · Speed went up — did quality hold? — an engineering or product lead · Is this ticket spike caused by what we shipped? — a support or product lead · Activity rose — did the deals move? — a sales lead · Is it feasible, what will it cost, how long, what risks? — a product lead | a conclusion for their team or cohort, with the evidence behind it · where the chain of evidence breaks in their area, and what would repair it · feasibility, cost, duration and risk of proposed work from the organization's own history | a verdict about a named individual · a comparative conclusion with fewer than eight people on each side — withheld, and says why · a conclusion built on a metric known to be defective — excluded by name, and says why |
+| **IC** | — | not an audience for diagnosis | a named example inside one |
+| **PEER** | any of EXEC's or LEAD's questions, at organization level | the same as EXEC, with one cohort: the comparison is against the organization's own history | records, cost or recommendations without their own grant · a causal claim where the evidence supports a correlation |
+| **ADMIN** | — | not here — what limits a conclusion is their view in [Sources and evidence coverage](#s-7--sources-and-evidence-coverage) | — |
 
 **Not this:** "AI sped up development by X%" is not a claim Insight makes; what it can say is that a
 cohort with high usage differs from one with low usage in stated ways, correlationally — with the word
-said on the surface, not in a footnote. Attribution reaches person × day × tool and no further, so
-"this change was written by AI" and "this change cost $N" are not claims Insight makes either. And
-work that cannot be traced is shown as an evidence gap, never converted into a confident claim.
+said on the surface. Attribution reaches person × day × tool and no further, so "this change was
+written by AI" and "this change cost $N" are not claims Insight makes either. Work that cannot be
+traced is shown as an evidence gap, never converted into a confident claim.
 
-## S-3 · Conclusions: recommendation and validation · Main
+### S-3 · Conclusions: recommendation and validation
 
-A recommendation is a structured improvement object: observed problem, affected area,
-evidence and confidence, recommended action, owner, expected metric movement, and the follow-up window
-used to check it. Its origin is declared — evidence-derived from the customer's own data, or heuristic
-— and afterwards the product reads the outcome from the measured system.
+A recommendation is one lever from a fixed set, with a named owner, the evidence and confidence behind
+it, what should move as a result, which guardrail must not slip, and a four-week window — counted from
+the day it is issued — after which the product reads the outcome from the measured system; its origin
+is declared, evidence-derived from the customer's own data or heuristic.
 
-**User scenarios in this class**
-- I can see the problem — what do I do? — LEAD
-- Was it applied? Did it help? — LEAD, EXEC
-- We had a reorg that month — how do I say so? — LEAD
+| Who | User scenarios | Can see and do | Boundaries |
+|---|---|---|---|
+| **EXEC** | Was it applied? Did it help? | one of four answers: the lever moved and the outcome moved · the lever moved and the outcome did not · the lever did not move · not enough data — when either side has fewer than eight people · read four weeks before against four weeks after, against a control: a group in the same size band that received no recommendation | a result assembled from metrics chosen after the fact — they are fixed when the recommendation is issued · a detector hunting for a shift, which on a team of ten finds noise |
+| **LEAD** | I can see the problem — what do I do? · Was it applied? Did it help? · We had a reorg that month — how do I say so? | one lever they can own, with how it is measured, what should move, the guardrail, and the check date | a recommendation that judges a named individual rather than a process, team or cohort — an owner is named, a subject is not · a recommendation whose origin is unstated |
+| **IC** | — | — | being the subject of a recommendation |
+| **PEER** | — | undecided — a recommendation names an owner, and a flat organization has no lead (see [Open points](#7-open-points)) | — |
+| **ADMIN** | — | which recommendation families are enabled, who owns them, and how validation windows are defined | — |
 
-| Who | Does here | Must never meet |
-|---|---|---|
-| **LEAD** | one lever they can own, from a fixed set rather than composed freely — three in the first version: reduce change size, spread review load, raise AI adoption where it is low at comparable load — with how the lever is measured, what should move, which guardrail must not slip, and when it is checked: four weeks, computed automatically | a recommendation that passes judgement on a named individual rather than a process, team or cohort — a named *owner* is expected, a named *subject* is not · a recommendation whose origin is unstated |
-| **EXEC** | whether the lever moved, whether the outcome moved, and the honest fourth answer: not enough data; read over a fixed window, four weeks before against four weeks after, and against a control — a comparable group that received no recommendation | a result assembled from metrics chosen after the fact — they are fixed when the recommendation is issued · a detector hunting for a shift, which on a team of ten finds noise |
-| **PEER** | undecided — a recommendation names an owner, and a flat organization has no lead to own a lever (see [Open points](#6-open-points)) | — |
-| **ADMIN** | which recommendation families are enabled, who owns them, and how validation windows are defined | — |
-| **IC** | — | being the subject of a recommendation |
+**Not this:** no surveys, and no self-reporting of any kind as an input — a validation that depends on
+people filling in a form does not run. Insight recommends; it does not execute ([rule 7](#6-rules-that-hold-in-every-scenario)).
 
-**Not this:** no surveys, and no self-reporting of any kind as an input — not because opinions do not
-matter, but because a validation that depends on people filling in a form does not run. Validation is
-read from the measured system. Insight recommends; it does not execute.
+**Today:** three levers — reduce change size, spread review load, raise AI adoption where it is low at
+comparable load.
 
 ---
 
-# 3. Secondary — new views, exploration, reuse
+## 4. Secondary — new views, exploration, reuse
 
 Everything here extends the main loop. None of it is where a customer starts.
 
-## S-4 · Dashboards, views and exploration · Secondary
+### S-4 · Dashboards, views and exploration
 
 Someone builds a view rather than reading one: composing dashboards from the metric and recommendation
 catalog, slicing by an attribute, defining a cohort, and following a figure back to how it was
 calculated. Exploration moves the question, never the boundary.
 
-**User scenarios in this class**
-- How does group A differ from group B in the same scope? — LEAD, EXEC
-- The slicing side of every [S-1](#s-1--metrics-review--main) question — who asks it there asks it here
+Boundaries are those of [Configuration and access](#s-9--configuration-and-access); this table lists only what the scenario adds.
 
-| Who | Does here | Must never meet |
-|---|---|---|
-| **LEAD** | compose from the catalog; slice by attribute; define cohorts and comparison groups; follow any figure back to how it was calculated; groups recalculated for whatever is on screen at the time | an exploration path that reaches outside their own team · a group figure below four people |
-| **EXEC** | the same, at organization and function level | — |
-| **PEER** | views over the whole organization; the same as EXEC | — |
-| **IC** | their own context only | — |
-| **ADMIN** | which metrics and thresholds exist, which cohorts are valid, who may publish a shared view | — |
+| Who | User scenarios | Can see and do | Boundaries |
+|---|---|---|---|
+| **EXEC** | How does group A differ from group B in the same scope? · How does the same figure split by one attribute? | the same as LEAD, at organization and function level | a follow-back from a figure that reaches underlying records without that grant |
+| **LEAD** | How does group A differ from group B in the same scope? · How does the same figure split by one attribute? | compose from the catalog · slice by attribute · define cohorts and comparison groups · follow any figure back to how it was calculated · groups recalculated for what is on screen | an exploration path that reaches outside their own team · a group figure for fewer than four people · a follow-back that reaches underlying records without that grant |
+| **IC** | — | their own context only | a follow-back that reaches underlying records without that grant |
+| **PEER** | the same as LEAD, over the whole organization | views over the whole organization; the same as EXEC | a follow-back that reaches underlying records without that grant |
+| **ADMIN** | — | which metrics and thresholds exist, which cohorts are valid, who may publish a shared view | — |
 
-**Not this:** a view carries the definitions and coverage of the metrics in it, never bare numbers.
-Saving a composed view and sharing it are proposals rather than restatements (see [Open points](#6-open-points)): if a view
-can be shared, what a viewer sees has to be re-evaluated for that viewer, so a shared dashboard cannot
-become a way around access rules — which is why it needs deciding before view sharing is built.
+**Not this:** a saved or shared view (see [Open points](#7-open-points)).
 
-## S-5 · Sharing and reuse · Secondary
+### S-5 · Sharing and reuse
 
 A number keeps its meaning when it leaves the product — views, summaries, APIs and governed data access
-carry the definition, coverage and confidence with the number.
+carry its definition, coverage and confidence with it.
 
-**User scenarios in this class**
-- How do we pull this into our BI, a report, or a bot? — ADMIN, LEAD
+Boundaries are those of [Configuration and access](#s-9--configuration-and-access); this table lists only what the scenario adds.
 
-| Who | Does here | Must never meet |
-|---|---|---|
-| **ADMIN** | API and governed data access, under the same access rules that apply inside the product | a number stripped of its definition and confidence, so that outside the product it becomes a fact without caveats |
-| **LEAD** | a conclusion in their own report or review | — |
+| Who | User scenarios | Can see and do | Boundaries |
+|---|---|---|---|
+| **ADMIN** | How do we pull this into our BI, a report, or a bot? | API and governed data access, under the access rules that apply inside the product | a number stripped of its definition and confidence — outside the product it becomes a fact without caveats |
+| **LEAD, EXEC** | How do we pull this into our BI, a report, or a bot? | a conclusion in their own report or review, upward or outward | — |
 
-## S-6 · External comparison · Secondary
+**Not this:** none.
+
+### S-6 · External comparison
 
 Comparison against the organization's own history by default; opt-in comparison against peers and
 public data where enabled. Every benchmark declares its source, cohort definition, coverage and
 confidence.
 
-**User scenarios in this class**
-- Our three-day cycle — is that bad? — EXEC
+Boundaries are those of [Configuration and access](#s-9--configuration-and-access); this table lists only what the scenario adds.
 
-| Who | Does here | Must never meet |
-|---|---|---|
-| **EXEC** | own history first, which requires sharing nothing; peer comparison only where the customer has opted in | — |
-| **ADMIN** | participation on and off; it is revocable | — |
+| Who | User scenarios | Can see and do | Boundaries |
+|---|---|---|---|
+| **EXEC** | Our three-day cycle — is that bad? | own history first, which requires sharing nothing · peer comparison only where the customer has opted in | — |
+| **ADMIN** | — | participation on and off; it is revocable | — |
 
-**Not this:** raw customer data never leaves the customer boundary. Only anonymized aggregates at
-cohort, team or organization level are shared — never individual data, never stack ranking.
+**Not this:** raw customer data leaving the customer boundary — only anonymized aggregates at cohort,
+team or organization level are shared, never individual data, never stack ranking
+([rule 8](#6-rules-that-hold-in-every-scenario)).
+
+**Today:** no surface.
 
 ---
 
-# 4. Service — setup, configuration, operation
+## 5. Service — setup, configuration, operation
 
-None of this is why anyone buys the product, and all of it has to work before the rest does.
+None of this is why anyone buys the product, and all of it has to work before the rest does. The four
+are also a sequence — connect the sources, resolve who is who, configure roles, metrics and access,
+with the installation itself underneath — and only then does the main tier hold anything.
 
-**These four are also a sequence.** A new customer walks them roughly in order — connect the sources
-([S-7](#s-7--sources-and-evidence-coverage--service)), resolve who is who ([S-8](#s-8--identity-roles-and-organization-model--service)), configure roles, metrics and access ([S-9](#s-9--configuration-and-access--service)), with the installation
-itself underneath ([S-10](#s-10--deployment-upgrade-and-migration--service)) — and only then does the main tier hold anything. The vision states the
-same adoption path: connect, configure, run readiness, start with directional insight, improve
-evidence, validate. Listed last by importance; met first in time.
-
-## S-7 · Sources and evidence coverage · Service
+### S-7 · Sources and evidence coverage
 
 Whatever the wiring state, the product says so plainly: what is connected, what that unlocks, and —
 where an answer is not possible — the cause and the smallest set of fixes with the largest gain in
 confidence.
 
-**User scenarios in this class**
-- Which questions can I already ask, and which not? — ADMIN
-- Why is this empty, and what would make it not empty? — ADMIN, LEAD
-- Is this an event in the business, or a break in the data? — ADMIN, LEAD, EXEC
+Boundaries are those of [Configuration and access](#s-9--configuration-and-access); this table lists only what the scenario adds.
 
-| Who | Does here | Must never meet |
-|---|---|---|
-| **ADMIN** | all eight evidence categories as connected, partly connected or absent — people, work, communication, delivery, support, sales, cost, AI — and which metrics each unlocks; what each source declares about itself: fields, window, freshness, blind spots, and which level it supports — measurement, diagnosis, recommendation or validation; which links between systems are weak or broken, and what would repair them | being left to guess why a screen is empty |
-| **LEAD, EXEC** | the cause named directly — which source is missing, which identities are unresolved, which link is broken — plus the minimal fix | a comparison across two periods whose source windows do not overlap |
-| **IC** | the same guarantee on their own context | — |
-| **PEER** | the same guarantee, on the whole organization at once | — |
+| Who | User scenarios | Can see and do | Boundaries |
+|---|---|---|---|
+| **ADMIN** | Which questions can I already ask, and which not? · Why is this empty, and what would make it not empty? · Is this an event in the business, or a break in the data? | all eight evidence categories as connected, partly connected or absent — people, work, communication, delivery, support, sales, cost, AI — and which metrics each unlocks · what each source declares about itself: fields, window, freshness, blind spots, and the level it supports · which links between systems are weak or broken, and what would repair them | being left to guess why a screen is empty |
+| **LEAD, EXEC** | Why is this empty, and what would make it not empty? · Is this an event in the business, or a break in the data? | the cause named directly — which source is missing, which identities are unresolved, which link is broken — plus the minimal fix | a comparison across two periods whose source windows do not overlap, rendered as a plain number — it is withheld, and the source is named |
+| **IC, PEER** | — | the same guarantee, on their own context or on the whole organization | — |
 
-**Not this:** no zero in place of missing data — a zero looks like a measurement and raises a false
-alarm. And no "rough estimate for now": the honest answer to a missing source is what is missing.
+**Not this:** a zero in place of missing data, or a "rough estimate for now" — the honest answer to a
+missing source is what is missing ([rule 1](#6-rules-that-hold-in-every-scenario)).
 
-## S-8 · Identity, roles and organization model · Service
+### S-8 · Identity, roles and organization model
 
 Someone who appears separately in code, tickets, chat and the HR system is recognised as one person,
 with a stated confidence. The customer can correct the result, the correction survives the next sync,
-and role and team history is preserved so past periods are not recalculated under a model that was not
-valid at the time.
+and role and team history is preserved so past periods are not recalculated under a model that was
+not valid at the time.
 
-**User scenarios in this class**
-- Which identity links did the system make, where is it unsure, where wrong? — ADMIN
-- How do I tell the product who is supposed to do what here? — ADMIN
-- Someone is listed in one role and does another — error or reality? — LEAD, ADMIN
-
-| Who | Does here | Must never meet |
-|---|---|---|
-| **ADMIN** | what was matched automatically, where the system is unsure, and where it got it wrong; merges and splits, reversibly; roles, several per person, and role history | losing a manual correction to the next sync |
-| **LEAD, EXEC** | a tree they can trust to roll up into, with team membership kept per period | a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it |
-| **IC, PEER** | being one person, not four | their work attributed to a duplicate of themselves |
+| Who | User scenarios | Can see and do | Boundaries |
+|---|---|---|---|
+| **ADMIN** | Which identity links did the system make, where is it unsure, where wrong? · How do I tell the product who is supposed to do what here? · Someone is listed in one role and does another — error or reality? | what was matched automatically, where the system is unsure, and where it got it wrong · merges and splits, reversibly · roles, several per person, and role history | losing a manual correction to the next sync |
+| **LEAD, EXEC** | Someone is listed in one role and does another — error or reality? | a tree they can trust to roll up into, with team membership kept per period | a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it |
+| **IC, PEER** | — | being one person, not four | their work attributed to a duplicate of themselves |
 
 **Not this:** where observed work does not match the configured role model, Insight recommends
 changing the configuration — not the person.
 
-## S-9 · Configuration and access · Service
+### S-9 · Configuration and access
 
 The customer configures roles, sources, metrics, thresholds, cohorts, dashboards, localization and
-access rules. Each of the five kinds of data is granted separately, and the boundary holds on every
-surface.
+access rules; each of the five kinds of data ([rule 5](#6-rules-that-hold-in-every-scenario)) is granted separately, and the boundary holds on
+every surface.
 
-**User scenarios in this class**
-- How do I give a lead their team and nothing more? — ADMIN
-- Can we work in our own language and timezone? — everyone
-- The configuration half of "who is supposed to do what here" — ADMIN
+| Who | User scenarios | Can see and do | Boundaries |
+|---|---|---|---|
+| **ADMIN** | How do I give a lead their team and nothing more? · How do I tell the product who is supposed to do what here? | grants the five kinds of data one by one · adapts roles, metrics and thresholds without engineering · sets language, date, number, currency and timezone rules | holding all five kinds implicitly · a refusal only hidden on screen rather than enforced by the system · data visibility from the admin role alone |
+| **LEAD** | — | their own team, in full, at every depth | one level up, or sideways — the limit is structural, not a filter on a screen |
+| **EXEC** | — | aggregates for the whole organization, and people where person-level access is granted | raw access as a privilege of rank — it is one of the five grants |
+| **PEER** | — | everyone by name — person-level sight is what the mode grants | records, cost or recommendations without their own grant |
+| **IC** | — | themselves — named to their own management chain and to anyone else granted person-level access for their part of the organization | being named to anyone outside it · cost figures · conclusions and advice |
+| **everyone** | Can we work in our own language and timezone? | the language, date, number, currency and timezone rules the administrator set | — |
 
-| Who | Does here | Must never meet |
-|---|---|---|
-| **ADMIN** | grants the five kinds of data one by one; adapts roles, metrics and thresholds without engineering involvement; sets language, date, number, currency and timezone rules; where a setting cannot yet be honoured, the gap is labelled on the surface — timezone today, with dates bucketed in UTC while the period is chosen in the viewer's own zone | holding all five kinds implicitly · a refusal only hidden on screen rather than enforced by the system |
-| **LEAD** | their own team, in full, at every depth | one level up, or sideways — the limit is structural, not a filter on a screen |
-| **EXEC** | the organization as a whole: aggregates, and people where person-level access is granted; the underlying records only where granted | raw access as a privilege of rank — it is one of the five grants |
-| **PEER** | the organization as a whole, everyone by name — person-level sight is what the mode grants | records, cost or recommendations without their own grant |
-| **IC** | themselves — named to their own management chain and to anyone else granted person-level access for their part of the organization | being named to anyone outside it |
+**Not this:** writing to a connected system — Insight writes its own configuration and annotations,
+nothing else ([rule 7](#6-rules-that-hold-in-every-scenario)).
 
-**Not this:** Insight is read-only towards connected systems: it writes its own configuration and
-annotations, nothing else.
+**Today:** timezone — dates are bucketed in UTC while the period is chosen in the viewer's own zone,
+so an event near local midnight can land a day either side; the divergence is labelled on the surface
+until sources carry people's timezones.
 
-## S-10 · Deployment, upgrade and migration · Service
+### S-10 · Deployment, upgrade and migration
 
 The product is installed, updated, upgraded and — where it replaces something — migrated into, without
 losing what already worked. Deployment models differ — Constructor-hosted, customer cloud, private
 cloud, customer-operated — and in all of them customer data stays under customer control.
 
-**User scenarios in this class**
-- How do we replace what we have without losing history? — ADMIN, EXEC
+| Who | User scenarios | Can see and do | Boundaries |
+|---|---|---|---|
+| **ADMIN** | How do we replace what we have without losing history? | install, configure, update and upgrade a customer-operated deployment · inventory what exists first, then keep, rename, replace or retire · import history where retention allows, and check parity over an agreed period | losing a surface that worked before an upgrade — what was live before it is checked after it |
+| **EXEC** | How do we replace what we have without losing history? | the previous system replaced with confidence — parity stated openly, including what could not be reproduced | a parity claim that quietly omits what could not be reproduced |
+| **LEAD, IC, PEER** | — | their history kept across the change | a past period silently recalculated under a new model |
 
-| Who | Does here | Must never meet |
-|---|---|---|
-| **ADMIN** | install, configure, update and upgrade a customer-operated deployment; inventory what exists first, then keep, rename, replace or retire; import history where retention allows, and check parity over an agreed period | losing a surface that worked before an upgrade — what was live before it is checked after it |
-| **EXEC** | the previous system replaced with confidence — parity stated openly, including what could not be reproduced | a parity claim that quietly omits what could not be reproduced |
-| **LEAD, IC, PEER** | their history kept across the change | a past period silently recalculated under a new model |
-
-**Not this:** Insight does not require Constructor to have default access to customer data in order
-to operate.
+**Not this:** Constructor holding default access to customer data in order to operate.
 
 ---
 
-## 5. Rules that hold in every scenario
+## 6. Rules that hold in every scenario
 
 From the vision, stated once here instead of repeated in each scenario.
 
@@ -382,7 +344,7 @@ From the vision, stated once here instead of repeated in each scenario.
 4. **No default ranking of named individuals, and no unexplained productivity scores** — people
    are named where person-level access has been granted; the ranking is what is ruled out.
 5. **People-level access is role-based and policy-controlled** — five kinds of data, granted
-   separately. The scope boundary holds by construction, not as a filter a screen applies: a viewer is
+   separately: underlying records, aggregates, person-level data, cost, and recommendations. The scope boundary holds by construction, not as a filter a screen applies: a viewer is
    handed their own part of the organization and cannot ask for more.
 6. **Cost movement is preserved, not folded away** — a local saving that shifts cost, risk or
    effort downstream is shown as a shift; seat-based and usage-based cost are never one figure.
@@ -392,7 +354,7 @@ From the vision, stated once here instead of repeated in each scenario.
    are shared, opt-in and revocable.
 9. **Role and activity are separate axes** — expected role model and observed activity are
    compared, never conflated; history is kept under the model valid at the time.
-10. **Two group-size thresholds, and they are different** — a group figure is not shown below **four**
+10. **Three group sizes, and they differ** — a group figure is not shown below **four**
     people, and a comparative conclusion is not drawn below **eight** on each side. The first keeps an
     individual unidentifiable behind a number; the second keeps a claim from resting on a handful. The
     one threshold the product enforces today sits between them: a peer comparison — the median and
@@ -407,36 +369,30 @@ From the vision, stated once here instead of repeated in each scenario.
 
 ---
 
-## 6. Open points
+---
 
-Several claims in this document go beyond what VISION.md and the scenario draft state. They are written
-as requirements because the alternative is to leave them undecided, but each needs a decision rather
-than a nod.
+## 7. Open points
 
-- **Administrative rights and data visibility** — settled. [Personas](#1-personas) asserts that ADMIN gains no data
-  visibility implicitly, and the access model agrees: the identity service computes an
-  administrator's visible set without the role, under either visibility mode.
-- **An executive is a manager with a larger subtree.** The product tells EXEC from LEAD only by how
-  much of the organization reports to them, so anything this document gives EXEC and withholds from
-  LEAD holds by scope, not by rule. An EXEC-only rule cannot be enforced until the product knows a
-  title.
-- **Ranking in flat mode.** A PEER sees every other member's position band. The vision rules out a
-  default view that ranks named individuals; a flat organization has opted into seeing everyone.
-  Which of the two this is has to be decided before the mode is sold as a feature — and if the bands
-  are a ranking, whether flat mode suppresses them or the customer accepts them.
-- **Saved and shared views** ([S-4](#s-4--dashboards-views-and-exploration--secondary)). Composing a view is in the vision; *saving* it and *sharing* it are
-  not. If sharing exists, the access rule has to come with it — what each viewer sees, re-evaluated for
-  them — and that is far cheaper to decide before the feature than after.
-- **An identity correction surviving the next sync** ([S-8](#s-8--identity-roles-and-organization-model--service)). The draft says merges and splits are
-  reversible; neither document says a correction is not undone by re-resolution. Stated here as a
-  requirement, because a correction that does not survive is not a correction.
-- **The group-size thresholds** ([rule 10](#5-rules-that-hold-in-every-scenario)). The four for a group figure and the eight per side for a
-  comparative conclusion come from the scenario draft rather than from the vision, and are worth
-  confirming as product rules — including whether a customer may configure them. The five for a peer
-  comparison is the product's own, and is the only one of the three confirmed to be enforced.
-- **Recommendation ownership in a flat organization.** [S-3](#s-3--conclusions-recommendation-and-validation--main) expects a named owner for every lever. A
-  flat organization has no lead, so either the owner is chosen some other way, or recommendations are
-  not offered under `flat` — and the mode should say which.
-- **IC has the narrowest surface and the tightest boundary.** Everything an IC sees is their own or a
-  median — the combination that is easiest to get wrong quietly.
-- **[S-6](#s-6--external-comparison--secondary) has no surface yet.** Listed so the capability stays planned for, not to imply it exists.
+Product decisions this document depends on and nobody has made. Each is a question, why it is due now,
+and what it blocks.
+
+- **Ranking in flat mode.** *Question:* is the position band every PEER sees the default ranking the
+  vision rules out, or a comparison the customer opted into by choosing the mode? *Why now:* before
+  flat mode is sold as a feature. *Blocks:* PEER's boundary in [Metrics review](#s-1--metrics-review); whether flat mode suppresses
+  the bands.
+- **Recommendation ownership in a flat organization.** *Question:* who owns a lever when there is no
+  lead? *Why now:* [Conclusions](#s-3--conclusions-recommendation-and-validation) expects a named owner for every recommendation. *Blocks:*
+  PEER's row there; whether recommendations are offered under flat at all.
+- **An executive is a manager with a larger subtree.** *Question:* does the product need a title to
+  enforce an EXEC-only rule? *Why now:* whatever this document gives EXEC and withholds from LEAD holds
+  by scope, not by rule. *Blocks:* any EXEC-only promise.
+- **Saved and shared views.** *Question:* if a view can be shared, is what each viewer sees
+  re-evaluated for that viewer? *Why now:* far cheaper to decide before the feature than after.
+  *Blocks:* sharing in [Dashboards, views and exploration](#s-4--dashboards-views-and-exploration).
+- **An identity correction surviving the next sync.** *Question:* is a manual merge or split undone by
+  re-resolution? *Why now:* a correction that does not survive is not a correction. *Blocks:* ADMIN's
+  promise in [Identity, roles and organization model](#s-8--identity-roles-and-organization-model).
+- **The group-size thresholds.** *Question:* are four (a group figure) and eight per side (a comparative
+  conclusion) product rules, and may a customer configure them? *Why now:* only five (a peer
+  comparison) is enforced today ([rule 10](#6-rules-that-hold-in-every-scenario)). *Blocks:* LEAD's cells in [Metrics review](#s-1--metrics-review) and
+  [Analysis and diagnosis](#s-2--analysis-and-diagnosis).

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -1,6 +1,6 @@
 # Constructor Insight — Main Scenarios by Persona
 
-**Status:** draft for review · Companion to [VISION.md](VISION.md)
+**Status:** draft for review · Companion to [INSIGHT_VISION.md](https://github.com/constructorfabric/vision/blob/main/INSIGHT_VISION.md)
 
 The vision says what Insight is and what it can do. This document says **who is standing in front of
 it, what they are there to do, and how far each of them may reach**. It adds no capability and changes

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -71,10 +71,10 @@ service's own design records that an administrator's visible set is computed wit
 
 **Function is the second axis.** Reach says how far a person may see; function says what they are
 looking at. The vision lists nine functions — Engineering / R&D, Product Management, Design / UX,
-DevOps / SRE,
-QA, Support, Sales, Marketing, Finance / FinOps — and a function is applied per user scenario, never
-per persona: a line reads `LEAD · Sales` or `EXEC · Finance`. Finance and product management are
-therefore not personas; their questions are carried by a reach persona in that function.
+DevOps / SRE, QA, Support, Sales, Marketing, Finance / FinOps — and a function is applied per user
+scenario, never per persona: a question is asked by *a sales lead*, or by *EXEC, from finance*.
+Finance and product management are therefore not personas; their questions are carried by a reach
+persona in that function.
 
 #### EXEC · an executive or portfolio leader
 
@@ -143,7 +143,7 @@ is worked out the same way for every persona and every scope.
 - Where is work stalling? — LEAD
 - What falls apart if a specific person drops out? — LEAD, EXEC
 - Where are we improving, and where just getting busier? — EXEC
-- How much does AI cost, who spends it, in what form? — EXEC · Finance
+- How much does AI cost, who spends it, in what form? — EXEC, from finance
 - How much goes into coordination instead of work? — LEAD
 - How are we doing, and where do I stand among my peers? — PEER
 
@@ -168,12 +168,12 @@ what to commit to, from the organization's own delivery history.
 **User scenarios in this class**
 - Did throughput rise where AI was adopted, and what did it cost? — LEAD, EXEC
 - Is speed limited by writing code or by reviewing it? — LEAD
-- Speed went up — did quality hold? — LEAD · Product
-- Is this ticket spike caused by what we shipped? — LEAD · Support
-- Activity rose — did the deals move? — LEAD, EXEC · Sales
-- Development got cheaper — did the cost move somewhere else? — EXEC · Finance
-- Is it feasible, what will it cost, how long, what risks? — EXEC, LEAD · Product
-- Where is the effect larger for less effort? — EXEC · Product
+- Speed went up — did quality hold? — an engineering or product lead
+- Is this ticket spike caused by what we shipped? — a support or product lead
+- Activity rose — did the deals move? — a sales lead, or EXEC
+- Development got cheaper — did the cost move somewhere else? — EXEC, from finance
+- Is it feasible, what will it cost, how long, what risks? — a product lead, or EXEC
+- Where is the effect larger for less effort? — EXEC, or a product lead
 
 | Who | Does here | Must never meet |
 |---|---|---|

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -78,53 +78,53 @@ therefore not personas; their questions are carried by a reach persona in that f
 
 #### EXEC · an executive or portfolio leader
 
-**Who:** a manager whose subtree is the whole organization — the product tells an executive from a
-manager only by how much of the organization reports to them, never by a title
-**Mode:** org_chart
-**Lands on:** the organization roll-up
-**Asks:** "Did it get better, or did we just get busier?"
-**Sees:** the whole organization; anyone by name where person-level access is granted
-**May compare:** functions, teams and people with one another
+- **Who:** a manager whose subtree is the whole organization — the product tells an executive from a
+  manager only by how much of the organization reports to them, never by a title
+- **Mode:** org_chart
+- **Lands on:** the organization roll-up
+- **Asks:** "Did it get better, or did we just get busier?"
+- **Sees:** the whole organization; anyone by name where person-level access is granted
+- **May compare:** functions, teams and people with one another
 
 #### LEAD · a functional leader or team manager
 
-**Who:** a manager whose subtree is smaller than the organization
-**Mode:** org_chart
-**Lands on:** their team's roll-up
-**Asks:** "Where exactly is work blocked, and what can I do?"
-**Sees:** their own team at any depth, the people in it by name, and no further
-**May compare:** groups inside their own team, and their own reports with one another
+- **Who:** a manager whose subtree is smaller than the organization
+- **Mode:** org_chart
+- **Lands on:** their team's roll-up
+- **Asks:** "Where exactly is work blocked, and what can I do?"
+- **Sees:** their own team at any depth, the people in it by name, and no further
+- **May compare:** groups inside their own team, and their own reports with one another
 
 #### IC · an individual contributor in a hierarchy
 
-**Who:** nobody reports to them
-**Mode:** org_chart
-**Lands on:** their own page
-**Asks:** "How does my own work look, and what is in my way?"
-**Sees:** themselves, with the department or cohort as a median; no cost figures, and no conclusions
-or advice
-**May compare:** nothing — they are placed against a department or cohort median, never against a
-named colleague
+- **Who:** nobody reports to them
+- **Mode:** org_chart
+- **Lands on:** their own page
+- **Asks:** "How does my own work look, and what is in my way?"
+- **Sees:** themselves, with the department or cohort as a median; no cost figures, and no conclusions
+  or advice
+- **May compare:** nothing — they are placed against a department or cohort median, never against a
+  named colleague
 
 #### PEER · a member of a flat organization
 
-**Who:** any signed-in person when the visibility policy is `flat`
-**Mode:** flat
-**Lands on:** the organization roll-up, the same landing as a manager
-**Asks:** "How are we doing, and where do I stand among my peers?"
-**Sees:** the whole organization, everyone by name, themselves included
-**May compare:** anyone with anyone; the organization is the only cohort
+- **Who:** any signed-in person when the visibility policy is `flat`
+- **Mode:** flat
+- **Lands on:** the organization roll-up, the same landing as a manager
+- **Asks:** "How are we doing, and where do I stand among my peers?"
+- **Sees:** the whole organization, everyone by name, themselves included
+- **May compare:** anyone with anyone; the organization is the only cohort
 
 #### ADMIN · a data steward or administrator
 
-**Who:** holds the admin role, whatever their reach. Two jobs in one persona — the *steward* decides
-who is who and who may see what; the *operator* installs, upgrades, migrates and wires sources. At
-most customers these are different people; in the product they are one role
-**Mode:** both
-**Lands on:** Manage
-**Asks:** "Which of these numbers can be trusted, and who may see them?"
-**Sees:** settings, not people's data — the role adds no visibility of its own
-**May compare:** nothing — the role sees settings, not people
+- **Who:** holds the admin role, whatever their reach. Two jobs in one persona — the *steward* decides
+  who is who and who may see what; the *operator* installs, upgrades, migrates and wires sources. At
+  most customers these are different people; in the product they are one role
+- **Mode:** both
+- **Lands on:** Manage
+- **Asks:** "Which of these numbers can be trusted, and who may see them?"
+- **Sees:** settings, not people's data — the role adds no visibility of its own
+- **May compare:** nothing — the role sees settings, not people
 
 ---
 

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -8,9 +8,9 @@ no commitment.
 
 - **Personas** — the target user groups of VISION §6.1, as five *reach* personas across the two
   visibility modes the product ships, plus the administrator role, which is a role and not a reach.
-- **Scenarios** — ten, in three tiers, ordered by what the product is for.
-- **Underneath** — the detailed user scenarios (Appendix A): thirty concrete questions, one person
-  asking one thing at one moment, each traced to the scenario it belongs to.
+- **Scenarios** — ten, in three tiers, ordered by what the product is for. Each one is a class of
+  user scenarios: the concrete questions people bring, and what each persona does and must never meet
+  while answering them.
 
 ## The three tiers
 
@@ -34,22 +34,19 @@ means four different things:
 - a **team manager** sees their team, the people in it by name, and groups recalculated for that team
   rather than carried over from the organization;
 - an **executive** sees the whole organization;
-- a **member** of a flat organization sees everyone, because there is no tree to bound them — the
+- a **peer** in a flat organization sees everyone, because there is no tree to bound them — the
   customer chose that mode, and the boundary is the organization itself.
 
 The activity is shared. The boundary is not, and the boundary is the part that gets lost in
 implementation. That is why it is written down as a statement rather than left implied.
 
-**How to read a scenario block**
+**How to read this document**
 
-- **The scenario** — what holds for everyone, whoever is looking.
-- **Per persona** — what each of them does, and what must never happen to them. Only the personas the
-  scenario concerns are listed.
-- **Not this** — what the scenario deliberately does not do, so it is not promised in a demo.
-- **Detail** — the user-scenario IDs from Appendix A that belong here. It lists the detailed
-  *questions*, not the source of every persona line: reach comes from VISION §6.1, what an
-  administrator may configure from §9. So a persona can appear in a scenario with no question of its
-  own beneath it — usually stating a limit rather than claiming a need.
+- A **persona block** has fixed labels in a fixed order, so the same label answers the same question
+  for every persona.
+- A **scenario block** is a title, one sentence that holds for everyone, the user scenarios in the
+  class with who asks each, a table of what each persona does here and what they must never meet, and
+  *Not this* — what the scenario deliberately does not do, so it is not promised in a demo.
 
 ---
 
@@ -61,70 +58,72 @@ chosen per installation by the identity service's `visibility_policy`.
 | Mode | Where reach comes from | Reach personas |
 |---|---|---|
 | `org_chart` | Reporting lines. A viewer sees themselves, the people who report to them, and whatever they have been granted on top. | EXEC · LEAD · IC |
-| `flat` | The organization. Every viewer sees everyone and the organization roll-up — the mode for a roster that carries no reporting lines. | MEMBER |
+| `flat` | The organization. Every viewer sees everyone and the organization roll-up — the mode for a roster that carries no reporting lines. | PEER |
 
 The mode belongs to the installation, not to a person, and the identity service reports it to every
-client (`GET /v1/me`), so a surface never infers it from an empty list of reports — a leaf IC and a
-MEMBER are served the same empty `subordinates`, and the policy is what tells them apart. Grants keep
-their meaning under either mode: underlying records, person-level data, cost and recommendations are
-still granted one by one (S-9).
+client (`GET /v1/me`) — a leaf IC and a PEER are served the same empty `subordinates`, and the policy
+is what tells them apart. Grants keep their meaning under either mode: underlying records, aggregates,
+person-level data, cost and recommendations are still granted one by one (S-9).
 
 **ADMIN is orthogonal to both.** Administration is a role, not a reach. An administrator is also an
-IC, LEAD, EXEC or MEMBER underneath, and the role adds no visibility of its own — the visible-set
+IC, LEAD, EXEC or PEER underneath, and the role adds no visibility of its own — the visible-set
 predicate in the identity service has no role term (ADR-0015).
 
-| Code | Group (VISION §6.1) | Mode | Arrives asking | What a failure costs them | How the product knows it is them |
-|---|---|---|---|---|---|
-| **EXEC** | Executives and portfolio leaders | `org_chart` | "Did it get better, or did we just get busier?" | A board-level number that is wrong or unexplained | A manager whose subtree is the whole organization |
-| **LEAD** | Functional leaders and team managers | `org_chart` | "Where exactly is work blocked, and what can I do?" | Acting on a jam that is a data artefact | A manager whose subtree is smaller than the organization |
-| **IC** | Functional teams and individual contributors | `org_chart` | "How does my own work look, and what is in my way?" | Seeing a colleague's activity, or their own work misattributed | Nobody reports to them |
-| **MEMBER** | Functional teams and individual contributors, in a flat organization | `flat` | "How are we doing, and where do I stand?" | A comparison shown to the whole company that was never meant as a ranking | Any viewer, when the policy is `flat` |
-| **ADMIN** | Data stewards and administrators | both | "Which of these numbers can be trusted, and who may see them?" | Shipping a customer that silently proves nothing | Holds the admin role, whatever their reach |
+**Function is the second axis.** Reach says how far a person may see; function says what they are
+looking at. VISION §6.2 lists nine — Engineering / R&D, Product Management, Design / UX, DevOps / SRE,
+QA, Support, Sales, Marketing, Finance / FinOps — and a function is applied per user scenario, never
+per persona: a line reads `LEAD · Sales` or `EXEC · Finance`. Finance and product management are
+therefore not personas; their questions are carried by a reach persona in that function.
 
-**EXEC and LEAD are one code path.** The product knows a manager and the size of their subtree; it
-does not know a title. Whatever §1.1 gives EXEC and withholds from LEAD — comparison across functions,
-organization-wide cost — holds because the subtree happens to be the whole organization, not because a
-rule enforces it. An EXEC-only rule cannot be enforced today, and a scenario that needs one should say
-so.
+#### EXEC · an executive or portfolio leader
 
-**ADMIN carries two jobs, and the persona says so rather than splitting.** The steward's — who is who
-(S-8), who may see what (S-9), which recommendation families are on (S-3) — and the operator's —
-install, upgrade, migrate (S-10), wire sources (S-7). At most customers these are different people;
-in the product they are one role, and the persona keeps them together until the product can tell them
-apart.
+**Who:** a manager whose subtree is the whole organization — the product tells an executive from a
+manager only by how much of the organization reports to them, never by a title
+**Mode:** org_chart
+**Lands on:** the organization roll-up
+**Asks:** "Did it get better, or did we just get busier?"
+**Sees:** the whole organization; anyone by name where person-level access is granted
+**May compare:** functions, teams and people with one another
 
-### 1.1 Reach
+#### LEAD · a functional leader or team manager
 
-The boundary each persona carries into every scenario below.
+**Who:** a manager whose subtree is smaller than the organization
+**Mode:** org_chart
+**Lands on:** their team's roll-up
+**Asks:** "Where exactly is work blocked, and what can I do?"
+**Sees:** their own team at any depth, the people in it by name, and no further
+**May compare:** groups inside their own team, and their own reports with one another
 
-| | EXEC | LEAD | IC | MEMBER | ADMIN |
-|---|---|---|---|---|---|
-| **How far they see** | The whole organization | Their own team, and no further | Themselves | The whole organization — the same as EXEC | Settings, not people's data |
-| **How far they zoom** | Organization, function, team, person | Team, sub-team, group, their own reports | Themselves, with the department or cohort as a median | Organization, group, person | n/a |
-| **People by name** | Anyone, where person-level access is granted | The people reporting to them — that is what a team view is for | Themselves | Anyone in the roster | Only while resolving who is who |
-| **Comparison** | Between functions, teams and people | Between groups inside their own team, and between their own reports | Against a median, never against a named colleague | Between anyone, themselves included, against named colleagues | n/a |
-| **Cost figures** | Where granted | Where granted | No | Where granted | Where granted |
-| **Conclusions and advice** | Reads conclusions | Reads conclusions, receives recommendations | Neither | Where granted | Neither |
-| **Never** | A default view that ranks people against one another · a number with no statement of coverage and confidence | Anything outside their own team · a default view that ranks their reports · group figures carried over from the organization instead of recalculated for the team | Any other person's activity · any team metric beyond the median they are placed against · their own place in a ranking | A group figure below four people · a number with no statement of coverage and confidence · the IC boundary is **not** on this list — a flat organization has chosen transparency over it, and the surface says so instead of implying the median-only rule still holds | Administrative rights do **not** carry the right to see data — each kind is granted separately (VISION §9) |
+#### IC · an individual contributor in a hierarchy
 
-**Naming and ranking are different things, and only one is restricted.** People are named wherever
-person-level access has been granted: a manager's team view names their reports, and that is the point
-of it. What VISION §3 rules out is a *default* view that ranks named individuals against one another,
-or an unexplained productivity score. The line is the default surface and the granted scope — not the
-name.
+**Who:** nobody reports to them
+**Mode:** org_chart
+**Lands on:** their own page
+**Asks:** "How does my own work look, and what is in my way?"
+**Sees:** themselves, with the department or cohort as a median; no cost figures, and no conclusions
+or advice
+**May compare:** nothing — they are placed against a department or cohort median, never against a
+named colleague
 
-**Flat mode is where that line needs an explicit answer.** A MEMBER sees every other member's position
-band on the same screen. Whether that is a comparison the customer opted into by choosing the mode, or
-the default ranking §3 rules out, is undecided (Appendix C) — and it has to be decided in the document,
-not discovered in a demo.
+#### PEER · a member of a flat organization
 
-### 1.2 Function — the second axis
+**Who:** any signed-in person when the visibility policy is `flat`
+**Mode:** flat
+**Lands on:** the organization roll-up, the same landing as a manager
+**Asks:** "How are we doing, and where do I stand among my peers?"
+**Sees:** the whole organization, everyone by name, themselves included
+**May compare:** anyone with anyone; the organization is the only cohort
 
-Reach says how far a person may see. Function says what they are looking at. VISION §6.2 lists nine:
-Engineering / R&D, Product Management, Design / UX, DevOps / SRE, QA, Support, Sales, Marketing,
-Finance / FinOps. A function is applied per scenario, never per persona — a line reads `LEAD · Sales`
-or `EXEC · Finance`. Finance and product management are therefore not personas: their questions are
-carried by a reach persona in that function, and Appendix A names which.
+#### ADMIN · a data steward or administrator
+
+**Who:** holds the admin role, whatever their reach. Two jobs in one persona — the *steward* decides
+who is who and who may see what; the *operator* installs, upgrades, migrates and wires sources. At
+most customers these are different people; in the product they are one role
+**Mode:** both
+**Lands on:** Manage
+**Asks:** "Which of these numbers can be trusted, and who may see them?"
+**Sees:** settings, not people's data — the role adds no visibility of its own
+**May compare:** nothing — the role sees settings, not people
 
 ---
 
@@ -134,131 +133,88 @@ The loop the product exists for: measure → diagnose → recommend → validate
 
 ## S-1 · Metrics review · Main
 
-**The scenario.** Someone opens the product to see how things are going. Every number carries a
-governed definition, unit, granularity, confidence and stated limitations, and is worked out the same
-way for every persona and every scope (VISION §8.4).
+Every number carries a governed definition, unit, granularity, confidence and stated limitations, and
+is worked out the same way for every persona and every scope (VISION §8.4).
 
-**EXEC** — See how the organization as a whole is doing.
-- organization, function and team, with change over time
-- coverage counted from people who actually have data behind the figure, never by treating missing
-  data as zero
-- never a default view that ranks people against one another
+**User scenarios in this class**
+- What is visible about me, and what is in my way? — IC
+- What changed for my team over the period? — LEAD
+- Where is work stalling? — LEAD
+- What falls apart if a specific person drops out? — LEAD, EXEC
+- Where are we improving, and where just getting busier? — EXEC
+- How much does AI cost, who spends it, in what form? — EXEC · Finance
+- How much goes into coordination instead of work? — LEAD
+- How are we doing, and where do I stand among my peers? — PEER
 
-**LEAD** — See how their team is doing and where work is stuck.
-- their own team at any depth, and the people in it by name
-- groups recalculated for the team in view, not carried over from the organization
-- a group of fewer than four people is not shown at all — that is what keeps an individual
-  unidentifiable behind a group figure
-- concentration read with the meaning of its domain: in code and documentation a high top-decile
-  share is a bus-factor risk, in communication it is a load imbalance. Same arithmetic, different
-  conclusion, and the surface says which one it means
-- never a team they do not manage
+| Who | Does here | Must never meet |
+|---|---|---|
+| **EXEC** | organization, function and team, with change over time; coverage counted from people who actually have data, never by treating missing data as zero | a default view that ranks people against one another · a number without its coverage |
+| **LEAD** | their own team at any depth, the people in it by name; groups recalculated for the team in view; concentration read with the meaning of its domain — in code and documentation a high top-decile share is a bus-factor risk, in communication a load imbalance, and the surface says which | a team they do not manage · a group figure below four people · a group figure carried over from the organization |
+| **IC** | their own activity, flow and AI usage, with the department or cohort as a median | another person's activity · any team metric beyond that median · their own rank |
+| **PEER** | the whole organization as one scope, themselves included, every member named; their own page against the organization as the median | a peer comparison below five people |
+| **ADMIN** | nothing by default | data visibility from the role alone |
 
-**IC** — See their own work, with a reference point.
-- their own activity, flow and AI usage
-- the department or cohort as a median to place themselves against
-- never another person's activity, never a team metric beyond that median, never their own rank
-
-**ADMIN** — Nothing by default.
-- never gains data visibility implicitly from administrative rights
-
-**Not this.** No single "value of AI" number: seat-based and usage-based cost are not summed into one
-figure, and unattributed cost stays its own line rather than being spread across the rest
+**Not this:** no single "value of AI" number — seat-based and usage-based cost are never summed into
+one figure, and unattributed cost stays its own line rather than being spread across the rest
 (VISION §6.2.9, §11.4).
-
-**Detail.** B1 (own context), B2 (team over a period), B3 (where work is stuck), B4 (knowledge
-concentration), B5 (organization roll-up), B6 (AI cost), B8 (cost of coordination).
 
 ## S-2 · Analysis and diagnosis · Main
 
-**The scenario.** The product stops showing shape and starts asserting a relationship — bottlenecks,
-risks, anomalies, cost drivers, quality issues, role and activity mismatches — and says which kind of
-claim it is making, with confidence and limitations (VISION §8.5). It rests on lineage: work is
-followed across the systems it passes through, and **lineage comes before attribution** (VISION §7.3)
-— what cannot be traced is shown as an evidence gap, never converted into a confident claim. Where
-observed work diverges from the configured role model, the divergence is surfaced here; the role model
-it is measured against belongs to S-8.
+The product stops showing shape and starts asserting a relationship — bottlenecks, risks, anomalies,
+cost drivers, quality issues, role and activity mismatches — and says which kind of claim it is making,
+with confidence and limitations (VISION §8.5). It rests on lineage, and lineage comes before
+attribution (VISION §7.3): what cannot be traced is shown as an evidence gap, never converted into a
+confident claim. Looking forward is the same scenario in the other direction — deciding what to commit
+to, from the organization's own delivery history rather than generic assumptions (VISION §1).
 
-**LEAD** — Understand why, not just what.
-- a conclusion for their team or cohort, with the evidence behind it
-- where the chain of evidence breaks in their own area, and what would repair it
-- never a verdict about a named individual
-- a comparative conclusion needs at least eight people on each side. Below that the surface does not
-  render it, and says why — the threshold is higher than the four that protects a group figure,
-  because a conclusion claims more than a number does
-- never built on a metric known to be defective: it is excluded by name, and the exclusion is stated
+**User scenarios in this class**
+- Did throughput rise where AI was adopted, and what did it cost? — LEAD, EXEC
+- Is speed limited by writing code or by reviewing it? — LEAD
+- Speed went up — did quality hold? — LEAD · Product
+- Is this ticket spike caused by what we shipped? — LEAD · Support
+- Activity rose — did the deals move? — LEAD, EXEC · Sales
+- Development got cheaper — did the cost move somewhere else? — EXEC · Finance
+- Is it feasible, what will it cost, how long, what risks? — EXEC, LEAD · Product
+- Where is the effect larger for less effort? — EXEC · Product
 
-**EXEC** — The same at organization level, plus a forecast for proposed work.
-- cost and outcome followed to the function, team, product or service — as far as the trail goes
-- never attribution stronger than the lineage supports
-- never a causal claim where the evidence supports a correlation
-- never a forecast presented as a guarantee
-
-**IC** — Not an audience for diagnosis, and never a named example inside one (VISION §6.1).
+| Who | Does here | Must never meet |
+|---|---|---|
+| **LEAD** | a conclusion for their team or cohort, with the evidence behind it; where the chain of evidence breaks in their own area, and what would repair it; for proposed work, feasibility, cost, duration and risk from the organization's own history | a verdict about a named individual · a comparative conclusion with fewer than eight people on each side — the surface does not render it, and says why · a conclusion built on a metric known to be defective; it is excluded by name, and the exclusion is stated |
+| **EXEC** | the same at organization level; cost and outcome followed to the function, team, product or service as far as the trail goes; ranked opportunities where the expected effect is larger for less effort | attribution stronger than the lineage supports · a causal claim where the evidence supports a correlation · a forecast presented as a guarantee — it is an extrapolation that strengthens as history and lineage improve |
+| **PEER** | the same as EXEC at organization level, with one cohort: the comparison is against the organization's own history, because there is no second group to compare with | the same as EXEC |
+| **IC** | not an audience for diagnosis | a named example inside one |
 
 What limits a conclusion — which sources are missing, which windows do not overlap, which metric is
 under a known defect — is an administrator's view, and it lives in S-7.
 
-### Looking forward — the other direction of the same scenario
-
-VISION §1 treats forward-looking work as a direction of its own, not an afterthought to diagnosis:
-looking back, the product improves work that has already happened; looking forward, it helps decide
-what to commit to. Both are analysis, which is why they sit in one scenario — but the questions differ.
-
-**EXEC, LEAD** — Decide what to take on.
-- is this feasible, what will it cost, how long will it take, what are the risks
-- the answer built from the organization's own delivery history, not from generic assumptions
-- ranked opportunities: where the expected effect is larger for less effort
-- the same evidence model, confidence and stated limitations as everything else
-- never a forecast presented as a guarantee — it is an extrapolation, and it strengthens as history
-  and lineage improve
-
-**Not this.** "AI sped up development by X%" is not a claim Insight makes; what it can say is that a
+**Not this:** "AI sped up development by X%" is not a claim Insight makes; what it can say is that a
 cohort with high usage differs from one with low usage in stated ways, correlationally — with the word
-said on the surface, not in a footnote. Attribution also has a ceiling, and the ceiling is stated
-rather than worked around: it reaches person × day × tool, and no further, so "this change was written
-by AI" and "this change cost $N" are not claims Insight makes.
-
-**Detail.** C1 (AI gain and price together), C2 (review as a bottleneck), C3 (did quality hold),
-C4 (support load vs release), C5 (sales activity vs pipeline), C6 (cost moved rather than fell),
-E1 (assess a feature before starting), E2 (where to invest next).
+said on the surface, not in a footnote. Attribution reaches person × day × tool and no further, so
+"this change was written by AI" and "this change cost $N" are not claims Insight makes either.
 
 ## S-3 · Conclusions: recommendation and validation · Main
 
-**The scenario.** A recommendation is a structured improvement object (VISION §1): observed problem,
-affected area, evidence and confidence, recommended action, owner, expected metric movement, and the
-follow-up window used to check it. Its origin is declared — evidence-derived from the customer's own
-data, or heuristic. Afterwards the product reads the outcome from the measured system.
+A recommendation is a structured improvement object (VISION §1): observed problem, affected area,
+evidence and confidence, recommended action, owner, expected metric movement, and the follow-up window
+used to check it. Its origin is declared — evidence-derived from the customer's own data, or heuristic
+— and afterwards the product reads the outcome from the measured system.
 
-**LEAD** — Get an action, not an observation.
-- one lever they can own, drawn from a fixed set rather than composed freely — three in the first
-  version: reduce change size, spread review load, raise AI adoption where it is low at comparable load
-- with it: how the lever itself is measured, what should move as a result, which guardrail must not
-  slip, and when it is checked — four weeks, computed automatically
-- never a recommendation that passes judgement on a named individual rather than on a process, team or
-  cohort — a named *owner* is expected, a named *subject* is not
-- never a recommendation whose origin is unstated
+**User scenarios in this class**
+- I can see the problem — what do I do? — LEAD
+- Was it applied? Did it help? — LEAD, EXEC
+- We had a reorg that month — how do I say so? — LEAD
 
-**EXEC** — Know whether it worked.
-- whether the lever moved, whether the outcome moved, and the honest fourth answer: not enough data
-- never a result assembled from metrics chosen after the fact — they are fixed when the recommendation
-  is issued
-- read over a fixed window, four weeks before against four weeks after, rather than by a detector
-  hunting for a shift — on a team of ten a detector finds noise
-- read against a control: a comparable group that received no recommendation, so a company-wide trend
-  is not mistaken for an effect
+| Who | Does here | Must never meet |
+|---|---|---|
+| **LEAD** | one lever they can own, from a fixed set rather than composed freely — three in the first version: reduce change size, spread review load, raise AI adoption where it is low at comparable load — with how the lever is measured, what should move, which guardrail must not slip, and when it is checked: four weeks, computed automatically | a recommendation that passes judgement on a named individual rather than a process, team or cohort — a named *owner* is expected, a named *subject* is not · a recommendation whose origin is unstated |
+| **EXEC** | whether the lever moved, whether the outcome moved, and the honest fourth answer: not enough data; read over a fixed window, four weeks before against four weeks after, and against a control — a comparable group that received no recommendation | a result assembled from metrics chosen after the fact — they are fixed when the recommendation is issued · a detector hunting for a shift, which on a team of ten finds noise |
+| **PEER** | undecided — a recommendation names an owner, and a flat organization has no lead to own a lever (Appendix C) | — |
+| **ADMIN** | which recommendation families are enabled, who owns them, and how validation windows are defined (VISION §9) | — |
+| **IC** | — | being the subject of a recommendation |
 
-**ADMIN** — Configure which recommendation families are enabled, who owns them, and how validation
-windows are defined (VISION §9).
-
-**IC** — Never the subject of a recommendation.
-
-**Not this.** No surveys, and no self-reporting of any kind as an input — not because opinions do not
+**Not this:** no surveys, and no self-reporting of any kind as an input — not because opinions do not
 matter, but because a validation that depends on people filling in a form does not run. Validation is
 read from the measured system. Insight recommends; it does not execute (VISION §13.3).
-
-**Detail.** D1 (a recommendation, not an observation), D2 (did it work, a month later), D3 (context
-the system cannot see).
 
 ---
 
@@ -268,75 +224,59 @@ Everything here extends the main loop. None of it is where a customer starts.
 
 ## S-4 · Dashboards, views and exploration · Secondary
 
-**The scenario.** Someone builds a view rather than reading one: composing dashboards from the metric
-and recommendation catalog (VISION §8.7, §9), slicing by an attribute, defining a cohort, and following
-a figure back to how it was calculated (VISION §2 — customers can see how metrics are calculated).
-Exploration moves the question, never the boundary.
+Someone builds a view rather than reading one: composing dashboards from the metric and recommendation
+catalog (VISION §8.7, §9), slicing by an attribute, defining a cohort, and following a figure back to
+how it was calculated (VISION §2). Exploration moves the question, never the boundary. Here a cohort is
+something a person builds — the attribute, the comparison group, the scope — where in S-1 it is the
+fixed backdrop a person is placed against; the machinery is shared, the activity is not.
 
-Two parts of this scenario go beyond what the vision states today and are proposals rather than
-restatements: **saving a composed view and sharing it with someone else**, and the access rule that
-follows from sharing. Both are marked in Appendix C.
+**User scenarios in this class**
+- How does group A differ from group B in the same scope? — LEAD, EXEC
+- The slicing side of every S-1 question — who asks it there asks it here
 
-**Cohorts appear in two roles, and only one of them is here.** In S-1 a cohort is a fixed backdrop —
-the median an individual is placed against, computed for them. Here a cohort is something a person
-builds: choosing the attribute, the comparison group and the scope. The machinery is shared; the
-activity is not.
+| Who | Does here | Must never meet |
+|---|---|---|
+| **LEAD** | compose from the catalog; slice by attribute; define cohorts and comparison groups; follow any figure back to how it was calculated; groups recalculated for whatever is on screen at the time | an exploration path that reaches outside their own team · a group figure below four people |
+| **EXEC** | the same, at organization and function level | — |
+| **PEER** | views over the whole organization; the same as EXEC | — |
+| **IC** | their own context only | — |
+| **ADMIN** | which metrics and thresholds exist, which cohorts are valid, who may publish a shared view (VISION §9) | — |
 
-**LEAD** — Build the view their team actually needs.
-- compose from the catalog; slice by attribute; define cohorts and comparison groups
-- follow any figure back to how it was calculated
-- groups recalculated for whatever is on screen at the time, and still suppressed below four people
-- never an exploration path that reaches outside their own team
-
-**EXEC** — Build the portfolio view.
-- the same, at organization and function level
-
-**IC** — Explore their own context only.
-
-**ADMIN** — Curate what can be built (VISION §9).
-- which metrics and thresholds exist, which cohorts are valid, who may publish a shared view
-
-**Not this.** A view carries the definitions and coverage of the metrics in it, not bare numbers.
-
-**Proposed, and the reason S-4 is worth arguing about.** If a view can be shared, it must not become a
-way around access rules: what a viewer sees would have to be re-evaluated for that viewer, so the same
-saved dashboard shows each person only what they may see. Neither the vision nor the scenario draft
-says this today — which is exactly why it needs deciding before view sharing is built rather than
-after.
-
-**Detail.** B7 (compare cohorts), and the slicing side of B2–B5.
+**Not this:** a view carries the definitions and coverage of the metrics in it, never bare numbers.
+Saving a composed view and sharing it are proposals rather than restatements (Appendix C): if a view
+can be shared, what a viewer sees has to be re-evaluated for that viewer, so a shared dashboard cannot
+become a way around access rules — which is why it needs deciding before view sharing is built.
 
 ## S-5 · Sharing and reuse · Secondary
 
-**The scenario.** A number keeps its meaning when it leaves the product — views, summaries, APIs and
-governed data access carry the definition, coverage and confidence with the number (VISION §8.8).
+A number keeps its meaning when it leaves the product — views, summaries, APIs and governed data access
+carry the definition, coverage and confidence with the number (VISION §8.8).
 
-**ADMIN** — Take Insight's output elsewhere.
-- API and governed data access, under the same access rules that apply inside the product
-- never a number stripped of its definition and confidence, so that outside the product it becomes a
-  fact without caveats
+**User scenarios in this class**
+- How do we pull this into our BI, a report, or a bot? — ADMIN, LEAD
 
-**LEAD** — Use a conclusion in their own report or review.
-
-**Detail.** G2 (use conclusions in another system).
+| Who | Does here | Must never meet |
+|---|---|---|
+| **ADMIN** | API and governed data access, under the same access rules that apply inside the product | a number stripped of its definition and confidence, so that outside the product it becomes a fact without caveats |
+| **LEAD** | a conclusion in their own report or review | — |
 
 ## S-6 · External comparison · Secondary
 
-**The scenario.** Comparison against the organization's own history by default; opt-in comparison
-against peers and public data where enabled. Every benchmark declares its source, cohort definition,
-coverage and confidence (VISION §8.9, §12).
+Comparison against the organization's own history by default; opt-in comparison against peers and
+public data where enabled. Every benchmark declares its source, cohort definition, coverage and
+confidence (VISION §8.9, §12).
 
-**EXEC** — Know whether a number is bad or normal.
-- own history first, which requires sharing nothing
-- peer comparison only where the customer has opted in
+**User scenarios in this class**
+- Our three-day cycle — is that bad? — EXEC
 
-**ADMIN** — Turn participation on and off; it is revocable (VISION §12).
+| Who | Does here | Must never meet |
+|---|---|---|
+| **EXEC** | own history first, which requires sharing nothing; peer comparison only where the customer has opted in | — |
+| **ADMIN** | participation on and off; it is revocable (VISION §12) | — |
 
-**Not this.** Raw customer data never leaves the customer boundary. Only anonymized aggregates at
+**Not this:** raw customer data never leaves the customer boundary. Only anonymized aggregates at
 cohort, team or organization level are shared — never individual data, never stack ranking
 (VISION §3, §12.2).
-
-**Detail.** F1 (are we slow, or is this normal).
 
 ---
 
@@ -352,114 +292,90 @@ evidence, validate. Listed last by importance; met first in time.
 
 ## S-7 · Sources and evidence coverage · Service
 
-**The scenario.** Whatever the wiring state, the product says so plainly: what is connected, what that
-unlocks, and — where an answer is not possible — the cause and the smallest set of fixes with the
-largest gain in confidence (readiness mode, VISION §7.5).
+Whatever the wiring state, the product says so plainly: what is connected, what that unlocks, and —
+where an answer is not possible — the cause and the smallest set of fixes with the largest gain in
+confidence (readiness mode, VISION §7.5).
 
-**ADMIN** — Know what can be proven.
-- all eight evidence categories as connected, partly connected or absent — people, work,
-  communication, delivery, support, sales, cost, AI — and which metrics each one unlocks
-- what each source declares about itself: fields, window, freshness, blind spots, and which level it
-  supports — measurement, diagnosis, recommendation or validation (VISION §10.10)
-- which links between systems are weak or broken, and what would repair them
-- never left to guess why a screen is empty
+**User scenarios in this class**
+- Which questions can I already ask, and which not? — ADMIN
+- Why is this empty, and what would make it not empty? — ADMIN, LEAD
+- Is this an event in the business, or a break in the data? — ADMIN, LEAD, EXEC
 
-**LEAD, EXEC** — Meet a gap and know what to do about it.
-- the cause named directly: which source is missing, which identities are unresolved, which link is
-  broken — plus the minimal fix
-- never a comparison across two periods whose source windows do not overlap
+| Who | Does here | Must never meet |
+|---|---|---|
+| **ADMIN** | all eight evidence categories as connected, partly connected or absent — people, work, communication, delivery, support, sales, cost, AI — and which metrics each unlocks; what each source declares about itself: fields, window, freshness, blind spots, and which level it supports — measurement, diagnosis, recommendation or validation (VISION §10.10); which links between systems are weak or broken, and what would repair them | being left to guess why a screen is empty |
+| **LEAD, EXEC** | the cause named directly — which source is missing, which identities are unresolved, which link is broken — plus the minimal fix | a comparison across two periods whose source windows do not overlap |
+| **IC** | the same guarantee on their own context | — |
+| **PEER** | the same guarantee, on the whole organization at once | — |
 
-**IC** — The same guarantee on their own context.
-
-**Not this.** No zero in place of missing data — a zero looks like a measurement and raises a false
+**Not this:** no zero in place of missing data — a zero looks like a measurement and raises a false
 alarm. And no "rough estimate for now": the honest answer to a missing source is what is missing.
-
-**Detail.** A1 (what can be proven), A4 (no answer, but what to connect), C8 (event in the business or
-break in the data).
 
 ## S-8 · Identity, roles and organization model · Service
 
-**The scenario.** Someone who appears separately in code, tickets, chat and the HR system is
-recognised as one person, with a stated confidence. The customer can correct the result, the correction
-survives the next sync, and role and team history is preserved so past periods are not recalculated
-under a model that was not valid at the time (VISION §8.2, §7.2).
+Someone who appears separately in code, tickets, chat and the HR system is recognised as one person,
+with a stated confidence. The customer can correct the result, the correction survives the next sync,
+and role and team history is preserved so past periods are not recalculated under a model that was not
+valid at the time (VISION §8.2, §7.2).
 
-**ADMIN** — Sort out who is who.
-- sees what was matched automatically, where the system is unsure, and where it got it wrong
-- merges and splits reversibly
-- defines roles, several roles per person, and role history
-- never loses a manual correction to the next sync
+**User scenarios in this class**
+- Which identity links did the system make, where is it unsure, where wrong? — ADMIN
+- How do I tell the product who is supposed to do what here? — ADMIN
+- Someone is listed in one role and does another — error or reality? — LEAD, ADMIN
 
-**LEAD, EXEC** — Trust the tree they roll up into (VISION §7.2 — temporal team membership).
-- never a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it
+| Who | Does here | Must never meet |
+|---|---|---|
+| **ADMIN** | what was matched automatically, where the system is unsure, and where it got it wrong; merges and splits, reversibly; roles, several per person, and role history | losing a manual correction to the next sync |
+| **LEAD, EXEC** | a tree they can trust to roll up into (VISION §7.2 — temporal team membership) | a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it |
+| **IC, PEER** | being one person, not four | their work attributed to a duplicate of themselves |
 
-**IC** — Be one person, not four.
-- never has their work attributed to a duplicate of themselves
-
-**Not this.** Where observed work does not match the configured role model, Insight recommends
+**Not this:** where observed work does not match the configured role model, Insight recommends
 changing the configuration — not the person (VISION §9).
-
-**Detail.** A2 (identity queue), A3 (roles and expected activities), C7 (role vs observed work).
 
 ## S-9 · Configuration and access · Service
 
-**The scenario.** The customer configures roles, activities, sources, metrics, thresholds, cohorts,
-dashboards, localization and access rules (VISION §9). Access to raw, people-level, aggregate, cost and
-recommendation data is role-based and policy-controlled, and the boundary holds on every surface.
+The customer configures roles, activities, sources, metrics, thresholds, cohorts, dashboards,
+localization and access rules (VISION §9). Access to raw, people-level, aggregate, cost and
+recommendation data is role-based and policy-controlled, and the boundary holds on every surface. Where
+a setting cannot yet be honoured, the gap is shown rather than implied — timezone is the live example:
+dates are bucketed in UTC while a period is chosen in the viewer's own zone, so an event near local
+midnight can land a day either side, and until sources carry people's timezones the divergence is
+labelled on the surface.
 
-**ADMIN** — Decide who gets what.
-- grants the five kinds of data one by one
-- adapts roles, metrics and thresholds without engineering involvement
-- sets language, date, number, currency and timezone rules
-- never holds all five kinds implicitly; a refusal is enforced by the system, not only hidden on screen
+**User scenarios in this class**
+- How do I give a lead their team and nothing more? — ADMIN
+- Can we work in our own language and timezone? — everyone
+- The configuration half of "who is supposed to do what here" — ADMIN
 
-**Where a setting cannot yet be honoured, the gap is shown rather than implied.** Timezone is the live
-example: dates are bucketed in UTC while a period is chosen in the viewer's own zone, so an event near
-local midnight can land a day either side. Until sources actually carry people's timezones, the
-divergence is labelled on the surface instead of being quietly absorbed — the same rule as evidence
-gaps in §5.
+| Who | Does here | Must never meet |
+|---|---|---|
+| **ADMIN** | grants the five kinds of data one by one; adapts roles, metrics and thresholds without engineering involvement; sets language, date, number, currency and timezone rules | holding all five kinds implicitly · a refusal only hidden on screen rather than enforced by the system |
+| **LEAD** | their own team, in full, at every depth | one level up, or sideways — the limit is structural, not a filter on a screen |
+| **EXEC** | the organization as a whole: aggregates, and people where person-level access is granted; the underlying records only where granted | raw access as a privilege of rank — it is one of the five grants |
+| **PEER** | the organization as a whole, everyone by name — person-level sight is what the mode grants | records, cost or recommendations without their own grant |
+| **IC** | themselves — named to their own management chain and to anyone else granted person-level access for their part of the organization | being named to anyone outside it |
 
-**LEAD** — Their own team, in full.
-- every depth inside it
-- never one level up, and never sideways — the limit is structural, not a filter on a screen
-
-**EXEC** — The organization as a whole.
-- aggregates, and people where person-level access is granted
-- the underlying records only where granted — raw access is one of the five grants, not a privilege of rank
-
-**IC** — Themselves.
-- named to their own management chain and to anyone else granted person-level access for their part of
-  the organization — and to nobody outside it
-
-**Not this.** Insight is read-only towards connected systems: it writes its own configuration and
+**Not this:** Insight is read-only towards connected systems: it writes its own configuration and
 annotations, nothing else (VISION §13.3).
-
-**Detail.** G1 (who sees what), G3 (language and timezone), and the configuration half of A3.
 
 ## S-10 · Deployment, upgrade and migration · Service
 
-**The scenario.** The product is installed, updated, upgraded and — where it replaces something —
-migrated into, without losing what already worked. Deployment models differ (Constructor-hosted,
-customer cloud, private cloud, customer-operated), and in all of them customer data stays under
-customer control (VISION §1, §14.1, §15.2).
+The product is installed, updated, upgraded and — where it replaces something — migrated into, without
+losing what already worked. Deployment models differ (Constructor-hosted, customer cloud, private
+cloud, customer-operated), and in all of them customer data stays under customer control (VISION §1,
+§14.1, §15.2).
 
-**ADMIN** — Run it.
-- install, configure, update and upgrade a customer-operated deployment
-- inventory what exists first, then keep / rename / replace / retire
-- import history where retention allows, and check parity over an agreed period
-- never lose a surface that worked before an upgrade — what was live before it is checked after it
+**User scenarios in this class**
+- How do we replace what we have without losing history? — ADMIN, EXEC
 
-**EXEC** — Replace the previous system with confidence.
-- parity stated openly, including what could not be reproduced
-- never a parity claim that quietly omits it
+| Who | Does here | Must never meet |
+|---|---|---|
+| **ADMIN** | install, configure, update and upgrade a customer-operated deployment; inventory what exists first, then keep, rename, replace or retire; import history where retention allows, and check parity over an agreed period | losing a surface that worked before an upgrade — what was live before it is checked after it |
+| **EXEC** | the previous system replaced with confidence — parity stated openly, including what could not be reproduced | a parity claim that quietly omits what could not be reproduced |
+| **LEAD, IC, PEER** | their history kept across the change (VISION §7.2) | a past period silently recalculated under a new model |
 
-**LEAD, IC** — Keep their history across the change (VISION §7.2 — past periods stay under the model valid at the time).
-- never a past period silently recalculated under a new model
-
-**Not this.** Insight does not require Constructor to have default access to customer data in order to
-operate (VISION §1).
-
-**Detail.** G4 (migrate off a legacy system).
+**Not this:** Insight does not require Constructor to have default access to customer data in order
+to operate (VISION §1).
 
 ---
 
@@ -487,7 +403,9 @@ From the vision, stated once here instead of repeated in each scenario.
    compared, never conflated; history is kept under the model valid at the time.
 10. **Two group-size thresholds, and they are different** — a group figure is not shown below **four**
     people, and a comparative conclusion is not drawn below **eight** on each side. The first keeps an
-    individual unidentifiable behind a number; the second keeps a claim from resting on a handful.
+    individual unidentifiable behind a number; the second keeps a claim from resting on a handful. The
+    one threshold the product enforces today sits between them: a peer comparison — the median and
+    quartiles behind a person's position — is not computed below **five** observed people.
 11. **A metric with a known defect says so on the metric itself** — and where a conclusion would rest
     on it, the metric is excluded by name rather than quietly included.
 12. **A group figure is computed for the group in view** — never inherited from a wider scope. This is
@@ -495,53 +413,6 @@ From the vision, stated once here instead of repeated in each scenario.
     that is correct rather than a discrepancy.
 
 ---
-
-## Appendix A · The detailed user scenarios
-
-Thirty concrete questions — one person, one question, one moment — from the product scenario draft of
-2026-08-04. They are the level at which features are specified and tested; the scenarios in §2–§4 are
-what all of them must obey. Availability is deliberately not recorded here: it changes per release and
-per customer, since the connected source set differs.
-
-| ID | The question behind it | Who asks | Scenario |
-|---|---|---|---|
-| B1 | What is visible about me, and what is in my way? | IC | S-1 |
-| B2 | What changed for my team over the period? | LEAD | S-1 |
-| B3 | Where is work stalling? | LEAD | S-1 |
-| B4 | What falls apart if a specific person drops out? | LEAD, EXEC | S-1 |
-| B5 | Where are we improving, and where just getting busier? | EXEC | S-1 |
-| B6 | How much does AI cost, who spends it, in what form? | EXEC · Finance | S-1 |
-| B8 | How much goes into coordination instead of work? | LEAD | S-1 |
-| C1 | Did throughput rise where AI was adopted, and what did it cost? | LEAD, EXEC | S-2 |
-| C2 | Is speed limited by writing code or by reviewing it? | LEAD | S-2 |
-| C3 | Speed went up — did quality hold? | LEAD · Product | S-2 |
-| C4 | Is this ticket spike caused by what we shipped? | LEAD · Support | S-2 |
-| C5 | Activity rose — did the deals move? | LEAD, EXEC | S-2 |
-| C6 | Development got cheaper — did the cost move somewhere else? | EXEC · Finance | S-2 |
-| E1 | Is it feasible, what will it cost, how long, what risks? | EXEC, LEAD · Product | S-2 |
-| E2 | Where is the effect larger for less effort? | EXEC · Product | S-2 |
-| D1 | I can see the problem — what do I do? | LEAD | S-3 |
-| D2 | Was it applied? Did it help? | LEAD, EXEC | S-3 |
-| D3 | We had a reorg that month — how do I say so? | LEAD | S-3 |
-| B7 | How does group A differ from group B in the same scope? | LEAD, EXEC | S-4 |
-| G2 | How do we pull this into our BI, a report, or a bot? | ADMIN, LEAD | S-5 |
-| F1 | Our three-day cycle — is that bad? | EXEC | S-6 |
-| A1 | Which questions can I already ask, and which not? | ADMIN | S-7 |
-| A4 | Why is this empty, and what would make it not empty? | ADMIN, LEAD | S-7 |
-| C8 | Is this an event in the business, or a break in the data? | ADMIN, LEAD, EXEC | S-7 |
-| A2 | Which identity links did the system make, where is it unsure, where wrong? | ADMIN | S-8 |
-| A3 | How do I tell the product who is supposed to do what here? | ADMIN | S-8, S-9 |
-| C7 | Someone is listed in one role and does another — error or reality? | LEAD, ADMIN | S-8 |
-| G1 | How do I give a lead their team and nothing more? | ADMIN | S-9 |
-| G3 | Can we work in our own language and timezone? | all | S-9 |
-| G4 | How do we replace what we have without losing history? | ADMIN, EXEC | S-10 |
-
-All thirty map to a scenario. S-6 is the only scenario with no concrete question behind it yet.
-
-Six questions arrive from a function rather than a reach — finance (B6, C6) and product management
-(C3, C4, E1, E2). Each is carried by a reach persona in that function (§1.2). In a `flat`
-installation, MEMBER may ask any question listed for EXEC, LEAD or IC; the reach personas name the
-`org_chart` case.
 
 ---
 
@@ -566,16 +437,22 @@ deployment comes from elsewhere in the vision.
 
 ---
 
+---
+
 ## Appendix C · Open points
 
 Several claims in this document go beyond what VISION.md and the scenario draft state. They are written
 as requirements because the alternative is to leave them undecided, but each needs a decision rather
 than a nod.
 
-- **Administrative rights and data visibility** — settled. §1.1 asserts that ADMIN gains no data
+- **Administrative rights and data visibility** — settled. §1 asserts that ADMIN gains no data
   visibility implicitly, and the access model agrees: the identity service's visible-set predicate
   carries no role term (ADR-0015), under either visibility mode.
-- **Ranking in flat mode.** A MEMBER sees every other member's position band. VISION §3 rules out a
+- **An executive is a manager with a larger subtree.** The product tells EXEC from LEAD only by how
+  much of the organization reports to them, so anything this document gives EXEC and withholds from
+  LEAD holds by scope, not by rule. An EXEC-only rule cannot be enforced until the product knows a
+  title.
+- **Ranking in flat mode.** A PEER sees every other member's position band. VISION §3 rules out a
   default view that ranks named individuals; a flat organization has opted into seeing everyone.
   Which of the two this is has to be decided before the mode is sold as a feature — and if the bands
   are a ranking, whether flat mode suppresses them or the customer accepts them.
@@ -585,9 +462,13 @@ than a nod.
 - **An identity correction surviving the next sync** (S-8). The draft says merges and splits are
   reversible; neither document says a correction is not undone by re-resolution. Stated here as a
   requirement, because a correction that does not survive is not a correction.
-- **The two group-size thresholds** (§5, rule 10) are four for a group figure and eight per side for a
-  comparative conclusion. Both come from the scenario draft rather than from the vision, and they are
-  worth confirming as product rules — including whether a customer may configure them.
+- **The group-size thresholds** (§5, rule 10). The four for a group figure and the eight per side for a
+  comparative conclusion come from the scenario draft rather than from the vision, and are worth
+  confirming as product rules — including whether a customer may configure them. The five for a peer
+  comparison is the product's own, and is the only one of the three confirmed to be enforced.
+- **Recommendation ownership in a flat organization.** S-3 expects a named owner for every lever. A
+  flat organization has no lead, so either the owner is chosen some other way, or recommendations are
+  not offered under `flat` — and the mode should say which.
 - **IC has the narrowest surface and the tightest boundary.** Everything an IC sees is their own or a
   median — the combination that is easiest to get wrong quietly.
 - **S-6 has no surface yet.** Listed so the capability stays planned for, not to imply it exists.

--- a/docs/testing/PERSONAS.md
+++ b/docs/testing/PERSONAS.md
@@ -1,59 +1,54 @@
 # Constructor Insight — Personas & Scenarios (quality baseline)
 
 **Date:** 2026-09-02 · **Status:** draft, for QA review
-**Product source of truth:** [`SCENARIOS.md`](../product/SCENARIOS.md) —
-five personas over two visibility modes, ten scenarios S-1…S-10 with per-persona boundary tables,
-and twelve rules that hold everywhere. The individual user questions (A1…G4) stay in the
-workspace's `quality/user-scenarios.md`. This document does not restate either; where it adds a
-requirement of its own, the line is marked **(QA addition)**.
+**Product source of truth:** [`SCENARIOS.md`](../product/SCENARIOS.md) — the personas, the
+scenarios, their per-persona boundaries and the rules that hold in every scenario. The individual
+user questions (A1…G4) stay in the workspace's `quality/user-scenarios.md`. This document does not
+restate either; where it adds a requirement of its own, the line is marked **(QA addition)**.
 
-**What this document holds** — the QA half the product doc deliberately omits: who we log in as on
-a stand and what that costs when it fails (§1), the mapping from test fixtures and markers to
-personas and scenarios (§2), the order in which the scenarios are verified and what a check asserts
-beyond the product tables (§3), the assertable invariants (Appendix A), and what is blocked and by
-what (Appendix B).
+**What this document holds** — the QA half the product doc deliberately omits: the logins and what
+a failure costs (§1), the mapping from test fixtures and markers to personas and scenarios (§2),
+the order in which the scenarios are verified and what a check adds beyond the product tables (§3),
+the invariant check registry (Appendix A), and what is blocked and by what (Appendix B).
 
-**Vocabulary.** A *stand* is a test environment running a full copy of the product. A *typical
-value* means one group-level figure — the median — never a list of colleagues. The two *visibility
-modes* (`org_chart`, `flat`) are defined in the product doc's Personas section.
+**Vocabulary.** A *stand* is a test environment running a full copy of the product. The two
+*visibility modes* (`org_chart`, `flat`) are defined in the product doc's Personas section.
 
 > **Where this stands today.** The 17 invariants in Appendix A are the first thing worth automating,
 > and most can start now: they are assertions against API responses and run on any stand that has
 > data. The exceptions are governance (A11–A13), which needs every persona present at once on one
-> stand with realistic reporting lines, and anything PEER, which needs a stand running flat — **and
-> no test stand satisfies either today.** Those fixtures, not the test design, are the blocker on
-> P0 coverage.
+> stand with realistic reporting lines, and anything PEER — **and no test stand satisfies either
+> today**: none runs flat, and no seeded org carries the full persona set. Those fixtures, not the
+> test design, are the blocker on P0 coverage.
 
 ---
 
 ## 1. Personas — the QA view
 
-Reach, questions and boundaries per persona live in the product doc. What QA adds is the login and
-the failure cost.
+Who each persona is, how far they see and what bounds them lives in the product doc. What QA adds
+is the login and the failure cost.
 
-The **mode is a property of the stand**, set once per installation. At test time it is read from
-`GET /v1/me` (`visibility_policy`), once per session — never assumed, never taken from a manifest.
-Observed 2026-09-01: dev and qaclust run `org_chart`; cf-prod runs `flat`. No stand we control for
-testing runs flat.
+The **mode is a property of the stand.** At test time it is read from `GET /v1/me`
+(`visibility_policy`), once per session — never assumed, never taken from a manifest. Observed
+2026-09-01: dev and qaclust run `org_chart`; cf-prod runs `flat`. No stand we control for testing
+runs flat.
 
 | Persona | Who we log in as, on a stand | What a failure costs them |
 |---|---|---|
-| **EXEC** | Someone whose subtree is the whole organization — the seed's `ceo`. That account also holds the admin role, so there is no EXEC-without-ADMIN login today (Appendix B) | A board-level number that is wrong or unexplained |
-| **LEAD** | A manager with at least eight people under them — a seed `*_lead`; comparative conclusions need eight per side | Acting on a jam that is a data artefact |
-| **IC** | Someone with nobody reporting to them — a seed `*_ic`; the tightest case in `org_chart` | Seeing colleagues' activity, or their own numbers misattributed |
-| **PEER** | Any signed-in person on a stand running flat — no such stand and no such fixture exists today (Appendix B) | A rank shown that the mode does not promise; a comparison computed below the five-person floor |
-| **ADMIN** | The seed's `admin_operator` — holds the admin role plus access to the stand itself | Shipping a customer that silently proves nothing |
+| **EXEC** | The seed's `ceo`. That account also holds the admin role, so there is no EXEC-without-ADMIN login today (Appendix B) | A board-level number that is wrong or unexplained |
+| **LEAD** | A seed `*_lead`, picked with at least eight reports so eight-per-side comparisons are exercisable | Acting on a jam that is a data artefact |
+| **IC** | A seed `*_ic` | A leak of what the product must withhold from them, or their own work credited away |
+| **PEER** | No fixture — blocked on a flat stand (Appendix B) | An identifiable person behind a figure the floor should have withheld |
+| **ADMIN** | The seed's `admin_operator`, which also carries access to the stand itself | Shipping a customer that silently proves nothing |
 | **none** | An account from another tenant, or one no person resolves to | Anything at all: the only correct responses are a refusal or an empty scope |
 
 Three consequences for the setup:
 
-- **A run covers one mode.** The personas a stand can host follow from its mode: `org_chart` gives
-  EXEC, LEAD, IC; `flat` gives PEER; ADMIN and `none` exist under both. A pass as EXEC says nothing
-  about IC — and nothing at all about PEER until a flat stand exists.
-- **IC is the tightest case in `org_chart`; PEER inverts it.** IC is where the product must refuse
-  the most, so it is the first place to check refusals. PEER has the broadest reach with one floor
-  under it — the five-person minimum on a comparison — so it is the first place to check that the
-  one remaining limit holds.
+- **A run covers one mode.** Which personas a stand can host follows from its mode (the product
+  doc's mode table); `none` is QA's own login, not a product persona, and exists under both. A pass
+  as EXEC says nothing about IC — and nothing at all about PEER until a flat stand exists.
+- **Refusals are checked first where the product bounds tightest.** Under `org_chart` that is IC;
+  under `flat` it is the five-person floor (A17) — the one limit the mode leaves standing.
 - **Logging in as every persona, plus `none`, is a prerequisite, not a detail.** The governance
   invariants (A11–A13) cannot be checked otherwise.
 
@@ -103,123 +98,103 @@ not a coverage matrix. Priority (§3) says what runs first; markers say what run
 ## 3. Scenario priorities
 
 The scenario definitions — one sentence, the per-persona table, *Not this*, *Today* — live in the
-product doc. This section holds only the verification order and what a check asserts beyond them.
+product doc. This section holds only the verification order and what a check adds beyond them.
 
 **The rule that produced the order:** a service scenario is verified before a main one in two cases
 — when the main tier cannot produce a correct answer without it, or when its failure cannot be
 undone afterwards. Identity (S-8) is the first case: a wrong person makes every number wrong.
 A governance breach (S-9) is the second: no patch un-leaks a name.
 
-| Priority | Scenario | Tier | Why here |
-|---|---|---|---|
-| **P0** | S-1 Metrics review | Main | Everything the product says stands on it, for every persona |
-| **P0** | S-9 Configuration and access | Service | Irreversible failure: one leak of a named individual is not fixable by a patch |
-| **P0** | S-8 Identity and organization model | Service | A wrong person makes every metric wrong |
-| **P1** | S-2 Analysis and diagnosis | Main | The differentiator vs a dashboard; the first vertical |
-| **P1** | S-3 Conclusions: recommendation and validation | Main | Its pre-declaration requirement expires at issue time |
-| **P1** | S-7 Sources and evidence coverage | Service | Saying plainly what is missing is what makes any number trustworthy |
-| **P2** | S-4 Dashboards, views and exploration | Secondary | What it adds beyond S-1 is composition; its boundary risks are S-9's checks run through exploration paths |
-| **P2** | S-5 Sharing and reuse | Secondary | Matters at specific moments — a number leaving the product — not continuously |
-| **P2** | S-10 Deployment, upgrade and migration | Service | Matters intensely at upgrade and migration moments, not continuously |
-| **P3** | S-6 External comparison | Secondary | No surface exists yet — carried so the clean-room rule is not silently lost |
+| Priority | Scenario | Why here |
+|---|---|---|
+| **P0** | S-1 Metrics review | Everything the product says stands on it, for every persona |
+| **P0** | S-9 Configuration and access | Irreversible failure: one leak of a named individual is not fixable by a patch |
+| **P0** | S-8 Identity and organization model | A wrong person makes every metric wrong |
+| **P1** | S-2 Analysis and diagnosis | The first vertical ships here, and its acceptance suite must exist first (§4) |
+| **P1** | S-3 Conclusions: recommendation and validation | Its pre-declaration check expires at issue time |
+| **P1** | S-7 Sources and evidence coverage | Honest emptiness is what makes every other number trustworthy |
+| **P2** | S-4 Dashboards, views and exploration | Verified by re-running S-9's checks through exploration paths |
+| **P2** | S-5 Sharing and reuse | Checked at export moments, not continuously |
+| **P2** | S-10 Deployment, upgrade and migration | Checked at upgrade and migration moments, not continuously |
+| **P3** | S-6 External comparison | A stub, carried so the clean-room rule is not silently lost |
 
-Read the three P0 rows as the answer to "what do we verify on every build": one main scenario and
-two service ones, because those two are the only failures that cannot be undone.
+Read the three P0 rows as the answer to "what do we verify on every build": one main-tier scenario
+and two service ones, because those two are the only failures that cannot be undone.
 
 For readers of the previous revision, the old function IDs map as: PF-3 → S-1 + S-4 · PF-6 → S-9 ·
 PF-2 → S-8 · PF-4 → S-2 · PF-5 → S-3 · PF-1 → S-7 · PF-7 → S-5 + S-10 · PF-8 → S-6 plus the
 forward-looking half of S-2.
 
-Each block below: **Asserts** — what a check verifies beyond the product tables; **Invariants** —
-which Appendix A rules bind here (Appendix A is the assertable form and wins over prose);
-**Traces** — the `user-scenarios.md` questions feature tests are written against; **Covers** — the
-vectors in the workspace's `quality/insight-quality-framework.md` this scenario feeds.
+Each block below: **Checks** — only what QA adds on top of the product tables; a block with nothing
+to add carries none. **Invariants** — the Appendix A checks that bind here. **Traces** — the
+`quality/user-scenarios.md` questions feature tests are written against. **Covers** — the vectors
+in the workspace's `quality/insight-quality-framework.md` this scenario feeds.
 
 ### S-1 · Metrics review · P0
 
-**Asserts.** Of the three group-size floors only one is enforced today — a peer comparison is not
-computed below five people with data (`MIN_PEER_N = 5` in the analytics metric-results compiler);
-the four-person floor on a group figure and the eight-per-side floor on a conclusion are promises.
-Checks assert the enforced floor as behavior and the promised floors as they land, and always
-against people-who-have-data, never headcount. Ranking checks assert the **default** screen — a
-named ranking a granted manager explicitly requests is permitted, so asserting impossibility is
-asserting the wrong thing.
+**Checks.** Of [rule 10](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario)'s three
+floors only A17 is enforced — asserted as behavior; A9 and A10 are asserted as they land. Ranking
+checks target the default screen, never impossibility
+([rule 4](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario)).
 **Invariants.** A1–A4, A9, A14–A17. **Traces.** B1–B8 (B4 concentration, B6 cost and B7 cohorts are
 the heterogeneous ones). **Covers.** Reliability.
 
 ### S-9 · Configuration and access · P0
 
-**Asserts.** The persona × grant negative matrix — five kinds of data, each granted one by one, each
-refusal enforced where the data is produced rather than hidden by the screen, so it holds for a
-direct API call too **(QA addition)**. The admin role alone grants no metric visibility — asserted
-against the identity service, not the UI. Expected values differ by mode: under flat, "their own
-part of the organization" is the whole organization, so the matrix is evaluated per mode, not once.
+**Checks.** The persona × grant negative matrix over the five kinds of data
+([rule 5](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario)), asserted with direct API
+calls and evaluated once per mode — the expected values differ between `org_chart` and `flat`. The
+admin-role check points at the identity service, not the UI.
 **Invariants.** A11–A13. **Traces.** G1, B1 (IC isolation), B4 (anonymous cut), F1 (clean room).
 **Covers.** Security.
 
 ### S-8 · Identity and organization model · P0
 
-**Asserts.** Every automatic match carries its grounds and confidence; every merge and split is
-reversible; a manual correction survives the next data refresh **and the next product upgrade**
-**(QA addition)**. Past periods keep the shape and numbers they were reported under.
+**Checks.** A manual correction must survive a product upgrade, not only the next sync
+**(QA addition)**.
 **Invariants.** — (none bind identity directly; it gates all of them instead.) **Traces.** A2; A3
 and C7 blocked (Appendix B). **Covers.** Reliability.
 
 ### S-2 · Analysis and diagnosis · P1
 
-**Asserts.** The refusal cases are the acceptance suite: exactly seven people on one side of a
-comparison — one below the floor — must yield a withheld conclusion that says why; a metric under a
-known defect must be excluded by name, not quietly folded in. Correlation is declared on the answer
-itself. The forward-looking half (feasibility and investment ranking) has no screen — carried, not
-asserted.
+**Checks.** The refusal cases are the acceptance suite. The concrete case: exactly seven people on
+one side of a comparison — one below A10's floor — must produce a withheld-with-reason response.
 **Invariants.** A5–A8, A10, A16. **Traces.** C1, C8; C2–C6 blocked, E1–E2 unbuilt (Appendix B).
 **Covers.** Reliability.
 
 ### S-3 · Conclusions: recommendation and validation · P1
 
-**Asserts.** The lever's measure, the outcome, the guardrail and the validation window are all fixed
-at issue time — pre-declaration is unrecoverable afterwards, so it must land with the first
-recommendation, not after it. "Not enough data" is available as an honest outcome. The product
-writes nothing back into a connected system. An IC is never the subject; the PEER row is an open
-product decision.
+**Checks.** Pre-declaration is unrecoverable after a recommendation is issued, so its check must
+land with the first recommendation, not after it (§4).
 **Invariants.** A13. **Traces.** D1; D2 and D3 blocked (Appendix B). **Covers.** Reliability,
 Security.
 
 ### S-7 · Sources and evidence coverage · P1
 
-**Asserts.** Never a zero standing in for missing data, never an estimate in place of an answer;
-a comparison across two periods whose source windows do not overlap is withheld with the source
-named. Every empty screen states its cause, for every persona including on an IC's own page.
 **Invariants.** A5–A8. **Traces.** A1, A4, C8 (the freshness and window part), G3 (the timezone
 caveat). **Covers.** Versatility, Reliability.
 
 ### S-4 · Dashboards, views and exploration · P2
 
-**Asserts.** Exploration moves the question, never the boundary: the S-9 matrix re-run through
-composed views, slices and follow-backs — an exploration path never reaches outside the viewer's
-reach, a follow-back never reaches underlying records without that grant, and a composed group
-figure is recalculated for what is on screen.
-**Invariants.** A4, A9, A11, A12. **Traces.** B7; the rest of the B family is reached here by
-composition rather than by reading. **Covers.** Reliability, Security.
+**Checks.** The S-9 matrix re-run through composed views, slices and follow-backs.
+**Invariants.** A4, A9, A11, A12. **Traces.** B7; the other B-family questions are reached here
+through composition. **Covers.** Reliability, Security.
 
 ### S-5 · Sharing and reuse · P2
 
-**Asserts.** A number leaves the product together with its definition, coverage and confidence, and
-the access rules that apply inside apply on the API and governed-access surface.
 **Invariants.** A12, A13. **Traces.** G2. **Covers.** Versatility.
 
 ### S-10 · Deployment, upgrade and migration · P2
 
-**Asserts.** Every view that worked before an upgrade works after it, and a breakage surfaces to
-whoever ran the upgrade before a user meets it **(QA addition)**. History — everyone's — is kept
-across the change; a migration states parity openly, including what could not be reproduced.
+**Checks.** A breakage after an upgrade must surface to whoever ran the upgrade before a user meets
+it **(QA addition)**.
 **Invariants.** — **Traces.** G4. **Covers.** Versatility, Reliability.
 
 ### S-6 · External comparison · P3
 
-**Stub — deliberately.** No surface exists, so there is nothing to assert yet. Carried so the
-clean-room rule is not silently lost: only anonymized, opt-in, revocable aggregates ever leave the
-customer boundary.
+**Stub — deliberately.** Nothing to assert until a surface exists (Appendix B); carried so
+[rule 8](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario) stays in the verification
+order.
 **Invariants.** — **Traces.** F1. **Covers.** — (assigned when a surface exists.)
 
 ---
@@ -238,7 +213,7 @@ customer boundary.
 4. **S-9 is the security vector's content** — a persona × grant × mode negative matrix, not a
    scanner.
 5. **S-2's acceptance suite must exist before the first vertical ships** — specifically the
-   seven-on-a-side refusal and the excluded-by-name defective metric. By the scenario's own
+   seven-on-a-side refusal (its Checks line) and A8's exclusion check. By the scenario's own
    definition, an incomplete answer there is not thin but wrong.
 6. **S-3's pre-declaration requirement expires.** It costs nothing at issue time and is
    unrecoverable afterwards; it lands with the first recommendation or the validation half is
@@ -254,90 +229,81 @@ customer boundary.
 
 Settled since the last revision:
 
-- **Who owns E1 now that PM is folded away** — settled by the product doc: function is an axis of
-  the user scenario, not a persona, so feasibility is asked by EXEC or a LEAD *from product* in S-2.
+- **Who owns E1 now that PM is folded away** — settled by the product doc's function axis: the
+  question rides S-2.
 - **Is this the missing persona catalog the framework asks for** — the product doc is that catalog;
   this document is the QA baseline over it, and both now link.
 
 Still open:
 
-- **Which stand hosts which scenario?** S-1 needs organization-scale data, S-2 needs eight per side,
-  S-9 needs every persona with realistic reporting lines, and PEER needs a flat stand — one chart
-  value on a compose release would create one, but nobody owns it. No seeded stand satisfies any of
-  the four today.
+- **Which stand hosts which scenario?** S-1 needs organization-scale data, S-2 needs eight people
+  with data on each comparison side, S-9 needs every persona with realistic reporting lines, and
+  PEER needs a flat stand — one chart value on a compose release would create one, but nobody owns
+  it. No seeded stand satisfies any of the four today.
 - **Are the five kinds of access enforced today, or only designed?** S-9's matrix and the ADMIN
   boundary both depend on the answer.
-- **Does ADMIN get metric visibility by default on current stands?** The product doc asserts it must
-  not; confirming it means asking the identity service, not the UI.
+- **Does ADMIN get metric visibility by default on current stands?** Confirming the product doc's
+  promise means asking the identity service, not the UI.
 - **Is the e2e rig in scope for the persona markers?** It is the second strict-marker root; leaving
   it out halves the meta test's value, taking it in drags the markers into a slower suite.
 - **When does `member_session` become `ic_session`?** The rename is agreed; it touches every test
   that names the fixture.
-- **The product doc's own open points that block QA expected values:** whether flat mode's position
-  band is a ranking (blocks PEER's S-1 assertions), who owns a recommendation under flat (blocks the
-  S-3 PEER row), and whether the four / eight thresholds are customer-configurable (blocks writing
-  the numbers into assertions).
+- **The product doc's [Open points](../product/SCENARIOS.md#7-open-points) that block expected
+  values:** *Ranking in flat mode* blocks PEER's S-1 assertions; *Recommendation ownership in a
+  flat organization* blocks the S-3 PEER row; *The group-size thresholds* blocks hardcoding four
+  and eight — until it is decided, checks reference the rule, not a literal.
 
 ---
 
 ## Appendix A · Cross-scenario invariants
 
-The product declares these rules itself, and each is a defect class already seen. They hold across
-every scenario above, so they are asserted once and reused rather than re-implemented inside each
-feature's tests. **This is the first automation target.**
+The check registry: each entry is a defect class already seen, asserted once and reused rather than
+re-implemented inside each feature's tests. **This is the first automation target.** The product doc
+owns what each rule means; an entry here names its owner and adds only what a check needs —
+enforcement status, code anchors, defect references, run requirements. Three entries (A1–A3) have no
+product owner: they are QA conventions carried from the workspace's `quality/user-scenarios.md`.
 
-Numbering is local to this document (A1–A17) — `user-scenarios.md` numbers its own rules
-differently, so cite these as "A4", never as "rule 4".
+Numbering is local to this document (A1–A17) — cite these as "A4", never as "rule 4", which names
+the product doc's own numbering.
 
 **Metric grammar** (S-1, inherited by S-2 and S-4)
 
-- **A1.** Counts are always shown per active person, with the change since last period; a team total
-  may appear as a caption, never as the headline number.
-- **A2.** Averages and medians are never added together.
-- **A3.** "Concentration" figures — what share sits with the top tenth — are computed only over
-  figures that can be added up, and framed per area: a risk in development and the wiki, a workload
-  imbalance in communication.
-- **A4.** Group figures are recalculated for the group on screen, never carried over from a wider
-  scope.
+- **A1 · per-person counts.** QA convention: counts are shown per active person with the change
+  since last period; a team total is a caption, never the headline number.
+- **A2 · no mixed averages.** QA convention: averages and medians are never added together.
+- **A3 · concentration additivity.** The S-1 LEAD row owns the domain framing; the QA half:
+  a top-tenth share is computed only over figures that can be added up.
+- **A4 · group-figure recalculation.** [Rule 12](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario).
 
 **Honest emptiness / data quality** (S-7, S-2)
 
-- **A5.** Never a zero in place of missing data (`#1517`).
-- **A6.** Never a rough estimate in place of an answer.
-- **A7.** Two periods are compared only over time both sources cover.
-- **A8.** A metric with a known defect says so on the metric itself.
+- **A5 · no zero for missing data.** [Rule 1](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario) — observed as `#1517`.
+- **A6 · no estimate in place of an answer.** [Rule 1](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario).
+- **A7 · overlapping windows only.** The [S-7](../product/SCENARIOS.md#s-7--sources-and-evidence-coverage) LEAD, EXEC row.
+- **A8 · defect declared, and excluded from conclusions.** [Rule 11](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario).
 
-**Suppression thresholds** (S-1, S-2, S-4) — *each counts people who have data, never headcount*
+**Suppression thresholds** (S-1, S-2, S-4) — all three owned by [rule 10](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario)
 
-- **A9.** A group of fewer than four people is not shown at all, in any chart. *A promise, not yet
-  enforced.*
-- **A10.** A conclusion needs at least eight people on each side; below that it does not render, and
-  says why. *A promise, not yet enforced.*
-- **A17.** A peer comparison — the median and quartiles behind a person's position — is not computed
-  below five people with data. *The one threshold enforced today (`MIN_PEER_N = 5`, analytics
-  metric-results compiler); it protects IC's median and every PEER comparison.*
+- **A9 · the group-figure floor.** Not yet enforced.
+- **A10 · the per-side conclusion floor.** Not yet enforced.
+- **A17 · the peer-comparison floor.** Enforced: `MIN_PEER_N = 5` in the analytics metric-results
+  compiler.
 
 **Governance** (S-9) — *the three that need the full persona set*
 
-- **A11.** No default screen ranks named individuals against one another. Naming people is expected
-  where person-level access has been granted — a manager's team view names their reports; what is
-  forbidden is the ranking, and naming anyone outside the viewer's granted part of the organization.
-- **A12.** A viewer cannot reach outside their own part of the organization — enforced where the
-  data is produced, so it holds for a direct API call too. *Under flat, "their own part" is the
-  whole organization: the assertion's expected value depends on the stand's mode.*
-- **A13.** The product writes only its own settings and notes, never back into a connected system.
+- **A11 · no default ranking.** [Rule 4](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario).
+- **A12 · reach held at the API.** [Rule 5](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario) — the expected value depends on the stand's mode.
+- **A13 · no write-back.** [Rule 7](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario).
 
 **Cost & AI** (S-1, S-2)
 
-- **A14.** Usage-priced and seat-priced costs are never added into one figure; cost that cannot be
-  attributed to anyone gets its own line.
-- **A15.** No single "value of AI" number; cost that moves from one area to another is shown as
-  moving, not folded away.
-- **A16.** Where a claim is a correlation, the answer says so on itself, not in a footnote.
+- **A14 · cost kinds never summed.** [Rule 6](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario).
+- **A15 · cost movement preserved.** [Rule 6](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario).
+- **A16 · correlation declared.** [Rule 2](../product/SCENARIOS.md#6-rules-that-hold-in-every-scenario) and the [S-2](../product/SCENARIOS.md#s-2--analysis-and-diagnosis) *Not this*.
 
-**Where they can run.** A1–A10, A14–A16 and A17 are assertions against API responses and need only
-a stand with data — though A12's and A17's expected values depend on the stand's mode. A11–A13 need
-every persona present at once, with realistic reporting lines — the fixture that does not exist yet.
+**Where they can run.** All but A11–A13 are assertions against API responses and need only a stand
+with data — though A12's and A17's expected values depend on the stand's mode. A11–A13 need every
+persona present at once, with realistic reporting lines — the fixture that does not exist yet.
 
 ---
 
@@ -358,5 +324,5 @@ than an omission.
 | S-2 | Cost moved rather than fell (C6) | Not built — no downstream cost-movement model |
 | S-2 | Feasibility and investment ranking (E1, E2) | No screen exists yet |
 | S-3 | Outcome read-back (D2), period annotations (D3) | Not built — but pre-declaration must land with D1 (§4) |
-| S-3 | The PEER row | Open product decision: recommendation ownership in a flat organization |
+| S-3 | The PEER row | The product doc's open point *Recommendation ownership in a flat organization* |
 | S-6 | Everything | No surface exists yet |

--- a/docs/testing/PERSONAS.md
+++ b/docs/testing/PERSONAS.md
@@ -1,0 +1,362 @@
+# Constructor Insight — Personas & Scenarios (quality baseline)
+
+**Date:** 2026-09-02 · **Status:** draft, for QA review
+**Product source of truth:** [`SCENARIOS.md`](../product/SCENARIOS.md) —
+five personas over two visibility modes, ten scenarios S-1…S-10 with per-persona boundary tables,
+and twelve rules that hold everywhere. The individual user questions (A1…G4) stay in the
+workspace's `quality/user-scenarios.md`. This document does not restate either; where it adds a
+requirement of its own, the line is marked **(QA addition)**.
+
+**What this document holds** — the QA half the product doc deliberately omits: who we log in as on
+a stand and what that costs when it fails (§1), the mapping from test fixtures and markers to
+personas and scenarios (§2), the order in which the scenarios are verified and what a check asserts
+beyond the product tables (§3), the assertable invariants (Appendix A), and what is blocked and by
+what (Appendix B).
+
+**Vocabulary.** A *stand* is a test environment running a full copy of the product. A *typical
+value* means one group-level figure — the median — never a list of colleagues. The two *visibility
+modes* (`org_chart`, `flat`) are defined in the product doc's Personas section.
+
+> **Where this stands today.** The 17 invariants in Appendix A are the first thing worth automating,
+> and most can start now: they are assertions against API responses and run on any stand that has
+> data. The exceptions are governance (A11–A13), which needs every persona present at once on one
+> stand with realistic reporting lines, and anything PEER, which needs a stand running flat — **and
+> no test stand satisfies either today.** Those fixtures, not the test design, are the blocker on
+> P0 coverage.
+
+---
+
+## 1. Personas — the QA view
+
+Reach, questions and boundaries per persona live in the product doc. What QA adds is the login and
+the failure cost.
+
+The **mode is a property of the stand**, set once per installation. At test time it is read from
+`GET /v1/me` (`visibility_policy`), once per session — never assumed, never taken from a manifest.
+Observed 2026-09-01: dev and qaclust run `org_chart`; cf-prod runs `flat`. No stand we control for
+testing runs flat.
+
+| Persona | Who we log in as, on a stand | What a failure costs them |
+|---|---|---|
+| **EXEC** | Someone whose subtree is the whole organization — the seed's `ceo`. That account also holds the admin role, so there is no EXEC-without-ADMIN login today (Appendix B) | A board-level number that is wrong or unexplained |
+| **LEAD** | A manager with at least eight people under them — a seed `*_lead`; comparative conclusions need eight per side | Acting on a jam that is a data artefact |
+| **IC** | Someone with nobody reporting to them — a seed `*_ic`; the tightest case in `org_chart` | Seeing colleagues' activity, or their own numbers misattributed |
+| **PEER** | Any signed-in person on a stand running flat — no such stand and no such fixture exists today (Appendix B) | A rank shown that the mode does not promise; a comparison computed below the five-person floor |
+| **ADMIN** | The seed's `admin_operator` — holds the admin role plus access to the stand itself | Shipping a customer that silently proves nothing |
+| **none** | An account from another tenant, or one no person resolves to | Anything at all: the only correct responses are a refusal or an empty scope |
+
+Three consequences for the setup:
+
+- **A run covers one mode.** The personas a stand can host follow from its mode: `org_chart` gives
+  EXEC, LEAD, IC; `flat` gives PEER; ADMIN and `none` exist under both. A pass as EXEC says nothing
+  about IC — and nothing at all about PEER until a flat stand exists.
+- **IC is the tightest case in `org_chart`; PEER inverts it.** IC is where the product must refuse
+  the most, so it is the first place to check refusals. PEER has the broadest reach with one floor
+  under it — the five-person minimum on a comparison — so it is the first place to check that the
+  one remaining limit holds.
+- **Logging in as every persona, plus `none`, is a prerequisite, not a detail.** The governance
+  invariants (A11–A13) cannot be checked otherwise.
+
+---
+
+## 2. Harness mapping **(QA addition — deliberately absent from the product doc)**
+
+None of this is built as of 2026-09-02; it is the agreed target.
+
+**Persona comes from the session fixture** — who signs in — never from `requires_seed`, which names
+data, not a viewer:
+
+| Session fixture | Persona | Notes |
+|---|---|---|
+| `realm_admin_session` | EXEC | logs in as the seed `ceo`, who also holds admin |
+| `lead_session` | LEAD | |
+| `member_session` | IC | to be renamed `ic_session` — "member" is retired vocabulary |
+| `admin_operator_session` | ADMIN | |
+| `other_tenant_session` | none | |
+| — | PEER | no fixture exists; blocked on a flat stand |
+
+Seed roles (the seed profile's eleven role × team fixtures) map the same way: `ceo` → EXEC,
+`*_lead` → LEAD, `*_ic` → IC, `admin_operator` → ADMIN. The realm roles behind them are
+`insight-admin`, `insight-lead`, `insight-member`. Tests that build a session by name
+(`session_for(...)`) declare persona explicitly with a marker.
+
+**Markers** — on the stand-facing suites only (`tests/stand` api + ui); unit and contract suites
+never carry them. Whether the e2e rig is in scope is an open question (§5).
+
+- `persona(*codes)` · `mode(policy)` · `scenario(id)` — declared in both strict-marker roots
+  (`tests/pyproject.toml`, `src/ingestion/tests/e2e/pytest.ini`) with a meta test that the two
+  declarations match.
+- Selection: `--persona` (repeatable), `--mode`, `--scenario`, deselecting in
+  `pytest_collection_modifyitems`. An empty selection fails the run; exit-5 is not tolerated.
+- Collection gates, beside the existing vector gate in `tests/stand/conftest.py`: exactly one
+  persona per test and it agrees with the session fixture; at most one mode, with `peer ⇒ flat` and
+  `ic/lead/exec ⇒ org_chart`; exactly one scenario.
+- `mode("flat")` on an `org_chart` stand skips with a stated reason — the `requires_ingestion`
+  pattern. Today `test_me.py` fails the whole run on a non-`org_chart` stand; the marker turns that
+  failure into a skip.
+
+The purpose is **selection** — run a persona's, a mode's or a scenario's tests against a stand —
+not a coverage matrix. Priority (§3) says what runs first; markers say what runs at all.
+
+---
+
+## 3. Scenario priorities
+
+The scenario definitions — one sentence, the per-persona table, *Not this*, *Today* — live in the
+product doc. This section holds only the verification order and what a check asserts beyond them.
+
+**The rule that produced the order:** a service scenario is verified before a main one in two cases
+— when the main tier cannot produce a correct answer without it, or when its failure cannot be
+undone afterwards. Identity (S-8) is the first case: a wrong person makes every number wrong.
+A governance breach (S-9) is the second: no patch un-leaks a name.
+
+| Priority | Scenario | Tier | Why here |
+|---|---|---|---|
+| **P0** | S-1 Metrics review | Main | Everything the product says stands on it, for every persona |
+| **P0** | S-9 Configuration and access | Service | Irreversible failure: one leak of a named individual is not fixable by a patch |
+| **P0** | S-8 Identity and organization model | Service | A wrong person makes every metric wrong |
+| **P1** | S-2 Analysis and diagnosis | Main | The differentiator vs a dashboard; the first vertical |
+| **P1** | S-3 Conclusions: recommendation and validation | Main | Its pre-declaration requirement expires at issue time |
+| **P1** | S-7 Sources and evidence coverage | Service | Saying plainly what is missing is what makes any number trustworthy |
+| **P2** | S-4 Dashboards, views and exploration | Secondary | What it adds beyond S-1 is composition; its boundary risks are S-9's checks run through exploration paths |
+| **P2** | S-5 Sharing and reuse | Secondary | Matters at specific moments — a number leaving the product — not continuously |
+| **P2** | S-10 Deployment, upgrade and migration | Service | Matters intensely at upgrade and migration moments, not continuously |
+| **P3** | S-6 External comparison | Secondary | No surface exists yet — carried so the clean-room rule is not silently lost |
+
+Read the three P0 rows as the answer to "what do we verify on every build": one main scenario and
+two service ones, because those two are the only failures that cannot be undone.
+
+For readers of the previous revision, the old function IDs map as: PF-3 → S-1 + S-4 · PF-6 → S-9 ·
+PF-2 → S-8 · PF-4 → S-2 · PF-5 → S-3 · PF-1 → S-7 · PF-7 → S-5 + S-10 · PF-8 → S-6 plus the
+forward-looking half of S-2.
+
+Each block below: **Asserts** — what a check verifies beyond the product tables; **Invariants** —
+which Appendix A rules bind here (Appendix A is the assertable form and wins over prose);
+**Traces** — the `user-scenarios.md` questions feature tests are written against; **Covers** — the
+vectors in the workspace's `quality/insight-quality-framework.md` this scenario feeds.
+
+### S-1 · Metrics review · P0
+
+**Asserts.** Of the three group-size floors only one is enforced today — a peer comparison is not
+computed below five people with data (`MIN_PEER_N = 5` in the analytics metric-results compiler);
+the four-person floor on a group figure and the eight-per-side floor on a conclusion are promises.
+Checks assert the enforced floor as behavior and the promised floors as they land, and always
+against people-who-have-data, never headcount. Ranking checks assert the **default** screen — a
+named ranking a granted manager explicitly requests is permitted, so asserting impossibility is
+asserting the wrong thing.
+**Invariants.** A1–A4, A9, A14–A17. **Traces.** B1–B8 (B4 concentration, B6 cost and B7 cohorts are
+the heterogeneous ones). **Covers.** Reliability.
+
+### S-9 · Configuration and access · P0
+
+**Asserts.** The persona × grant negative matrix — five kinds of data, each granted one by one, each
+refusal enforced where the data is produced rather than hidden by the screen, so it holds for a
+direct API call too **(QA addition)**. The admin role alone grants no metric visibility — asserted
+against the identity service, not the UI. Expected values differ by mode: under flat, "their own
+part of the organization" is the whole organization, so the matrix is evaluated per mode, not once.
+**Invariants.** A11–A13. **Traces.** G1, B1 (IC isolation), B4 (anonymous cut), F1 (clean room).
+**Covers.** Security.
+
+### S-8 · Identity and organization model · P0
+
+**Asserts.** Every automatic match carries its grounds and confidence; every merge and split is
+reversible; a manual correction survives the next data refresh **and the next product upgrade**
+**(QA addition)**. Past periods keep the shape and numbers they were reported under.
+**Invariants.** — (none bind identity directly; it gates all of them instead.) **Traces.** A2; A3
+and C7 blocked (Appendix B). **Covers.** Reliability.
+
+### S-2 · Analysis and diagnosis · P1
+
+**Asserts.** The refusal cases are the acceptance suite: exactly seven people on one side of a
+comparison — one below the floor — must yield a withheld conclusion that says why; a metric under a
+known defect must be excluded by name, not quietly folded in. Correlation is declared on the answer
+itself. The forward-looking half (feasibility and investment ranking) has no screen — carried, not
+asserted.
+**Invariants.** A5–A8, A10, A16. **Traces.** C1, C8; C2–C6 blocked, E1–E2 unbuilt (Appendix B).
+**Covers.** Reliability.
+
+### S-3 · Conclusions: recommendation and validation · P1
+
+**Asserts.** The lever's measure, the outcome, the guardrail and the validation window are all fixed
+at issue time — pre-declaration is unrecoverable afterwards, so it must land with the first
+recommendation, not after it. "Not enough data" is available as an honest outcome. The product
+writes nothing back into a connected system. An IC is never the subject; the PEER row is an open
+product decision.
+**Invariants.** A13. **Traces.** D1; D2 and D3 blocked (Appendix B). **Covers.** Reliability,
+Security.
+
+### S-7 · Sources and evidence coverage · P1
+
+**Asserts.** Never a zero standing in for missing data, never an estimate in place of an answer;
+a comparison across two periods whose source windows do not overlap is withheld with the source
+named. Every empty screen states its cause, for every persona including on an IC's own page.
+**Invariants.** A5–A8. **Traces.** A1, A4, C8 (the freshness and window part), G3 (the timezone
+caveat). **Covers.** Versatility, Reliability.
+
+### S-4 · Dashboards, views and exploration · P2
+
+**Asserts.** Exploration moves the question, never the boundary: the S-9 matrix re-run through
+composed views, slices and follow-backs — an exploration path never reaches outside the viewer's
+reach, a follow-back never reaches underlying records without that grant, and a composed group
+figure is recalculated for what is on screen.
+**Invariants.** A4, A9, A11, A12. **Traces.** B7; the rest of the B family is reached here by
+composition rather than by reading. **Covers.** Reliability, Security.
+
+### S-5 · Sharing and reuse · P2
+
+**Asserts.** A number leaves the product together with its definition, coverage and confidence, and
+the access rules that apply inside apply on the API and governed-access surface.
+**Invariants.** A12, A13. **Traces.** G2. **Covers.** Versatility.
+
+### S-10 · Deployment, upgrade and migration · P2
+
+**Asserts.** Every view that worked before an upgrade works after it, and a breakage surfaces to
+whoever ran the upgrade before a user meets it **(QA addition)**. History — everyone's — is kept
+across the change; a migration states parity openly, including what could not be reproduced.
+**Invariants.** — **Traces.** G4. **Covers.** Versatility, Reliability.
+
+### S-6 · External comparison · P3
+
+**Stub — deliberately.** No surface exists, so there is nothing to assert yet. Carried so the
+clean-room rule is not silently lost: only anonymized, opt-in, revocable aggregates ever leave the
+customer boundary.
+**Invariants.** — **Traces.** F1. **Covers.** — (assigned when a surface exists.)
+
+---
+
+## 4. What this changes for the quality setup
+
+1. **The 17 invariants are the first automation target.** They hold across every scenario above and
+   each maps to a defect class already observed. Most are stand-independent — see Appendix A.
+2. **The fixtures, not the test design, are the blocker.** Governance (A11–A13) needs every persona
+   at once with realistic reporting lines; PEER needs a stand running flat; EXEC-without-ADMIN needs
+   a fixture that separates the two roles `ceo` currently conflates. Until those exist, P0 coverage
+   is partial by construction, however many checks are written.
+3. **Every persona-specific check runs once per persona the stand's mode admits.** That is the
+   practical meaning of §1: a pass as EXEC says nothing about IC, and a whole mode is dark until a
+   stand runs it.
+4. **S-9 is the security vector's content** — a persona × grant × mode negative matrix, not a
+   scanner.
+5. **S-2's acceptance suite must exist before the first vertical ships** — specifically the
+   seven-on-a-side refusal and the excluded-by-name defective metric. By the scenario's own
+   definition, an incomplete answer there is not thin but wrong.
+6. **S-3's pre-declaration requirement expires.** It costs nothing at issue time and is
+   unrecoverable afterwards; it lands with the first recommendation or the validation half is
+   unbuildable later.
+7. **Service does not mean second.** Two of the three P0 scenarios are service, because theirs are
+   the only failures that cannot be undone.
+8. **Two vectors still have no home here.** Efficiency (compute footprint) and Performance
+   (per-endpoint latency) are measured on the reference-organisation fixture
+   ([`REFERENCE-ORGS.md`](REFERENCE-ORGS.md)) rather than per persona, so no scenario claims
+   them. That remains a real gap, and it is the same fixture question as item 2.
+
+## 5. Open questions
+
+Settled since the last revision:
+
+- **Who owns E1 now that PM is folded away** — settled by the product doc: function is an axis of
+  the user scenario, not a persona, so feasibility is asked by EXEC or a LEAD *from product* in S-2.
+- **Is this the missing persona catalog the framework asks for** — the product doc is that catalog;
+  this document is the QA baseline over it, and both now link.
+
+Still open:
+
+- **Which stand hosts which scenario?** S-1 needs organization-scale data, S-2 needs eight per side,
+  S-9 needs every persona with realistic reporting lines, and PEER needs a flat stand — one chart
+  value on a compose release would create one, but nobody owns it. No seeded stand satisfies any of
+  the four today.
+- **Are the five kinds of access enforced today, or only designed?** S-9's matrix and the ADMIN
+  boundary both depend on the answer.
+- **Does ADMIN get metric visibility by default on current stands?** The product doc asserts it must
+  not; confirming it means asking the identity service, not the UI.
+- **Is the e2e rig in scope for the persona markers?** It is the second strict-marker root; leaving
+  it out halves the meta test's value, taking it in drags the markers into a slower suite.
+- **When does `member_session` become `ic_session`?** The rename is agreed; it touches every test
+  that names the fixture.
+- **The product doc's own open points that block QA expected values:** whether flat mode's position
+  band is a ranking (blocks PEER's S-1 assertions), who owns a recommendation under flat (blocks the
+  S-3 PEER row), and whether the four / eight thresholds are customer-configurable (blocks writing
+  the numbers into assertions).
+
+---
+
+## Appendix A · Cross-scenario invariants
+
+The product declares these rules itself, and each is a defect class already seen. They hold across
+every scenario above, so they are asserted once and reused rather than re-implemented inside each
+feature's tests. **This is the first automation target.**
+
+Numbering is local to this document (A1–A17) — `user-scenarios.md` numbers its own rules
+differently, so cite these as "A4", never as "rule 4".
+
+**Metric grammar** (S-1, inherited by S-2 and S-4)
+
+- **A1.** Counts are always shown per active person, with the change since last period; a team total
+  may appear as a caption, never as the headline number.
+- **A2.** Averages and medians are never added together.
+- **A3.** "Concentration" figures — what share sits with the top tenth — are computed only over
+  figures that can be added up, and framed per area: a risk in development and the wiki, a workload
+  imbalance in communication.
+- **A4.** Group figures are recalculated for the group on screen, never carried over from a wider
+  scope.
+
+**Honest emptiness / data quality** (S-7, S-2)
+
+- **A5.** Never a zero in place of missing data (`#1517`).
+- **A6.** Never a rough estimate in place of an answer.
+- **A7.** Two periods are compared only over time both sources cover.
+- **A8.** A metric with a known defect says so on the metric itself.
+
+**Suppression thresholds** (S-1, S-2, S-4) — *each counts people who have data, never headcount*
+
+- **A9.** A group of fewer than four people is not shown at all, in any chart. *A promise, not yet
+  enforced.*
+- **A10.** A conclusion needs at least eight people on each side; below that it does not render, and
+  says why. *A promise, not yet enforced.*
+- **A17.** A peer comparison — the median and quartiles behind a person's position — is not computed
+  below five people with data. *The one threshold enforced today (`MIN_PEER_N = 5`, analytics
+  metric-results compiler); it protects IC's median and every PEER comparison.*
+
+**Governance** (S-9) — *the three that need the full persona set*
+
+- **A11.** No default screen ranks named individuals against one another. Naming people is expected
+  where person-level access has been granted — a manager's team view names their reports; what is
+  forbidden is the ranking, and naming anyone outside the viewer's granted part of the organization.
+- **A12.** A viewer cannot reach outside their own part of the organization — enforced where the
+  data is produced, so it holds for a direct API call too. *Under flat, "their own part" is the
+  whole organization: the assertion's expected value depends on the stand's mode.*
+- **A13.** The product writes only its own settings and notes, never back into a connected system.
+
+**Cost & AI** (S-1, S-2)
+
+- **A14.** Usage-priced and seat-priced costs are never added into one figure; cost that cannot be
+  attributed to anyone gets its own line.
+- **A15.** No single "value of AI" number; cost that moves from one area to another is shown as
+  moving, not folded away.
+- **A16.** Where a claim is a correlation, the answer says so on itself, not in a footnote.
+
+**Where they can run.** A1–A10, A14–A16 and A17 are assertions against API responses and need only
+a stand with data — though A12's and A17's expected values depend on the stand's mode. A11–A13 need
+every persona present at once, with realistic reporting lines — the fixture that does not exist yet.
+
+---
+
+## Appendix B · Blocked, and by what
+
+Carried at scenario level so that "we don't test it" reads as a consequence of a known gap rather
+than an omission.
+
+| Scenario | What is blocked | Blocker |
+|---|---|---|
+| every scenario, as PEER | All PEER assertions | No test stand runs flat and no peer fixture exists; one chart value on a compose release would create the stand, but it has no owner |
+| every scenario, EXEC vs ADMIN | Proving an EXEC promise is not an artefact of the admin role | The seed `ceo` holds both; no EXEC-without-ADMIN login exists |
+| S-8 | The operator queue for working through matches (A2) | The matching engine alone is a table in a database; the queue UI has no owner |
+| S-8 | Expected functions / role model (A3), role-vs-work divergence (C7) | `#1455` blocked by `#1873` (both open, 2026-09-02) |
+| S-2 | Review as bottleneck (C2) | `silver.fct_git_review` empty; reviewer keys in another namespace (`#1985 §3`); on dev, review attribution is 0% (`#3013`) |
+| S-2 | Quality held after a speed-up (C3) | Former blocker `#2027` closed — unblocked on paper; needs re-triage before tests are written |
+| S-2 | Support load vs release (C4), sales activity vs pipeline (C5) | Support/CRM outside the semantic layer (`#1930`) |
+| S-2 | Cost moved rather than fell (C6) | Not built — no downstream cost-movement model |
+| S-2 | Feasibility and investment ranking (E1, E2) | No screen exists yet |
+| S-3 | Outcome read-back (D2), period annotations (D3) | Not built — but pre-declaration must land with D1 (§4) |
+| S-3 | The PEER row | Open product decision: recommendation ownership in a flat organization |
+| S-6 | Everything | No surface exists yet |

--- a/docs/testing/REFERENCE-ORGS.md
+++ b/docs/testing/REFERENCE-ORGS.md
@@ -7,7 +7,7 @@ denominator.
 
 Figures are derived from measuring **two production installations** with identical SQL and are
 stated here as project standards. Companion documents: [`TESTING.md`](TESTING.md) (where these
-fixtures run) and [`product/VISION.md`](../product/VISION.md) §6.4.2 (the company-size tiers).
+fixtures run) and [`INSIGHT_VISION.md`](https://github.com/constructorfabric/vision/blob/main/INSIGHT_VISION.md) §6.4.2 (the company-size tiers).
 Tracked in #2215 (reference organisations) and #2216 (recommended resource requirements).
 
 ---
@@ -52,7 +52,7 @@ identity resolution is precisely what they stress.
 
 ## 3. The reference organisations
 
-Aligned to the company-size tiers in [`product/VISION.md`](../product/VISION.md) §6.4.2. One reference
+Aligned to the company-size tiers in [`INSIGHT_VISION.md`](https://github.com/constructorfabric/vision/blob/main/INSIGHT_VISION.md) §6.4.2. One reference
 organisation per tier, placed at the tier ceiling so that passing at the reference covers the tier
 below it.
 


### PR DESCRIPTION
**Why.** Nothing in the repo stated who uses Insight, how far each persona may reach, or where the boundaries sit — and the QA baseline kept a diverging copy outside it.

**What changed.** `docs/product/SCENARIOS.md` is rewritten around the two visibility modes (`org_chart`, `flat`): four reach personas plus ADMIN, and ten scenarios in three tiers, one row per persona with observable boundaries. The QA layer moves in as `docs/testing/PERSONAS.md`, so product and QA read the same source. Vision links now point at `constructorfabric/vision`.

**Out of scope.** The persona/mode/scenario test markers `PERSONAS.md` maps; open decisions sit in its §5.

**Verified.** Docs-only — every internal link and anchor resolves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Restructured product scenarios around installation modes, reach definitions, and role-based views.
  - Added the PEER persona and clarified ADMIN’s role.
  - Clarified rules for metric defect labeling, group calculations, and group-size thresholds.
  - Added a QA baseline covering personas, prioritized scenarios, assertions, invariants, and blockers.
  - Updated reference links for company-size guidance and documented outstanding product decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
