### PR TITLE
test(e2e): harden git.commit_size coverage and add gitlab/bitbucket git fixtures

### DIFF
--- a/src/ingestion/tests/e2e/metrics/git_branch_scope.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_branch_scope.test.yaml
@@ -152,6 +152,9 @@ cases:
             views:
               - {view: period}
               - {view: breakdown, dimensions: [branch_scope]}
+          - metric_key: git.commit_size
+            views:
+              - {view: breakdown, dimensions: [branch_scope]}
     expect:
       - assert: "status == 200"
 
@@ -381,6 +384,17 @@ cases:
         view: breakdown
         find: {entity_id: alice@example.com, dimensions: {key: branch_scope, value: non_default}}
         equal: {value: 20}
+
+      # Sizes split with their commits: the landed 11 and the in-flight 22
+      # never pool into one median.
+      - metric: git.commit_size
+        view: breakdown
+        find: {entity_id: alice@example.com, dimensions: {key: branch_scope, value: default}}
+        equal: {value: 11}
+      - metric: git.commit_size
+        view: breakdown
+        find: {entity_id: alice@example.com, dimensions: {key: branch_scope, value: non_default}}
+        equal: {value: 22}
 
   - name: A merged request into the default branch promotes its commit
     request:

--- a/src/ingestion/tests/e2e/metrics/git_commit_size.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_commit_size.test.yaml
@@ -1,0 +1,124 @@
+spec_version: 1
+description: >
+  Metric: git.commit_size — median diff size (lines added plus removed) of a
+  person's authored commits. Values chosen so the median is the ONLY aggregate
+  that fits: erin's sizes over the window are {4, 6, 10, 30, 204} — median 10,
+  mean 50.8, max 204 — so a mean, a sum, an extremum or a wrong percentile all
+  fail the period assertion. No file-change rows are seeded, so every commit
+  reports the size its own stats gave (the file-grain corrections have their
+  own specs: content identity, work identity, uncollected file changes).
+
+  Fixture:
+    * erin, 2026-10-01, acme/api: sizes 10, 30, 204 — an odd pool whose median
+      is 30, plus a merge commit (1000) that must contribute nothing.
+    * erin, 2026-10-02, acme/web: sizes 4, 6 — an even pool; ClickHouse
+      quantileExact(0.5) takes the UPPER middle element, so the day reads 6.
+    * dave, 2026-10-01, acme/api: one commit whose bronze row carries no
+      stats at all. Staging projects absent stats to zero, so the commit
+      enters the median as 0 rather than abstaining.
+
+  Cases: period median over both days, per-day timeseries medians, per-repo
+  breakdown medians, deterministic histogram bins over erin's [4, 204], the
+  stats-less commit reading 0.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/dave
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_github.commits:
+    # Day one, acme/api: {10, 30, 204}.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cs-erin-a1, repository: "https://github.com/acme/api.git", sha: cs-a1, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 8, deletions: 2}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cs-erin-a2, repository: "https://github.com/acme/api.git", sha: cs-a2, committed_date: "2026-10-01T10:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 25, deletions: 5}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cs-erin-a3, repository: "https://github.com/acme/api.git", sha: cs-a3, committed_date: "2026-10-01T11:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 200, deletions: 4}
+    # A merge commit with a huge diff: excluded from the pool entirely. If it
+    # counted, the period median could not read 10.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cs-erin-merge, repository: "https://github.com/acme/api.git", sha: cs-merge, committed_date: "2026-10-01T12:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 900, deletions: 100, is_merge: true}
+    # Day two, acme/web: {4, 6}.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cs-erin-w1, repository: "https://github.com/acme/web.git", sha: cs-w1, committed_date: "2026-10-02T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 3, deletions: 1}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cs-erin-w2, repository: "https://github.com/acme/web.git", sha: cs-w2, committed_date: "2026-10-02T10:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 5, deletions: 1}
+    # dave: a commit whose source reported no line stats.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cs-dave-nostats, repository: "https://github.com/acme/api.git", sha: cs-d1, committed_date: "2026-10-01T09:00:00Z", author_name: dave, author_email: dave@example.com, committer_name: dave, committer_email: dave@example.com, additions: null, deletions: null}
+
+cases:
+  - name: The period value is the exact median of the per-commit sizes
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.commit_size
+            views:
+              - {view: period}
+              - {view: timeseries, bucket: day}
+              - {view: breakdown, dimensions: [repository]}
+              - {view: histogram}
+    expect:
+      - assert: "status == 200"
+      # {4, 6, 10, 30, 204}: median 10. Mean (50.8), max (204), min (4), sum
+      # (254) and p75 (30) all disagree with this value.
+      - metric: git.commit_size
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 10}
+      # Each day buckets its own median: {10, 30, 204} reads 30, and the even
+      # pair {4, 6} reads its upper middle, 6 — not the interpolated 5.
+      - metric: git.commit_size
+        view: timeseries
+        find: {entity_id: erin@example.com}
+        contains: {points: {bucket_start: "2026-10-01", value: 30}}
+      - metric: git.commit_size
+        view: timeseries
+        find: {entity_id: erin@example.com}
+        contains: {points: {bucket_start: "2026-10-02", value: 6}}
+      # Per-repository medians over each repository's own pool.
+      - metric: git.commit_size
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:acme/api"}}
+        equal: {value: 30}
+      - metric: git.commit_size
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:acme/web"}}
+        equal: {value: 6}
+      # Ten fixed-width bins over erin's own [4, 204], width 20: the first bin
+      # holds {4, 6, 10} and the last closes exactly at 204 with the one
+      # outlier. A pool including the merge commit would rescale every bin.
+      - metric: git.commit_size
+        view: histogram
+        find: {entity_id: erin@example.com}
+        contains: {bins: {lo: 4, count: 3}}
+      - metric: git.commit_size
+        view: histogram
+        find: {entity_id: erin@example.com}
+        contains: {bins: {hi: 204, count: 1}}
+
+  - name: A commit whose source reported no stats reads zero, not absent
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [dave@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: period}
+          - metric_key: git.commit_size
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      - metric: git.commits
+        view: period
+        find: {entity_id: dave@example.com}
+        equal: {value: 1}
+      # Staging projects absent stats to zero, so the commit enters the size
+      # pool as 0 instead of abstaining. This pins the served behavior; a
+      # staging change that lets the NULL flow through would surface here as
+      # value: null.
+      - metric: git.commit_size
+        view: period
+        find: {entity_id: dave@example.com}
+        equal: {value: 0}

