### PR TITLE
fix(gitlab): attribute merge requests through the author's account

### DIFF
--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__identity_inputs.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__identity_inputs.sql
@@ -36,7 +36,7 @@
 -- Column order matches the macro's output — silver.identity_inputs is a
 -- positional UNION ALL, and check-field-parity.py audits the shape.
 
-WITH observations AS (
+WITH claims AS (
     SELECT
         toUUID(UUIDNumToString(sipHash128(coalesce(tenant_id, '')))) AS insight_tenant_id,
         toUUID(UUIDNumToString(sipHash128(coalesce(source_id, '')))) AS insight_source_id,
@@ -50,7 +50,12 @@ WITH observations AS (
         -- identity_inputs model admits only rows above its global max(_version)
         -- watermark, so a claim versioned by a past instant would be silently
         -- dropped whenever any other feeder has already stamped a newer version.
-        now64(3) AS _synced_at
+        now64(3) AS _synced_at,
+        -- Which field the claim is preferred from when two carry the same
+        -- address. `email` is what GitLab hands an admin token and is the one
+        -- the account is reachable at; `public_email` is what the user chose to
+        -- show, and the same address often sits in both.
+        1 AS field_rank
     FROM {{ source('bronze_gitlab', 'users') }} FINAL
     WHERE COALESCE(id, 0) > 0
       AND COALESCE(email, '') != ''
@@ -66,7 +71,8 @@ WITH observations AS (
         lower(trimBoth(COALESCE(public_email, ''))) AS value,
         'bronze_gitlab.users.public_email' AS value_field_name,
         'UPSERT' AS operation_type,
-        now64(3) AS _synced_at
+        now64(3) AS _synced_at,
+        2 AS field_rank
     FROM {{ source('bronze_gitlab', 'users') }} FINAL
     WHERE COALESCE(id, 0) > 0
       AND COALESCE(public_email, '') != ''
@@ -82,10 +88,40 @@ WITH observations AS (
         COALESCE(name, '') AS value,
         'bronze_gitlab.users.name' AS value_field_name,
         'UPSERT' AS operation_type,
-        now64(3) AS _synced_at
+        now64(3) AS _synced_at,
+        1 AS field_rank
     FROM {{ source('bronze_gitlab', 'users') }} FINAL
     WHERE COALESCE(id, 0) > 0
       AND COALESCE(name, '') != ''
+),
+
+-- INVARIANT: one row per claim key, and the key is exactly what `unique_key`
+-- below hashes. A user may publish the SAME address as both `email` and
+-- `public_email`, which are two rows here and one key — a collision the anti
+-- join against the target cannot see, because neither row is in the target yet.
+-- `field_rank` decides which survives, so the provenance a claim carries does
+-- not depend on the order rows happen to arrive in.
+distinct_claims AS (
+    SELECT
+        insight_tenant_id,
+        insight_source_id,
+        insight_source_type,
+        source_account_id,
+        value_type,
+        value,
+        value_field_name,
+        operation_type,
+        _synced_at
+    FROM claims
+    ORDER BY field_rank
+    LIMIT 1 BY
+        insight_tenant_id,
+        insight_source_id,
+        insight_source_type,
+        source_account_id,
+        value_type,
+        value,
+        operation_type
 )
 
 SELECT
@@ -101,9 +137,17 @@ SELECT
         o.operation_type, '-',
         hex(sipHash64(o.value))
     ) AS String) AS unique_key,
-    o.*,
+    o.insight_tenant_id,
+    o.insight_source_id,
+    o.insight_source_type,
+    o.source_account_id,
+    o.value_type,
+    o.value,
+    o.value_field_name,
+    o.operation_type,
+    o._synced_at,
     toUnixTimestamp64Milli(o._synced_at) AS _version
-FROM observations AS o
+FROM distinct_claims AS o
 {% if is_incremental() %}
 LEFT ANTI JOIN {{ this }} AS existing
     ON  o.value_type                 = existing.value_type

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__identity_inputs.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__identity_inputs.sql
@@ -1,0 +1,115 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    schema='staging',
+    tags=['gitlab', 'silver', 'silver:identity_inputs']
+) }}
+
+-- What GitLab itself reports about a user account, unioned into
+-- silver.identity_inputs via the `silver:identity_inputs` tag.
+--
+-- The account id is the numeric GitLab user id, stringified — the same key
+-- `gitlab__pull_requests` puts on a merge request's author (ADR-0002 binding
+-- key), so the two meet in the join.
+--
+-- Two value types, from two different questions:
+--   `email`        — which addresses the account itself publishes, the edge
+--                    that lets an e-mail-keyed fact reach a person
+--   `display_name` — who the account is, so an operator reviewing an unbound
+--                    account can recognise it. GitLab returns `email` only to
+--                    a token with admin scope and `public_email` only where the
+--                    user filled it in, so for many accounts this is the only
+--                    thing an operator has to go on.
+--
+-- INVARIANT: every claim here is a fact GitLab states about the account itself.
+-- A merge request's commits are NOT evidence about its author — the author of a
+-- request and the author of a commit it carries are different identities, and
+-- `git.prs_merged` counts the request for the former. Inferring an address for
+-- an account from a request's commits would hand one person's address to
+-- another, and the claim is append-only, so it could not be withdrawn later.
+--
+-- No `value_type='id'` binding: what an account means is the persons-seed's
+-- decision, not this model's. The seed attaches a claimed e-mail to whichever
+-- person its roster binding or e-mail match names, and mints a new person for
+-- an unmatched active account.
+--
+-- Column order matches the macro's output — silver.identity_inputs is a
+-- positional UNION ALL, and check-field-parity.py audits the shape.
+
+WITH observations AS (
+    SELECT
+        toUUID(UUIDNumToString(sipHash128(coalesce(tenant_id, '')))) AS insight_tenant_id,
+        toUUID(UUIDNumToString(sipHash128(coalesce(source_id, '')))) AS insight_source_id,
+        'gitlab' AS insight_source_type,
+        toString(COALESCE(id, 0)) AS source_account_id,
+        'email' AS value_type,
+        lower(trimBoth(COALESCE(email, ''))) AS value,
+        'bronze_gitlab.users.email' AS value_field_name,
+        'UPSERT' AS operation_type,
+        -- Insertion time, NOT the historical observation time: the shared
+        -- identity_inputs model admits only rows above its global max(_version)
+        -- watermark, so a claim versioned by a past instant would be silently
+        -- dropped whenever any other feeder has already stamped a newer version.
+        now64(3) AS _synced_at
+    FROM {{ source('bronze_gitlab', 'users') }} FINAL
+    WHERE COALESCE(id, 0) > 0
+      AND COALESCE(email, '') != ''
+
+    UNION ALL
+
+    SELECT
+        toUUID(UUIDNumToString(sipHash128(coalesce(tenant_id, '')))) AS insight_tenant_id,
+        toUUID(UUIDNumToString(sipHash128(coalesce(source_id, '')))) AS insight_source_id,
+        'gitlab' AS insight_source_type,
+        toString(COALESCE(id, 0)) AS source_account_id,
+        'email' AS value_type,
+        lower(trimBoth(COALESCE(public_email, ''))) AS value,
+        'bronze_gitlab.users.public_email' AS value_field_name,
+        'UPSERT' AS operation_type,
+        now64(3) AS _synced_at
+    FROM {{ source('bronze_gitlab', 'users') }} FINAL
+    WHERE COALESCE(id, 0) > 0
+      AND COALESCE(public_email, '') != ''
+
+    UNION ALL
+
+    SELECT
+        toUUID(UUIDNumToString(sipHash128(coalesce(tenant_id, '')))) AS insight_tenant_id,
+        toUUID(UUIDNumToString(sipHash128(coalesce(source_id, '')))) AS insight_source_id,
+        'gitlab' AS insight_source_type,
+        toString(COALESCE(id, 0)) AS source_account_id,
+        'display_name' AS value_type,
+        COALESCE(name, '') AS value,
+        'bronze_gitlab.users.name' AS value_field_name,
+        'UPSERT' AS operation_type,
+        now64(3) AS _synced_at
+    FROM {{ source('bronze_gitlab', 'users') }} FINAL
+    WHERE COALESCE(id, 0) > 0
+      AND COALESCE(name, '') != ''
+)
+
+SELECT
+    -- The value and the source are part of the key: two e-mails on one account
+    -- stay two claims, and the same pair under two connections stays two
+    -- accounts.
+    CAST(concat(
+        toString(o.insight_tenant_id), '-',
+        toString(o.insight_source_id), '-',
+        o.insight_source_type, '-',
+        o.source_account_id, '-',
+        o.value_type, '-',
+        o.operation_type, '-',
+        hex(sipHash64(o.value))
+    ) AS String) AS unique_key,
+    o.*,
+    toUnixTimestamp64Milli(o._synced_at) AS _version
+FROM observations AS o
+{% if is_incremental() %}
+LEFT ANTI JOIN {{ this }} AS existing
+    ON  o.value_type                 = existing.value_type
+    AND o.value                      = existing.value
+    AND o.source_account_id          = existing.source_account_id
+    AND existing.insight_source_type = o.insight_source_type
+    AND existing.insight_tenant_id   = o.insight_tenant_id
+    AND existing.insight_source_id   = o.insight_source_id
+{% endif %}

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests.sql
@@ -50,9 +50,11 @@ SELECT
     ) AS state,
     COALESCE(mr.author_username, '') AS author_name,
     COALESCE(u.email, '') AS author_email,
