### PR TITLE
test(git-cli-proxy): cover the gateway-capability router wiring

### DIFF
--- a/src/backend/services/git-cli-proxy/src/gear.rs
+++ b/src/backend/services/git-cli-proxy/src/gear.rs
@@ -130,7 +130,7 @@ impl ApiGatewayCapability for GitCliProxyGear {
         router: Router,
         _hc_registry: Arc<toolkit::RestHealthcheckRegistry>,
     ) -> anyhow::Result<Router> {
-        Ok(router.route("/healthz", get(|| async { "ok" })))
+        Ok(prepared_router(router))
     }
 
     fn rest_finalize(
@@ -139,21 +139,84 @@ impl ApiGatewayCapability for GitCliProxyGear {
         router: Router,
         _hc_registry: Arc<toolkit::RestHealthcheckRegistry>,
     ) -> anyhow::Result<Router> {
-        // Panics are caught below the canonical layer, so the 500 it produces
-        // is rendered like every other failure.
-        let router = router
-            .layer(CatchPanicLayer::new())
-            .layer(axum::middleware::from_fn(
-                toolkit::api::canonical_error_middleware,
-            ));
-
-        self.router
-            .set(router.clone())
-            .map_err(|_| anyhow::anyhow!("the router was finalized twice"))?;
-        Ok(router)
+        finalize_router(router, &self.router)
     }
 
     fn as_registry(&self) -> &dyn OpenApiRegistry {
         &self.openapi
+    }
+}
+
+fn prepared_router(router: Router) -> Router {
+    router.route("/healthz", get(|| async { "ok" }))
+}
+
+/// Layer the router and persist it for [`GitCliProxyGear::serve`]; a second
+/// finalize is a wiring bug and errors.
+fn finalize_router(router: Router, slot: &OnceLock<Router>) -> anyhow::Result<Router> {
+    // Panics are caught below the canonical layer, so the 500 it produces
+    // is rendered like every other failure.
+    let router = router
+        .layer(CatchPanicLayer::new())
+        .layer(axum::middleware::from_fn(
+            toolkit::api::canonical_error_middleware,
+        ));
+
+    slot.set(router.clone())
+        .map_err(|_| anyhow::anyhow!("the router was finalized twice"))?;
+    Ok(router)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use super::*;
+
+    type R = Result<(), Box<dyn std::error::Error>>;
+
+    #[tokio::test]
+    async fn the_prepared_router_serves_healthz() -> R {
+        let router = prepared_router(Router::new());
+
+        let response = router
+            .oneshot(Request::get("/healthz").body(Body::empty())?)
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_finalized_router_turns_a_panic_into_a_500() -> R {
+        let slot = OnceLock::new();
+        let panicking = Router::new().route(
+            "/boom",
+            get(|| async {
+                panic!("handler panic");
+                #[expect(unreachable_code)]
+                ""
+            }),
+        );
+
+        let router = finalize_router(panicking, &slot)?;
+        let response = router
+            .oneshot(Request::get("/boom").body(Body::empty())?)
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        Ok(())
+    }
+
+    #[test]
+    fn a_second_finalize_is_rejected() {
+        let slot = OnceLock::new();
+
+        let first = finalize_router(Router::new(), &slot);
+
+        assert!(first.is_ok());
+        assert!(finalize_router(Router::new(), &slot).is_err());
     }
 }


### PR DESCRIPTION
**Why.** The Coverage gate on #3031 flagged git-cli-proxy's `rest_prepare`/`rest_finalize` as new uncovered lines (the toolkit 0.7 signature change pulled them into the diff); the fix couldn't be pushed while the PR sat in the merge queue.

**What changed.** The router transforms move out of the trait impl into free functions (`prepared_router`, `finalize_router`) and get unit tests: `/healthz` is served, a handler panic renders as a 500 through the canonical layer, and a second finalize is rejected.

**Verified.** `cargo test -p git-cli-proxy` (218 passed), `clippy --all-targets` zero warnings, `cargo fmt --check` — locally on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service reliability by ensuring panics are returned as HTTP 500 responses.
  * Added safeguards against finalizing the router more than once.
  * Confirmed that the health check endpoint remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->