### PR TITLE
feat(observability): promote the UI-authored dashboards; retire HTTP and Service health

### DIFF
--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -104,10 +104,10 @@ HELM_ATOMIC_FLAG := $(if $(filter false,$(ATOMIC)),,--atomic)
 #                         helm to print every kubectl API call it makes
 #                         (verbose; great for diagnosing a stuck install).
 #                     Example: HELM_EXTRA_FLAGS=--debug make deploy ENV=local
-# HELM_UPGRADE_FLAGS: passed ONLY to the umbrella `helm upgrade --install`.
-#                     Use for apply-time flags like `--force-conflicts`
-#                     (SSA ownership override) that error out on
-#                     read-only `helm show` / `helm template`.
+# HELM_UPGRADE_FLAGS: passed to every `helm upgrade --install` (umbrella,
+#                     system-*, bootstrap-*). Use for apply-time flags like
+#                     `--force-conflicts` (SSA ownership override) that
+#                     error out on read-only `helm show` / `helm template`.
 HELM_EXTRA_FLAGS   ?=
 HELM_UPGRADE_FLAGS ?=
 
@@ -729,7 +729,7 @@ system-mariadb: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(MARIADB_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,mariadb) \
-		--wait --timeout 10m
+		--wait --timeout 10m $(HELM_UPGRADE_FLAGS)
 
 .PHONY: system-clickhouse
 system-clickhouse: vpn-up kube-ctx
@@ -738,7 +738,7 @@ system-clickhouse: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(CLICKHOUSE_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,clickhouse) \
-		--wait --timeout 10m
+		--wait --timeout 10m $(HELM_UPGRADE_FLAGS)
 
 .PHONY: system-redis
 system-redis: vpn-up kube-ctx
@@ -747,7 +747,7 @@ system-redis: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(REDIS_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,redis) \
-		--wait --timeout 5m
+		--wait --timeout 5m $(HELM_UPGRADE_FLAGS)
 
 .PHONY: system-redpanda
 system-redpanda: vpn-up kube-ctx
@@ -757,7 +757,7 @@ system-redpanda: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(REDPANDA_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,redpanda) \
-		--wait --timeout 10m
+		--wait --timeout 10m $(HELM_UPGRADE_FLAGS)
 
 .PHONY: system-redpanda-console
 system-redpanda-console: vpn-up kube-ctx
@@ -767,7 +767,7 @@ system-redpanda-console: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(REDPANDA_CONSOLE_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,redpanda-console) \
-		--wait --timeout 5m
+		--wait --timeout 5m $(HELM_UPGRADE_FLAGS)
 
 # ── Observability (LGTM) ────────────────────────────────────────────────
 # VictoriaMetrics (metrics store) + Loki (log store) + Tempo (trace store)
@@ -784,7 +784,7 @@ system-victoriametrics: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(VICTORIAMETRICS_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,victoriametrics) \
-		--wait --timeout 10m
+		--wait --timeout 10m $(HELM_UPGRADE_FLAGS)
 
 .PHONY: system-loki
 system-loki: vpn-up kube-ctx
@@ -794,7 +794,7 @@ system-loki: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(LOKI_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,loki) \
-		--wait --timeout 10m
+		--wait --timeout 10m $(HELM_UPGRADE_FLAGS)
 
 .PHONY: system-tempo
 system-tempo: vpn-up kube-ctx
@@ -804,7 +804,7 @@ system-tempo: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(TEMPO_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,tempo) \
-		--wait --timeout 10m
+		--wait --timeout 10m $(HELM_UPGRADE_FLAGS)
 
 .PHONY: system-alloy
 system-alloy: vpn-up kube-ctx
@@ -814,7 +814,7 @@ system-alloy: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(ALLOY_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,alloy) \
-		--wait --timeout 5m
+		--wait --timeout 5m $(HELM_UPGRADE_FLAGS)
 
 # Infra metrics: kube-state-metrics first (alloy-metrics scrapes it),
 # then the alloy-metrics scraper. Both remote-write into VictoriaMetrics.
@@ -826,7 +826,7 @@ system-kube-state-metrics: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(KUBE_STATE_METRICS_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,kube-state-metrics) \
-		--wait --timeout 5m
+		--wait --timeout 5m $(HELM_UPGRADE_FLAGS)
 
 .PHONY: system-alloy-metrics
 system-alloy-metrics: vpn-up kube-ctx
@@ -836,7 +836,7 @@ system-alloy-metrics: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(ALLOY_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,alloy-metrics) \
-		--wait --timeout 5m
+		--wait --timeout 5m $(HELM_UPGRADE_FLAGS)
 
 .PHONY: system-grafana
 system-grafana: vpn-up kube-ctx
@@ -845,7 +845,7 @@ system-grafana: vpn-up kube-ctx
 	helm upgrade --install $(GRAFANA_RELEASE) $(GRAFANA_CHART) \
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(GRAFANA_VERSION) $(HELM_EXTRA_FLAGS) \
-		$(call _system_values_args,grafana) \
+		$(call _system_values_args,grafana) $(HELM_UPGRADE_FLAGS) \
 		--wait --timeout 5m
 
 # Airbyte: helm-install the upstream chart, then run the post-install
@@ -873,7 +873,7 @@ system-airbyte: vpn-up kube-ctx
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(AIRBYTE_VERSION) $(HELM_EXTRA_FLAGS) \
 		$(call _system_values_args,airbyte) \
-		--wait --timeout 15m
+		--wait --timeout 15m $(HELM_UPGRADE_FLAGS)
 	@NAMESPACE=$(NS_INFRA) AIRBYTE_RELEASE=$(AIRBYTE_RELEASE) \
 		AIRBYTE_SETUP_EMAIL="$$AIRBYTE_SETUP_EMAIL" \
 		AIRBYTE_SETUP_ORG="$$AIRBYTE_SETUP_ORG" \
@@ -901,7 +901,7 @@ system-argo: vpn-up kube-ctx
 		--set controller.workflowNamespaces[1]=$(NS_APP) \
 		--set controller.instanceID.enabled=true \
 		--set controller.instanceID.explicitID=$(ARGO_RELEASE)-$(NS_INFRA) \
-		--wait --timeout 5m
+		--wait --timeout 5m $(HELM_UPGRADE_FLAGS)
 	@command -v envsubst >/dev/null \
 		|| { echo "$(C_RED)ERROR$(C_RST): envsubst not found (install gettext)"; exit 1; }
 	@NAMESPACE=$(NS_INFRA) SA_NAMESPACE=$(NS_INFRA) WORKFLOW_SA=$(ARGO_WORKFLOW_SA) \
@@ -1216,7 +1216,7 @@ bootstrap-envoy-gateway: vpn-up kube-ctx
 		--namespace $(ENVOY_GATEWAY_NAMESPACE) --create-namespace \
 		--version $(ENVOY_GATEWAY_VERSION) $(HELM_EXTRA_FLAGS) \
 		$$VALUES_ARGS \
-		--wait --timeout 5m
+		--wait --timeout 5m $(HELM_UPGRADE_FLAGS)
 	@# Namespaces come from inventory.yaml (namespaces.*), never hardcoded:
 	@# ${NS_APP} / ${NS_INFRA} / ${NS_PREVIEWS} placeholders in gateway.yaml
 	@# are substituted here. A manifest without placeholders applies as-is.
@@ -1243,7 +1243,7 @@ bootstrap-cert-manager: vpn-up kube-ctx
 		--set crds.enabled=true \
 		--set config.enableGatewayAPI=$(CERT_MANAGER_GATEWAY_SHIM) \
 		$$VALUES_ARGS \
-		--wait --timeout 5m
+		--wait --timeout 5m $(HELM_UPGRADE_FLAGS)
 	@kubectl --context $(KUBE_CTX) -n $(CERT_MANAGER_NAMESPACE) \
 		rollout status deploy/$(CERT_MANAGER_RELEASE)-webhook --timeout=60s
 	@# INVARIANT: bootstrap returns only once every issuer this file defines is
@@ -1280,7 +1280,7 @@ bootstrap-sealed-secrets: vpn-up kube-ctx
 		--namespace $(SEALED_SECRETS_NAMESPACE) \
 		--version $(SEALED_SECRETS_VERSION) $(HELM_EXTRA_FLAGS) \
 		$$VALUES_ARGS \
-		--wait --timeout 3m
+		--wait --timeout 3m $(HELM_UPGRADE_FLAGS)
 
 .PHONY: bootstrap-status
 bootstrap-status: vpn-up kube-ctx

--- a/deploy/gitops/system/clickhouse/values.yaml
+++ b/deploy/gitops/system/clickhouse/values.yaml
@@ -59,3 +59,16 @@ keeper:
 # Service's `http-metrics` port. alloy-metrics scrapes it into VictoriaMetrics.
 metrics:
   enabled: true
+
+# Query journal for the slow-query dashboard panels (the chart's generated
+# config omits it). TTL keeps the journal from growing unbounded.
+configdFiles:
+  query-log.xml: |
+    <clickhouse>
+      <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+        <ttl>event_date + INTERVAL 14 DAY DELETE</ttl>
+      </query_log>
+    </clickhouse>

--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -46,10 +46,10 @@ persistence:
 initChownData:
   enabled: false
 
-# The ClickHouse SQL datasource plugin (#2888). Space-separated pin — the
-# image's run.sh passes "id version" to `grafana cli plugins install`.
+# The ClickHouse SQL datasource plugin (#2888). `id@version` — the only form
+# Grafana's background installer (GF_INSTALL_PLUGINS) accepts.
 plugins:
-  - grafana-clickhouse-datasource 4.21.1
+  - grafana-clickhouse-datasource@4.21.1
 
 # Password for the SELECT-only `grafana` ClickHouse user (#2888), provisioned
 # by the app deploy hook (apply-ch-migrations -> provision-grafana-access.sh)

--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -139,6 +139,7 @@ datasources:
 # Deploy markers: every umbrella deploy runs the insight-post-upgrade hook
 # pod; its log lines drive the dashboard annotations. The "deploy output"
 # panel shows what scripts/push-deploy-log.sh ships ({job="deploy-insight"}).
+# UI-authored dashboards are exports: edit a copy in the UI, re-export, replace the JSON here.
 dashboardProviders:
   dashboardproviders.yaml:
     apiVersion: 1
@@ -154,79 +155,6 @@ dashboardProviders:
 
 dashboards:
   insight:
-    insight-http:
-      json: |
-        {
-          "uid": "insight-http",
-          "title": "Insight · HTTP",
-          "schemaVersion": 39,
-          "time": {"from": "now-6h", "to": "now"},
-          "refresh": "1m",
-          "annotations": {"list": [
-            {"name": "Deploys", "enable": true, "iconColor": "purple",
-             "datasource": {"type": "loki", "uid": "loki"},
-             "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"}
-          ]},
-          "panels": [
-            {"id": 1, "type": "timeseries", "title": "Requests by status (rps)",
-             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
-             "datasource": {"type": "loki", "uid": "loki"},
-             "fieldConfig": {"defaults": {"unit": "reqps", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
-             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
-             "targets": [
-               {"refId": "A", "legendFormat": "2xx", "expr": "sum(rate({namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"2..\" [$__auto]))"},
-               {"refId": "B", "legendFormat": "4xx", "expr": "sum(rate({namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"4..\" [$__auto]))"},
-               {"refId": "C", "legendFormat": "5xx", "expr": "sum(rate({namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"5..\" [$__auto]))"}
-             ]},
-            {"id": 2, "type": "timeseries", "title": "2xx latency by route, p95 (ms)",
-             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
-             "datasource": {"type": "loki", "uid": "loki"},
-             "fieldConfig": {"defaults": {"unit": "ms", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
-             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
-             "targets": [
-               {"refId": "A", "legendFormat": "{{route}}", "expr": "quantile_over_time(0.95, {namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"2..\" | label_format route=`{{ regexReplaceAll \"(/[0-9]+|/[0-9a-fA-F-]{16,}|/[^/?]*%40[^/?]*)\" .uri \"/{id}\" }}` | unwrap duration_ms [$__auto]) by (route)"}
-             ]},
-            {"id": 3, "type": "timeseries", "title": "2xx latency, p50 / p99 (ms)",
-             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
-             "datasource": {"type": "loki", "uid": "loki"},
-             "fieldConfig": {"defaults": {"unit": "ms", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
-             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
-             "targets": [
-               {"refId": "A", "legendFormat": "p50", "expr": "quantile_over_time(0.5, {namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"2..\" | unwrap duration_ms [$__auto])"},
-               {"refId": "B", "legendFormat": "p99", "expr": "quantile_over_time(0.99, {namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"2..\" | unwrap duration_ms [$__auto])"}
-             ]},
-            {"id": 4, "type": "logs", "title": "4xx / 5xx responses",
-             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
-             "datasource": {"type": "loki", "uid": "loki"},
-             "options": {"showTime": true, "wrapLogMessage": true, "sortOrder": "Descending"},
-             "targets": [
-               {"refId": "A", "expr": "{namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"[45]..\""}
-             ]},
-            {"id": 6, "type": "timeseries", "title": "4xx by status code (count)",
-             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
-             "datasource": {"type": "loki", "uid": "loki"},
-             "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "bars", "fillOpacity": 60, "stacking": {"mode": "normal"}}}, "overrides": []},
-             "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["sum"]}},
-             "targets": [
-               {"refId": "A", "legendFormat": "{{status}}", "expr": "sum by (status) (count_over_time({namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"4..\" [$__auto]))"}
-             ]},
-            {"id": 7, "type": "timeseries", "title": "5xx by status code (count)",
-             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
-             "datasource": {"type": "loki", "uid": "loki"},
-             "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "bars", "fillOpacity": 60, "stacking": {"mode": "normal"}}}, "overrides": []},
-             "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["sum"]}},
-             "targets": [
-               {"refId": "A", "legendFormat": "{{status}}", "expr": "sum by (status) (count_over_time({namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"5..\" [$__auto]))"}
-             ]},
-            {"id": 5, "type": "logs", "title": "Service errors (gateway / analytics / identity-resolution)",
-             "gridPos": {"h": 8, "w": 24, "x": 0, "y": 24},
-             "datasource": {"type": "loki", "uid": "loki"},
-             "options": {"showTime": true, "wrapLogMessage": true, "sortOrder": "Descending"},
-             "targets": [
-               {"refId": "A", "expr": "{namespace=\"insight\", container=~\"api-gateway|analytics|identity-resolution\"} |= \"ERROR\""}
-             ]}
-          ]
-        }
     insight-ingestion:
       json: |
         {
@@ -266,71 +194,6 @@ dashboards:
              "datasource": {"type": "loki", "uid": "loki"},
              "options": {"showTime": true, "wrapLogMessage": true, "sortOrder": "Ascending"},
              "targets": [{"refId": "A", "expr": "{job=\"deploy-insight\"}"}]}
-          ]
-        }
-    insight-services:
-      json: |
-        {
-          "uid": "insight-services",
-          "title": "Insight · Service health",
-          "schemaVersion": 39,
-          "time": {"from": "now-6h", "to": "now"},
-          "refresh": "1m",
-          "annotations": {"list": [
-            {"name": "Deploys", "enable": true, "iconColor": "purple",
-             "datasource": {"type": "loki", "uid": "loki"},
-             "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"}
-          ]},
-          "panels": [
-            {"id": 1, "type": "timeseries", "title": "CPU by service (cores)",
-             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
-             "datasource": {"type": "prometheus", "uid": "vm"},
-             "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
-             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
-             "targets": [
-               {"refId": "A", "legendFormat": "{{container}}", "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|keycloak|analytics|identity-resolution|previews|git-cli-proxy|frontend\"}[$__rate_interval]))"}
-             ]},
-            {"id": 2, "type": "timeseries", "title": "Memory by service (working set)",
-             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
-             "datasource": {"type": "prometheus", "uid": "vm"},
-             "fieldConfig": {"defaults": {"unit": "bytes", "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
-             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
-             "targets": [
-               {"refId": "A", "legendFormat": "{{container}}", "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|keycloak|analytics|identity-resolution|previews|git-cli-proxy|frontend\"})"}
-             ]},
-            {"id": 3, "type": "timeseries", "title": "Container restarts",
-             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
-             "datasource": {"type": "prometheus", "uid": "vm"},
-             "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "bars", "fillOpacity": 60, "stacking": {"mode": "normal"}}}, "overrides": []},
-             "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["sum"]}},
-             "targets": [
-               {"refId": "A", "legendFormat": "{{container}}", "expr": "sum by (container) (increase(kube_pod_container_status_restarts_total{namespace=\"insight\"}[$__rate_interval])) > 0"}
-             ]},
-            {"id": 4, "type": "timeseries", "title": "Ready vs desired replicas",
-             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
-             "datasource": {"type": "prometheus", "uid": "vm"},
-             "fieldConfig": {"defaults": {"unit": "short", "min": 0, "custom": {"drawStyle": "line", "fillOpacity": 0}}, "overrides": []},
-             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
-             "targets": [
-               {"refId": "A", "legendFormat": "{{deployment}} ready", "expr": "sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\"})"},
-               {"refId": "B", "legendFormat": "{{deployment}} desired", "expr": "sum by (deployment) (kube_deployment_spec_replicas{namespace=\"insight\"})"}
-             ]},
-            {"id": 5, "type": "timeseries", "title": "Unready pods",
-             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
-             "datasource": {"type": "prometheus", "uid": "vm"},
-             "fieldConfig": {"defaults": {"unit": "short", "min": 0, "custom": {"drawStyle": "line", "fillOpacity": 10}}, "overrides": []},
-             "options": {"legend": {"displayMode": "list", "placement": "bottom"}},
-             "targets": [
-               {"refId": "A", "legendFormat": "{{pod}}", "expr": "kube_pod_status_ready{namespace=\"insight\", condition=\"false\"} == 1"}
-             ]},
-            {"id": 6, "type": "timeseries", "title": "OOM kills / abnormal terminations",
-             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
-             "datasource": {"type": "prometheus", "uid": "vm"},
-             "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "bars", "fillOpacity": 60, "stacking": {"mode": "normal"}}}, "overrides": []},
-             "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["sum"]}},
-             "targets": [
-               {"refId": "A", "legendFormat": "{{container}} {{reason}}", "expr": "sum by (container, reason) (kube_pod_container_status_last_terminated_reason{namespace=\"insight\", reason!=\"Completed\"})"}
-             ]}
           ]
         }
     insight-red:
@@ -552,6 +415,11046 @@ dashboards:
                 "rawSql": "SELECT configured.connector AS connector, if(last.status = '', 'never synced', last.status) AS last_outcome FROM (SELECT DISTINCT connector FROM ingestion_history.sync_events WHERE event = 'connector.configured' AND tick_id = (SELECT argMax(tick_id, ts) FROM ingestion_history.sync_events WHERE event = 'sweep.completed')) AS configured LEFT JOIN (SELECT connector, argMax(status, (coalesce(job_updated_at, ts), toUInt64OrZero(job_id), status IN ('succeeded', 'failed', 'cancelled', 'incomplete'), ts)) AS status FROM ingestion_history.sync_events WHERE event = 'sync.completed' GROUP BY connector) AS last ON last.connector = configured.connector ORDER BY connector"}
              ]}
           ]
+        }
+    insight-endpoints:
+      json: |
+        {
+          "annotations": {
+            "list": [
+              {
+                "name": "Deploys",
+                "enable": true,
+                "iconColor": "purple",
+                "datasource": {
+                  "type": "loki",
+                  "uid": "loki"
+                },
+                "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"
+              }
+            ]
+          },
+          "description": "Per-endpoint traffic, status codes and latency, parsed from the gateway's JSON access log. Replaces the provisioned 'Insight · HTTP' dashboard, which still queries container=\"api-gateway\" and a logfmt access_log line — neither has existed since the NGINX_BFF rewrite, so every panel on it is empty.",
+          "panels": [
+            {
+              "gridPos": {
+                "h": 3,
+                "w": 24,
+                "x": 0,
+                "y": 0
+              },
+              "id": 900,
+              "options": {
+                "content": "Routes are **normalised** before grouping: `/assets/<hashed>.js` collapses to `/assets/*` (the filenames change on every frontend build and would otherwise mint new series on each deploy), and numeric / hash / URL-encoded-email path segments collapse to `/{id}`. Use the **Route filter** variable to narrow to an area, e.g. `^/v1/`.",
+                "mode": "markdown"
+              },
+              "title": "",
+              "type": "text"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 3
+              },
+              "id": 100,
+              "title": "Status codes by endpoint",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "The whole question in one panel: which endpoint returned what, and how often. Sorted by 5xx, then 4xx.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "5xx"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": null
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "4xx"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 11,
+                "w": 14,
+                "x": 0,
+                "y": 4
+              },
+              "id": 1,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "5xx"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "expr": "sum by (route) (count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` | status >= 200 | status < 300 [$__range]))",
+                  "instant": true,
+                  "legendFormat": "2xx",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum by (route) (count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` | status >= 300 | status < 400 [$__range]))",
+                  "instant": true,
+                  "legendFormat": "3xx",
+                  "refId": "B"
+                },
+                {
+                  "expr": "sum by (route) (count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` | status >= 400 | status < 500 [$__range]))",
+                  "instant": true,
+                  "legendFormat": "4xx",
+                  "refId": "C"
+                },
+                {
+                  "expr": "sum by (route) (count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` | status >= 500 [$__range]))",
+                  "instant": true,
+                  "legendFormat": "5xx",
+                  "refId": "D"
+                }
+              ],
+              "title": "Endpoint × status code",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "route",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true,
+                      "Time 1": true,
+                      "Time 2": true,
+                      "Time 3": true,
+                      "Time 4": true
+                    },
+                    "renameByName": {
+                      "Value #A": "2xx",
+                      "Value #B": "3xx",
+                      "Value #C": "4xx",
+                      "Value #D": "5xx"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "Broken out per code rather than per class — a wall of 401s on /auth/me reads very differently from a wall of 403s.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 11,
+                "w": 10,
+                "x": 14,
+                "y": 4
+              },
+              "id": 2,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "count"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "expr": "sum by (route, status) (count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` | status >= 400 [$__range]))",
+                  "instant": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Exact status codes seen",
+              "transformations": [
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true
+                    },
+                    "renameByName": {
+                      "Value": "count"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 70,
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "noValue": "no 5xx in this window",
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 15
+              },
+              "id": 3,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (route, status) (count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` | status >= 500 [$__auto]))",
+                  "legendFormat": "{{route}} · {{status}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "5xx by endpoint",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 70,
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 15
+              },
+              "id": 4,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (route, status) (count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` | status >= 400 | status < 500 [$__auto]))",
+                  "legendFormat": "{{route}} · {{status}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "4xx by endpoint",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "Errors as a share of that endpoint's own traffic. A route called twice an hour with one failure matters more than it looks in a raw count, and less than a busy route with the same count.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "max": 100,
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 24
+              },
+              "id": 5,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "100 * sum by (route) (count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` | status >= 400 [$__auto])) / sum by (route) (count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` [$__auto]))",
+                  "legendFormat": "{{route}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Error ratio by endpoint (%)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "unit": "reqps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 24
+              },
+              "id": 6,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (route) (rate({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` [$__auto]))",
+                  "legendFormat": "{{route}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Request rate by endpoint",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 33
+              },
+              "id": 200,
+              "title": "Latency",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "request_time is emitted in seconds by nginx; scaled here.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 0
+                  },
+                  "unit": "ms"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 34
+              },
+              "id": 7,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "topk(10, 1000 * quantile_over_time(0.95, {namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` | unwrap request_time [$__auto]) by (route))",
+                  "legendFormat": "{{route}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "p95 by endpoint (ms)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "unit": "ms"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 34
+              },
+              "id": 8,
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "1000 * quantile_over_time(0.50, {namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | unwrap request_time [$__auto]) by ()",
+                  "legendFormat": "p50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "1000 * quantile_over_time(0.95, {namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | unwrap request_time [$__auto]) by ()",
+                  "legendFormat": "p95",
+                  "refId": "B"
+                },
+                {
+                  "expr": "1000 * quantile_over_time(0.99, {namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | unwrap request_time [$__auto]) by ()",
+                  "legendFormat": "p99",
+                  "refId": "C"
+                }
+              ],
+              "title": "Overall p50 / p95 / p99 (ms)",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 43
+              },
+              "id": 300,
+              "title": "The failing requests themselves",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "Each line carries correlation_id and upstream_addr — the two fields that let you follow a failure from the edge into whichever service actually produced it.",
+              "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 44
+              },
+              "id": 9,
+              "options": {
+                "enableLogDetails": true,
+                "prettifyLogMessage": false,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "wrapLogMessage": true
+              },
+              "targets": [
+                {
+                  "expr": "{namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | label_format route=`{{ regexReplaceAll \"(/[0-9a-fA-F][0-9a-fA-F_-]{11,}|/[0-9]+|/[^/?]*(?:%40|@)[^/?]*)\" (regexReplaceAll \"^/assets/.+$\" .uri \"/assets/*\") \"/{id}\" }}` | route=~`$route` | status >= 400 | line_format `{{.status}} {{.method}} {{.uri}} {{.request_time}}s`",
+                  "refId": "A"
+                }
+              ],
+              "title": "4xx / 5xx requests",
+              "type": "logs"
+            },
+            {
+              "id": 901,
+              "type": "logs",
+              "title": "Service errors (gateway / analytics / identity-resolution)",
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 56
+              },
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "options": {
+                "showTime": true,
+                "wrapLogMessage": true,
+                "sortOrder": "Descending"
+              },
+              "targets": [
+                {
+                  "refId": "A",
+                  "expr": "{namespace=\"insight\", container=~\"api-gateway|analytics|identity-resolution\"} |= \"ERROR\""
+                }
+              ]
+            }
+          ],
+          "refresh": "1m",
+          "schemaVersion": 39,
+          "tags": [
+            "insight",
+            "http"
+          ],
+          "templating": {
+            "list": [
+              {
+                "current": {
+                  "text": ".+",
+                  "value": ".+"
+                },
+                "description": "Regex matched against the normalised route, e.g. /v1/.* or /auth/.*",
+                "label": "Route filter",
+                "name": "route",
+                "query": ".+",
+                "type": "textbox"
+              }
+            ]
+          },
+          "time": {
+            "from": "now-24h",
+            "to": "now"
+          },
+          "timezone": "utc",
+          "title": "Insight · API endpoints",
+          "uid": "insight-endpoints"
+        }
+    insight-logs:
+      json: |
+        {
+          "annotations": {
+            "list": [
+              {
+                "name": "Deploys",
+                "enable": true,
+                "iconColor": "purple",
+                "datasource": {
+                  "type": "loki",
+                  "uid": "loki"
+                },
+                "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"
+              }
+            ]
+          },
+          "description": "Every service's logs in one place, with a per-service error breakdown. Pick services with the Service variable — it defaults to All, so the bottom panel is a single stream you can read across the whole stand.",
+          "panels": [
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+              },
+              "id": 100,
+              "title": "Per-service overview",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.\n\nThe starting point: which services are talking, and which of them are unhappy. `error rate` is errors as a share of that service's own lines, so a quiet service with a few failures still stands out.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "errors"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": null
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "warnings"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "text",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "error rate"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "max",
+                        "value": 100
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "red",
+                              "value": 10
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 12,
+                "w": 15,
+                "x": 0,
+                "y": 1
+              },
+              "id": 1,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "errors"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "expr": "sum by (container) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\"} [$__range]))",
+                  "instant": true,
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum by (container) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=~\"error|fatal\"} [$__range]))",
+                  "instant": true,
+                  "refId": "B"
+                },
+                {
+                  "expr": "sum by (container) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=\"warn\"} [$__range]))",
+                  "instant": true,
+                  "refId": "C"
+                },
+                {
+                  "expr": "100 * sum by (container) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=~\"error|fatal\"} [$__range])) / sum by (container) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=~\"error|fatal\"} [$__range]))",
+                  "instant": true,
+                  "refId": "D"
+                }
+              ],
+              "title": "Every service — volume, errors, warnings",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true,
+                      "Time 1": true,
+                      "Time 2": true,
+                      "Time 3": true,
+                      "Time 4": true
+                    },
+                    "renameByName": {
+                      "Value #A": "lines",
+                      "Value #B": "errors",
+                      "Value #C": "warnings",
+                      "Value #D": "error rate",
+                      "container": "service"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 70,
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 12,
+                "w": 9,
+                "x": 15,
+                "y": 1
+              },
+              "id": 2,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "sum"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "topk(12, sum by (container) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\"} [$__auto])))",
+                  "legendFormat": "{{container}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Log volume by service",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.",
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 13
+              },
+              "id": 200,
+              "title": "Errors",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.\n\nMatches all four log formats on this stand: Rust tracing (ERROR), ClickHouse (<Error>), nginx ([error]) and JSON (\"level\":\"error\"). Filtering on the `level` label alone would miss most of them — see the dashboard notes.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      },
+                      {
+                        "color": "red",
+                        "value": 50
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 0,
+                "y": 14
+              },
+              "id": 3,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "reduceOptions": {
+                  "calcs": [
+                    "sum"
+                  ]
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=~\"error|fatal\"} [$__range]))",
+                  "instant": true,
+                  "queryType": "instant",
+                  "refId": "A"
+                }
+              ],
+              "title": "Errors",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.",
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "yellow",
+                    "mode": "fixed"
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 4,
+                "y": 14
+              },
+              "id": 4,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "reduceOptions": {
+                  "calcs": [
+                    "sum"
+                  ]
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=\"warn\"} [$__range]))",
+                  "instant": true,
+                  "queryType": "instant",
+                  "refId": "A"
+                }
+              ],
+              "title": "Warnings",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 70,
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 10,
+                "w": 16,
+                "x": 8,
+                "y": 14
+              },
+              "id": 5,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "sum"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (container) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=~\"error|fatal\"} [$__auto]))",
+                  "legendFormat": "{{container}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Error rate by service",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.\n\nOnly counts lines whose level was successfully parsed. Access-log lines legitimately have no severity, so this is a share of levelled lines, not of all traffic.",
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "error"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "warn"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "orange",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 0,
+                "y": 19
+              },
+              "id": 6,
+              "options": {
+                "displayLabels": [
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "values": [
+                    "value",
+                    "percent"
+                  ]
+                },
+                "pieType": "donut",
+                "reduceOptions": {
+                  "calcs": [
+                    "sum"
+                  ]
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (level) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=~\"info|warn|error|fatal\"} [$__auto]))",
+                  "legendFormat": "{{level}}",
+                  "queryType": "range",
+                  "refId": "A"
+                }
+              ],
+              "title": "By level",
+              "type": "piechart"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.",
+              "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 24
+              },
+              "id": 7,
+              "options": {
+                "enableLogDetails": true,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "wrapLogMessage": true
+              },
+              "targets": [
+                {
+                  "expr": "{namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=~\"error|fatal\"}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Live errors — selected services",
+              "type": "logs"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 36
+              },
+              "id": 300,
+              "title": "ClickHouse",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "ClickHouse names its failures: 47 = UNKNOWN_IDENTIFIER (a query referencing a column that does not exist), 60 = UNKNOWN_TABLE, 210 = NETWORK_ERROR, 241 = MEMORY_LIMIT_EXCEEDED, 236 = ABORTED.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 70,
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 37
+              },
+              "id": 8,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "sum"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (code, kind) (count_over_time({namespace=\"insight-infra\", container=\"clickhouse\"} |~ `<Error>` | regexp `Code: (?P<code>\\d+)\\..*\\((?P<kind>[A-Z_]+)\\)` [$__auto]))",
+                  "legendFormat": "Code {{code}} · {{kind}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "ClickHouse exceptions by error code",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 37
+              },
+              "id": 9,
+              "options": {
+                "showTime": true,
+                "sortOrder": "Descending",
+                "wrapLogMessage": true
+              },
+              "targets": [
+                {
+                  "expr": "{namespace=\"insight-infra\", container=\"clickhouse\"} |~ `<Error>`",
+                  "refId": "A"
+                }
+              ],
+              "title": "ClickHouse errors",
+              "type": "logs"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 46
+              },
+              "id": 400,
+              "title": "Browse everything",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "Leave Service on All and Contains empty to read the whole stand. Set Contains to grep, e.g. a correlation_id from the endpoints dashboard, an email, or a workflow name.",
+              "gridPos": {
+                "h": 18,
+                "w": 24,
+                "x": 0,
+                "y": 47
+              },
+              "id": 10,
+              "options": {
+                "enableLogDetails": true,
+                "showLabels": true,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "wrapLogMessage": true
+              },
+              "targets": [
+                {
+                  "expr": "{namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\"} |~ `(?i)$search`",
+                  "refId": "A"
+                }
+              ],
+              "title": "All logs — selected services, filtered by \"$search\"",
+              "type": "logs"
+            }
+          ],
+          "refresh": "5m",
+          "schemaVersion": 39,
+          "tags": [
+            "insight",
+            "logs"
+          ],
+          "templating": {
+            "list": [
+              {
+                "allValue": ".+",
+                "current": {
+                  "text": [
+                    "insight",
+                    "insight-infra"
+                  ],
+                  "value": [
+                    "insight",
+                    "insight-infra"
+                  ]
+                },
+                "datasource": {
+                  "type": "loki",
+                  "uid": "loki"
+                },
+                "includeAll": true,
+                "label": "Namespace",
+                "multi": true,
+                "name": "ns",
+                "query": {
+                  "label": "namespace",
+                  "refId": "ns"
+                },
+                "refresh": 1,
+                "sort": 1,
+                "type": "query"
+              },
+              {
+                "allValue": ".+",
+                "current": {
+                  "text": [
+                    "All"
+                  ],
+                  "value": [
+                    "$__all"
+                  ]
+                },
+                "datasource": {
+                  "type": "loki",
+                  "uid": "loki"
+                },
+                "includeAll": true,
+                "label": "Service",
+                "multi": true,
+                "name": "svc",
+                "query": {
+                  "label": "container",
+                  "refId": "svc",
+                  "stream": "{namespace=~\"$ns\"}"
+                },
+                "refresh": 2,
+                "sort": 1,
+                "type": "query"
+              },
+              {
+                "current": {
+                  "text": "",
+                  "value": ""
+                },
+                "description": "Free-text filter applied to the browse panel at the bottom. Case-insensitive.",
+                "label": "Contains",
+                "name": "search",
+                "query": "",
+                "type": "textbox"
+              }
+            ]
+          },
+          "time": {
+            "from": "now-6h",
+            "to": "now"
+          },
+          "timezone": "utc",
+          "title": "Insight · Logs by service",
+          "uid": "insight-logs"
+        }
+    insight-uptime:
+      json: |
+        {
+          "annotations": {
+            "list": [
+              {
+                "name": "Deploys",
+                "enable": true,
+                "iconColor": "purple",
+                "datasource": {
+                  "type": "loki",
+                  "uid": "loki"
+                },
+                "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"
+              }
+            ]
+          },
+          "description": "Availability of Insight, two ways. REPORTABLE: request-based at the gateway, failures = 5xx and timeouts, 4xx counts as success, 30-day rolling — the AWS/GCP SLA and Google SLI convention. DIAGNOSTIC: healthcheck uptime of Insight's own components (gateway, authenticator, analytics, identity-resolution, frontend, git-cli-proxy), composited as every-component-serving-at-once. Third-party software is out of scope, Keycloak included. Both halves break down by service. User journeys are NOT measured — that needs browser emulation, which this stand does not have. Readiness comes from kube-state-metrics on the qaclust VictoriaMetrics (cluster=dev, 30s); request and probe-log panels come from this stand's Loki. Target 99.9%.",
+          "editable": true,
+          "graphTooltip": 1,
+          "panels": [
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+              },
+              "id": 1,
+              "panels": [],
+              "title": "Availability · requests through the gateway, 5xx and timeouts count as failures",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3,
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 99
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 99.9
+                      },
+                      {
+                        "color": "green",
+                        "value": 99.95
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 7,
+                "x": 0,
+                "y": 1
+              },
+              "id": 2,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 44
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "100 * (1 - ((sum(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | status >= 500 or status == 499 [$__range])) or (sum(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` [$__range])) * 0)) / sum(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` [$__range]))))",
+                  "queryType": "instant",
+                  "refId": "A"
+                }
+              ],
+              "timeFrom": "30d",
+              "title": "Availability · 30 days",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3,
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 99
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 99.9
+                      },
+                      {
+                        "color": "green",
+                        "value": 99.95
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 7,
+                "y": 1
+              },
+              "id": 3,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 30
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "100 * (1 - ((sum(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | status >= 500 or status == 499 [$__range])) or (sum(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` [$__range])) * 0)) / sum(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` [$__range]))))",
+                  "queryType": "instant",
+                  "refId": "A"
+                }
+              ],
+              "title": "Availability · selected range",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 5,
+                "x": 13,
+                "y": 1
+              },
+              "id": 4,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 30
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "sum(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | status >= 500 or status == 499 [$__range]))",
+                  "queryType": "instant",
+                  "refId": "A"
+                }
+              ],
+              "title": "Failed requests · 5xx + timeouts",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 18,
+                "y": 1
+              },
+              "id": 5,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 30
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "sum(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` [$__range]))",
+                  "queryType": "instant",
+                  "refId": "A"
+                }
+              ],
+              "title": "Requests",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "Requests the gateway answered itself (empty upstream_addr) are EXCLUDED. That bucket is only rate-limit rejections and auth denials, against ~1% of traffic, so it scored a working proxy at 39% and dragged the composite. The gateway's real availability is every row here: each of these requests crossed it and was forwarded.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "component"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "service"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "availability"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 3
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 99
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 99.9
+                            },
+                            {
+                              "color": "green",
+                              "value": 99.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "requests"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "failures"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 0,
+                "y": 6
+              },
+              "id": 6,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "availability"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "100 * (1 - ((sum by (component)(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | upstream_addr!=`` | label_format component=`{{ regexReplaceAll \"^$\" (regexReplaceAll \"^[0-9.]+:8085$\" (regexReplaceAll \"^[0-9.]+:80$\" (regexReplaceAll \"^[0-9.]+:8083$\" (regexReplaceAll \"^[0-9.]+:8082$\" (regexReplaceAll \"^[0-9.]+:8081$\" .upstream_addr \"analytics\") \"identity-resolution\") \"authenticator\") \"frontend\") \"keycloak\") \"gateway\" }}` | status >= 500 or status == 499 [$__range])) or (sum by (component)(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | upstream_addr!=`` | label_format component=`{{ regexReplaceAll \"^$\" (regexReplaceAll \"^[0-9.]+:8085$\" (regexReplaceAll \"^[0-9.]+:80$\" (regexReplaceAll \"^[0-9.]+:8083$\" (regexReplaceAll \"^[0-9.]+:8082$\" (regexReplaceAll \"^[0-9.]+:8081$\" .upstream_addr \"analytics\") \"identity-resolution\") \"authenticator\") \"frontend\") \"keycloak\") \"gateway\" }}` [$__range])) * 0)) / sum by (component)(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | upstream_addr!=`` | label_format component=`{{ regexReplaceAll \"^$\" (regexReplaceAll \"^[0-9.]+:8085$\" (regexReplaceAll \"^[0-9.]+:80$\" (regexReplaceAll \"^[0-9.]+:8083$\" (regexReplaceAll \"^[0-9.]+:8082$\" (regexReplaceAll \"^[0-9.]+:8081$\" .upstream_addr \"analytics\") \"identity-resolution\") \"authenticator\") \"frontend\") \"keycloak\") \"gateway\" }}` [$__range]))))",
+                  "legendFormat": "{{component}}",
+                  "queryType": "instant",
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "sum by (component)(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | upstream_addr!=`` | label_format component=`{{ regexReplaceAll \"^$\" (regexReplaceAll \"^[0-9.]+:8085$\" (regexReplaceAll \"^[0-9.]+:80$\" (regexReplaceAll \"^[0-9.]+:8083$\" (regexReplaceAll \"^[0-9.]+:8082$\" (regexReplaceAll \"^[0-9.]+:8081$\" .upstream_addr \"analytics\") \"identity-resolution\") \"authenticator\") \"frontend\") \"keycloak\") \"gateway\" }}` [$__range]))",
+                  "legendFormat": "{{component}}",
+                  "queryType": "instant",
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "sum by (component)(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | upstream_addr!=`` | label_format component=`{{ regexReplaceAll \"^$\" (regexReplaceAll \"^[0-9.]+:8085$\" (regexReplaceAll \"^[0-9.]+:80$\" (regexReplaceAll \"^[0-9.]+:8083$\" (regexReplaceAll \"^[0-9.]+:8082$\" (regexReplaceAll \"^[0-9.]+:8081$\" .upstream_addr \"analytics\") \"identity-resolution\") \"authenticator\") \"frontend\") \"keycloak\") \"gateway\" }}` | status >= 500 or status == 499 [$__range]))",
+                  "legendFormat": "{{component}}",
+                  "queryType": "instant",
+                  "refId": "C"
+                }
+              ],
+              "title": "Availability by service",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "component",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "barAlignment": 0,
+                    "drawStyle": "bars",
+                    "fillOpacity": 80,
+                    "lineWidth": 0,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    }
+                  },
+                  "min": 0,
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 6,
+                "w": 12,
+                "x": 12,
+                "y": 6
+              },
+              "id": 7,
+              "maxDataPoints": 400,
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "sum by (status) (count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | status >= 500 or status == 499 [1d]))",
+                  "interval": "1d",
+                  "legendFormat": "{{status}}",
+                  "queryType": "range",
+                  "refId": "A",
+                  "step": "1d"
+                }
+              ],
+              "timeFrom": "30d",
+              "title": "Failures per day · 30 days",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "description": "Requests the gateway answered itself (empty upstream_addr) are EXCLUDED. That bucket is only rate-limit rejections and auth denials, against ~1% of traffic, so it scored a working proxy at 39% and dragged the composite. The gateway's real availability is every row here: each of these requests crossed it and was forwarded.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 0,
+                    "lineWidth": 2,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "decimals": 2,
+                  "max": 100,
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 12
+              },
+              "id": 8,
+              "maxDataPoints": 2000,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "min",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "100 * (1 - ((sum by (component)(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | upstream_addr!=`` | label_format component=`{{ regexReplaceAll \"^$\" (regexReplaceAll \"^[0-9.]+:8085$\" (regexReplaceAll \"^[0-9.]+:80$\" (regexReplaceAll \"^[0-9.]+:8083$\" (regexReplaceAll \"^[0-9.]+:8082$\" (regexReplaceAll \"^[0-9.]+:8081$\" .upstream_addr \"analytics\") \"identity-resolution\") \"authenticator\") \"frontend\") \"keycloak\") \"gateway\" }}` | status >= 500 or status == 499 [1h])) or (sum by (component)(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | upstream_addr!=`` | label_format component=`{{ regexReplaceAll \"^$\" (regexReplaceAll \"^[0-9.]+:8085$\" (regexReplaceAll \"^[0-9.]+:80$\" (regexReplaceAll \"^[0-9.]+:8083$\" (regexReplaceAll \"^[0-9.]+:8082$\" (regexReplaceAll \"^[0-9.]+:8081$\" .upstream_addr \"analytics\") \"identity-resolution\") \"authenticator\") \"frontend\") \"keycloak\") \"gateway\" }}` [1h])) * 0)) / sum by (component)(count_over_time({namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | upstream_addr!=`` | label_format component=`{{ regexReplaceAll \"^$\" (regexReplaceAll \"^[0-9.]+:8085$\" (regexReplaceAll \"^[0-9.]+:80$\" (regexReplaceAll \"^[0-9.]+:8083$\" (regexReplaceAll \"^[0-9.]+:8082$\" (regexReplaceAll \"^[0-9.]+:8081$\" .upstream_addr \"analytics\") \"identity-resolution\") \"authenticator\") \"frontend\") \"keycloak\") \"gateway\" }}` [1h]))))",
+                  "interval": "1h",
+                  "legendFormat": "{{component}}",
+                  "queryType": "range",
+                  "refId": "A",
+                  "step": "1h"
+                }
+              ],
+              "title": "Availability by service · hourly",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 20
+              },
+              "id": 9,
+              "options": {
+                "enableLogDetails": true,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "wrapLogMessage": true
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "{namespace=\"insight\", container=\"gateway\"} | json | __error__=`` | uri!~`/grafana.*|/apis/.*|/favicon.ico|/apple-touch-icon.*|/.well-known/.*` | status >= 500 or status == 499 | line_format `{{.status}} {{.method}} {{.uri}} {{.request_time}}s upstream={{.upstream_addr}}`",
+                  "queryType": "range",
+                  "refId": "A"
+                }
+              ],
+              "title": "Failing requests · 5xx + timeouts",
+              "type": "logs"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 28
+              },
+              "id": 10,
+              "panels": [],
+              "title": "Component health · Kubernetes readiness probes",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3,
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 99
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 99.9
+                      },
+                      {
+                        "color": "green",
+                        "value": 99.95
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 0,
+                "y": 29
+              },
+              "id": 11,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 44
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * avg_over_time((min(clamp_max(sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}), 1)))[$__range:30s])",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Healthcheck uptime · all components serving",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3,
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 5,
+                "x": 6,
+                "y": 29
+              },
+              "id": 12,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 30
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "avg(100 * avg_over_time((clamp_max(sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}), 1))[$__range:30s]))",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Healthcheck uptime · mean of components",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.4
+                      },
+                      {
+                        "color": "red",
+                        "value": 5
+                      }
+                    ]
+                  },
+                  "unit": "m"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 11,
+                "y": 29
+              },
+              "id": 13,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 30
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "0.5 * sum_over_time((min(clamp_max(sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}), 1)) == bool 0)[$__range:30s])",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Time with a component down",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 5,
+                "x": 15,
+                "y": 29
+              },
+              "id": 14,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 30
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "count(sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}))",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Components measured",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3,
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 99
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 99.9
+                      },
+                      {
+                        "color": "green",
+                        "value": 99.95
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 20,
+                "y": 29
+              },
+              "id": 15,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 22
+                },
+                "textMode": "value_and_name"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "bottomk(1, 100 * avg_over_time((clamp_max(sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}), 1))[$__range:30s]))",
+                  "instant": true,
+                  "legendFormat": "{{deployment}}",
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Lowest component uptime",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "fillOpacity": 100,
+                    "lineWidth": 0,
+                    "spanNulls": false
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "red",
+                          "index": 0,
+                          "text": "Down"
+                        },
+                        "1": {
+                          "color": "orange",
+                          "index": 1,
+                          "text": "Degraded"
+                        },
+                        "2": {
+                          "color": "green",
+                          "index": 2,
+                          "text": "Healthy"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "max": 2,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      },
+                      {
+                        "color": "green",
+                        "value": 2
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 34
+              },
+              "id": 16,
+              "maxDataPoints": 20000,
+              "options": {
+                "alignValue": "center",
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "mergeValues": true,
+                "rowHeight": 0.9,
+                "showValue": "never",
+                "tooltip": {
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "min((clamp_max(sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}), 1) + (sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}) >= bool sum by (deployment) (kube_deployment_spec_replicas{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}))))",
+                  "instant": false,
+                  "interval": "30s",
+                  "legendFormat": "ALL COMPONENTS",
+                  "range": true,
+                  "refId": "A",
+                  "step": "30s"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "(clamp_max(sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}), 1) + (sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}) >= bool sum by (deployment) (kube_deployment_spec_replicas{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"})))",
+                  "instant": false,
+                  "interval": "30s",
+                  "legendFormat": "{{deployment}}",
+                  "range": true,
+                  "refId": "B",
+                  "step": "30s"
+                }
+              ],
+              "title": "Component health · green healthy, amber degraded, red down",
+              "type": "state-timeline"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 44
+              },
+              "id": 17,
+              "panels": [],
+              "title": "Per component",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "deployment"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "component"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "uptime"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 3
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 99
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 99.9
+                            },
+                            {
+                              "color": "green",
+                              "value": 99.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "down"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "m"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "degraded"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "m"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "ready now"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "desired"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 15,
+                "x": 0,
+                "y": 45
+              },
+              "id": 18,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "uptime"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * avg_over_time((clamp_max(sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}), 1))[$__range:30s])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "0.5 * sum_over_time((clamp_max(sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}), 1) == bool 0)[$__range:30s])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "0.5 * sum_over_time(((sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}) < bool sum by (deployment) (kube_deployment_spec_replicas{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"})) * (sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"}) > bool 0))[$__range:30s])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (deployment) (kube_deployment_spec_replicas{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "E"
+                }
+              ],
+              "title": "Healthcheck uptime by component",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "deployment",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Field"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "container"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Last *"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "restarts"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 9,
+                "x": 15,
+                "y": 45
+              },
+              "id": 19,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "restarts"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (increase(kube_pod_container_status_restarts_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\"}[$__range])) > 0",
+                  "instant": true,
+                  "legendFormat": "{{container}}",
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Container restarts",
+              "transformations": [
+                {
+                  "id": "reduce",
+                  "options": {
+                    "reducers": [
+                      "lastNotNull"
+                    ]
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 0,
+                    "lineInterpolation": "stepAfter",
+                    "lineWidth": 2,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "decimals": 0,
+                  "min": 0,
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*desired$"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.lineStyle",
+                        "value": {
+                          "dash": [
+                            6,
+                            6
+                          ],
+                          "fill": "dash"
+                        }
+                      },
+                      {
+                        "id": "custom.lineWidth",
+                        "value": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 54
+              },
+              "id": 20,
+              "maxDataPoints": 20000,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "min",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"})",
+                  "instant": false,
+                  "interval": "30s",
+                  "legendFormat": "{{deployment}}",
+                  "range": true,
+                  "refId": "A",
+                  "step": "30s"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (deployment) (kube_deployment_spec_replicas{namespace=\"insight\", deployment=~\"insight-gateway|insight-authenticator|insight-analytics|insight-identity-resolution|insight-frontend|insight-git-cli-proxy\"})",
+                  "instant": false,
+                  "interval": "30s",
+                  "legendFormat": "{{deployment}} desired",
+                  "range": true,
+                  "refId": "B",
+                  "step": "30s"
+                }
+              ],
+              "title": "Ready replicas vs desired",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 63
+              },
+              "id": 21,
+              "panels": [],
+              "title": "Healthcheck traffic · logged by analytics, authenticator and identity-resolution only",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 99.9
+                      },
+                      {
+                        "color": "green",
+                        "value": 99.99
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "analytics"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "authenticator"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "identity-resolution"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 12,
+                "x": 0,
+                "y": 64
+              },
+              "id": 22,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 26
+                },
+                "textMode": "value_and_name"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "100 * (1 - ((sum (count_over_time({namespace=\"insight\", container=\"analytics\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | status >= 400 [$__range])) or (sum (count_over_time({namespace=\"insight\", container=\"analytics\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range])) * 0)) / sum (count_over_time({namespace=\"insight\", container=\"analytics\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range]))))",
+                  "legendFormat": "analytics",
+                  "queryType": "instant",
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "100 * (1 - ((sum (count_over_time({namespace=\"insight\", container=\"authenticator\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | status >= 400 [$__range])) or (sum (count_over_time({namespace=\"insight\", container=\"authenticator\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range])) * 0)) / sum (count_over_time({namespace=\"insight\", container=\"authenticator\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range]))))",
+                  "legendFormat": "authenticator",
+                  "queryType": "instant",
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "100 * (1 - ((sum (count_over_time({namespace=\"insight\", container=\"identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | status >= 400 [$__range])) or (sum (count_over_time({namespace=\"insight\", container=\"identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range])) * 0)) / sum (count_over_time({namespace=\"insight\", container=\"identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range]))))",
+                  "legendFormat": "identity-resolution",
+                  "queryType": "instant",
+                  "refId": "C"
+                }
+              ],
+              "title": "Healthcheck success rate",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "mappings": [],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 12,
+                "y": 64
+              },
+              "id": 23,
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 30
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "sum (count_over_time({namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range]))",
+                  "queryType": "instant",
+                  "refId": "A"
+                }
+              ],
+              "title": "Healthchecks answered",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "mappings": [
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "0"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 6,
+                "x": 18,
+                "y": 64
+              },
+              "id": 24,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 30
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "sum (count_over_time({namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | status >= 400 [$__range]))",
+                  "queryType": "instant",
+                  "refId": "A"
+                }
+              ],
+              "title": "Healthchecks failed",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "min": 0,
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 69
+              },
+              "id": 25,
+              "maxDataPoints": 12000,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "min",
+                    "mean"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "sum by (container) (count_over_time({namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [1m]))",
+                  "interval": "1m",
+                  "legendFormat": "{{container}}",
+                  "queryType": "range",
+                  "refId": "A",
+                  "step": "1m"
+                }
+              ],
+              "title": "Healthchecks per minute · a gap is an outage",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 0,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "unit": "µs"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 69
+              },
+              "id": 26,
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "quantile_over_time(0.95, {namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | unwrap duration [$__auto]) by (container)",
+                  "legendFormat": "{{container}}",
+                  "queryType": "range",
+                  "refId": "A"
+                }
+              ],
+              "title": "Healthcheck response time p95",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 77
+              },
+              "id": 27,
+              "options": {
+                "enableLogDetails": true,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "wrapLogMessage": true
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "loki",
+                    "uid": "loki"
+                  },
+                  "expr": "{namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | status >= 400 | line_format `{{.container}} {{.status}} {{.uri}} {{.duration}}us`",
+                  "queryType": "range",
+                  "refId": "A"
+                }
+              ],
+              "title": "Failed healthchecks",
+              "type": "logs"
+            }
+          ],
+          "refresh": "5m",
+          "schemaVersion": 39,
+          "tags": [
+            "insight",
+            "uptime",
+            "sre"
+          ],
+          "templating": {
+            "list": []
+          },
+          "time": {
+            "from": "now-24h",
+            "to": "now"
+          },
+          "timezone": "utc",
+          "title": "Insight · Uptime",
+          "uid": "insight-uptime"
+        }
+    insight-resources:
+      json: |
+        {
+          "annotations": {
+            "list": [
+              {
+                "name": "Deploys",
+                "enable": true,
+                "iconColor": "purple",
+                "datasource": {
+                  "type": "loki",
+                  "uid": "loki"
+                },
+                "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"
+              }
+            ]
+          },
+          "panels": [
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+              },
+              "id": 100,
+              "title": "Cluster overview",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 0,
+                "y": 1
+              },
+              "id": 5,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ]
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(kube_pod_status_phase{phase=\"Running\"})",
+                  "refId": "A"
+                }
+              ],
+              "title": "Pods running",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      },
+                      {
+                        "color": "red",
+                        "value": 5
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 4,
+                "y": 1
+              },
+              "id": 6,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ]
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=~\"$ns\"}[$__range]))",
+                  "instant": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Restarts within this time range",
+              "type": "stat"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+              },
+              "id": 200,
+              "title": "Workloads",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto"
+                  },
+                  "decimals": 3,
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "cores"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 10,
+                "w": 12,
+                "x": 0,
+                "y": 7
+              },
+              "id": 10,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "cores"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "expr": "topk(20, sum by (namespace, pod) (rate(container_cpu_usage_seconds_total{namespace=~\"$ns\", container!=\"\"}[$__rate_interval])))",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Top consumers — CPU",
+              "transformations": [
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto"
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "working set"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 10,
+                "w": 12,
+                "x": 12,
+                "y": 7
+              },
+              "id": 11,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "working set"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "expr": "topk(20, sum by (namespace, pod) (container_memory_working_set_bytes{namespace=~\"$ns\", container!=\"\"}))",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Top consumers — memory",
+              "transformations": [
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 17
+              },
+              "id": 12,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "topk(12, sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=~\"$ns\", container!=\"\"}[$__rate_interval])))",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU by pod (cores)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 17
+              },
+              "id": 13,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "topk(12, sum by (pod) (container_memory_working_set_bytes{namespace=~\"$ns\", container!=\"\"}))",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory working set by pod",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "description": "Anything approaching 100% is a future OOMKill. ClickHouse's limit was already raised to 8Gi on this stand after Airbyte bulk inserts blew past the 4Gi default.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "thresholdsStyle": {
+                      "mode": "line"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 90
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 26
+              },
+              "id": 14,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "100 * max by (pod) ( max by (pod, container) (container_memory_working_set_bytes{namespace=~\"$ns\", container!=\"\"}) / on (pod, container) max by (pod, container) (kube_pod_container_resource_limits{namespace=~\"$ns\", resource=\"memory\"}) )",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory against limit (%)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "description": "Share of CFS periods in which the container was throttled. Sustained throttling means the CPU limit is too low, and it shows up as latency long before it shows up as an error.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 26
+              },
+              "id": 15,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "100 * sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{namespace=~\"$ns\", container!=\"\"}[$__rate_interval])) / sum by (pod) (rate(container_cpu_cfs_periods_total{namespace=~\"$ns\", container!=\"\"}[$__rate_interval])) > 0",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU throttling (%)",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "unit": "Bps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 35
+              },
+              "id": 16,
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "topk(5, sum by (pod) (rate(container_network_receive_bytes_total{namespace=~\"$ns\"}[$__rate_interval])))",
+                  "legendFormat": "{{pod}} rx",
+                  "refId": "A"
+                },
+                {
+                  "expr": "topk(5, sum by (pod) (rate(container_network_transmit_bytes_total{namespace=~\"$ns\"}[$__rate_interval])))",
+                  "legendFormat": "{{pod}} tx",
+                  "refId": "B"
+                }
+              ],
+              "title": "Network I/O by pod",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 44
+              },
+              "id": 300,
+              "title": "Health",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto"
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "restarts"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 45
+              },
+              "id": 17,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "restarts"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "expr": "sum by (namespace, pod, container) (kube_pod_container_status_restarts_total{namespace=~\"$ns\"}) > 0",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Restart counter by container (lifetime, not range-scoped)",
+              "transformations": [
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "description": "Empty is healthy. A non-zero row here is the definition of an outage on this stand.",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto"
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "missing replicas"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 45
+              },
+              "id": 18,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "missing replicas"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "expr": "(kube_deployment_spec_replicas{namespace=~\"$ns\"} - kube_deployment_status_replicas_available{namespace=~\"$ns\"}) > 0",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "A"
+                },
+                {
+                  "expr": "(kube_statefulset_replicas{namespace=~\"$ns\"} - kube_statefulset_status_replicas_ready{namespace=~\"$ns\"}) > 0",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "Workloads below desired replicas",
+              "transformations": [
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 15,
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*Failed.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*Pending.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "orange",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*Unknown.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "yellow",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 54
+              },
+              "id": 19,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (namespace, phase) (kube_pod_status_phase{namespace=~\"$ns\", phase=~\"Pending|Failed|Unknown\"}) > 0",
+                  "legendFormat": "{{namespace}} · {{phase}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Pods not Running",
+              "type": "timeseries"
+            },
+            {
+              "id": 301,
+              "type": "timeseries",
+              "title": "Ready vs desired replicas",
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 62
+              },
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "min": 0,
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 0
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "refId": "A",
+                  "legendFormat": "{{deployment}} ready",
+                  "expr": "sum by (deployment) (kube_deployment_status_replicas_ready{namespace=\"insight\"})"
+                },
+                {
+                  "refId": "B",
+                  "legendFormat": "{{deployment}} desired",
+                  "expr": "sum by (deployment) (kube_deployment_spec_replicas{namespace=\"insight\"})"
+                }
+              ]
+            },
+            {
+              "id": 302,
+              "type": "timeseries",
+              "title": "OOM kills / abnormal terminations",
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 62
+              },
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 60,
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "right",
+                  "calcs": [
+                    "sum"
+                  ]
+                }
+              },
+              "targets": [
+                {
+                  "refId": "A",
+                  "legendFormat": "{{container}} {{reason}}",
+                  "expr": "sum by (container, reason) (kube_pod_container_status_last_terminated_reason{namespace=\"insight\", reason!=\"Completed\"})"
+                }
+              ]
+            }
+          ],
+          "refresh": "1m",
+          "schemaVersion": 39,
+          "tags": [
+            "insight",
+            "resources"
+          ],
+          "templating": {
+            "list": [
+              {
+                "allValue": ".+",
+                "current": {
+                  "text": [
+                    "insight",
+                    "insight-infra"
+                  ],
+                  "value": [
+                    "insight",
+                    "insight-infra"
+                  ]
+                },
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "vm"
+                },
+                "definition": "label_values(kube_pod_info, namespace)",
+                "includeAll": true,
+                "label": "Namespace",
+                "multi": true,
+                "name": "ns",
+                "query": {
+                  "query": "label_values(kube_pod_info, namespace)",
+                  "refId": "ns"
+                },
+                "refresh": 1,
+                "sort": 1,
+                "type": "query"
+              }
+            ]
+          },
+          "time": {
+            "from": "now-6h",
+            "to": "now"
+          },
+          "timezone": "utc",
+          "title": "Insight · Resources",
+          "uid": "insight-resources"
+        }
+    insight-utilization:
+      json: |
+        {
+          "annotations": {
+            "list": [
+              {
+                "name": "Deploys",
+                "enable": true,
+                "iconColor": "purple",
+                "datasource": {
+                  "type": "loki",
+                  "uid": "loki"
+                },
+                "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"
+              }
+            ]
+          },
+          "description": "Resource utilization by service: request vs limit vs actual usage for each of Insight's own service containers, plus the stores and observability stack they run on. Usage against request is the right-sizing question; usage against limit is the throttling and OOM-kill risk. Keyed on container name because cadvisor carries no deployment label. Metrics come from the qaclust VictoriaMetrics, filtered to cluster=dev. Set a range that contains real load before drawing conclusions — this stand idles.",
+          "editable": true,
+          "graphTooltip": 1,
+          "panels": [
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+              },
+              "id": 1,
+              "panels": [],
+              "title": "Footprint · Insight services, reserved vs used",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 0,
+                "y": 1
+              },
+              "id": 2,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 34
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum(sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"cpu\"}))",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU requested",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 4,
+                "y": 1
+              },
+              "id": 3,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 34
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum(quantile_over_time(0.95, (sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[5m])))[$__range:5m]))",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU used · p95",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.3
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 8,
+                "y": 1
+              },
+              "id": 4,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 34
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum(sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"cpu\"})) - sum(quantile_over_time(0.95, (sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[5m])))[$__range:5m]))",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU reserved and unused",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 12,
+                "y": 1
+              },
+              "id": 5,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 34
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum(sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"memory\"}))",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory requested",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 16,
+                "y": 1
+              },
+              "id": 6,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 34
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum(quantile_over_time(0.95, (sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}))[$__range:5m]))",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory used · p95",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 70
+                      },
+                      {
+                        "color": "orange",
+                        "value": 85
+                      },
+                      {
+                        "color": "red",
+                        "value": 95
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 4,
+                "x": 20,
+                "y": 1
+              },
+              "id": 7,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 34
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * sum(kube_pod_container_resource_requests{resource=\"cpu\"}) / sum(kube_node_status_allocatable{resource=\"cpu\"})",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Node CPU reserved · all namespaces",
+              "type": "stat"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 6
+              },
+              "id": 8,
+              "panels": [],
+              "title": "CPU by service",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "container"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "container"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 3
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "avg used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 4
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 4
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 4
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 vs request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "orange",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 15
+                            },
+                            {
+                              "color": "green",
+                              "value": 40
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 90
+                            },
+                            {
+                              "color": "red",
+                              "value": 110
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #G"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak vs limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 70
+                            },
+                            {
+                              "color": "orange",
+                              "value": 85
+                            },
+                            {
+                              "color": "red",
+                              "value": 95
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #H"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "suggested request · per replica"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 7
+              },
+              "id": 9,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "p95 vs request"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "avg_over_time((sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[5m])))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "quantile_over_time(0.95, (sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[5m])))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "max_over_time((sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[5m])))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * quantile_over_time(0.95, (sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[5m])))[$__range:5m]) / sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "F"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * max_over_time((sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[5m])))[$__range:5m]) / sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "G"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "clamp_min(ceil(20 * quantile_over_time(0.95, (max by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[5m])))[$__range:5m])) / 20, 0.05)",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "H"
+                }
+              ],
+              "title": "CPU · reserved vs used, cores",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "max": 120,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "orange",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 15
+                      },
+                      {
+                        "color": "green",
+                        "value": 40
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 90
+                      },
+                      {
+                        "color": "red",
+                        "value": 110
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 16
+              },
+              "id": 10,
+              "options": {
+                "displayMode": "gradient",
+                "minVizHeight": 14,
+                "minVizWidth": 8,
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * quantile_over_time(0.95, (sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[5m])))[$__range:5m]) / sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"cpu\"})",
+                  "instant": true,
+                  "legendFormat": "{{container}}",
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "p95 CPU as a share of its request",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "decimals": 4,
+                  "min": 0,
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 16,
+                "x": 8,
+                "y": 16
+              },
+              "id": 11,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[5m]))",
+                  "instant": false,
+                  "legendFormat": "{{container}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU used · cores",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "decimals": 4,
+                  "min": 0,
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 24
+              },
+              "id": 12,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (pod, container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[5m]))",
+                  "instant": false,
+                  "legendFormat": "{{container}} · {{pod}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU used · by replica",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 31
+              },
+              "id": 13,
+              "panels": [],
+              "title": "Memory by service",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "container"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "container"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "avg used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 vs request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "orange",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 15
+                            },
+                            {
+                              "color": "green",
+                              "value": 40
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 90
+                            },
+                            {
+                              "color": "red",
+                              "value": 110
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #G"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak vs limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 70
+                            },
+                            {
+                              "color": "orange",
+                              "value": 85
+                            },
+                            {
+                              "color": "red",
+                              "value": 95
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #H"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "suggested request · per replica"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 32
+              },
+              "id": 14,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "peak vs limit"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "avg_over_time((sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "quantile_over_time(0.95, (sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "max_over_time((sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * quantile_over_time(0.95, (sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}))[$__range:5m]) / sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "F"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * max_over_time((sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}))[$__range:5m]) / sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "G"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "clamp_min(ceil(quantile_over_time(0.95, (max by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}))[$__range:5m]) / 33554432) * 33554432, 33554432)",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "H"
+                }
+              ],
+              "title": "Memory · reserved vs used",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 70
+                      },
+                      {
+                        "color": "orange",
+                        "value": 85
+                      },
+                      {
+                        "color": "red",
+                        "value": 95
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 41
+              },
+              "id": 15,
+              "options": {
+                "displayMode": "gradient",
+                "minVizHeight": 14,
+                "minVizWidth": 8,
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * max_over_time((sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}))[$__range:5m]) / sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"memory\"})",
+                  "instant": true,
+                  "legendFormat": "{{container}}",
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Peak memory as a share of its limit",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "min": 0,
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 16,
+                "x": 8,
+                "y": 41
+              },
+              "id": 16,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"})",
+                  "instant": false,
+                  "legendFormat": "{{container}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory used · working set",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "min": 0,
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 49
+              },
+              "id": 17,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (pod, container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"})",
+                  "instant": false,
+                  "legendFormat": "{{container}} · {{pod}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory · by replica",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "min": 0,
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 49
+              },
+              "id": 18,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (container_memory_cache{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"})",
+                  "instant": false,
+                  "legendFormat": "{{container}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Page cache by service · reclaimable",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 56
+              },
+              "id": 19,
+              "panels": [],
+              "title": "Network I/O by service",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "min": 0,
+                  "unit": "Bps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 57
+              },
+              "id": 20,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (svc) (label_replace(rate(container_network_receive_bytes_total{namespace=\"insight\", pod=~\"insight-(gateway|authenticator|analytics|identity-resolution|frontend|git-cli-proxy)-.*\"}[5m]), \"svc\", \"$1\", \"pod\", \"^insight-(.*)-[^-]+-[^-]+$\"))",
+                  "instant": false,
+                  "legendFormat": "{{svc}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Network received · by service",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "min": 0,
+                  "unit": "Bps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 57
+              },
+              "id": 21,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (svc) (label_replace(rate(container_network_transmit_bytes_total{namespace=\"insight\", pod=~\"insight-(gateway|authenticator|analytics|identity-resolution|frontend|git-cli-proxy)-.*\"}[5m]), \"svc\", \"$1\", \"pod\", \"^insight-(.*)-[^-]+-[^-]+$\"))",
+                  "instant": false,
+                  "legendFormat": "{{svc}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Network transmitted · by service",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 64
+              },
+              "id": 22,
+              "panels": [],
+              "title": "Pressure and risk",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "decimals": 2,
+                  "min": 0,
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 65
+              },
+              "id": 23,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * sum by (container) (rate(container_cpu_cfs_throttled_periods_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[15m])) / sum by (container) (rate(container_cpu_cfs_periods_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[15m]))",
+                  "instant": false,
+                  "legendFormat": "{{container}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU throttling · limit biting",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "decimals": 3,
+                  "min": 0,
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 65
+              },
+              "id": 24,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * sum by (container) (rate(container_pressure_cpu_waiting_seconds_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[15m]))",
+                  "instant": false,
+                  "legendFormat": "{{container}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU pressure · stalls even without a limit",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "container"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "container"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "no CPU request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "no memory limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 73
+              },
+              "id": 25,
+              "options": {
+                "showHeader": true,
+                "sortBy": []
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "count by (container) (kube_pod_container_info{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}) unless sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "count by (container) (kube_pod_container_info{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}) unless sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                }
+              ],
+              "title": "Containers with no request or limit set",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "container"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "container"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "restarts in range"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "seen"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "reason"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "last termination reason"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "OOM kills in range"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 16,
+                "x": 8,
+                "y": 73
+              },
+              "id": 26,
+              "options": {
+                "showHeader": true,
+                "sortBy": []
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (increase(kube_pod_container_status_restarts_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[$__range])) > 0",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container, reason) (kube_pod_container_status_last_terminated_reason{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}) > 0",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (increase(container_oom_events_total{namespace=\"insight\", container=~\"gateway|authenticator|authn-tls|analytics|identity-resolution|frontend|git-cli-proxy\", pod=~\"insight-.*\"}[$__range])) > 0",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "C"
+                }
+              ],
+              "title": "Restarts and last termination reason",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 81
+              },
+              "id": 27,
+              "panels": [],
+              "title": "Stores and observability · not Insight code, shown for context",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "container"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "container"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 200
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "cpu now"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 3
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "cpu p95"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 3
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "cpu request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "mem now"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "mem p95"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "mem limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 82
+              },
+              "id": 28,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "cpu p95"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight-infra\", container!=\"\"}[5m]))",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "quantile_over_time(0.95, (sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight-infra\", container!=\"\"}[5m])))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_requests{namespace=\"insight-infra\", container!=\"\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"insight-infra\", container!=\"\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "quantile_over_time(0.95, (sum by (container) (container_memory_working_set_bytes{namespace=\"insight-infra\", container!=\"\"}))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"insight-infra\", container!=\"\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "F"
+                }
+              ],
+              "title": "Stores and observability · CPU and memory",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "decimals": 3,
+                  "min": 0,
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 92
+              },
+              "id": 29,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight-infra\", container!=\"\"}[5m]))",
+                  "instant": false,
+                  "legendFormat": "{{container}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU used · stores and observability",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "min": 0,
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 92
+              },
+              "id": 30,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"insight-infra\", container!=\"\"})",
+                  "instant": false,
+                  "legendFormat": "{{container}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory used · stores and observability",
+              "type": "timeseries"
+            }
+          ],
+          "refresh": "5m",
+          "schemaVersion": 39,
+          "tags": [
+            "insight",
+            "capacity",
+            "sre"
+          ],
+          "templating": {
+            "list": []
+          },
+          "time": {
+            "from": "now-24h",
+            "to": "now"
+          },
+          "timezone": "utc",
+          "title": "Insight · Utilization",
+          "uid": "insight-utilization"
+        }
+    insight-databases:
+      json: |
+        {
+          "annotations": {
+            "list": [
+              {
+                "name": "Deploys",
+                "enable": true,
+                "iconColor": "purple",
+                "datasource": {
+                  "type": "loki",
+                  "uid": "loki"
+                },
+                "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"
+              }
+            ]
+          },
+          "panels": [
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+              },
+              "id": 100,
+              "title": "All stores · side by side",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 0,
+                "y": 1
+              },
+              "id": 1,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container!=\"\"}[$__rate_interval]))",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU · cores",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 8,
+                "y": 1
+              },
+              "id": 2,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container!=\"\"})",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory · working set",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "thresholdsStyle": {
+                      "mode": "line"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 90
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 16,
+                "y": 1
+              },
+              "id": 3,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "100 * max by (pod) ( max by (pod, container) (container_memory_working_set_bytes{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0\", container!=\"\"}) / on (pod, container) max by (pod, container) (kube_pod_container_resource_limits{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0\", resource=\"memory\"}) )",
+                  "legendFormat": "{{pod}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory · % of limit",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto"
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "restarts"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 10
+              },
+              "id": 4,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "restarts"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "expr": "sum by (pod, container) (kube_pod_container_status_restarts_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\"})",
+                  "format": "table",
+                  "instant": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Restarts · all time",
+              "transformations": [
+                {
+                  "id": "organize",
+                  "options": {
+                    "excludeByName": {
+                      "Time": true
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "unit": "Bps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 10
+              },
+              "id": 5,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum by (pod) (rate(container_fs_reads_bytes_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container!=\"\"}[$__rate_interval])) > 0",
+                  "legendFormat": "{{pod}} read",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum by (pod) (rate(container_fs_writes_bytes_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container!=\"\"}[$__rate_interval])) > 0",
+                  "legendFormat": "{{pod}} write",
+                  "refId": "B"
+                }
+              ],
+              "title": "Disk I/O · by store",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 18
+              },
+              "id": 300,
+              "title": "ClickHouse · native metrics (:8001)",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "spanNulls": true
+                  },
+                  "unit": "qps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 19
+              },
+              "id": 10,
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "max without (job, instance) (rate(ClickHouseProfileEvents_Query[$__rate_interval]))",
+                  "legendFormat": "queries",
+                  "refId": "A"
+                },
+                {
+                  "expr": "max without (job, instance) (rate(ClickHouseProfileEvents_FailedQuery[$__rate_interval]))",
+                  "legendFormat": "failed",
+                  "refId": "B"
+                }
+              ],
+              "title": "Queries · rate and failures",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "unit": "short"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*throw insert.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.axisPlacement",
+                        "value": "right"
+                      },
+                      {
+                        "id": "custom.lineStyle",
+                        "value": {
+                          "dash": [
+                            10,
+                            10
+                          ],
+                          "fill": "dash"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 19
+              },
+              "id": 11,
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "max without (job, instance) (ClickHouseMetrics_Merge)",
+                  "legendFormat": "active merges",
+                  "refId": "A"
+                },
+                {
+                  "expr": "max without (job, instance) (ClickHouseMetrics_PartsActive)",
+                  "legendFormat": "parts to throw insert",
+                  "refId": "B"
+                }
+              ],
+              "title": "Merges · parts",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "http connections"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "tcp connections"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": ".*connections.*"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.axisPlacement",
+                        "value": "right"
+                      },
+                      {
+                        "id": "custom.drawStyle",
+                        "value": "line"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 19
+              },
+              "id": 12,
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "max without (job, instance) (ClickHouseMetrics_MemoryTracking)",
+                  "legendFormat": "memory tracked",
+                  "refId": "A"
+                },
+                {
+                  "expr": "max without (job, instance) (ClickHouseMetrics_HTTPConnection)",
+                  "legendFormat": "http connections",
+                  "refId": "B"
+                },
+                {
+                  "expr": "max without (job, instance) (ClickHouseMetrics_TCPConnection)",
+                  "legendFormat": "tcp connections",
+                  "refId": "C"
+                }
+              ],
+              "title": "Memory tracked · connections",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 27
+              },
+              "id": 500,
+              "title": "Utilization · reserved vs used",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "container"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 3
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 3
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 vs request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "orange",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 15
+                            },
+                            {
+                              "color": "green",
+                              "value": 40
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 90
+                            },
+                            {
+                              "color": "red",
+                              "value": 110
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak vs limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 70
+                            },
+                            {
+                              "color": "orange",
+                              "value": 85
+                            },
+                            {
+                              "color": "red",
+                              "value": 95
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 28
+              },
+              "id": 50,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "p95 vs request"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_requests{namespace=\"insight-infra\", container=~\"clickhouse|mariadb|redis|redpanda|loki\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"insight-infra\", container=~\"clickhouse|mariadb|redis|redpanda|loki\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "quantile_over_time(0.95, (sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container=~\"clickhouse|mariadb|redis|redpanda|loki\"}[5m])))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "max_over_time((sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container=~\"clickhouse|mariadb|redis|redpanda|loki\"}[5m])))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * quantile_over_time(0.95, (sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container=~\"clickhouse|mariadb|redis|redpanda|loki\"}[5m])))[$__range:5m]) / sum by (container) (kube_pod_container_resource_requests{namespace=\"insight-infra\", container=~\"clickhouse|mariadb|redis|redpanda|loki\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * max_over_time((sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container=~\"clickhouse|mariadb|redis|redpanda|loki\"}[5m])))[$__range:5m]) / sum by (container) (kube_pod_container_resource_limits{namespace=\"insight-infra\", container=~\"clickhouse|mariadb|redis|redpanda|loki\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "F"
+                }
+              ],
+              "title": "CPU · reserved vs used · p95 and peak over range",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "container"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 vs request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "orange",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 15
+                            },
+                            {
+                              "color": "green",
+                              "value": 40
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 90
+                            },
+                            {
+                              "color": "red",
+                              "value": 110
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak vs limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 70
+                            },
+                            {
+                              "color": "orange",
+                              "value": 85
+                            },
+                            {
+                              "color": "red",
+                              "value": 95
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 35
+              },
+              "id": 51,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "p95 vs request"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_requests{namespace=\"insight-infra\", container=~\"clickhouse|mariadb|redis|redpanda|loki\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"insight-infra\", container=~\"clickhouse|mariadb|redis|redpanda|loki\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "quantile_over_time(0.95, (sum by (container) (container_memory_working_set_bytes{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container=~\"clickhouse|mariadb|redis|redpanda|loki\"}))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "max_over_time((sum by (container) (container_memory_working_set_bytes{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container=~\"clickhouse|mariadb|redis|redpanda|loki\"}))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * quantile_over_time(0.95, (sum by (container) (container_memory_working_set_bytes{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container=~\"clickhouse|mariadb|redis|redpanda|loki\"}))[$__range:5m]) / sum by (container) (kube_pod_container_resource_requests{namespace=\"insight-infra\", container=~\"clickhouse|mariadb|redis|redpanda|loki\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * max_over_time((sum by (container) (container_memory_working_set_bytes{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container=~\"clickhouse|mariadb|redis|redpanda|loki\"}))[$__range:5m]) / sum by (container) (kube_pod_container_resource_limits{namespace=\"insight-infra\", container=~\"clickhouse|mariadb|redis|redpanda|loki\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "F"
+                }
+              ],
+              "title": "Memory · reserved vs used · p95 and peak over range",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "thresholdsStyle": {
+                      "mode": "line"
+                    }
+                  },
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 25
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 42
+              },
+              "id": 52,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * sum by (pod, container) (rate(container_cpu_cfs_throttled_periods_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container!=\"\"}[$__rate_interval])) / sum by (pod, container) (rate(container_cpu_cfs_periods_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container!=\"\"}[$__rate_interval]))",
+                  "legendFormat": "{{pod}} · {{container}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU throttling · share of periods throttled",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "thresholdsStyle": {
+                      "mode": "line"
+                    }
+                  },
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 90
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 42
+              },
+              "id": 53,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container=~\"clickhouse|mariadb|redis|redpanda|loki\"}[$__rate_interval])) / sum by (container) (kube_pod_container_resource_limits{namespace=\"insight-infra\", container=~\"clickhouse|mariadb|redis|redpanda|loki\", resource=\"cpu\"})",
+                  "legendFormat": "{{container}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU · % of limit",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 8,
+                "x": 16,
+                "y": 42
+              },
+              "id": 54,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ]
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum(increase(container_oom_events_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\", container!=\"\"}[$__range]))",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "OOM kills · over range",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      },
+                      {
+                        "color": "red",
+                        "value": 3
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 8,
+                "x": 16,
+                "y": 50
+              },
+              "id": 55,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ]
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"insight-infra\", pod=~\"clickhouse-shard0-0|mariadb-0|redis-master-0|redpanda-0|loki-0\"}[$__range]))",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Restarts · over range",
+              "type": "stat"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 54
+              },
+              "id": 600,
+              "title": "Disk · ClickHouse on-disk",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto"
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "bytes"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "parts"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 55
+              },
+              "id": 63,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "bytes"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "grafana-clickhouse-datasource",
+                    "uid": "clickhouse"
+                  },
+                  "format": 1,
+                  "meta": {
+                    "builderOptions": {
+                      "mode": "trend"
+                    }
+                  },
+                  "queryType": "table",
+                  "rawSql": "SELECT database, sum(bytes_on_disk) AS bytes, count() AS parts FROM system.parts WHERE active GROUP BY database ORDER BY bytes DESC",
+                  "refId": "A"
+                }
+              ],
+              "title": "ClickHouse · on-disk by database",
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 4,
+                "x": 8,
+                "y": 55
+              },
+              "id": 64,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ]
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "grafana-clickhouse-datasource",
+                    "uid": "clickhouse"
+                  },
+                  "format": 1,
+                  "meta": {
+                    "builderOptions": {
+                      "mode": "trend"
+                    }
+                  },
+                  "queryType": "table",
+                  "rawSql": "SELECT sum(bytes_on_disk) FROM system.parts WHERE active",
+                  "refId": "A"
+                }
+              ],
+              "title": "ClickHouse · on-disk total",
+              "type": "stat"
+            }
+          ],
+          "refresh": "1m",
+          "schemaVersion": 39,
+          "tags": [
+            "insight",
+            "databases"
+          ],
+          "time": {
+            "from": "now-6h",
+            "to": "now"
+          },
+          "timezone": "utc",
+          "title": "Insight · Databases",
+          "uid": "insight-databases"
+        }
+    insight-ingestion-resources:
+      json: |
+        {
+          "annotations": {
+            "list": [
+              {
+                "name": "Deploys",
+                "enable": true,
+                "iconColor": "purple",
+                "datasource": {
+                  "type": "loki",
+                  "uid": "loki"
+                },
+                "expr": "{namespace=\"insight\", pod=~\"insight-post-upgrade.*\"}"
+              }
+            ]
+          },
+          "description": "Resource utilization of the ingestion machinery: the persistent Airbyte and Argo Workflows plane in ns insight (usage vs request vs limit per component) plus the aggregate cost of the ephemeral pods it spawns — Argo connector steps, Airbyte replication jobs and the reconcile loop. Per-connector sync cost lives on Insight · Connector syncs; this is the machinery's own bill and its share of the node. Ephemeral pods keep only cadvisor cpu/memory series (the cardinality guard drops the rest), so their requests, throttling and OOM events are not measurable. Metrics from the qaclust VictoriaMetrics, filtered to cluster=dev. The nightly sync window is roughly 02:00-06:00 UTC — set a range that contains it before reading the peaks.",
+          "editable": true,
+          "graphTooltip": 1,
+          "panels": [
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+              },
+              "id": 1,
+              "panels": [],
+              "title": "Footprint · what ingestion reserves and what it uses",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 3,
+                "x": 0,
+                "y": 1
+              },
+              "id": 2,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum(sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"cpu\"}))",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU reserved · machinery",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 3,
+                "x": 3,
+                "y": 1
+              },
+              "id": 3,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "quantile_over_time(0.95, ((sum(sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[5m]))) + ((sum(rate(container_cpu_usage_seconds_total{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"}[5m]))) or vector(0))))[$__range:5m])",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU used · p95",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 3,
+                "x": 6,
+                "y": 1
+              },
+              "id": 4,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "max_over_time(((sum(sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[5m]))) + ((sum(rate(container_cpu_usage_seconds_total{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"}[5m]))) or vector(0))))[$__range:5m])",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU used · peak",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 25
+                      },
+                      {
+                        "color": "orange",
+                        "value": 40
+                      },
+                      {
+                        "color": "red",
+                        "value": 60
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 3,
+                "x": 9,
+                "y": 1
+              },
+              "id": 5,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * max_over_time(((sum(sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[5m]))) + ((sum(rate(container_cpu_usage_seconds_total{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"}[5m]))) or vector(0))))[$__range:5m]) / sum(kube_node_status_allocatable{resource=\"cpu\"})",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Node CPU share · peak",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 3,
+                "x": 12,
+                "y": 1
+              },
+              "id": 6,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum(sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"memory\"}))",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory reserved · machinery",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 3,
+                "x": 15,
+                "y": 1
+              },
+              "id": 7,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "quantile_over_time(0.95, ((sum(sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"})) + ((sum(container_memory_working_set_bytes{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"})) or vector(0))))[$__range:5m])",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory used · p95",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 3,
+                "x": 18,
+                "y": 1
+              },
+              "id": 8,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "max_over_time(((sum(sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"})) + ((sum(container_memory_working_set_bytes{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"})) or vector(0))))[$__range:5m])",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory used · peak",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 25
+                      },
+                      {
+                        "color": "orange",
+                        "value": 40
+                      },
+                      {
+                        "color": "red",
+                        "value": 60
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 5,
+                "w": 3,
+                "x": 21,
+                "y": 1
+              },
+              "id": 9,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * max_over_time(((sum(sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"})) + ((sum(container_memory_working_set_bytes{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"})) or vector(0))))[$__range:5m]) / sum(kube_node_status_allocatable{resource=\"memory\"})",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Node memory share · peak",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    }
+                  },
+                  "min": 0,
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 6
+              },
+              "id": 10,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum(sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}))",
+                  "instant": false,
+                  "legendFormat": "machinery · persistent",
+                  "range": true,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "(sum(container_memory_working_set_bytes{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"})) or vector(0)",
+                  "instant": false,
+                  "legendFormat": "sync pods · ephemeral",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "Memory · persistent machinery vs sync pods",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    }
+                  },
+                  "decimals": 3,
+                  "min": 0,
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 6
+              },
+              "id": 11,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum(sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[5m])))",
+                  "instant": false,
+                  "legendFormat": "machinery · persistent",
+                  "range": true,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "(sum(rate(container_cpu_usage_seconds_total{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"}[5m]))) or vector(0)",
+                  "instant": false,
+                  "legendFormat": "sync pods · ephemeral",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "CPU · persistent machinery vs sync pods",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 14
+              },
+              "id": 12,
+              "panels": [],
+              "title": "Machinery components · usage vs request and limit",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "container"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "container"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 230
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 3
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 3
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 vs request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "orange",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 15
+                            },
+                            {
+                              "color": "green",
+                              "value": 40
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 90
+                            },
+                            {
+                              "color": "red",
+                              "value": 110
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak vs limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 70
+                            },
+                            {
+                              "color": "orange",
+                              "value": 85
+                            },
+                            {
+                              "color": "red",
+                              "value": 95
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 10,
+                "w": 12,
+                "x": 0,
+                "y": 15
+              },
+              "id": 13,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "peak vs limit"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "quantile_over_time(0.95, (sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[5m])))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "max_over_time((sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[5m])))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * quantile_over_time(0.95, (sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[5m])))[$__range:5m]) / sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * max_over_time((sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[5m])))[$__range:5m]) / sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "F"
+                }
+              ],
+              "title": "CPU · cores",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "container"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "container"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 230
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak used"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 vs request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "orange",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 15
+                            },
+                            {
+                              "color": "green",
+                              "value": 40
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 90
+                            },
+                            {
+                              "color": "red",
+                              "value": 110
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "peak vs limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 70
+                            },
+                            {
+                              "color": "orange",
+                              "value": 85
+                            },
+                            {
+                              "color": "red",
+                              "value": 95
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 10,
+                "w": 12,
+                "x": 12,
+                "y": 15
+              },
+              "id": 14,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "peak vs limit"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "quantile_over_time(0.95, (sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "max_over_time((sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}))[$__range:5m])",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * quantile_over_time(0.95, (sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}))[$__range:5m]) / sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "E"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * max_over_time((sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}))[$__range:5m]) / sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "F"
+                }
+              ],
+              "title": "Memory · working set",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "decimals": 3,
+                  "min": 0,
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 25
+              },
+              "id": 15,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[5m]))",
+                  "instant": false,
+                  "legendFormat": "{{container}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU used · by component",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "min": 0,
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 25
+              },
+              "id": 16,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"})",
+                  "instant": false,
+                  "legendFormat": "{{container}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory used · by component",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 33
+              },
+              "id": 17,
+              "panels": [],
+              "title": "Sync pods · the ephemeral cost, nightly window included",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 0,
+                "y": 34
+              },
+              "id": 18,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "count(sum by (pod) (container_memory_working_set_bytes{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"})) or vector(0)",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Pods running now",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 6,
+                "y": 34
+              },
+              "id": 19,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "max_over_time((count(sum by (pod) (container_memory_working_set_bytes{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"})) or vector(0))[$__range:5m])",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Peak concurrent pods",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 12,
+                "y": 34
+              },
+              "id": 20,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "(sum(increase(container_cpu_usage_seconds_total{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"}[$__range])) / 3600) or vector(0)",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Core-hours burned",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 4,
+                "w": 6,
+                "x": 18,
+                "y": 34
+              },
+              "id": 21,
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "text": {
+                  "titleSize": 13,
+                  "valueSize": 32
+                },
+                "textMode": "auto"
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "max_over_time(((sum(container_memory_working_set_bytes{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"})) or vector(0))[$__range:5m])",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Peak aggregate memory",
+              "type": "stat"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    }
+                  },
+                  "min": 0,
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 38
+              },
+              "id": 22,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (family) (label_replace(label_replace(label_replace(container_memory_working_set_bytes{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"}, \"family\", \"connector step\", \"pod\", \".*-default-(sync|manual|now|fixtest)-.*\"), \"family\", \"airbyte replication\", \"pod\", \"replication-job-[0-9]+-attempt-[0-9]+.*\"), \"family\", \"reconcile loop\", \"pod\", \"insight-reconcile-loop-[0-9]+.*\"))",
+                  "instant": false,
+                  "legendFormat": "{{family}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory · by pod family",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    }
+                  },
+                  "decimals": 3,
+                  "min": 0,
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 38
+              },
+              "id": 23,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (family) (label_replace(label_replace(label_replace(rate(container_cpu_usage_seconds_total{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"}[5m]), \"family\", \"connector step\", \"pod\", \".*-default-(sync|manual|now|fixtest)-.*\"), \"family\", \"airbyte replication\", \"pod\", \"replication-job-[0-9]+-attempt-[0-9]+.*\"), \"family\", \"reconcile loop\", \"pod\", \"insight-reconcile-loop-[0-9]+.*\"))",
+                  "instant": false,
+                  "legendFormat": "{{family}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU · by pod family",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    }
+                  },
+                  "decimals": 0,
+                  "min": 0,
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 46
+              },
+              "id": 24,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "count by (family) (label_replace(label_replace(label_replace(sum by (pod) (container_memory_working_set_bytes{namespace=\"insight\", pod=~\".*-default-(sync|manual|now|fixtest)-.*|replication-job-[0-9]+-attempt-[0-9]+.*|insight-reconcile-loop-[0-9]+.*\", container!=\"\"}), \"family\", \"connector step\", \"pod\", \".*-default-(sync|manual|now|fixtest)-.*\"), \"family\", \"airbyte replication\", \"pod\", \"replication-job-[0-9]+-attempt-[0-9]+.*\"), \"family\", \"reconcile loop\", \"pod\", \"insight-reconcile-loop-[0-9]+.*\"))",
+                  "instant": false,
+                  "legendFormat": "{{family}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Concurrent pods · by family",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    }
+                  },
+                  "min": 0,
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 46
+              },
+              "id": 25,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", pod=~\"replication-job-[0-9]+-attempt-[0-9]+.*\", container!=\"\"})",
+                  "instant": false,
+                  "legendFormat": "{{container}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "Airbyte replication · memory by role",
+              "type": "timeseries"
+            },
+            {
+              "collapsed": false,
+              "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 53
+              },
+              "id": 26,
+              "panels": [],
+              "title": "Risk · limits biting, retries, blind spots",
+              "type": "row"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "decimals": 2,
+                  "min": 0,
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 54
+              },
+              "id": 27,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * sum by (container) (rate(container_cpu_cfs_throttled_periods_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[15m])) / sum by (container) (rate(container_cpu_cfs_periods_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[15m]))",
+                  "instant": false,
+                  "legendFormat": "{{container}}",
+                  "range": true,
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU throttling · machinery only, sync pods not measurable",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 70
+                      },
+                      {
+                        "color": "orange",
+                        "value": 85
+                      },
+                      {
+                        "color": "red",
+                        "value": 95
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 54
+              },
+              "id": 28,
+              "options": {
+                "displayMode": "gradient",
+                "minVizHeight": 14,
+                "minVizWidth": 8,
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "100 * max_over_time((sum by (container) (container_memory_working_set_bytes{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}))[$__range:5m]) / sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"memory\"})",
+                  "instant": true,
+                  "legendFormat": "{{container}}",
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Peak memory vs limit · OOM-kill distance",
+              "type": "bargauge"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "container"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "container"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "restarts in range"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "seen"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "reason"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "last termination"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 62
+              },
+              "id": 29,
+              "options": {
+                "showHeader": true,
+                "sortBy": []
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (increase(kube_pod_container_status_restarts_total{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}[$__range])) > 0",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container, reason) (kube_pod_container_status_last_terminated_reason{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}) > 0",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                }
+              ],
+              "title": "Restarts and last termination",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "container"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "container"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "no CPU request"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "no memory limit"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 62
+              },
+              "id": 30,
+              "options": {
+                "showHeader": true,
+                "sortBy": []
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "count by (container) (kube_pod_container_info{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}) unless sum by (container) (kube_pod_container_resource_requests{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"cpu\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "count by (container) (kube_pod_container_info{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\"}) unless sum by (container) (kube_pod_container_resource_limits{namespace=\"insight\", container=~\"airbyte-connector-builder-server|airbyte-cron|airbyte-db-container|airbyte-minio|airbyte-server-container|airbyte-temporal|airbyte-worker-container|airbyte-workload-api-server-container|airbyte-workload-launcher-container|argo-server|controller\", pod=~\"airbyte-.*|argo-workflows-.*\", resource=\"memory\"})",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "B"
+                }
+              ],
+              "title": "No request or limit set",
+              "transformations": [
+                {
+                  "id": "joinByField",
+                  "options": {
+                    "byField": "container",
+                    "mode": "outer"
+                  }
+                },
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "jobid"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "airbyte job"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "attempts"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "text",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 2
+                            },
+                            {
+                              "color": "red",
+                              "value": 5
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 62
+              },
+              "id": 31,
+              "options": {
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "attempts"
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "count by (jobid) (label_replace(count by (pod) (max_over_time(container_memory_working_set_bytes{namespace=\"insight\", pod=~\"replication-job-[0-9]+-attempt-[0-9]+.*\", container!=\"\"}[$__range])), \"jobid\", \"$1\", \"pod\", \"replication-job-([0-9]+)-attempt-.*\"))",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Replication attempts per job · retries mean failing syncs",
+              "transformations": [
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "fillOpacity": 10,
+                    "lineWidth": 2,
+                    "showPoints": "never",
+                    "spanNulls": true
+                  },
+                  "min": 0,
+                  "unit": "Bps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 69
+              },
+              "id": 32,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (rate(container_fs_writes_bytes_total{namespace=\"insight\", container=~\"airbyte-db-container|airbyte-minio\"}[5m]))",
+                  "instant": false,
+                  "legendFormat": "{{container}} · write",
+                  "range": true,
+                  "refId": "A"
+                },
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "sum by (container) (rate(container_fs_reads_bytes_total{namespace=\"insight\", container=~\"airbyte-db-container|airbyte-minio\"}[5m]))",
+                  "instant": false,
+                  "legendFormat": "{{container}} · read",
+                  "range": true,
+                  "refId": "B"
+                }
+              ],
+              "title": "Disk I/O · airbyte-db and minio",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "vm"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "align": "auto",
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "persistentvolumeclaim"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "claim"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 320
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "reserved"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 69
+              },
+              "id": 33,
+              "options": {
+                "showHeader": true,
+                "sortBy": []
+              },
+              "targets": [
+                {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "vm"
+                  },
+                  "expr": "kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace=\"insight\", persistentvolumeclaim=~\"airbyte-.*|insight-reconcile-logs\"}",
+                  "format": "table",
+                  "instant": true,
+                  "range": false,
+                  "refId": "A"
+                }
+              ],
+              "title": "Ingestion PVCs · reserved size only, usage not scraped",
+              "transformations": [
+                {
+                  "id": "filterFieldsByName",
+                  "options": {
+                    "exclude": {
+                      "pattern": "^Time.*"
+                    }
+                  }
+                }
+              ],
+              "type": "table"
+            }
+          ],
+          "refresh": "5m",
+          "schemaVersion": 39,
+          "tags": [
+            "insight",
+            "capacity",
+            "ingestion",
+            "sre"
+          ],
+          "templating": {
+            "list": []
+          },
+          "time": {
+            "from": "now-24h",
+            "to": "now"
+          },
+          "timezone": "utc",
+          "title": "Insight · Ingestion resources",
+          "uid": "insight-ingestion-resources"
         }
 
 # Admin credentials. For anything past a throwaway PoC, seal a Secret named