-    -- Always '': the GitLab connector emits no identity inputs, so no account
-    -- binding exists to resolve against; attribution stays on author_email.
-    '' AS author_account_id,
+    -- The numeric GitLab user id, stringified — the same key
+    -- gitlab__identity_inputs binds accounts on, so attribution survives an
+    -- author GitLab exposes no address for. '' when the source reports no
+    -- author, which leaves resolution on author_email.
+    if(COALESCE(mr.author_id, 0) > 0, toString(COALESCE(mr.author_id, 0)), '') AS author_account_id,
     COALESCE(mr.source_branch, '') AS source_branch,
     COALESCE(mr.target_branch, '') AS destination_branch,
     parseDateTimeBestEffortOrNull(mr.created_at) AS created_on,

--- a/src/ingestion/connectors/git/gitlab/dbt/schema.yml
+++ b/src/ingestion/connectors/git/gitlab/dbt/schema.yml
@@ -52,9 +52,43 @@ models:
         data_tests:
           - accepted_values:
               values: ["gitlab"]
+      - name: insight_tenant_id
+        description: "The tenant the claim belongs to, hashed from the connector's tenant_id"
+        data_tests:
+          - not_null
+      - name: insight_source_id
+        description: "The connector instance the claim came from, hashed from its source_id — the same id names different accounts under two GitLab connections"
+        data_tests:
+          - not_null
       - name: source_account_id
         description: "The numeric GitLab user id, stringified"
+      - name: value_type
+        description: "`email` for an address the account publishes, `display_name` for the user's name"
+        data_tests:
+          - accepted_values:
+              values: ["email", "display_name"]
       - name: value
         description: "An address the account itself publishes, or the user's name for a display_name row"
+        data_tests:
+          - not_null
+      - name: value_field_name
+        description: "The bronze field the claim was read from, for provenance. `email` outranks `public_email` when a user publishes one address in both"
+        data_tests:
+          - accepted_values:
+              values:
+                - bronze_gitlab.users.email
+                - bronze_gitlab.users.public_email
+                - bronze_gitlab.users.name
+      - name: operation_type
+        description: "`UPSERT` — GitLab reports what an account currently states, never a retraction"
+        data_tests:
+          - accepted_values:
+              values: ["UPSERT"]
+      - name: _synced_at
+        description: "Insertion time, not the observation time: the shared union admits only rows above its global max(_version) watermark"
+        data_tests:
+          - not_null
+      - name: _version
+        description: "`_synced_at` in epoch milliseconds — the ReplacingMergeTree version the shared union orders by"
         data_tests:
           - not_null

--- a/src/ingestion/connectors/git/gitlab/dbt/schema.yml
+++ b/src/ingestion/connectors/git/gitlab/dbt/schema.yml
@@ -38,3 +38,23 @@ models:
 
   - name: gitlab__pull_requests_reviewers
     description: "GitLab merge-request approvals -> staging, feeds class_git_pull_requests_reviewers"