--- a/src/ingestion/tests/e2e/metrics/git_commit_work_identity.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_commit_work_identity.test.yaml
@@ -35,6 +35,10 @@ description: >
       only under the repository that loses the commit collapse. The lines
       count once, under the surviving repository.
 
+  Commit size reads the same commit set: the squash pool is {10, 10, 6}
+  (median 10), the surviving patch copy is 7, the partial-branch pair is
+  {3, 2} (median 3), and the cross-repository survivor keeps its 4.
+
 bronze:
   bronze_bamboohr.employees:
     - $ref: templates/people.yaml#/templates/erin
@@ -130,6 +134,9 @@ cases:
           - metric_key: git.lines_removed
             views:
               - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.commit_size
+            views:
+              - {view: breakdown, dimensions: [repository]}
     expect:
       - assert: "status == 200"
       # The three branch originals; the squash result is the fourth sha and
@@ -148,6 +155,12 @@ cases:
         view: breakdown
         find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/squash-merge"}}
         equal: {value: 3}
+      # The size pool is the same commit set: the branch sizes {10, 10, 6}
+      # read a median of 10, with nothing contributed by the squash result.
+      - metric: git.commit_size
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/squash-merge"}}
+        equal: {value: 10}
 
   - name: A fast-forward merge promotes an original, which stays authored
     request:
@@ -188,6 +201,9 @@ cases:
           - metric_key: git.lines_added
             views:
               - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.commit_size
+            views:
+              - {view: breakdown, dimensions: [repository]}
     expect:
       - assert: "status == 200"
       - metric: git.commits
@@ -198,6 +214,11 @@ cases:
         view: breakdown
         find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/patch-copy"}}
         equal: {value: 6}
