### PR TITLE
chore(keycloak): bump Keycloak to 26.7 and keycloak-config-cli to 6.5.1-26.5.5

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -473,7 +473,7 @@ keycloak:
   deploy: false
   image:
     repository: quay.io/keycloak/keycloak
-    tag: "26.4"
+    tag: "26.7"
     pullPolicy: IfNotPresent
   # Advertised issuer BASE (must end in /kc) — the URL browser AND
   # authenticator reach, e.g. https://<host>/kc.
@@ -508,7 +508,7 @@ keycloakConfig:
   image:
     repository: adorsys/keycloak-config-cli
     # Release line must match the Keycloak server major.
-    tag: "6.5.1-26.1.0"
+    tag: "6.5.1-26.5.5"
     pullPolicy: IfNotPresent
   # Keycloak base URL (tpl-rendered). Must be https; plain http only with
   # allowInsecureUrl=true (in-cluster dev/CI Keycloak only).

--- a/deploy/compose/keycloak/README.md
+++ b/deploy/compose/keycloak/README.md
@@ -1,7 +1,7 @@
 # Keycloak auth (compose stack)
 
 The compose stack always authenticates against a real
-[Keycloak](https://www.keycloak.org/) 26.4 container: full cookie/BFF auth
+[Keycloak](https://www.keycloak.org/) 26.7 container: full cookie/BFF auth
 (NGINX_BFF #1583) — the nginx `gateway` `auth_request`s the `authenticator`,
 which does the OIDC login server-side against Keycloak (real login form,
 **confidential** client, real token claims) and mints the ES256 gateway JWT.

--- a/deploy/compose/keycloak/tests/tenant_contract_guard.py
+++ b/deploy/compose/keycloak/tests/tenant_contract_guard.py
@@ -34,7 +34,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 CANONICAL_REALM = REPO_ROOT / "deploy/gitops/environments/local/keycloak/realms/insight-broker.yaml"
-KC_IMAGE = "quay.io/keycloak/keycloak:26.4"
+KC_IMAGE = "quay.io/keycloak/keycloak:26.7"
 KC_PORT = 18086
 BASE = f"http://127.0.0.1:{KC_PORT}"
 CONTAINER = "tenant-guard-kc"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -477,7 +477,7 @@ services:
   # insight_seed.keycloak_realm, gitignored). Gated behind
   # --profile auth-keycloak.
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4
+    image: quay.io/keycloak/keycloak:26.7
     container_name: ${COMPOSE_PROJECT_NAME:-insight}-keycloak
     command: ["start-dev", "--import-realm", "--http-relative-path=/kc"]
     environment:

--- a/src/backend/services/authenticator/tests/run-e2e.sh
+++ b/src/backend/services/authenticator/tests/run-e2e.sh
@@ -46,7 +46,7 @@ IDENTITY_PORT="${IDENTITY_PORT:-8092}"
 REDIS_CT=authenticator-e2e-redis
 KC_CT=authenticator-e2e-keycloak
 # Same image the compose stack pins for its realm (docker-compose.yml).
-KC_IMAGE=quay.io/keycloak/keycloak:26.4
+KC_IMAGE=quay.io/keycloak/keycloak:26.7
 KC_REALM=insight
 KC_REALM_B=insight-b
 KC_ADMIN_USER=admin

--- a/src/backend/services/gateway/tests/docker-compose.e2e.yml
+++ b/src/backend/services/gateway/tests/docker-compose.e2e.yml
@@ -28,7 +28,7 @@ services:
   # the generated roster realm (conftest.py runs insight-seed-realm into
   # ./keycloak-import before `up`).
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4
+    image: quay.io/keycloak/keycloak:26.7
     command: ["start-dev", "--import-realm"]
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin

--- a/src/backend/services/gateway/tests/downstream-verify/docker-compose.e2e.yml
+++ b/src/backend/services/gateway/tests/downstream-verify/docker-compose.e2e.yml
@@ -42,7 +42,7 @@ services:
   # the generated roster realm (conftest.py runs insight-seed-realm into
   # ./keycloak-import before `up`).
   keycloak:
-    image: quay.io/keycloak/keycloak:26.4
+    image: quay.io/keycloak/keycloak:26.7
     command: ["start-dev", "--import-realm"]
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin

--- a/src/backend/services/keycloak/helm/Chart.yaml
+++ b/src/backend/services/keycloak/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: insight-keycloak
 description: The stack's Keycloak — identity broker per ADR-0003, MariaDB-backed, realm content as code
 version: 0.1.0
-appVersion: "26.4"
+appVersion: "26.7"
 type: application

--- a/src/backend/services/keycloak/helm/values.yaml
+++ b/src/backend/services/keycloak/helm/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/keycloak/keycloak
-  tag: "26.4"
+  tag: "26.7"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
**Why.** The broker image and its realm-import CLI have fallen three Keycloak minors behind upstream (26.4 vs 26.7, config-cli built against 26.1).

**What changed.** Every `quay.io/keycloak/keycloak` pin moves to `26.7` (subchart + `appVersion`, umbrella values, compose stack, e2e harnesses) and `keycloak-config-cli` moves to `6.5.1-26.5.5`, the newest build on the Keycloak 26 line the values comment requires.

**Verified.** `helm lint`/`helm template` on the keycloak subchart render the new tag; checked 26.5–26.7 migration notes — the redirect-URI and introspection breaking changes don't apply (all realm redirect URIs are exact strings, no introspection callers).
