### PR TITLE
fix(frontend): order org-chart reports by display name

### DIFF
--- a/src/frontend/src/api/identity-client.test.ts
+++ b/src/frontend/src/api/identity-client.test.ts
@@ -82,12 +82,12 @@ describe("getPerson", () => {
     const person = await getPerson("019e27bc-dec0-7626-81a9-c5524662a6aa");
 
     expect(person.subordinates.map((s) => s.person_id)).toEqual([
-      "019e27bc-dec0-7626-81a9-c5524662a6ab",
       "019e27bc-dec0-7626-81a9-c5524662a6a9",
+      "019e27bc-dec0-7626-81a9-c5524662a6ab",
     ]);
     expect(person.subordinates.map((s) => s.email)).toEqual([
-      "ic1@example.com",
       "",
+      "ic1@example.com",
     ]);
   });
 
@@ -107,6 +107,58 @@ describe("getPerson", () => {
     const person = await getPerson("019e27bc-dec0-7626-81a9-c5524662a6aa");
 
     expect(person.subordinates.map((s) => s.person_id)).toEqual(["019e27bc-dec0-7626-81a9-c5524662a6ab"]);
+  });
+
+  it("orders subordinates by display name at every level, whatever order the wire had", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({
+        person_id: "p-root",
+        insight_tenant_id: "t-1",
+        display_name: "Root",
+        subordinates: [
+          { person_id: "p-zed", insight_tenant_id: "t-1", display_name: "Zed" },
+          {
+            person_id: "p-ann",
+            insight_tenant_id: "t-1",
+            display_name: "Ann",
+            subordinates: [
+              { person_id: "p-yan", insight_tenant_id: "t-1", display_name: "Yan" },
+              { person_id: "p-bob", insight_tenant_id: "t-1", display_name: "Bob" },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const person = await getPerson("p-root");
+
+    expect(person.subordinates.map((s) => s.display_name)).toEqual(["Ann", "Zed"]);
+    expect(person.subordinates[0]!.subordinates.map((s) => s.display_name)).toEqual([
+      "Bob",
+      "Yan",
+    ]);
+  });
+
+  it("sorts under the name a person is shown by — handle, then address, when there is no display name", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({
+        person_id: "p-root",
+        insight_tenant_id: "t-1",
+        subordinates: [
+          { person_id: "p-handle", insight_tenant_id: "t-1", username: "octo-bot" },
+          { person_id: "p-named", insight_tenant_id: "t-1", display_name: "Mia" },
+          { person_id: "p-address", insight_tenant_id: "t-1", email: "ada@example.com" },
+        ],
+      }),
+    );
+
+    const person = await getPerson("p-root");
+
+    expect(person.subordinates.map((s) => s.person_id)).toEqual([
+      "p-address",
+      "p-named",
+      "p-handle",
+    ]);
   });
 
   it("throws IdentityApiError with the status + body on a non-ok response", async () => {

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -11,6 +11,7 @@
  */
 
 import { fetchWithAuth } from "@/api/fetch-with-auth";
+import { personDisplayName } from "@/lib/identities/person-display";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import type { IdentityPerson } from "@/types/insight";
 
@@ -602,8 +603,13 @@ function toIdentityPerson(p: ProfileResponse): IdentityPerson {
     supervisor_name: p.supervisor_name ?? null,
     subordinates: (p.subordinates ?? [])
       .filter((s) => Boolean(s.person_id?.trim()))
-      .map(toIdentityPerson),
+      .map(toIdentityPerson)
+      .sort(byDisplayName),
   };
+}
+
+function byDisplayName(a: IdentityPerson, b: IdentityPerson): number {
+  return personDisplayName(a).localeCompare(personDisplayName(b));
 }
 
 /**


### PR DESCRIPTION
Closes #3126.

**Why.** WorkChart lists a manager's reports, and the Scope picker its managers, in the order the identity API sends them — person-id order — so finding a name means scanning the whole list.

**What changed.** `toIdentityPerson` now sorts `subordinates` at every level by `personDisplayName`, the key the flat roster and the peers list already sort under, so every consumer of the identity tree shares one alphabetical sibling order. The picker keeps its outline order; only siblings move.

**Verified.** Frontend `pnpm test` (2366 passing), `pnpm lint`, `pnpm typecheck`. No screenshot: the mock fixture is already alphabetical, so a local run cannot show a before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subordinates are now consistently sorted by display name at every level.
  * When a display name is unavailable, sorting falls back to username and then email address.
  * Updated ordering improves consistency when viewing hierarchical person information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->