+      # The one surviving commit's size: 6 added plus 1 removed.
+      - metric: git.commit_size
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/patch-copy"}}
+        equal: {value: 7}
 
   - name: The later carrier of an already-authored patch reports nothing
     request:
@@ -213,14 +234,20 @@ cases:
           - metric_key: git.lines_added
             views:
               - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.commit_size
+            views:
+              - {view: breakdown, dimensions: [repository]}
     expect:
       - assert: "status == 200"
-      # The November copy carries the October patch: no commit row and no
-      # lines at all for the repository in November.
+      # The November copy carries the October patch: no commit row, no lines,
+      # and no size at all for the repository in November.
       - metric: git.commits
         view: breakdown
         assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'repository' && d.value == 'git-test:constructor/patch-copy'))"
       - metric: git.lines_added
+        view: breakdown
+        assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'repository' && d.value == 'git-test:constructor/patch-copy'))"
+      - metric: git.commit_size
         view: breakdown
         assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'repository' && d.value == 'git-test:constructor/patch-copy'))"
 
@@ -263,6 +290,9 @@ cases:
           - metric_key: git.lines_added
             views:
               - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.commit_size
+            views:
+              - {view: breakdown, dimensions: [repository]}
     expect:
       - assert: "status == 200"
       # One hash, one commit, counted under the surviving repository.
@@ -276,6 +306,13 @@ cases:
       # The lines were recorded only under xr-upstream, whose commit row lost
       # the collapse — they attach to the surviving row instead of vanishing.
       - metric: git.lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/xr-fork"}}
+        equal: {value: 4}
+      # The size correction joins file rows by hash, not repository: the
+      # surviving commit's stats stay uncorrected at 4 even though its only
+      # file row was recorded under the losing repository.
+      - metric: git.commit_size
         view: breakdown
         find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/xr-fork"}}
         equal: {value: 4}
@@ -294,6 +331,9 @@ cases:
           - metric_key: git.lines_added
             views:
               - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.commit_size
+            views:
+              - {view: breakdown, dimensions: [repository]}
     expect:
       - assert: "status == 200"
       # One of the two linked commits was collected, so coverage is incomplete
@@ -309,6 +349,13 @@ cases:
         view: breakdown
         find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/partial-branch"}}
         equal: {value: 5}
+      # The original reads 3; the result keeps only what the oid fold did not
+      # remove — 5 reported less the 3 folded lines is 2. Sizes {2, 3} read 3
+      # (upper middle on an even count).
+      - metric: git.commit_size
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/partial-branch"}}
+        equal: {value: 3}
 
   - name: The same patch id in unrelated repositories is two authored changes
     request:

--- a/src/ingestion/tests/e2e/metrics/git_commits_bitbucket.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_commits_bitbucket.test.yaml
@@ -10,7 +10,9 @@ description: >
       changes contributes zero rather than dropping out;
     * a merge commit is excluded from the commit count;
     * pull-request line totals are summed from the per-file diffstat rows, and
-      closed_on comes from the terminal MERGED activity event.
+      closed_on comes from the terminal MERGED activity event;
+    * commit size reads the commits' own stats — {12, 0} with the merge commit
+      contributing nothing — and the even-count median takes the upper middle.
 
 bronze:
   bronze_bamboohr.employees:
@@ -55,6 +57,9 @@ cases:
           - metric_key: git.lines_removed
             views:
               - { view: breakdown, dimensions: [source] }
+          - metric_key: git.commit_size
+            views:
+              - { view: breakdown, dimensions: [source] }
     expect:
       - assert: "status == 200"
       # commit-a and commit-b count; the merge commit does not.
@@ -71,6 +76,13 @@ cases:
         view: breakdown
         find: { entity_id: erin@example.com, dimensions: { key: source, value: bitbucket_cloud } }
         equal: { value: 2 }
+      # Sizes {12, 0}: commit-a's own stats, commit-b's empty diff. The merge
+      # commit contributes no size, and quantileExact(0.5) on the even pair
+      # takes the upper middle.
+      - metric: git.commit_size
+        view: breakdown
+        find: { entity_id: erin@example.com, dimensions: { key: source, value: bitbucket_cloud } }
+        equal: { value: 12 }
 
   - name: Bitbucket git metrics empty window
     request:

--- a/src/ingestion/tests/e2e/metrics/git_commits_gitlab.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_commits_gitlab.test.yaml
@@ -1,0 +1,105 @@
+spec_version: 1
+description: >
+  GitLab git metrics. Seeds the connector's bronze and drives it through the
+  gitlab__commits / __file_changes staging models into the shared git classes.
+  Assertions use the `source=gitlab` breakdown so they are unaffected by any
+  other git connector seeded in the suite.
+
+  Fixture covers:
+    * commit line stats come from the commit's own stats fields, so commit
+      size is additions plus deletions per commit;
+    * a merge commit (parent_count > 1) is excluded from the commit count and
+      from the size pool;
+    * GitLab's diff API reports no object ids, so repeated content cannot be
+      folded: identical file rows on two commits keep both commits' full sizes
+      and both commits' lines — unknown identity is never collapsed;
+    * per-file lines feed Lines added / Lines removed through the file rows.
+
+  Sizes: {12, 0, 8, 8} — median 8. Lines added: 10 + 7 + 7 = 24; removed:
+  2 + 1 + 1 = 4.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_gitlab.projects:
+    - {$ref: templates/gitlab_git.yaml#/templates/project, unique_key: "gl-proj:101"}
+
+  bronze_gitlab.commits:
+    # Stats and the file row agree: size 12.
+    - {$ref: templates/gitlab_git.yaml#/templates/commit, unique_key: "gl-c:commit-a", id: gl-commit-a, author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, stats_additions: 10, stats_deletions: 2, stats_total: 12}
+    # An empty diff: size 0, not absent.
+    - {$ref: templates/gitlab_git.yaml#/templates/commit, unique_key: "gl-c:commit-b", id: gl-commit-b, author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com}
+    # A merge commit: two parents, excluded everywhere.
+    - {$ref: templates/gitlab_git.yaml#/templates/commit, unique_key: "gl-c:commit-m", id: gl-commit-m, author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, parent_count: 2, stats_additions: 500, stats_deletions: 500, stats_total: 1000}
+    # The same content on two commits. Without object ids the rows cannot be
+    # folded, so each commit keeps its own 8.
+    - {$ref: templates/gitlab_git.yaml#/templates/commit, unique_key: "gl-c:commit-c1", id: gl-commit-c1, committed_date: "2026-10-01T10:00:00Z", author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, stats_additions: 7, stats_deletions: 1, stats_total: 8}
+    - {$ref: templates/gitlab_git.yaml#/templates/commit, unique_key: "gl-c:commit-c2", id: gl-commit-c2, committed_date: "2026-10-01T11:00:00Z", author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, stats_additions: 7, stats_deletions: 1, stats_total: 8}
+
+  bronze_gitlab.commit_file_changes:
+    - {$ref: templates/gitlab_git.yaml#/templates/file_change, unique_key: "gl-fc:commit-a:a.py", commit_sha: gl-commit-a, new_path: src/a.py, lines_added: 10, lines_removed: 2}
+    # Identical transitions on the same path, no object ids on either side.
+    - {$ref: templates/gitlab_git.yaml#/templates/file_change, unique_key: "gl-fc:commit-c1:c.py", commit_sha: gl-commit-c1, new_path: src/c.py, lines_added: 7, lines_removed: 1}
+    - {$ref: templates/gitlab_git.yaml#/templates/file_change, unique_key: "gl-fc:commit-c2:c.py", commit_sha: gl-commit-c2, new_path: src/c.py, lines_added: 7, lines_removed: 1}
+
+cases:
+  - name: GitLab git metrics build and resolve through the source breakdown
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: breakdown, dimensions: [source]}
+          - metric_key: git.lines_added
+            views:
+              - {view: breakdown, dimensions: [source]}
+          - metric_key: git.lines_removed
+            views:
+              - {view: breakdown, dimensions: [source]}
+          - metric_key: git.commit_size
+            views:
+              - {view: breakdown, dimensions: [source]}
+    expect:
+      - assert: "status == 200"
+      # commit-a, commit-b and both carriers of the repeated content; the
+      # merge commit does not count.
+      - metric: git.commits
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: source, value: gitlab}}
+        equal: {value: 4}
+      # No object ids, so the repeated content counts under both commits:
+      # 10 + 7 + 7 and 2 + 1 + 1.
+      - metric: git.lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: source, value: gitlab}}
+        equal: {value: 24}
+      - metric: git.lines_removed
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: source, value: gitlab}}
+        equal: {value: 4}
+      # Sizes {12, 0, 8, 8}: median 8, with the merge commit's 1000
+      # contributing nothing.
+      - metric: git.commit_size
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: source, value: gitlab}}
+        equal: {value: 8}
+
+  - name: GitLab git metrics empty window
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2025-01-01", to: "2025-01-31"}
+        metrics:
+          - {metric_key: git.commits, views: [{view: period}]}
+          - {metric_key: git.commit_size, views: [{view: period}]}
+    expect:
+      - assert: "status == 200"
+      - {metric: git.commits, view: period, find: {entity_id: erin@example.com}, equal: {value: null}}
+      - {metric: git.commit_size, view: period, find: {entity_id: erin@example.com}, equal: {value: null}}