+
+  - name: gitlab__identity_inputs
+    description: "What GitLab reports about a user account — its published e-mail addresses and its name -> staging, feeds silver.identity_inputs"
+    columns:
+      - name: unique_key
+        description: "One claim per (tenant, source, account, value_type, operation, value)"
+        data_tests:
+          - not_null
+          - unique
+      - name: insight_source_type
+        description: "`gitlab` — the numeric user id is the binding key"
+        data_tests:
+          - accepted_values:
+              values: ["gitlab"]
+      - name: source_account_id
+        description: "The numeric GitLab user id, stringified"
+      - name: value
+        description: "An address the account itself publishes, or the user's name for a display_name row"
+        data_tests:
+          - not_null

--- a/src/ingestion/connectors/git/gitlab/descriptor.yaml
+++ b/src/ingestion/connectors/git/gitlab/descriptor.yaml
@@ -39,7 +39,20 @@ name: gitlab
 #   commit it has already materialized.
 #   Safe: both dates have been in Bronze all along, and the author date falls
 #   back to the committer date where a source left it empty. #3153
-version: "2.1.0"
+# 3.0.0: the class-contract column `author_account_id` now carries the merge
+#   request's author id instead of the empty string, so a request attributes
+#   through the account binding rather than through an address GitLab may never
+#   expose. MAJOR for the same reason as 2.0.0: staging is incremental on
+#   _airbyte_extracted_at and never re-reads Bronze, so every merge request
+#   already materialized keeps the empty string forever and the install runs in
+#   two regimes — recent requests attribute by account, older ones do not.
+#   ROLLOUT: type=cdk, so reconcile emits bump_kind=patch and the bump alone
+#   dispatches NO full refresh (ADR-0015 §Bump-kind storage scope). An operator
+#   has to run the scoped `dbt --full-refresh` for `tag:gitlab+` once, or this
+#   install keeps attributing its history the old way.
+#   Safe: author_id has been in Bronze all along, and the model falls back to
+#   the address map where a request reports no author. #3142
+version: "3.0.0"
 type: cdk
 schedule: "0 2 * * *"
 workflow: sync

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -403,11 +403,12 @@ pull_requests_source AS (
         ) AS entity_id,
         -- identity's source_type vocabulary, not data_source's: the binding
         -- rows say 'bitbucket', the class rows say 'insight_bitbucket_cloud'.
-        -- '' (gitlab — no identity inputs exist) keeps the account join
+        -- '' for a connector with no identity inputs keeps the account join
         -- unmatched and resolution on the email path.
         multiIf(
             prs.data_source = 'insight_github', 'github',
             prs.data_source = 'insight_bitbucket_cloud', 'bitbucket',
+            prs.data_source = 'insight_gitlab', 'gitlab',
             ''
         ) AS account_source_type,
         prs.source_id AS account_source_id,

--- a/src/ingestion/silver/_shared/identity_inputs.sql
+++ b/src/ingestion/silver/_shared/identity_inputs.sql
@@ -24,7 +24,24 @@
 ) }}
 
 
