### PR TITLE
feat(frontend): show the cohort control only with planned sections on

### DIFF
--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -151,7 +151,10 @@ resolution. A `planned` entry is demoted to the "Planned" menu group and
 toggled by the viewer's "Show planned sections" switch. Planning is entirely
 deployment-owned: entries absent from `nav.planned` are treated as live. A path
 in both lists is hidden; a path that matches nothing is ignored (malformed ones
-warn in the browser console).
+warn in the browser console). One control is planned in code rather than by
+path: the topbar Cohort select renders only while the switch is on, and with it
+off the `?slice=` parameter is ignored so no view compares against a cohort the
+reader cannot see or change.
 This is presentation, not authorization — the API refuses on its own
 regardless of what the menu shows. Parsing and semantics live in
 [src/lib/portal/nav-policy.ts](src/lib/portal/nav-policy.ts).

--- a/src/frontend/src/components/portal/ai-cost-view.test.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.test.tsx
@@ -16,6 +16,7 @@ import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import { setPortalShowPlanned } from "@/lib/portal/portal-store";
 import { identityPerson, pid } from "@/test/identity";
 import type { IdentityPerson, TeamMember } from "@/types/insight";
 
@@ -160,6 +161,7 @@ beforeEach(() => {
   act(() => {
     portalRouter.set({ slice: undefined });
     portalRouter.set({ scope: undefined, direct: false });
+    setPortalShowPlanned(true);
   });
 });
 

--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -20,6 +20,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GROUPS } from "@/lib/insight/groups";
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import { setPortalShowPlanned } from "@/lib/portal/portal-store";
 import { identityPerson, pid } from "@/test/identity";
 import type { IdentityPerson } from "@/types/insight";
 
@@ -222,6 +223,7 @@ beforeEach(() => {
   act(() => {
     portalRouter.set({ slice: undefined, repo: undefined });
     portalRouter.set({ scope: undefined, direct: false });
+    setPortalShowPlanned(true);
   });
 });
 

--- a/src/frontend/src/components/portal/portal-shell.test.tsx
+++ b/src/frontend/src/components/portal/portal-shell.test.tsx
@@ -96,6 +96,7 @@ import {
   usePortalSlice,
   usePortalZone,
 } from "@/lib/portal/portal-nav";
+import { setPortalShowPlanned } from "@/lib/portal/portal-store";
 import { renderHook } from "@testing-library/react";
 
 import { DirectionView } from "./direction-view";
@@ -130,6 +131,7 @@ beforeEach(() => {
     portalRouter.set({ lens: "Delivery" });
     portalRouter.set({ slice: undefined });
     portalRouter.set({ scope: undefined, direct: false });
+    setPortalShowPlanned(true);
   });
 });
 