--- a/src/ingestion/tests/e2e/metrics/git_metrics.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_metrics.test.yaml
@@ -10,11 +10,14 @@ bronze:
     - $ref: templates/people.yaml#/templates/erin
     - {$ref: templates/people.yaml#/templates/bamboohr_employee, id: e006, unique_key: bamboohr-test-e006, firstName: Frank, lastName: Zeta, displayName: Frank Zeta, workEmail: frank@example.com, department: Quality}
   bronze_github.commits:
-    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-alice, sha: hash-alice, author_name: alice, author_email: alice@example.com, committer_name: alice, committer_email: alice@example.com, additions: 10}
-    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-bob, sha: hash-bob, author_name: bob, author_email: bob@example.com, committer_name: bob, committer_email: bob@example.com, additions: 20}
-    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-carol, sha: hash-carol, author_name: carol, author_email: carol@example.com, committer_name: carol, committer_email: carol@example.com, additions: 30}
-    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-dave, sha: hash-dave, author_name: dave, author_email: dave@example.com, committer_name: dave, committer_email: dave@example.com, additions: 40}
-    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-erin, sha: hash-erin, author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 50}
+    # Commit stats agree with the file-change rows below, so the commit sizes
+    # are additions plus deletions: 12, 24, 36, 48, 60 — and erin's second
+    # commit (no file changes collected) is 50.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-alice, sha: hash-alice, author_name: alice, author_email: alice@example.com, committer_name: alice, committer_email: alice@example.com, additions: 10, deletions: 2}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-bob, sha: hash-bob, author_name: bob, author_email: bob@example.com, committer_name: bob, committer_email: bob@example.com, additions: 20, deletions: 4}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-carol, sha: hash-carol, author_name: carol, author_email: carol@example.com, committer_name: carol, committer_email: carol@example.com, additions: 30, deletions: 6}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-dave, sha: hash-dave, author_name: dave, author_email: dave@example.com, committer_name: dave, committer_email: dave@example.com, additions: 40, deletions: 8}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-erin, sha: hash-erin, author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 50, deletions: 10}
     - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-erin-second, repository: "https://github.com/constructor/example.git", sha: hash-erin-second, author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 50}
   bronze_github.file_changes:
     - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: file-alice, sha: hash-alice, additions: 10, deletions: 2}
@@ -384,26 +387,34 @@ cases:
       - metric: git.commits_per_active_day
         view: breakdown
         assert: "size(items) == 2 && items.all(v, v.dimensions.exists(d, d.key == 'repository') && v.value == 1.0)"
+      # erin's commit sizes are {50, 60}: quantileExact(0.5) on an even count
+      # returns the UPPER middle element, not the mean of the middles.
       - metric: git.commit_size
         view: period
         find: {entity_id: erin@example.com}
-        equal: {value: 50}
+        equal: {value: 60}
       - metric: git.commit_size
         view: peer
         find: {entity_id: erin@example.com}
