### PR TITLE
feat(observability): ship the MariaDB slow log through a dedicated sidecar stream

### DIFF
--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -8909,14 +8909,14 @@ dashboards:
                 {
                   "refId": "A",
                   "legendFormat": "slow queries",
-                  "expr": "sum(count_over_time({namespace=\"insight-infra\", container=\"mariadb\"} |= \"# Query_time\" [$__auto]))"
+                  "expr": "sum(count_over_time({namespace=\"insight-infra\", pod=~\"mariadb-.*\", container=\"slow-log\"} |= \"# Query_time\" [$__auto]))"
                 }
               ]
             },
             {
               "id": 604,
               "type": "logs",
-              "title": "MariaDB · log (slow query entries)",
+              "title": "MariaDB · slow query log",
               "gridPos": {
                 "h": 8,
                 "w": 12,
@@ -8935,7 +8935,7 @@ dashboards:
               "targets": [
                 {
                   "refId": "A",
-                  "expr": "{namespace=\"insight-infra\", container=\"mariadb\"}"
+                  "expr": "{namespace=\"insight-infra\", pod=~\"mariadb-.*\", container=\"slow-log\"}"
                 }
               ]
             }

--- a/deploy/gitops/system/mariadb/values.yaml
+++ b/deploy/gitops/system/mariadb/values.yaml
@@ -36,12 +36,34 @@ auth:
   username: insight
 
 primary:
-  # Slow query log to stderr -> pod log -> Loki (#3141); read by the
-  # Databases dashboard. /dev/stderr because the container log IS the shipped
-  # stream — a file on the PVC would be invisible to Alloy.
+  # Slow query log (#3141) into its own file on a shared emptyDir; the slow-log
+  # sidecar tails it to stdout, giving Loki a dedicated stream the Databases
+  # dashboard selects by container name — no filtering heuristics against the
+  # interleaved error log.
   # INVARIANT: helm replaces this scalar — an overlay that sets extraFlags
   # must restate these slow-log flags or it silently turns the log off.
-  extraFlags: "--slow-query-log=1 --long-query-time=1 --slow-query-log-file=/dev/stderr"
+  extraFlags: "--slow-query-log=1 --long-query-time=1 --slow-query-log-file=/logs/mariadb-slow.log"
+  extraVolumes:
+    - name: slow-log
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: slow-log
+      mountPath: /logs
+  # `tail -n0` so a sidecar restart re-ships nothing (a short gap beats
+  # duplicate entries in Loki).
+  sidecars:
+    - name: slow-log
+      image: docker.io/busybox:1.36
+      command: ["sh", "-c", "touch /logs/mariadb-slow.log && exec tail -n0 -F /logs/mariadb-slow.log"]
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+      resources:
+        requests: { cpu: 5m,  memory: 8Mi }
+        limits:   { cpu: 50m, memory: 32Mi }
+      volumeMounts:
+        - name: slow-log
+          mountPath: /logs
   persistence:
     enabled: true
     size: 8Gi


### PR DESCRIPTION
**Why.** The slow log rode /dev/stderr interleaved with the error log, and the dashboard told them apart with a no-leading-date heuristic — which silently swallows any SQL text line that happens to start with a date.

**What changed.** The slow log goes to its own file on a shared emptyDir; a busybox `tail -F` sidecar ships it as its own container stream, and the Databases panels select `container="slow-log"` positively — no filtering heuristics. **`tail -n0`:** a sidecar restart re-ships nothing; a short gap beats duplicate Loki entries.

**Verified.** `helm template` with these values renders the sidecar, the shared mount and the flags; a throwaway bitnami container already proved the flag set writes slow entries. Not verified live: needs a `system-mariadb` apply (restarts MariaDB). Mirror pair in the operator gitops repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved MariaDB slow-query log collection by routing logs through a dedicated stream.
  * Updated the Grafana dashboard to display slow-query entries from the dedicated log source.
  * Renamed the panel title to “MariaDB · slow query log” for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->