### PR TITLE
fix(gold): label proxy change types removed, copied and type_changed in git evidence

### DIFF
--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -242,7 +242,9 @@ file_changes_source AS (
                 lower(raw_file_change.change_type) = 'added', 'Added',
                 lower(raw_file_change.change_type) = 'modified', 'Modified',
                 lower(raw_file_change.change_type) = 'renamed', 'Renamed',
-                lower(raw_file_change.change_type) = 'deleted', 'Deleted',
+                lower(raw_file_change.change_type) IN ('deleted', 'removed'), 'Deleted',
+                lower(raw_file_change.change_type) = 'copied', 'Copied',
+                lower(raw_file_change.change_type) = 'type_changed', 'Type changed',
                 raw_file_change.change_type
             ) AS change_type_label,
             sum(lines_added) AS lines_added,


### PR DESCRIPTION
**Why:** the change_type label map in the git evidence model knew only `added`/`modified`/`renamed`/`deleted`; the git-cli-proxy emits `removed`, `copied` and `type_changed`, so on proxy-backed sources deletions surfaced with the raw lowercase `removed` label beside `Added` / `Modified` / `Renamed`.

**What changed:** `removed` labels as `Deleted` (the same label the CDK `deleted` value carries), `copied` as `Copied`, `type_changed` as `Type changed`. Dimension values are unchanged — only the human label.

**Verified:** `dbt parse`; evidence rebuilt and served through a git e2e spec locally. A label assertion for the `removed` row can follow in `git_line_counts.test.yaml` once #3154 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git file-change metrics now consistently classify both “deleted” and “removed” files as **Deleted**.
  * Copied and type-changed files continue to receive their appropriate labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->