-        equal: {target_value: 50, p25: 20, median: 30, p75: 40, min: 10, max: 50, n: 5}
+        equal: {target_value: 60, p25: 24, median: 36, p75: 48, min: 12, max: 60, n: 5}
       - metric: git.commit_size
         view: timeseries
         find: {entity_id: erin@example.com}
-        contains: {points: {bucket_start: "2026-10-01", value: 50}}
+        contains: {points: {bucket_start: "2026-10-01", value: 60}}
       - metric: git.commit_size
         view: breakdown
         find: {entity_id: erin@example.com, dimensions: {key: source, value: github}}
-        equal: {value: 50}
+        equal: {value: 60}
+      # Ten fixed-width bins over erin's own [50, 60]: her two events land in
+      # the first and last bin, one each.
       - metric: git.commit_size
         view: histogram
         find: {entity_id: erin@example.com}
-        nonempty: [bins]
+        contains: {bins: {lo: 50, count: 1}}
+      - metric: git.commit_size
+        view: histogram
+        find: {entity_id: erin@example.com}
+        contains: {bins: {hi: 60, count: 1}}
       - metric: git.pr_size
         view: period
         find: {entity_id: erin@example.com}

--- a/src/ingestion/tests/e2e/metrics/git_uncollected_file_changes.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_uncollected_file_changes.test.yaml
@@ -9,6 +9,12 @@ description: >-
   commit's change WAS collected and then lost the content dedup, which is not
   the same thing as never arriving.
 
+  Commit size reads the same corrected numbers: alice's sizes are {11, 22}
+  (median 22 — quantileExact(0.5) on an even count takes the upper middle),
+  bob's single empty commit reads 0, and carol's repeat commit keeps only the
+  part of its own stats the dedup did not remove: 26 reported less the 11
+  deduplicated lines is 15, so her median over {11, 15} is 15.
+
 bronze:
   bronze_bamboohr.employees:
     - $ref: templates/people.yaml#/templates/alice
@@ -58,6 +64,9 @@ cases:
           - metric_key: git.code_lines
             views:
               - {view: period}
+          - metric_key: git.commit_size
+            views:
+              - {view: period}
     expect:
       - assert: "status == 200"
 
@@ -92,6 +101,12 @@ cases:
         find: {entity_id: alice@example.com}
         equal: {value: 10}
 
+      # Both sizes enter the median: {11, 22} reads 22 (upper middle).
+      - metric: git.commit_size
+        view: period
+        find: {entity_id: alice@example.com}
+        equal: {value: 22}
+
   - name: A commit that changed nothing reports zero, not an absent value
     request:
       url: /v1/metric-results
@@ -109,6 +124,9 @@ cases:
           - metric_key: git.lines_removed
             views:
               - {view: period}
+          - metric_key: git.commit_size
+            views:
+              - {view: period}
     expect:
       - assert: "status == 200"
       - metric: git.commits
@@ -120,6 +138,12 @@ cases:
         find: {entity_id: bob@example.com}
         equal: {value: 0}
       - metric: git.lines_removed
+        view: period
+        find: {entity_id: bob@example.com}
+        equal: {value: 0}
+      # Zero size, not an absent value: the source said the commit changed
+      # nothing.
+      - metric: git.commit_size
         view: period
         find: {entity_id: bob@example.com}
         equal: {value: 0}
@@ -139,6 +163,9 @@ cases:
             views:
               - {view: period}
               - {view: breakdown, dimensions: [category]}
+          - metric_key: git.commit_size
+            views:
+              - {view: period}
     expect:
       - assert: "status == 200"
 
@@ -164,3 +191,12 @@ cases:
       - metric: git.lines_added
         view: breakdown
         assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'category' && d.value == '__unknown__') && v.entity_id == 'carol@example.com')"
+
+      # The repeat commit keeps only the part of its stats the dedup did not
+      # remove: 26 reported less the 11 deduplicated lines is 15. Sizes {11, 15}
+      # read 15 — a size restored in full (26) or zeroed outright would both
+      # fail here.
+      - metric: git.commit_size
+        view: period
+        find: {entity_id: carol@example.com}
+        equal: {value: 15}

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_github.commits.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_github.commits.yaml
@@ -19,9 +19,9 @@ schemas:
       committer_email: {type: string}
       message: {type: string}
       committed_date: {type: string}
