### PR TITLE
fix(observability): drop health-probe routes from the RED metrics pipeline

### DIFF
--- a/deploy/gitops/system/alloy/values.yaml
+++ b/deploy/gitops/system/alloy/values.yaml
@@ -120,8 +120,22 @@ alloy:
           endpoint = "0.0.0.0:4318"
         }
         output {
-          metrics = [otelcol.exporter.prometheus.to_victoriametrics.input]
+          metrics = [otelcol.processor.filter.drop_probe_routes.input]
           traces  = [otelcol.exporter.otlp.to_tempo.input]
+        }
+      }
+
+      // Liveness/readiness probes out of the RED metrics: they are traffic
+      // nobody sent, and the toolkit records them with a coarser bucket set
+      // whose merge skews every histogram_quantile over the service.
+      otelcol.processor.filter "drop_probe_routes" {
+        metrics {
+          datapoint = [
+            "IsMatch(attributes[\"http.route\"], \"^/health(z)?$\")",
+          ]
+        }
+        output {
+          metrics = [otelcol.exporter.prometheus.to_victoriametrics.input]
         }
       }
 


### PR DESCRIPTION
**Why.** The RED dashboard showed a 21.5s p99 for identity-resolution that no real request produced: /health and /healthz are recorded by the toolkit's built-in layer with the OTel default bucket set, and merging that coarse layout with the services' custom buckets makes `histogram_quantile` interpolate multi-second values out of millisecond probes (all probe mass sits in the first 0–5 bucket; 0.99 × 5 ≈ 4.95s, and the cross-layout merge lands mid-bucket at ~21.5s).

**What changed.** An `otelcol.processor.filter` in the Alloy OTLP pipeline drops metric datapoints whose `http.route` is `/health` or `/healthz` before they reach VictoriaMetrics. Probe traffic is synthetic; kubelet already alerts on failing probes. **Pipeline filter over a toolkit fix:** the recording layer ships in a crates.io-pinned toolkit crate — filtering at collection fixes every service at once and needs no toolkit release.

**Verified.** Config extracted and passed `alloy fmt` and `alloy validate` (component wiring + OTTL expression); bucket-diff over the fine-grained buckets confirms zero real requests above 10s in 24h on the affected service. Mirror pair in the operator gitops repo.