### PR TITLE
test(e2e): harden git.commits_per_active_day coverage across git connectors

### DIFF
--- a/src/ingestion/tests/e2e/metrics/git_commits_bitbucket.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_commits_bitbucket.test.yaml
@@ -60,6 +60,9 @@ cases:
           - metric_key: git.commit_size
             views:
               - { view: breakdown, dimensions: [source] }
+          - metric_key: git.commits_per_active_day
+            views:
+              - { view: breakdown, dimensions: [source] }
     expect:
       - assert: "status == 200"
       # commit-a and commit-b count; the merge commit does not.
@@ -83,6 +86,12 @@ cases:
         view: breakdown
         find: { entity_id: erin@example.com, dimensions: { key: source, value: bitbucket_cloud } }
         equal: { value: 12 }
+      # Two authored commits, one calendar day: 2.0. The merge commit adds
+      # neither a commit nor an active day.
+      - metric: git.commits_per_active_day
+        view: breakdown
+        find: { entity_id: erin@example.com, dimensions: { key: source, value: bitbucket_cloud } }
+        equal: { value: 2 }
 
   - name: Bitbucket git metrics empty window
     request:

--- a/src/ingestion/tests/e2e/metrics/git_commits_gitlab.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_commits_gitlab.test.yaml
@@ -64,6 +64,9 @@ cases:
           - metric_key: git.commit_size
             views:
               - {view: breakdown, dimensions: [source]}
+          - metric_key: git.commits_per_active_day
+            views:
+              - {view: breakdown, dimensions: [source]}
     expect:
       - assert: "status == 200"
       # commit-a, commit-b and both carriers of the repeated content; the
@@ -88,6 +91,12 @@ cases:
         view: breakdown
         find: {entity_id: erin@example.com, dimensions: {key: source, value: gitlab}}
         equal: {value: 8}
+      # Four authored commits, one calendar day: 4.0. The merge commit adds
+      # neither a commit nor an active day.
+      - metric: git.commits_per_active_day
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: source, value: gitlab}}
+        equal: {value: 4}
 
   - name: GitLab git metrics empty window
     request:

--- a/src/ingestion/tests/e2e/metrics/git_commits_per_active_day.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_commits_per_active_day.test.yaml
@@ -1,0 +1,95 @@
+spec_version: 1
+description: >
+  Metric: git.commits_per_active_day — authored commits divided by the number
+  of DISTINCT calendar days with at least one authored commit. Values chosen so
+  every wrong denominator disagrees: erin lands 6 commits on 2 active days
+  inside a 7-day window, so the period reads 3.0 — dividing by the window's
+  calendar days (7) reads 0.86, counting the commit_day ROWS instead of
+  distinct dates (3 rows: two repositories share one of the days) reads 2.0,
+  and counting the merge-only day as active (3 days) reads 2.0 as well.
+
+  Fixture:
+    * erin, acme/api: two commits on 2026-10-01, one on 2026-10-02 — 3 commits
+      over 2 active days, a fractional 1.5 per repository.
+    * erin, acme/web: three commits on 2026-10-01 — 3 commits over 1 day, 3.0.
+    * erin, acme/api, 2026-10-03: a merge commit ONLY. A merge commit is not
+      an authored commit, so the day must not count as active.
+
+  Cases: fractional period ratio with cross-repository day dedup, per-day
+  timeseries (and no bucket for the merge-only day), per-repository breakdown
+  with distinct ratios, empty window.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_github.commits:
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cpad-a1, repository: "https://github.com/acme/api.git", sha: cpad-a1, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cpad-a2, repository: "https://github.com/acme/api.git", sha: cpad-a2, committed_date: "2026-10-01T10:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cpad-a3, repository: "https://github.com/acme/api.git", sha: cpad-a3, committed_date: "2026-10-02T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cpad-w1, repository: "https://github.com/acme/web.git", sha: cpad-w1, committed_date: "2026-10-01T11:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cpad-w2, repository: "https://github.com/acme/web.git", sha: cpad-w2, committed_date: "2026-10-01T12:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cpad-w3, repository: "https://github.com/acme/web.git", sha: cpad-w3, committed_date: "2026-10-01T13:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com}
+    # A day whose only commit is a merge: 2026-10-03 must not be active.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: cpad-m, repository: "https://github.com/acme/api.git", sha: cpad-m, committed_date: "2026-10-03T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, is_merge: true}
+
+cases:
+  - name: Commits divide by distinct active days, not window days or day rows
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-07"}
+        metrics:
+          - metric_key: git.commits_per_active_day
+            views:
+              - {view: period}
+              - {view: timeseries, bucket: day}
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      # 6 commits over the distinct days {10-01, 10-02}: 3.0. Calendar days
+      # (7) would read ~0.86, per-dimension day rows (3) would read 2.0, and
+      # an active 10-03 (merge-only) would also read 2.0.
+      - metric: git.commits_per_active_day
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 3}
+      # Each bucket is that day's own ratio: five commits on 10-01, one on
+      # 10-02 — and the merge-only 10-03 bucket reads null, not a value.
+      - metric: git.commits_per_active_day
+        view: timeseries
+        find: {entity_id: erin@example.com}
+        contains: {points: {bucket_start: "2026-10-01", value: 5}}
+      - metric: git.commits_per_active_day
+        view: timeseries
+        find: {entity_id: erin@example.com}
+        contains: {points: {bucket_start: "2026-10-02", value: 1}}
+      - metric: git.commits_per_active_day
+        view: timeseries
+        find: {entity_id: erin@example.com}
+        assert: "it.points.exists(p, p.bucket_start == '2026-10-03' && p.value == null)"
+      # Per-repository ratios over each repository's own active days: the
+      # fractional 1.5 pins the actual division.
+      - metric: git.commits_per_active_day
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:acme/api"}}
+        equal: {value: 1.5}
+      - metric: git.commits_per_active_day
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:acme/web"}}
+        equal: {value: 3}
+
+  - name: Empty window
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2025-01-01", to: "2025-01-31"}
+        metrics:
+          - {metric_key: git.commits_per_active_day, views: [{view: period}]}
+    expect:
+      - assert: "status == 200"
+      - {metric: git.commits_per_active_day, view: period, find: {entity_id: erin@example.com}, equal: {value: null}}


### PR DESCRIPTION
Part of #3045. Stacked on #3133.

**Why:** every seeded ratio for `git.commits_per_active_day` was an integer over a single active day, so a wrong denominator — window calendar days, per-dimension day rows instead of distinct dates, or a merge-only day counted as active — could pass; gitlab/bitbucket sources were unasserted.

**What changed:**
- New `git_commits_per_active_day.test.yaml`: 6 commits over 2 distinct days in a 7-day window (period 3.0 — calendar days would read 0.86, day rows 2.0, merge-day-active 2.0), fractional per-repository breakdown (1.5 vs 3.0), per-day timeseries with the merge-only day's bucket reading null, empty window.
- `git_commits_gitlab.test.yaml` / `git_commits_bitbucket.test.yaml`: commits_per_active_day asserted through the source breakdown (4.0 / 2.0), pinning that a merge commit adds neither a commit nor an active day.

**Verified:** the three touched specs pass locally against the full bronze → dbt → API rig.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage for the `git.commits_per_active_day` metric across Bitbucket Cloud and GitLab.
  - Added scenarios validating period ratios, daily time-series results, repository breakdowns, merge-only days, and empty time windows.
  - Verified expected metric values based on authored commits and distinct active days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->