-      changed_files: {type: integer}
-      additions: {type: integer}
-      deletions: {type: integer}
+      changed_files: {type: [integer, "null"]}
+      additions: {type: [integer, "null"]}
+      deletions: {type: [integer, "null"]}
       is_merge: {type: boolean}
       is_in_default_branch: {type: [boolean, "null"]}
       patch_id: {type: [string, "null"]}

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_gitlab.commit_file_changes.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_gitlab.commit_file_changes.yaml
@@ -1,0 +1,26 @@
+# Derived from the bronze_gitlab DDL snapshot.
+schemas:
+  bronze_gitlab.commit_file_changes:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      unique_key: { type: [string, "null"] }
+      tenant_id: { type: [string, "null"] }
+      source_id: { type: [string, "null"] }
+      data_source: { type: [string, "null"] }
+      collected_at: { type: [string, "null"] }
+      project_id: { type: [integer, "null"] }
+      commit_sha: { type: [string, "null"] }
+      old_path: { type: [string, "null"] }
+      new_path: { type: [string, "null"] }
+      new_file: { type: [boolean, "null"] }
+      deleted_file: { type: [boolean, "null"] }
+      renamed_file: { type: [boolean, "null"] }
+      lines_added: { type: [integer, "null"] }
+      lines_removed: { type: [integer, "null"] }
+      diff_truncated: { type: [boolean, "null"] }
+      _airbyte_raw_id: { type: string }
+      _airbyte_extracted_at: { type: string, format: date-time }
+      _airbyte_meta: { type: string }
+      _airbyte_generation_id: { type: integer }

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_gitlab.commits.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_gitlab.commits.yaml
@@ -1,0 +1,34 @@
+# Derived from the bronze_gitlab DDL snapshot.
+schemas:
+  bronze_gitlab.commits:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      unique_key: { type: [string, "null"] }
+      tenant_id: { type: [string, "null"] }
+      source_id: { type: [string, "null"] }
+      data_source: { type: [string, "null"] }
+      collected_at: { type: [string, "null"] }
+      project_id: { type: [integer, "null"] }
+      id: { type: [string, "null"] }
+      short_id: { type: [string, "null"] }
+      title: { type: [string, "null"] }
+      title_truncated: { type: [boolean, "null"] }
+      message: { type: [string, "null"] }
+      message_truncated: { type: [boolean, "null"] }
+      author_name: { type: [string, "null"] }
+      author_email: { type: [string, "null"] }
+      authored_date: { type: [string, "null"] }
+      committer_name: { type: [string, "null"] }
+      committer_email: { type: [string, "null"] }
+      committed_date: { type: [string, "null"] }
+      parent_count: { type: [integer, "null"] }
+      stats_additions: { type: [integer, "null"] }
+      stats_deletions: { type: [integer, "null"] }
+      stats_total: { type: [integer, "null"] }
+      is_in_default_branch: { type: [boolean, "null"] }
+      _airbyte_raw_id: { type: string }
+      _airbyte_extracted_at: { type: string, format: date-time }
+      _airbyte_meta: { type: string }
+      _airbyte_generation_id: { type: integer }

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_gitlab.projects.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_gitlab.projects.yaml
@@ -1,0 +1,32 @@
+# Derived from the bronze_gitlab DDL snapshot.
+schemas:
+  bronze_gitlab.projects:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      unique_key: { type: [string, "null"] }
+      tenant_id: { type: [string, "null"] }
+      source_id: { type: [string, "null"] }
+      data_source: { type: [string, "null"] }
+      collected_at: { type: [string, "null"] }
+      id: { type: [integer, "null"] }
+      name: { type: [string, "null"] }
+      path: { type: [string, "null"] }
+      path_with_namespace: { type: [string, "null"] }
+      description: { type: [string, "null"] }
+      default_branch: { type: [string, "null"] }
+      visibility: { type: [string, "null"] }
+      archived: { type: [boolean, "null"] }
+      empty_repo: { type: [boolean, "null"] }
+      created_at: { type: [string, "null"] }
+      last_activity_at: { type: [string, "null"] }
+      web_url: { type: [string, "null"] }
+      namespace_id: { type: [integer, "null"] }
+      namespace_full_path: { type: [string, "null"] }
+      statistics_commit_count: { type: [integer, "null"] }
+      statistics_repository_size: { type: [integer, "null"] }
+      _airbyte_raw_id: { type: string }
+      _airbyte_extracted_at: { type: string, format: date-time }
+      _airbyte_meta: { type: string }
+      _airbyte_generation_id: { type: integer }