--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -8774,6 +8774,103 @@ dashboards:
               ],
               "title": "ClickHouse · on-disk total",
               "type": "stat"
+            },
+            {
+              "id": 601,
+              "type": "timeseries",
+              "title": "ClickHouse · slow queries (>1s) by user",
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 63
+              },
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 60,
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "right",
+                  "calcs": [
+                    "sum"
+                  ]
+                }
+              },
+              "targets": [
+                {
+                  "refId": "A",
+                  "editorType": "sql",
+                  "format": 0,
+                  "rawSql": "SELECT toStartOfInterval(event_time, toIntervalSecond($__interval_s)) AS t, user, count() AS slow FROM system.query_log WHERE type = 'QueryFinish' AND query_duration_ms > 1000 AND user != 'grafana' AND $__timeFilter(event_time) GROUP BY t, user ORDER BY t"
+                }
+              ]
+            },
+            {
+              "id": 602,
+              "type": "table",
+              "title": "ClickHouse · slowest queries",
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 63
+              },
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "filterable": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "query_duration_ms"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "ms"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "sortBy": [
+                  {
+                    "displayName": "query_duration_ms",
+                    "desc": true
+                  }
+                ]
+              },
+              "targets": [
+                {
+                  "refId": "A",
+                  "editorType": "sql",
+                  "format": 1,
+                  "rawSql": "SELECT event_time, query_duration_ms, user, read_rows, formatReadableSize(memory_usage) AS memory, normalizeQuery(query) AS query FROM system.query_log WHERE type = 'QueryFinish' AND user != 'grafana' AND $__timeFilter(event_time) ORDER BY query_duration_ms DESC LIMIT 20"
+                }
+              ]
             }
           ],
           "refresh": "1m",


### PR DESCRIPTION
Stacked on #3139 — draft until it merges; the diff includes its commit until then.

**Why.** Seven dashboards authored in a stand's Grafana UI live only in grafana.db on that stand's PVC — one volume failure from gone, and no other install gets them.

**What changed.** They are exported into provisioning (API endpoints, Logs by service, Uptime, Resources, Utilization, Databases, Ingestion resources), each gaining the house Deploys annotation. **HTTP and Service health retire:** API endpoints supersedes HTTP (its service-error tail carries over as a panel), and Service health's replica and OOM panels move into Resources. Net provisioned set: 11 dashboards.

**Verified.** Values parse as YAML, every dashboard decodes as JSON, `render-system-values.sh` output still parses, dashboard JSON is byte-identical to the operator gitops mirror's, and the exports scanned clean for operator-private strings.