--- a/src/frontend/src/components/portal/portal-topbar.test.tsx
+++ b/src/frontend/src/components/portal/portal-topbar.test.tsx
@@ -15,10 +15,11 @@ vi.mock("@tanstack/react-router", async () => {
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { MetricDefinitionListResponse } from "@/api/metric-definitions-client";
+import { setPortalShowPlanned } from "@/lib/portal/portal-store";
 import { identityPerson, pid } from "@/test/identity";
 
 const mocks = vi.hoisted(() => ({
@@ -114,6 +115,8 @@ beforeEach(() => {
     dispatchEvent: () => false,
   })) as unknown as typeof window.matchMedia;
   mocks.definitions = { metrics: [] };
+  mocks.isFlat = false;
+  act(() => setPortalShowPlanned(true));
   portalRouter.reset();
 });
 
@@ -178,5 +181,19 @@ describe("PortalTopBar · zones that filter nothing", () => {
     bar();
 
     expect(screen.queryByText("Cohort")).toBeNull();
+  });
+});
+
+describe("PortalTopBar · planned sections", () => {
+  it("keeps the cohort control off the bar until the reader turns planned sections on", async () => {
+    act(() => setPortalShowPlanned(false));
+    bar();
+
+    await waitFor(() => expect(filters()).toBeInTheDocument());
+    expect(screen.queryByText("Cohort")).toBeNull();
+    expect(screen.queryByTestId("dims")).toBeNull();
+
+    act(() => setPortalShowPlanned(true));
+    expect(screen.getByText("Cohort")).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/portal/portal-topbar.tsx
+++ b/src/frontend/src/components/portal/portal-topbar.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/tooltip";
 import { PeriodSelectorBar } from "@/components/widgets/period-selector-bar";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
+import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 import { useActiveZone } from "@/lib/portal/use-active-zone";
 import { useCohortOptions } from "@/lib/portal/use-cohort-options";
 import { useVisibilityPolicy } from "@/queries/identity-me";
@@ -72,6 +73,8 @@ function ViewFilters() {
   // would offer a single choice and the tooltip would describe a cut that
   // cannot be made.
   const { isFlat } = useVisibilityPolicy();
+  const showPlanned = usePortalShowPlanned();
+  const cohortShown = showPlanned && !isFlat;
 
   return (
     // Narrow screens keep the three controls on ONE scrollable row: wrapped,
@@ -87,7 +90,7 @@ function ViewFilters() {
       className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto md:flex-wrap md:justify-end md:overflow-x-visible"
     >
       {scoped ? <ScopeSelect /> : null}
-      {isFlat ? null : (
+      {cohortShown ? (
         <span className="flex shrink-0 items-center gap-1.5">
           <span className="hidden text-xs text-muted-foreground md:inline">
             Cohort
@@ -120,7 +123,7 @@ function ViewFilters() {
           </TooltipProvider>
           <SliceSelect dims={dims} />
         </span>
-      )}
+      ) : null}
       <PeriodSelectorBar
         period={period}
         customRange={customRange}

--- a/src/frontend/src/lib/portal/portal-hooks.test.tsx
+++ b/src/frontend/src/lib/portal/portal-hooks.test.tsx
@@ -69,6 +69,8 @@ vi.mock("@tanstack/react-router", async () => {
   return portalRouterMock();
 });
 
+import { usePortalSlice } from "./portal-nav";
+import { setPortalShowPlanned } from "./portal-store";
 import { useActiveZone } from "./use-active-zone";
 import { useOrgScope } from "./use-org-scope";
 import { usePersonCohort } from "./use-person-cohort";
@@ -104,6 +106,7 @@ beforeEach(() => {
   mocks.ic.isError = false;
   act(() => {
     portalRouter.reset();
+    setPortalShowPlanned(true);
   });
 });
 
@@ -188,6 +191,18 @@ describe("useViewerIsManager", () => {
     mocks.ic.isPending = true;
     const { result } = renderHook(() => useViewerIsManager());
     expect(result.current).toEqual({ isManager: false, isPending: true });
+  });
+});
+
+describe("usePortalSlice", () => {
+  it("ignores the URL slice while planned sections are off", () => {
+    act(() => setPortalShowPlanned(false));
+    act(() => portalRouter.set({ slice: "division" }));
+    const { result } = renderHook(() => usePortalSlice());
+    expect(result.current).toBe("");
+
+    act(() => setPortalShowPlanned(true));
+    expect(result.current).toBe("division");
   });
 });
 

--- a/src/frontend/src/lib/portal/portal-nav.ts
+++ b/src/frontend/src/lib/portal/portal-nav.ts
@@ -2,7 +2,7 @@ import { useRouterState } from "@tanstack/react-router";
 import { useMemo } from "react";
 
 import { normalizePersonId } from "@/lib/metrics/entity";
-import type { OrgScope } from "@/lib/portal/portal-store";
+import { type OrgScope, usePortalShowPlanned } from "@/lib/portal/portal-store";
 import { recordUsageEvent, scopeLabel } from "@/telemetry";
 import { usePortalSearch, useSetPortalSearch } from "@/lib/portal/portal-search";
 
@@ -41,9 +41,10 @@ export function usePortalLens(): string {
   return usePortalSearch().lens ?? "";
 }
 
-/** The active slice attribute, or "" when the roster is one undivided cohort. */
+/** The active slice attribute, or "" while no cohort is in effect. */
 export function usePortalSlice(): string {
-  return usePortalSearch().slice ?? "";
+  const slice = usePortalSearch().slice ?? "";
+  return usePortalShowPlanned() ? slice : "";
 }
 
 /** The org scope the URL names: a root person id (absent = the viewer) + direct-only. */

--- a/src/frontend/src/lib/portal/use-cohort-label.test.tsx
+++ b/src/frontend/src/lib/portal/use-cohort-label.test.tsx
@@ -14,6 +14,7 @@ import { renderHook } from "@testing-library/react";
 import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { setPortalShowPlanned } from "@/lib/portal/portal-store";
 import { identityPerson, pid } from "@/test/identity";
 import type { IdentityPerson } from "@/types/insight";
 
@@ -48,6 +49,7 @@ const person = (
 
 beforeEach(() => {
   portalRouter.reset();
+  act(() => setPortalShowPlanned(true));
   mocks.isFlat = false;
   // A roster that offers two real dimensions, so a slice has something to name.
   mocks.tree = person("boss", {}, [


### PR DESCRIPTION
Closes #3130.

**Why.** The Cohort select sat in the portal topbar on every filtered zone whatever the reader's "Show planned sections" switch said, so a control for an unfinished comparison feature was always on screen.

**What changed.** The control renders only while the switch is on. While it is off, `usePortalSlice` reads as empty, so a `?slice=` deep link cannot make a view compare against a cohort the reader has no control to see or change. Every slice reader follows from that one hook.

**Planned in code, not through `nav.planned`.** The control is planned product-wide, not per install, so a config path would only add a values step to every deployment. A `control:` path kind can replace the hardcode later.

Planned sections off (default):

![Portal overview with the switch off: Scope and period only](https://raw.githubusercontent.com/constructorfabric/insight/pr-3129-assets/planned-off.png)

Planned sections on:

![Portal overview with the switch on: Cohort select back between Scope and period](https://raw.githubusercontent.com/constructorfabric/insight/pr-3129-assets/planned-on.png)

| Topbar | |
|---|---|
| off | ![](https://raw.githubusercontent.com/constructorfabric/insight/pr-3129-assets/topbar-planned-off.png) |
| on | ![](https://raw.githubusercontent.com/constructorfabric/insight/pr-3129-assets/topbar-planned-on.png) |

**Verified.** Frontend unit suite green (2366 tests), lint and typecheck clean. Headless browser on the MSW mock stand: the switch removes and restores the control, and `?slice=division` with the switch off renders no division grouping.
