### PR TITLE
fix(connectors): retry proxy connection failures with an exponential ladder instead of dying in two tries

### DIFF
--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -95,6 +95,12 @@ definitions:
       - type: WaitTimeFromHeader
         header: Retry-After
         max_waiting_time_in_seconds: 600
+      # Fallback for failures that carry no response and so no header — a
+      # connection refused or reset while the proxy restarts during a deploy.
+      # Without it the request dies after two immediate tries; the ladder
+      # rides out any restart shorter than the CDK's overall retry ceiling.
+      - type: ExponentialBackoffStrategy
+        factor: 5
     response_filters:
       # The repository is being cloned in the background: the proxy is
       # working, the caller waits.

--- a/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
@@ -12,7 +12,7 @@ name: bitbucket-cloud
 #   same reason as github 6.0.0 — the patch id has been in Bronze all along,
 #   but staging never re-reads Bronze, so the column heals to NULL on existing
 #   rows and a NULL identity never folds.
-version: "5.0.0"
+version: "5.0.1"
 # A slot of its own: replication pods sharing a slot with other connector
 # syncs can be starved of workers, which surfaces as startup and activity
 # timeouts rather than as a connector error.

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -212,6 +212,12 @@ definitions:
       - type: WaitTimeFromHeader
         header: Retry-After
         max_waiting_time_in_seconds: 600
+      # Fallback for failures that carry no response and so no header — a
+      # connection refused or reset while the proxy restarts during a deploy.
+      # Without it the request dies after two immediate tries; the ladder
+      # rides out any restart shorter than the CDK's overall retry ceiling.
+      - type: ExponentialBackoffStrategy
+        factor: 5
     response_filters:
       # The repository is being cloned or purged in the background: the proxy
       # is working, the caller waits.

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -35,7 +35,7 @@ name: github
 #   drops a bronze column.
 #   Additive alongside: a new `issue_links` stream, twelve link event types on
 #   `issue_timeline_events`, and four columns for the link target.
-version: "7.0.0"
+version: "7.0.1"
 schedule: "0 */4 * * *"
 workflow: sync
 


### PR DESCRIPTION
**Why.** The git connectors' proxy error handler carries `max_retries: 100` but only a `WaitTimeFromHeader` backoff strategy. A connection failure has no response and so no header, and the CDK then gives up after two immediate tries — every proxy restart (a deploy rollout, a pod replacement) kills whatever stream partitions were mid-request, and a killed partition re-walks its whole range next attempt.

**What changed.** Both git connectors' proxy error handlers gain the `ExponentialBackoffStrategy` fallback the vendor handlers already have, so responseless failures ladder (1 s, 5 s, 25 s, …) up to the CDK's overall retry ceiling — riding out any restart of a couple of minutes. Descriptor patch bumps (bitbucket-cloud 5.0.1, github 7.0.1).

**Verified.** Connector mock suites for both connectors: 66 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitHub and Bitbucket Cloud connector recovery from proxy connection failures by adding exponential backoff when no retry timing information is available.
  - Reduced the likelihood of ingestion failures during temporary proxy restarts or connection resets.

- **Chores**
  - Updated the GitHub connector to version 7.0.1.
  - Updated the Bitbucket Cloud connector to version 5.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->