### PR TITLE
fix(observability): one recorder per service for the RED histogram

### DIFF
--- a/src/backend/services/analytics/config/insight.yaml
+++ b/src/backend/services/analytics/config/insight.yaml
@@ -36,6 +36,11 @@ logging:
 gears:
   api-gateway:
     config:
+      # INVARIANT: the service router's insight-http-metrics is the single
+      # writer of http.server.request.duration — the host's copy stays renamed
+      # or two bucket layouts collide in one series.
+      metrics:
+        prefix: "host"
       # analytics is addressed directly (the platform gateway proxies
       # `/analytics` → here), so no prefix_path is set.
       bind_addr: "0.0.0.0:8081"

--- a/src/backend/services/analytics/helm/templates/configmap.yaml
+++ b/src/backend/services/analytics/helm/templates/configmap.yaml
@@ -41,6 +41,11 @@ data:
     gears:
       api-gateway:
         config:
+          # INVARIANT: the service router's insight-http-metrics is the single
+          # writer of http.server.request.duration — the host's copy stays renamed
+          # or two bucket layouts collide in one series.
+          metrics:
+            prefix: "host"
           bind_addr: "0.0.0.0:{{ .Values.service.port }}"
           # analytics is addressed directly (the platform gateway proxies
           # `/analytics` → here), so no prefix_path.

--- a/src/backend/services/authenticator/config/insight.yaml
+++ b/src/backend/services/authenticator/config/insight.yaml
@@ -37,6 +37,11 @@ logging:
 gears:
   api-gateway:
     config:
+      # INVARIANT: the service router's insight-http-metrics is the single
+      # writer of http.server.request.duration — the host's copy stays renamed
+      # or two bucket layouts collide in one series.
+      metrics:
+        prefix: "host"
       bind_addr: "0.0.0.0:8083"
       enable_docs: true
       cors_enabled: true

--- a/src/backend/services/authenticator/helm/templates/configmap.yaml
+++ b/src/backend/services/authenticator/helm/templates/configmap.yaml
@@ -46,6 +46,11 @@ data:
     gears:
       api-gateway:
         config:
+          # INVARIANT: the service router's insight-http-metrics is the single
+          # writer of http.server.request.duration — the host's copy stays renamed
+          # or two bucket layouts collide in one series.
+          metrics:
+            prefix: "host"
           bind_addr: "0.0.0.0:{{ .Values.service.port }}"
           auth_disabled: false
           cors_enabled: false

--- a/src/backend/services/identity-resolution/config/insight.yaml
+++ b/src/backend/services/identity-resolution/config/insight.yaml
@@ -24,6 +24,11 @@ logging:
 gears:
   api-gateway:
     config:
+      # INVARIANT: the service router's insight-http-metrics is the single
+      # writer of http.server.request.duration — the host's copy stays renamed
+      # or two bucket layouts collide in one series.
+      metrics:
+        prefix: "host"
       # Consumers reach identity at <host>:8082.
       bind_addr: "0.0.0.0:8082"
       enable_docs: true

--- a/src/backend/services/identity-resolution/helm/templates/configmap.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/configmap.yaml
@@ -40,6 +40,11 @@ data:
     gears:
       api-gateway:
         config:
+          # INVARIANT: the service router's insight-http-metrics is the single
+          # writer of http.server.request.duration — the host's copy stays renamed
+          # or two bucket layouts collide in one series.
+          metrics:
+            prefix: "host"
           bind_addr: "0.0.0.0:{{ .Values.service.port }}"
           # Auth ENABLED: the oidc-authn-plugin verifies the ES256 gateway JWT
           # and maps its claims into the SecurityContext (R1).


### PR DESCRIPTION
**Why.** Every service route is recorded twice into `http.server.request.duration`: once by the api-gateway host middleware and once by `insight-http-metrics` — two instruments with different bucket layouts feeding one series, which double-counts rates and skews every `histogram_quantile`. The host also records `/health`/`/healthz`, whose probe mass fabricated a multi-second p99 on the RED dashboard.

**What changed.** `metrics.prefix: host` in the api-gateway config of identity-resolution, analytics and authenticator (config + helm configmap). The host's copy becomes `host.http.server.request.duration`; the service router's `insight-http-metrics` — with the full 0.01–600s bucket range — is the single writer of the semconv name, and probe routes leave the RED metric entirely. **Previews stays unprefixed:** it has no layer of its own, so the host recorder is its only RED source (semconv buckets from the #3031 toolkit bump).

**Out of scope.** The Alloy-side probe filter (#3149) stays as defense in depth for previews and any future host-only service.

**Verified.** `metrics.prefix` checked against the pinned `cf-gears-api-gateway 0.4.x` config struct; all six YAML files parse; the host config is `deny_unknown_fields`, so a wrong key fails the service boot in compose CI rather than silently.