-SELECT * FROM (
+-- Named, not `SELECT *`: the union inside is POSITIONAL and takes its column
+-- names from whichever contributor lands first, so a producer that adds or
+-- reorders a column would silently re-point this relation's columns at other
+-- producers' values. Selecting by name here makes that a build failure instead.
+-- check-field-parity.py audits the contributors against this shape.
+SELECT
+    unique_key,
+    insight_tenant_id,
+    insight_source_id,
+    insight_source_type,
+    source_account_id,
+    value_type,
+    value,
+    value_field_name,
+    operation_type,
+    _synced_at,
+    _version
+FROM (
     {{ union_by_tag('silver:identity_inputs') }}
 )
 {% if is_incremental() %}

--- a/src/ingestion/silver/_shared/identity_inputs.sql
+++ b/src/ingestion/silver/_shared/identity_inputs.sql
@@ -10,6 +10,7 @@
 -- depends_on: {{ ref('github_directory__identity_inputs') }}
 -- depends_on: {{ ref('github__identity_inputs') }}
 -- depends_on: {{ ref('bitbucket_cloud__identity_inputs') }}
+-- depends_on: {{ ref('gitlab__identity_inputs') }}
 -- @cpt-principle:cpt-dataflow-principle-rmt-with-version:p1
 {{ config(
     materialized='incremental',

--- a/src/ingestion/tests/e2e/identity/test_gitlab_account_binding.py
+++ b/src/ingestion/tests/e2e/identity/test_gitlab_account_binding.py
@@ -13,11 +13,18 @@ are append-only: an address inferred from a request's commits could hand one
 person's address to another and could not be withdrawn afterwards. So the
 fixture gives the request a commit written under a second address and expects
 no account to claim it.
+
+The last test covers the one shape that collides with itself: a user who
+publishes the SAME address as both `email` and `public_email`. The claim key
+does not distinguish the two fields, so without a dedup inside the run they are
+two rows under one `unique_key` — which the anti join against the target cannot
+catch, because neither row is in the target yet.
 """
 
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -35,34 +42,108 @@ USERS = "bronze_gitlab.users"
 REQUESTS = "bronze_gitlab.merge_requests"
 COMMITS = "bronze_gitlab.merge_request_commits"
 
+#: A bronze cell, as ClickHouse takes it from the seeder.
+type BronzeValue = str | int | bool | None
+#: One bronze row: column name to value.
+type BronzeRow = dict[str, BronzeValue]
+#: A JSON-schema document, as the metrics rig declares one per bronze table.
+type TableSchemas = dict[str, dict[str, object]]
+#: The seeder's input: rows to insert, keyed by fully-qualified table name.
+type BronzeTables = dict[str, list[BronzeRow]]
+
 # The metrics rig already declares every column of these three tables.
 _SCHEMA_DIR = Path(__file__).resolve().parents[1] / "metrics" / "schemas"
 
 READ_AT = "2026-10-02T00:00:00Z"
 
 
-def _schemas(tables: list[str]) -> dict:
-    merged: dict = {}
+@dataclass(frozen=True)
+class Envelope:
+    """The CDK and routing columns every bronze row this test seeds carries.
+
+    Its own tenant and connection per run: the shared union keeps every run's
+    claims, and `source_account_id` is only unique within one connection.
+    """
+
+    run_tag: str
+    unique_key: str
+
+    def row(self) -> BronzeRow:
+        """Render the envelope as the bronze columns the seeder writes."""
+        return {
+            "_airbyte_raw_id": str(uuid.uuid4()),
+            "_airbyte_extracted_at": READ_AT,
+            "_airbyte_meta": "{}",
+            "_airbyte_generation_id": 0,
+            "tenant_id": f"gitlab-tenant-{self.run_tag}",
+            "source_id": f"gitlab-source-{self.run_tag}",
+            "data_source": "insight_gitlab",
+            "collected_at": READ_AT,
+            "unique_key": self.unique_key,
+        }
+
+
+def _schemas(tables: list[str]) -> TableSchemas:
+    """Load the metrics rig's column declarations for the given bronze tables."""
+    merged: TableSchemas = {}
     for table in tables:
         doc = yaml.safe_load((_SCHEMA_DIR / f"{table}.yaml").read_text(encoding="utf-8"))
         merged |= doc["schemas"]
     return merged
 
 
-def _envelope(run_tag: str, unique_key: str) -> dict:
-    return {
-        "_airbyte_raw_id": str(uuid.uuid4()),
-        "_airbyte_extracted_at": READ_AT,
-        "_airbyte_meta": "{}",
-        "_airbyte_generation_id": 0,
-        # Its own tenant and connection per run: the shared union keeps every
-        # run's claims, and `source_account_id` is only unique within one.
-        "tenant_id": f"gitlab-tenant-{run_tag}",
-        "source_id": f"gitlab-source-{run_tag}",
-        "data_source": "insight_gitlab",
-        "collected_at": READ_AT,
-        "unique_key": unique_key,
+def _user(run_tag: str, user_id: int, name: str, email: str = "", public_email: str = "") -> BronzeRow:
+    """A GitLab user record, publishing whichever addresses it was given."""
+    return Envelope(run_tag, f"u-{user_id}").row() | {
+        "id": user_id,
+        "username": f"user-{user_id}",
+        "name": name,
+        "state": "active",
+        "email": email,
+        "public_email": public_email,
+        "bot": False,
     }
+
+
+def _request(run_tag: str, iid: int, author_id: int) -> BronzeRow:
+    """A merged merge request opened by the given account."""
+    return Envelope(run_tag, f"mr-{iid}").row() | {
+        "project_id": 101,
+        "iid": iid,
+        "id": 90_000 + iid,
+        "title": "change",
+        "state": "merged",
+        "author_id": author_id,
+        "author_username": f"user-{author_id}",
+        "source_branch": "feature",
+        "target_branch": "main",
+        "created_at": "2026-10-01T08:00:00Z",
+        "updated_at": "2026-10-01T13:00:00Z",
+        "merged_at": "2026-10-01T09:00:00Z",
+    }
+
+
+def _commit(run_tag: str, sha: str, iid: int, author_email: str) -> BronzeRow:
+    """A commit the given merge request carries, authored under `author_email`."""
+    return Envelope(run_tag, f"mc-{sha}").row() | {
+        "project_id": 101,
+        "mr_iid": iid,
+        "id": sha,
+        "short_id": sha[:8],
+        "title": "change",
+        "message": "change",
+        "author_name": "Someone Else",
+        "author_email": author_email,
+        "authored_date": "2026-10-01T08:30:00Z",
+        "committer_name": "Someone Else",
+        "committer_email": author_email,
+        "committed_date": "2026-10-01T08:30:00Z",
+    }
+
+
+def _account_id(run_tag: str) -> int:
+    """A per-run account id, so a claim from another run cannot answer for this one."""
+    return 700_000 + int(run_tag[:5], 16) % 100_000
 
 
 def _run_connector_dbt_path(
@@ -70,8 +151,13 @@ def _run_connector_dbt_path(
     dbt_runner: DbtRunner,
     tracked_models: TrackedModels,
     worker_ctx: WorkerContext,
-    bronze: dict[str, list[dict]],
+    bronze: BronzeTables,
 ) -> None:
+    """Seed bronze, build the connector's models, then the shared union.
+
+    `build` runs the models' data tests too, so a duplicate `unique_key` fails
+    here rather than surviving into an assertion.
+    """
     ch_seeder.truncate_touched()
     ch_seeder.seed_bronze(bronze, _schemas(list(bronze)))
 
@@ -85,6 +171,17 @@ def _run_connector_dbt_path(
     tracked_models.run(["identity_inputs"], worker_ctx=worker_ctx)
 
 
+def _claims(cfg: SessionConfig, account_id: int) -> list[tuple[str, str, str]]:
+    """Every claim the shared union holds for one GitLab account."""
+    rows = clickhouse.query(
+        cfg,
+        "SELECT value_type, value, value_field_name FROM identity.identity_inputs"
+        f" WHERE insight_source_type = 'gitlab' AND source_account_id = '{account_id}'"
+        "   AND operation_type = 'UPSERT' ORDER BY value_type, value",
+    )
+    return [(row[0], row[1], row[2]) for row in rows]
+
+
 def test_gitlab_publishes_its_account_claims_and_infers_none_from_commits(
     ch_seeder: CHSeeder,
     dbt_runner: DbtRunner,
@@ -92,9 +189,9 @@ def test_gitlab_publishes_its_account_claims_and_infers_none_from_commits(
     worker_ctx: WorkerContext,
     compose_stack: SessionConfig,
 ) -> None:
+    """The account's own address and name arrive; a commit's address does not."""
     run_tag = uuid.uuid4().hex[:10]
-    # A per-run id, so a claim from another run cannot answer for this one.
-    account_id = 700_000 + int(run_tag[:5], 16) % 100_000
+    account_id = _account_id(run_tag)
     published = f"author.{run_tag}@e2e.test"
     display_name = "Request Author"
     # The address on the request's commit, written by somebody else.
@@ -106,64 +203,16 @@ def test_gitlab_publishes_its_account_claims_and_infers_none_from_commits(
         tracked_models,
         worker_ctx,
         {
-            USERS: [
-                _envelope(run_tag, f"u-{account_id}")
-                | {
-                    "id": account_id,
-                    "username": f"author-{run_tag}",
-                    "name": display_name,
-                    "state": "active",
-                    "email": published,
-                    "public_email": "",
-                    "bot": False,
-                }
-            ],
-            REQUESTS: [
-                _envelope(run_tag, f"mr-{account_id}")
-                | {
-                    "project_id": 101,
-                    "iid": 1,
-                    "id": 90_001,
-                    "title": "change",
-                    "state": "merged",
-                    "author_id": account_id,
-                    "author_username": f"author-{run_tag}",
-                    "source_branch": "feature",
-                    "target_branch": "main",
-                    "created_at": "2026-10-01T08:00:00Z",
-                    "updated_at": "2026-10-01T13:00:00Z",
-                    "merged_at": "2026-10-01T09:00:00Z",
-                }
-            ],
-            COMMITS: [
-                _envelope(run_tag, f"mc-{account_id}")
-                | {
-                    "project_id": 101,
-                    "mr_iid": 1,
-                    "id": f"sha-{run_tag}",
-                    "short_id": run_tag[:8],
-                    "title": "change",
-                    "message": "change",
-                    "author_name": "Someone Else",
-                    "author_email": commit_author,
-                    "authored_date": "2026-10-01T08:30:00Z",
-                    "committer_name": "Someone Else",
-                    "committer_email": commit_author,
-                    "committed_date": "2026-10-01T08:30:00Z",
-                }
-            ],
+            USERS: [_user(run_tag, account_id, display_name, email=published)],
+            REQUESTS: [_request(run_tag, 1, account_id)],
+            COMMITS: [_commit(run_tag, f"sha-{run_tag}", 1, commit_author)],
         },
     )
 
-    claims = clickhouse.query(
-        compose_stack,
-        "SELECT value_type, value FROM identity.identity_inputs"
-        f" WHERE insight_source_type = 'gitlab' AND source_account_id = '{account_id}'"
-        "   AND operation_type = 'UPSERT' ORDER BY value_type, value",
-    )
-    assert [tuple(row) for row in claims] == [("display_name", display_name), ("email", published)], (
-        "the account's own e-mail and name are what the persons-seed binds on"
-    )
+    assert [(kind, value) for kind, value, _ in _claims(compose_stack, account_id)] == [
+        ("display_name", display_name),
+        ("email", published),
+    ], "the account's own e-mail and name are what the persons-seed binds on"
 
     inferred = clickhouse.query(
         compose_stack,
@@ -173,4 +222,33 @@ def test_gitlab_publishes_its_account_claims_and_infers_none_from_commits(
     assert int(inferred[0][0]) == 0, (
         "an address from the request's commits was claimed for an account — a commit says "
         "nothing about who opened the request, and the claim cannot be withdrawn later"
+    )
+
+
+def test_one_address_published_in_both_fields_is_one_claim(
+    ch_seeder: CHSeeder,
+    dbt_runner: DbtRunner,
+    tracked_models: TrackedModels,
+    worker_ctx: WorkerContext,
+    compose_stack: SessionConfig,
+) -> None:
+    """A user showing the same address twice yields one claim, not a key collision."""
+    run_tag = uuid.uuid4().hex[:10]
+    account_id = _account_id(run_tag)
+    published = f"both.{run_tag}@e2e.test"
+
+    # Reaching the assertions at all is half the proof: the model's `unique`
+    # data test runs inside this build, so two rows under one key fail here.
+    _run_connector_dbt_path(
+        ch_seeder,
+        dbt_runner,
+        tracked_models,
+        worker_ctx,
+        {USERS: [_user(run_tag, account_id, "Both Fields", email=published, public_email=published)]},
+    )
+
+    emails = [(value, field) for kind, value, field in _claims(compose_stack, account_id) if kind == "email"]
+    assert emails == [(published, "bronze_gitlab.users.email")], (
+        "one address published in both fields must be one claim, and its provenance must not "
+        "depend on the order the rows happened to arrive in"
     )

--- a/src/ingestion/tests/e2e/identity/test_gitlab_account_binding.py
+++ b/src/ingestion/tests/e2e/identity/test_gitlab_account_binding.py
@@ -1,0 +1,176 @@
+"""What GitLab says about a user account reaches the shared identity inputs.
+
+`gitlab__pull_requests` keys a merge request's author on the numeric GitLab
+user id, and the account-first resolution in gold reads that key. The key is
+worth nothing until something binds it to a person, and the persons-seed binds
+from `identity.identity_inputs` — so this test drives the real path (bronze ->
+the connector's dbt models -> the shared `identity_inputs` union) and asserts
+the claims arrive there under that same numeric id.
+
+It also pins what must NOT arrive. A merge request's commits are evidence about
+whoever wrote them, never about whoever opened the request, and the claims here
+are append-only: an address inferred from a request's commits could hand one
+person's address to another and could not be withdrawn afterwards. So the
+fixture gives the request a commit written under a second address and expects
+no account to claim it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+import yaml
+from lib import clickhouse
+from lib.ch_seeder import CHSeeder
+from lib.config import SessionConfig
+from lib.dbt_runner import DbtRunner
+from lib.tracked_models import TrackedModels
+from lib.worker import WorkerContext
+
+pytestmark = [pytest.mark.identity, pytest.mark.mutating]
+
+USERS = "bronze_gitlab.users"
+REQUESTS = "bronze_gitlab.merge_requests"
+COMMITS = "bronze_gitlab.merge_request_commits"
+
+# The metrics rig already declares every column of these three tables.
+_SCHEMA_DIR = Path(__file__).resolve().parents[1] / "metrics" / "schemas"
+
+READ_AT = "2026-10-02T00:00:00Z"
+
+
+def _schemas(tables: list[str]) -> dict:
+    merged: dict = {}
+    for table in tables:
+        doc = yaml.safe_load((_SCHEMA_DIR / f"{table}.yaml").read_text(encoding="utf-8"))
+        merged |= doc["schemas"]
+    return merged
+
+
+def _envelope(run_tag: str, unique_key: str) -> dict:
+    return {
+        "_airbyte_raw_id": str(uuid.uuid4()),
+        "_airbyte_extracted_at": READ_AT,
+        "_airbyte_meta": "{}",
+        "_airbyte_generation_id": 0,
+        # Its own tenant and connection per run: the shared union keeps every
+        # run's claims, and `source_account_id` is only unique within one.
+        "tenant_id": f"gitlab-tenant-{run_tag}",
+        "source_id": f"gitlab-source-{run_tag}",
+        "data_source": "insight_gitlab",
+        "collected_at": READ_AT,
+        "unique_key": unique_key,
+    }
+
+
+def _run_connector_dbt_path(
+    ch_seeder: CHSeeder,
+    dbt_runner: DbtRunner,
+    tracked_models: TrackedModels,
+    worker_ctx: WorkerContext,
+    bronze: dict[str, list[dict]],
+) -> None:
+    ch_seeder.truncate_touched()
+    ch_seeder.seed_bronze(bronze, _schemas(list(bronze)))
+
+    seeded = {tuple(fqn.split(".", 1)) for fqn in bronze}
+    staging, silver = dbt_runner.derive_selectors(seeded)
+    tracked_models.build(staging, worker_ctx=worker_ctx, with_ancestors=True)
+    assert "identity_inputs" in silver, (
+        f"gitlab__identity_inputs did not surface a silver:identity_inputs tag (silver={silver}) "
+        "— the connector's identity path is not reachable from its bronze tables"
+    )
+    tracked_models.run(["identity_inputs"], worker_ctx=worker_ctx)
+
+
+def test_gitlab_publishes_its_account_claims_and_infers_none_from_commits(
+    ch_seeder: CHSeeder,
+    dbt_runner: DbtRunner,
+    tracked_models: TrackedModels,
+    worker_ctx: WorkerContext,
+    compose_stack: SessionConfig,
+) -> None:
+    run_tag = uuid.uuid4().hex[:10]
+    # A per-run id, so a claim from another run cannot answer for this one.
+    account_id = 700_000 + int(run_tag[:5], 16) % 100_000
+    published = f"author.{run_tag}@e2e.test"
+    display_name = "Request Author"
+    # The address on the request's commit, written by somebody else.
+    commit_author = f"committer.{run_tag}@e2e.test"
+
+    _run_connector_dbt_path(
+        ch_seeder,
+        dbt_runner,
+        tracked_models,
+        worker_ctx,
+        {
+            USERS: [
+                _envelope(run_tag, f"u-{account_id}")
+                | {
+                    "id": account_id,
+                    "username": f"author-{run_tag}",
+                    "name": display_name,
+                    "state": "active",
+                    "email": published,
+                    "public_email": "",
+                    "bot": False,
+                }
+            ],
+            REQUESTS: [
+                _envelope(run_tag, f"mr-{account_id}")
+                | {
+                    "project_id": 101,
+                    "iid": 1,
+                    "id": 90_001,
+                    "title": "change",
+                    "state": "merged",
+                    "author_id": account_id,
+                    "author_username": f"author-{run_tag}",
+                    "source_branch": "feature",
+                    "target_branch": "main",
+                    "created_at": "2026-10-01T08:00:00Z",
+                    "updated_at": "2026-10-01T13:00:00Z",
+                    "merged_at": "2026-10-01T09:00:00Z",
+                }
+            ],
+            COMMITS: [
+                _envelope(run_tag, f"mc-{account_id}")
+                | {
+                    "project_id": 101,
+                    "mr_iid": 1,
+                    "id": f"sha-{run_tag}",
+                    "short_id": run_tag[:8],
+                    "title": "change",
+                    "message": "change",
+                    "author_name": "Someone Else",
+                    "author_email": commit_author,
+                    "authored_date": "2026-10-01T08:30:00Z",
+                    "committer_name": "Someone Else",
+                    "committer_email": commit_author,
+                    "committed_date": "2026-10-01T08:30:00Z",
+                }
+            ],
+        },
+    )
+
+    claims = clickhouse.query(
+        compose_stack,
+        "SELECT value_type, value FROM identity.identity_inputs"
+        f" WHERE insight_source_type = 'gitlab' AND source_account_id = '{account_id}'"
+        "   AND operation_type = 'UPSERT' ORDER BY value_type, value",
+    )
+    assert [tuple(row) for row in claims] == [("display_name", display_name), ("email", published)], (
+        "the account's own e-mail and name are what the persons-seed binds on"
+    )
+
+    inferred = clickhouse.query(
+        compose_stack,
+        "SELECT count() FROM identity.identity_inputs"
+        f" WHERE insight_source_type = 'gitlab' AND value = '{commit_author}'",
+    )
+    assert int(inferred[0][0]) == 0, (
+        "an address from the request's commits was claimed for an account — a commit says "
+        "nothing about who opened the request, and the claim cannot be withdrawn later"
+    )

--- a/src/ingestion/tests/e2e/metrics/git_pr_gitlab_account_attribution.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_pr_gitlab_account_attribution.test.yaml
@@ -1,0 +1,144 @@
+spec_version: 1
+description: >
+  Metrics: git.prs_created and git.prs_merged — GitLab merge requests attribute
+  through the author's account, not only through an address, #3142
+  (#3067, #3068).
+  How it's computed (bronze → silver → gold):
+    • bronze: merge requests naming their author's numeric account id, and the
+      user records that may or may not carry an address for it
+    • silver: one class row per merge request, carrying both the author's
+      address and the author's account id
+    • gold:   the account binding resolves the author first; the address map
+      decides only when no account id exists
+
+  GitLab returns a user's address only to a token with admin scope, so an
+  installation without one has merge requests whose author has no address
+  anywhere — and a squash-merged request whose commits were never collected has
+  no address to borrow either. Before the account key existed those requests
+  counted for nobody.
+
+  Both metrics are here because ONE test decides them: every pull-request
+  measure is emitted from the same gold row, which survives on an address or an
+  account id and is dropped whole when it has neither. A request that reaches
+  nobody is therefore missing from its author's created count and merged count
+  alike, and the two are asserted together so a later change cannot restore one
+  and quietly leave the other behind.
+
+  Cases: a merged request whose author has no address and no collected commits
+  still counts, through the account binding alone; a request carrying SOMEBODY
+  ELSE'S commit still counts for the request's author and not for the person who
+  wrote the commit; the created count follows the same binding, in the window the
+  requests were opened in; and a request from an account nothing has bound counts
+  for nobody, so the binding is what carries it and not some other path.
+
+identity_accounts:
+  - {source_type: gitlab, source_id: gitlab-test, account_id: "700", person: bob@example.com}
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+    - $ref: templates/people.yaml#/templates/dave
+
+  bronze_gitlab.projects:
+    - {$ref: templates/gitlab_git.yaml#/templates/project, unique_key: gl-proj-101}
+
+  bronze_gitlab.users:
+    # Neither address is set — the state an installation without an admin token
+    # is in. The name is all an operator would have to recognise the account by.
+    - {$ref: templates/gitlab_git.yaml#/templates/user, unique_key: gl-user-bob, id: 700, username: bob-gl, name: Bob Beta}
+    - {$ref: templates/gitlab_git.yaml#/templates/user, unique_key: gl-user-carol, id: 701, username: carol-gl, name: Carol Gamma}
+
+  bronze_gitlab.merge_requests:
+    # Squash-merged, source branch gone: no merge-request commits were ever
+    # collected, so no commit address can stand in for the missing profile one.
+    - {$ref: templates/gitlab_git.yaml#/templates/merge_request, unique_key: gl-mr-201, iid: 201, id: 90201, author_id: 700, author_username: bob-gl, created_at: "2026-09-20T08:00:00Z", merged_at: "2026-10-01T09:00:00Z", merge_commit_sha: gl-squash-201}
+    # Bob's request, dave's commit. The address the request can borrow names
+    # dave, and the account it carries names bob — only one of them opened it.
+    - {$ref: templates/gitlab_git.yaml#/templates/merge_request, unique_key: gl-mr-202, iid: 202, id: 90202, author_id: 700, author_username: bob-gl, created_at: "2026-09-20T08:00:00Z", merged_at: "2026-10-01T11:00:00Z", merge_commit_sha: gl-merge-202}
+    # Same shape as 201, but account 701 is bound to nobody.
+    - {$ref: templates/gitlab_git.yaml#/templates/merge_request, unique_key: gl-mr-301, iid: 301, id: 90301, author_id: 701, author_username: carol-gl, created_at: "2026-09-20T08:00:00Z", merged_at: "2026-10-01T10:00:00Z", merge_commit_sha: gl-squash-301}
+
+  bronze_gitlab.merge_request_commits:
+    # The link that makes dave's address reachable from bob's request.
+    - {$ref: templates/gitlab_git.yaml#/templates/merge_request_commit, unique_key: gl-mc-202, mr_iid: 202, id: gl-commit-dave, author_name: Dave Delta, author_email: dave@example.com}
+
+  bronze_gitlab.commits:
+    - {$ref: templates/gitlab_git.yaml#/templates/commit, unique_key: gl-commit-dave, id: gl-commit-dave, short_id: gl-commi, author_name: Dave Delta, author_email: dave@example.com, committer_name: Dave Delta, committer_email: dave@example.com, stats_additions: 5, stats_total: 5}
+
+cases:
+  - name: A merge request with no author address counts through the account binding
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [bob@example.com, carol@example.com, dave@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.prs_merged
+            views:
+              - {view: period}
+              - {view: breakdown, dimensions: [source]}
+    expect:
+      - assert: "status == 200"
+      # Both of bob's requests. Account 700 is bound to him and that binding is
+      # the only thing naming him on 201 — the user record carries no address and
+      # the request no commits. On 202 the binding has to WIN against dave's
+      # commit address rather than merely fill a gap.
+      - metric: git.prs_merged
+        view: period
+        find: {entity_id: bob@example.com}
+        equal: {value: 2}
+      - metric: git.prs_merged
+        view: breakdown
+        find: {entity_id: bob@example.com, dimensions: {key: source, value: gitlab}}
+        equal: {value: 2}
+      # Dave wrote the commit request 202 carries and opened nothing, so the
+      # merge is not his. An address borrowed from a commit must never move a
+      # request off the person who opened it.
+      - metric: git.prs_merged
+        view: period
+        find: {entity_id: dave@example.com}
+        equal: {value: null}
+      # Account 701 is bound to nobody, so its merge request reaches nobody —
+      # which is what makes the assertions above about the binding.
+      - metric: git.prs_merged
+        view: period
+        find: {entity_id: carol@example.com}
+        equal: {value: null}
+
+  - name: The created count follows the same binding, in the window they were opened in
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [bob@example.com, carol@example.com, dave@example.com]}
+        period: {from: "2026-09-20", to: "2026-09-21"}
+        metrics:
+          - metric_key: git.prs_created
+            views:
+              - {view: period}
+              - {view: breakdown, dimensions: [source]}
+    expect:
+      - assert: "status == 200"
+      # Every pull-request measure rides the same gold row, so a request that
+      # reaches nobody is missing from the created count exactly as it is from
+      # the merged one. Both of bob's requests were opened on the 20th.
+      - metric: git.prs_created
+        view: period
+        find: {entity_id: bob@example.com}
+        equal: {value: 2}
+      - metric: git.prs_created
+        view: breakdown
+        find: {entity_id: bob@example.com, dimensions: {key: source, value: gitlab}}
+        equal: {value: 2}
+      # Dave opened nothing; writing a commit that a request carries does not
+      # make him its author here any more than it does for the merge.
+      - metric: git.prs_created
+        view: period
+        find: {entity_id: dave@example.com}
+        equal: {value: null}
+      - metric: git.prs_created
+        view: period
+        find: {entity_id: carol@example.com}
+        equal: {value: null}

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_gitlab.merge_request_commits.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_gitlab.merge_request_commits.yaml
@@ -1,0 +1,31 @@
+# Derived from the bronze_gitlab DDL snapshot.
+schemas:
+  bronze_gitlab.merge_request_commits:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      unique_key: { type: [string, "null"] }
+      tenant_id: { type: [string, "null"] }
+      source_id: { type: [string, "null"] }
+      data_source: { type: [string, "null"] }
+      collected_at: { type: [string, "null"] }
+      project_id: { type: [integer, "null"] }
+      mr_iid: { type: [integer, "null"] }
+      mr_updated_at: { type: [string, "null"] }
+      id: { type: [string, "null"] }
+      short_id: { type: [string, "null"] }
+      title: { type: [string, "null"] }
+      title_truncated: { type: [boolean, "null"] }
+      message: { type: [string, "null"] }
+      message_truncated: { type: [boolean, "null"] }
+      author_name: { type: [string, "null"] }
+      author_email: { type: [string, "null"] }
+      authored_date: { type: [string, "null"] }
+      committer_name: { type: [string, "null"] }
+      committer_email: { type: [string, "null"] }
+      committed_date: { type: [string, "null"] }
+      _airbyte_raw_id: { type: string }
+      _airbyte_extracted_at: { type: string, format: date-time }
+      _airbyte_meta: { type: string }
+      _airbyte_generation_id: { type: integer }

--- a/src/ingestion/tests/e2e/metrics/templates/gitlab_git.yaml
+++ b/src/ingestion/tests/e2e/metrics/templates/gitlab_git.yaml
@@ -66,6 +66,23 @@ templates:
     public_email: ""
     bot: false
 
+  # The merge request <-> commit link. Its own author fields are the commit's,
+  # not the request author's — the two are different identities.
+  merge_request_commit:
+    $ref: "#/templates/base"
+    project_id: 101
+    mr_iid: null
+    id: null
+    short_id: null
+    title: change
+    message: change
+    author_name: null
+    author_email: null
+    authored_date: "2026-10-01T08:30:00Z"
+    committer_name: null
+    committer_email: null
+    committed_date: "2026-10-01T08:30:00Z"
+
   merge_request:
     $ref: "#/templates/base"
     project_id: 101


### PR DESCRIPTION
Part of #3142 — deliberately NOT `Closes`. Merging fixes attribution from the next sync onward; the history already in staging needs a backfill an operator has to run, so the issue stays open until that lands.

**Why.** A GitLab merge request reached a person only through an address, and GitLab hands one out only to a token with admin scope. Without it the author has no address at all, a squash-merged request has no commit address to borrow, and the request is counted for nobody — no error, no empty value, just a lower total.

**And a request that DOES have commits was counted for the wrong person.** With no author address, gold borrows the address its commits agree on, so a request opened by one person and written by another was credited to whoever wrote the commit. That is a misattribution, not a gap, and it is live on `main` today.

**One row, one gate, 21 metrics.** Every pull-request measure is emitted from the same gold row, which survives on an address or an account id and is dropped whole when it has neither — 19 measures behind 21 registry metrics. `git.prs_created` (#3067) and `git.prs_merged` (#3068) are two of them, and they fail and recover together; the fixture asserts both so a later change cannot restore one and quietly leave the other behind.

**What changed.** The merge request already names its author's numeric account id and the model read straight past it. It is now the class contract's `author_account_id`, gold maps `insight_gitlab` onto identity's own source-type vocabulary, and the account binding resolves the author ahead of the address map — the order GitHub and Bitbucket have resolved in since #2819.

**An account key is worth nothing until something binds it, so the connector gains the identity inputs it never had.** `gitlab__identity_inputs` publishes what GitLab states about the account: the addresses it exposes (`email`, `public_email`) and the account's name, so one with no address still arrives with something an operator can recognise it by.

**Nothing is inferred from a merge request's commits.** A commit is evidence about whoever wrote it, never about whoever opened the request — and these claims are append-only UPSERTs with no retract, so a wrong one could not be withdrawn later. With only the account's own published facts left, that lifecycle needs no further machinery: every claim was true of the account when GitLab said it.

**Out of scope.** No `gitlab-commit-email` source type, the arm its two siblings use to surface an address no account claims. Commits already attribute by address directly, so nothing in this issue needs it. The admin-token rollout stays out too.

**Rollout — what has to happen after merge.** `gitlab__pull_requests` is incremental on `_airbyte_extracted_at` and never re-reads bronze, so every merge request already materialized keeps `author_account_id = ''` and the install would run in two regimes.

- **What is refreshed:** `dbt run --full-refresh --select tag:gitlab+` — it rebuilds `gitlab__pull_requests` from bronze, which is where `author_account_id` comes from, and cascades into `class_git_pull_requests` and the gold evidence.
- **How and when:** not automatic. The descriptor goes to **3.0.0** by the same criterion 2.0.0 used, but this connector is `type=cdk`, and reconcile emits `bump_kind=patch` for a CDK image change (ADR-0015 §Bump-kind storage scope), so the bump alone dispatches **no** full refresh. An operator runs it once after deploy — either directly, or by submitting the `dbt-run` workflow with `dbt_full_refresh=true` and `dbt_select=tag:gitlab+`, which is the supported one-shot path in ADR-0015. The descriptor carries this as a ROLLOUT note, exactly as 2.0.0 does.
- **How it is checked:** count merge requests still carrying no account id — `SELECT countIf(author_account_id = '') , count() FROM staging.gitlab__pull_requests` — before and after. It should fall to the requests whose source reports no author at all. Then re-run the attribution query in #3142; what remains is the genuinely unattributable set.

**What this branch does, and only that.** It puts the right `author_account_id` on a merge request, stops a commit's author displacing the request's author, and makes attribution work for account bindings that are already resolvable. Person creation is untouched: an account nobody has bound and that has never published an address stays unresolved, which is the identity contract, not a gap here — the fixture pins it as expected behaviour with an unbound account whose requests reach nobody.

**Verified.** Reverting only the `author_account_id` line and reading gold directly gives, for a fixture where bob opened two requests and dave wrote the commit one of them carries:

| | `pr_created` | `pr_merged` |
|---|---|---|
| before — bob (opened both) | — | — |
| before — dave (wrote a commit) | 1 | 1 |
| after — bob | 2 | 2 |
| after — dave | — | — |

Both metrics lose the same request and hand it to the same wrong person, and both recover together. `identity/test_gitlab_account_binding.py` drives bronze → the connector's models → the shared `identity_inputs` union and pins what arrives (the account's own address and name, keyed on the numeric id) and what must not (no claim anywhere for the commit author's address). The `git`/`gitlab` metric suites are green. `ruff` 0.15.21 check and format clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GitLab user identities now support account-based matching using published email addresses and display names.
  - GitLab merge requests can be attributed to authors through their account ID, even when email data is unavailable.

- **Bug Fixes**
  - Merge request metrics now correctly attribute activity through GitLab account bindings.
  - Commit author details no longer incorrectly influence merge request identity attribution.
  - Unbound GitLab accounts are excluded from attribution rather than being assigned through unrelated commit addresses.

- **Tests**
  - Added end-to-end coverage for GitLab identity binding and merge request attribution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Review round.** CodeRabbit's duplicate-claim finding was real and is fixed: `email` and `public_email` normalizing to one address emitted two rows under one `unique_key`, which the anti join cannot see because neither row is in the target yet. Reverting the dedup fails `unique_gitlab__identity_inputs_unique_key` with "Got 1 result", so the new regression bites at the dbt data test rather than at an assertion. The shared `identity_inputs` union no longer projects `SELECT *` across a positional boundary, every output column of `gitlab__identity_inputs` is documented, and the identity test carries typed record shapes and docstrings.