--- a/src/ingestion/tests/e2e/metrics/templates/gitlab_git.yaml
+++ b/src/ingestion/tests/e2e/metrics/templates/gitlab_git.yaml
@@ -1,0 +1,55 @@
+# Reusable GitLab bronze records for the git-domain fixture. Commit line stats
+# come from the commit's own stats fields; per-file rows carry no object ids
+# (the GitLab diff API reports none). project_key / repo_slug resolve through
+# the projects row. Missing schema columns pad to null.
+templates:
+  base:
+    _airbyte_raw_id: "00000000-0000-0000-0000-000000000000"
+    _airbyte_extracted_at: "2026-10-02T00:00:00"
+    _airbyte_meta: "{}"
+    _airbyte_generation_id: 0
+    tenant_id: "11111111-1111-1111-1111-111111111111"
+    source_id: gitlab-test
+    data_source: insight_gitlab
+
+  project:
+    $ref: "#/templates/base"
+    id: 101
+    name: platform
+    path: platform
+    path_with_namespace: acme/platform
+    namespace_id: 1
+    namespace_full_path: acme
+    default_branch: main
+
+  commit:
+    $ref: "#/templates/base"
+    project_id: 101
+    id: null
+    short_id: null
+    title: change
+    message: change
+    author_name: null
+    author_email: null
+    authored_date: "2026-10-01T09:00:00Z"
+    committer_name: null
+    committer_email: null
+    committed_date: "2026-10-01T09:00:00Z"
+    parent_count: 1
+    stats_additions: 0
+    stats_deletions: 0
+    stats_total: 0
+    is_in_default_branch: true
+
+  file_change:
+    $ref: "#/templates/base"
+    project_id: 101
+    commit_sha: null
+    old_path: null
+    new_path: null
+    new_file: false
+    deleted_file: false
+    renamed_file: false
+    lines_added: 0
+    lines_removed: 0
+    diff_truncated: false


### PR DESCRIPTION
Part of #3044.

**Why:** `git.commit_size` had thin e2e coverage: the only per-person fixture held two identical sizes (any aggregate — mean, min, max — passed), the histogram assertion accepted any non-empty bins, commit stats disagreed with their own file-change rows, and the metric was asserted for the github source only.

**What changed:**
- New `git_commit_size.test.yaml`: a value pool where only the median fits (mean, extrema, sum and p75 all disagree), merge-commit exclusion, per-day timeseries medians, per-repository breakdown medians, deterministic histogram bins, and a stats-less commit reading 0.
- `git_metrics.test.yaml`: commit stats now agree with the file-change rows; commit_size expectations pin the even-count `quantileExact(0.5)` upper-middle rule; the histogram asserts exact first/last bins.
- commit_size expectations added to the existing dedup scenarios: uncollected file changes (partial correction: 26 reported − 11 deduplicated = 15), work identity (squash / patch-copy / partial-branch / cross-repo pools), branch-scope split, bitbucket.
- New `git_commits_gitlab.test.yaml` + gitlab bronze schemas/template: first gitlab e2e fixture; pins that a source reporting no object ids never folds repeated content.
- `bronze_github.commits` schema: `additions`/`deletions`/`changed_files` widened to nullable, matching the DDL snapshot.

**Out of scope:** staging models coalesce absent commit stats to 0; the stats-less-commit case pins that served behavior rather than changing it.

**Verified:** all 8 touched git metric specs pass locally against the full bronze → dbt → API rig (`./e2e.sh test`, 8 passed).