### PR TITLE
feat(observability): MariaDB slow queries to Loki and onto the Databases dashboard

### DIFF
--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -8871,6 +8871,73 @@ dashboards:
                   "rawSql": "SELECT event_time, query_duration_ms, user, read_rows, formatReadableSize(memory_usage) AS memory, normalizeQuery(query) AS query FROM system.query_log WHERE type = 'QueryFinish' AND user != 'grafana' AND $__timeFilter(event_time) ORDER BY query_duration_ms DESC LIMIT 20"
                 }
               ]
+            },
+            {
+              "id": 603,
+              "type": "timeseries",
+              "title": "MariaDB · slow queries (>1s)",
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 71
+              },
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "custom": {
+                    "drawStyle": "bars",
+                    "fillOpacity": 60,
+                    "stacking": {
+                      "mode": "normal"
+                    }
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "bottom"
+                }
+              },
+              "targets": [
+                {
+                  "refId": "A",
+                  "legendFormat": "slow queries",
+                  "expr": "sum(count_over_time({namespace=\"insight-infra\", container=\"mariadb\"} |= \"# Query_time\" [$__auto]))"
+                }
+              ]
+            },
+            {
+              "id": 604,
+              "type": "logs",
+              "title": "MariaDB · log (slow query entries)",
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 71
+              },
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "options": {
+                "showTime": true,
+                "wrapLogMessage": true,
+                "sortOrder": "Descending"
+              },
+              "targets": [
+                {
+                  "refId": "A",
+                  "expr": "{namespace=\"insight-infra\", container=\"mariadb\"}"
+                }
+              ]
             }
           ],
           "refresh": "1m",

--- a/deploy/gitops/system/mariadb/values.yaml
+++ b/deploy/gitops/system/mariadb/values.yaml
@@ -36,6 +36,12 @@ auth:
   username: insight
 
 primary:
+  # Slow query log to stderr -> pod log -> Loki (#3141); read by the
+  # Databases dashboard. /dev/stderr because the container log IS the shipped
+  # stream — a file on the PVC would be invisible to Alloy.
+  # INVARIANT: helm replaces this scalar — an overlay that sets extraFlags
+  # must restate these slow-log flags or it silently turns the log off.
+  extraFlags: "--slow-query-log=1 --long-query-time=1 --slow-query-log-file=/dev/stderr"
   persistence:
     enabled: true
     size: 8Gi


### PR DESCRIPTION
Closes #3141.

**Why.** The Databases dashboard has no query-level signal for MariaDB — only container CPU/memory/disk. There is no data source to chart: the slow query log is off and nothing exports query metrics.

**What changed.** `primary.extraFlags` enables the slow query log (threshold 1s) aimed at `/dev/stderr`, so entries ride the existing pod-log path (Alloy → Loki) with no new component. The Databases dashboard gains a slow-query rate panel and a log panel over the mariadb container stream. **Slow-log-to-Loki over mysqld-exporter:** the exporter counts slow queries but never shows their text, and costs an always-on sidecar; the log gives the query itself for free.

**Verified.** The `/dev/stderr` slow log proven on the bitnami image in a throwaway container — `SELECT SLEEP(2)` lands in container stderr as `# Query_time: 2.0…` followed by the statement. Values parse as YAML, dashboard JSON byte-identical to the operator gitops mirror's. Not verified live: needs a `system-mariadb` re-apply, which restarts MariaDB.

Mirror pair in the operator gitops repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MariaDB slow-query monitoring to the Databases dashboard, including a time-series view of slow-query activity.
  - Added a MariaDB log panel for viewing raw database log entries.
  - Enabled MariaDB slow-query logging so relevant activity is available in monitoring dashboards and application logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->