### PR TITLE
fix(gold): stop a squash re-counting the branch work it re-applies

### DIFF
--- a/src/ingestion/dbt/macros/git_file_content_identity.sql
+++ b/src/ingestion/dbt/macros/git_file_content_identity.sql
@@ -1,0 +1,22 @@
+{# The identity of one file change's CONTENT: the object id it produced.
+
+   Keyed on the post-image alone rather than the (pre, post) pair, because a
+   squash re-applies a branch's whole span as one step — the branch makes
+   A to B then B to C, the squash makes A to C — and a pair key reads that as a
+   third, unseen change. The resulting content is what the two lines of history
+   share, so it is what identifies the work.
+
+   A deletion produces no content, so its identity is what it REMOVED: without
+   the pre-image the key would be constant and every deletion at one path would
+   collapse into one, whatever content each removed.
+
+   Empty on both sides means the source reports no object id at all. The caller
+   keeps those rows distinct per commit — see the tie-breaker in
+   `deduplicated_file_changes`. #}
+{% macro git_file_content_identity(post_image_oid, pre_image_oid) -%}
+if(
+        coalesce({{ post_image_oid }}, '') != '',
+        {{ post_image_oid }},
+        concat('~removed~', coalesce({{ pre_image_oid }}, ''))
+    )
+{%- endmacro %}

--- a/src/ingestion/gold/git_default_branch_commits.sql
+++ b/src/ingestion/gold/git_default_branch_commits.sql
@@ -18,6 +18,17 @@
 -- request whose destination IS the default branch is standing proof that its
 -- commits landed, and it is proof the sources keep indefinitely.
 --
+-- A squash merged with NO pull request has no membership edge to read, and the
+-- squash rewrites history, so the originals are unreachable from the default
+-- branch for good. The second half of this model reads the content instead: a
+-- change whose object id sits on a default-branch commit at the same path
+-- landed, whichever commit carries it there.
+--
+-- INVARIANT: content can only heal what SURVIVED into the default branch. A
+-- path a branch touched more than once keeps its intermediate versions
+-- nowhere but the branch, so those commits stay `non_default` — a squash
+-- carries the span's end, not its steps.
+--
 -- INVARIANT: this cannot see a branch merged by a fast-forward push with no
 -- pull request. GitLab still corrects those itself (advancing the default head
 -- re-walks the range), the proxy-backed sources only within their lookback
@@ -37,25 +48,90 @@ repository_default_branches AS (
     FROM {{ ref('class_git_repository_branches') }} FINAL
     WHERE is_default = 1
     GROUP BY tenant_id, source_id, project_key, repo_slug
-)
+),
 
+-- The content that reached the default branch, by path. Object ids only: a
+-- source that reports none says nothing about where its content is, and an
+-- empty identity would match every such row to every other.
+landed_content AS (
+    SELECT DISTINCT
+        landed_change.tenant_id AS tenant_id,
+        landed_change.source_id AS source_id,
+        landed_change.project_key AS project_key,
+        landed_change.repo_slug AS repo_slug,
+        landed_change.file_path AS file_path,
+        {{ git_file_content_identity('landed_change.post_image_oid', 'landed_change.pre_image_oid') }} AS content_identity
+    FROM {{ ref('class_git_file_changes') }} AS landed_change FINAL
+    WHERE (landed_change.tenant_id, landed_change.source_id, landed_change.project_key, landed_change.repo_slug, landed_change.commit_hash) IN (
+        SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
+        FROM {{ ref('class_git_commits') }} FINAL
+        WHERE is_default_branch = 1
+    )
+      AND NOT (
+          coalesce(landed_change.pre_image_oid, '') = ''
+              AND coalesce(landed_change.post_image_oid, '') = ''
+      )
+),
+-- The candidates: commits the default branch does not reach. Narrowing here
+-- rather than filtering afterwards is what keeps a commit from matching its
+-- own content and reporting itself as healed.
+unlanded_commits AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        commit_hash
+    FROM {{ ref('class_git_commits') }} FINAL
+    WHERE coalesce(is_default_branch, 0) != 1
+      AND is_merge_commit = 0
+)
 SELECT DISTINCT
-    links.tenant_id AS tenant_id,
-    links.source_id AS source_id,
-    links.project_key AS project_key,
-    links.repo_slug AS repo_slug,
-    links.commit_hash AS commit_hash
-FROM {{ ref('class_git_pull_requests_commits') }} AS links FINAL
-INNER JOIN {{ ref('class_git_pull_requests') }} AS prs FINAL
-    ON prs.tenant_id = links.tenant_id
-    AND prs.source_id = links.source_id
-    AND prs.project_key = links.project_key
-    AND prs.repo_slug = links.repo_slug
-    AND prs.pr_id = links.pr_id
-INNER JOIN repository_default_branches AS defaults
-    ON defaults.tenant_id = links.tenant_id
-    AND defaults.source_id = links.source_id
-    AND defaults.project_key = links.project_key
-    AND defaults.repo_slug = links.repo_slug
-WHERE prs.state = 'MERGED'
-  AND prs.destination_branch = defaults.branch_name
+    tenant_id,
+    source_id,
+    project_key,
+    repo_slug,
+    commit_hash
+FROM (
+    SELECT
+        links.tenant_id AS tenant_id,
+        links.source_id AS source_id,
+        links.project_key AS project_key,
+        links.repo_slug AS repo_slug,
+        links.commit_hash AS commit_hash
+    FROM {{ ref('class_git_pull_requests_commits') }} AS links FINAL
+    INNER JOIN {{ ref('class_git_pull_requests') }} AS prs FINAL
+        ON prs.tenant_id = links.tenant_id
+        AND prs.source_id = links.source_id
+        AND prs.project_key = links.project_key
+        AND prs.repo_slug = links.repo_slug
+        AND prs.pr_id = links.pr_id
+    INNER JOIN repository_default_branches AS defaults
+        ON defaults.tenant_id = links.tenant_id
+        AND defaults.source_id = links.source_id
+        AND defaults.project_key = links.project_key
+        AND defaults.repo_slug = links.repo_slug
+    WHERE prs.state = 'MERGED'
+      AND prs.destination_branch = defaults.branch_name
+
+    UNION ALL
+
+    SELECT
+        branch_change.tenant_id AS tenant_id,
+        branch_change.source_id AS source_id,
+        branch_change.project_key AS project_key,
+        branch_change.repo_slug AS repo_slug,
+        branch_change.commit_hash AS commit_hash
+    FROM {{ ref('class_git_file_changes') }} AS branch_change FINAL
+    INNER JOIN landed_content AS landed
+        ON landed.tenant_id IS NOT DISTINCT FROM branch_change.tenant_id
+        AND landed.source_id IS NOT DISTINCT FROM branch_change.source_id
+        AND landed.project_key = branch_change.project_key
+        AND landed.repo_slug = branch_change.repo_slug
+        AND landed.file_path = branch_change.file_path
+        AND landed.content_identity = {{ git_file_content_identity('branch_change.post_image_oid', 'branch_change.pre_image_oid') }}
+    WHERE (branch_change.tenant_id, branch_change.source_id, branch_change.project_key, branch_change.repo_slug, branch_change.commit_hash) IN (
+        SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
+        FROM unlanded_commits
+    )
+)

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -59,9 +59,10 @@ repository_default_branches AS (
 ),
 -- One row per change CONTENT, not per commit that carries it. The same content
 -- entering a repository on two lines of history — a branch whose copy of a
--- tree also landed on the default branch, a cherry-pick, a
--- reverted-then-restored file — is one authored change with one oid pair, and
--- summing both commits' diffs would count those lines twice.
+-- tree also landed on the default branch, a cherry-pick, a squash that
+-- re-applies its branch's whole span, a reverted-then-restored file — is one
+-- authored change, and summing every carrier's diff would count those lines
+-- more than once. `git_file_content_identity` is what "same content" means.
 --
 -- Earliest commit wins, so the value lands in the period the content was first
 -- authored and does not move when a later commit repeats it.
@@ -70,6 +71,11 @@ repository_default_branches AS (
 -- that reports no oid, or a row collected before the proxy did) distinct per
 -- commit: without it every such row for one path would collapse into one,
 -- because LIMIT 1 BY reads their NULL keys as equal.
+--
+-- The superseded set is the case content identity alone cannot reach: a squash
+-- whose branch was only PARTLY collected carries the collected commits' work
+-- under a span no single commit made, so nothing folds it. See
+-- git_superseded_file_changes.
 deduplicated_file_changes AS (
     SELECT
         tenant_id,
@@ -84,6 +90,10 @@ deduplicated_file_changes AS (
         lines_added,
         lines_removed
     FROM {{ ref('git_commit_file_changes') }}
+    WHERE (tenant_id, data_source, commit_hash, file_path) NOT IN (
+        SELECT tenant_id, data_source, commit_hash, file_path
+        FROM {{ ref('git_superseded_file_changes') }}
+    )
     -- INVARIANT: committer_date breaks the tie, and must stay ahead of the
     -- hash. observed_at is the AUTHOR date, which a rebase preserves — so the
     -- copy and its original tie there, and without this the survivor (and with
@@ -96,9 +106,7 @@ deduplicated_file_changes AS (
         project_key,
         repo_slug,
         file_path,
-        lower(change_type),
-        pre_image_oid,
-        post_image_oid,
+        {{ git_file_content_identity('post_image_oid', 'pre_image_oid') }},
         if(
             coalesce(pre_image_oid, '') = ''
                 AND coalesce(post_image_oid, '') = '',

--- a/src/ingestion/gold/git_superseded_file_changes.sql
+++ b/src/ingestion/gold/git_superseded_file_changes.sql
@@ -1,0 +1,99 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'data_source', 'commit_hash'],
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Paths on a merge-result commit whose work a COLLECTED commit of the same
+-- pull request already carries. The content dedup cannot reach them: a squash
+-- re-applies its branch as one span, and when only PART of the branch was
+-- collected the span matches no collected commit's own transition, so both
+-- the original and the squash's copy of it count.
+--
+-- Only PARTIAL coverage reaches this model. With every linked commit collected
+-- the whole squash is already excluded as a derived commit
+-- (git_derived_commits), and with none collected it is the only record of the
+-- work and every path of it must count.
+--
+-- Suppressed per PATH, not per commit: the squash is the only record of the
+-- commits that were never collected, so its rows for paths no collected commit
+-- touched stay. What cannot be recovered is a lost commit's delta on a path a
+-- collected commit also touched — that work is unknowable, and undercounting
+-- it is the deliberate trade against counting the collected commit's lines
+-- twice.
+--
+-- The join to the file-change class is what restricts the branch side to
+-- collected commits: an uncollected commit reaches no file row.
+
+WITH
+collected_branch_commits AS (
+    SELECT DISTINCT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        commit_hash
+    FROM {{ ref('class_git_commits') }} FINAL
+    WHERE is_merge_commit = 0
+),
+pull_request_links AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        pr_id,
+        groupUniqArray(commit_hash) AS linked_hashes,
+        uniqExactIf(
+            commit_hash,
+            (tenant_id, source_id, project_key, repo_slug, commit_hash) IN (
+                SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
+                FROM collected_branch_commits
+            )
+        ) AS collected_branch_commit_count
+    FROM {{ ref('class_git_pull_requests_commits') }} FINAL
+    GROUP BY tenant_id, source_id, project_key, repo_slug, pr_id
+),
+partly_collected_results AS (
+    SELECT DISTINCT
+        prs.tenant_id AS tenant_id,
+        prs.data_source AS data_source,
+        prs.merge_commit_hash AS commit_hash,
+        links.linked_hashes AS linked_hashes
+    FROM {{ ref('class_git_pull_requests') }} AS prs FINAL
+    INNER JOIN pull_request_links AS links
+        ON links.tenant_id = prs.tenant_id
+        AND links.source_id = prs.source_id
+        AND links.project_key = prs.project_key
+        AND links.repo_slug = prs.repo_slug
+        AND links.pr_id = prs.pr_id
+    WHERE prs.state = 'MERGED'
+      AND prs.merge_commit_hash != ''
+      AND links.collected_branch_commit_count > 0
+      AND links.collected_branch_commit_count < length(links.linked_hashes)
+      -- A fast-forward merge promotes an original, which owns its own rows.
+      AND NOT has(links.linked_hashes, prs.merge_commit_hash)
+),
+linked_commit_of_result AS (
+    SELECT
+        tenant_id,
+        data_source,
+        commit_hash,
+        linked_hash
+    FROM partly_collected_results
+    ARRAY JOIN linked_hashes AS linked_hash
+)
+SELECT DISTINCT
+    result.tenant_id AS tenant_id,
+    result.data_source AS data_source,
+    result.commit_hash AS commit_hash,
+    branch_change.file_path AS file_path
+FROM linked_commit_of_result AS result
+INNER JOIN {{ ref('class_git_file_changes') }} AS branch_change FINAL
+    ON branch_change.tenant_id IS NOT DISTINCT FROM result.tenant_id
+    AND branch_change.data_source = result.data_source
+    AND branch_change.commit_hash = result.linked_hash

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -115,14 +115,31 @@ models:
 
   - name: git_default_branch_commits
     description: >
-      Commits that reached a repository's default branch through a merged pull
-      request: one row per tenant/source/project/repo/commit. Materialized so
-      the pull-request membership joins run once per build in their own query
-      budget; the git evidence build reads it as a semi-join set alongside the
-      sync-time is_default_branch flag.
+      Commits that reached a repository's default branch, either through a
+      merged pull request or by carrying content a default-branch commit also
+      carries at the same path: one row per tenant/source/project/repo/commit.
+      Materialized so the membership joins run once per build in their own
+      query budget; the git evidence build reads it as a semi-join set
+      alongside the sync-time is_default_branch flag.
     columns:
       - name: commit_hash
         description: "Commit identifier within the repository"
+        tests:
+          - not_null
+
+  - name: git_superseded_file_changes
+    description: >
+      Paths on a merge-result commit whose work a collected commit of the same
+      pull request already carries, for the partial-coverage case the content
+      dedup cannot reach: one row per tenant/source/commit/path. The git
+      evidence build subtracts it before deduplicating file changes.
+    columns:
+      - name: commit_hash
+        description: "The merge-result commit whose copy of the path is suppressed"
+        tests:
+          - not_null
+      - name: file_path
+        description: "Path a collected commit of the same request already carries"
         tests:
           - not_null
 

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -250,6 +250,7 @@ CREATE TABLE IF NOT EXISTS insight.git_authored_commits
     `author_name` String,
     `message` String,
     `observed_at` Nullable(DateTime),
+    `committer_date` Nullable(DateTime),
     `entity_id` String,
     `metric_date` Nullable(Date),
     `lines_added` Nullable(Int64),
@@ -280,6 +281,7 @@ CREATE TABLE IF NOT EXISTS insight.git_commit_file_changes
     `repo_slug` String,
     `commit_hash` String,
     `observed_at` Nullable(DateTime),
+    `committer_date` Nullable(DateTime),
     `data_source` String,
     `file_path` String,
     `file_extension` String,
@@ -441,6 +443,18 @@ CREATE TABLE IF NOT EXISTS insight.git_review_events
 )
 ENGINE = MergeTree
 ORDER BY (tenant_id, entity_id, metric_date)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.git_superseded_file_changes
+(
+    `tenant_id` Nullable(String),
+    `data_source` String,
+    `commit_hash` String,
+    `file_path` String
+)
+ENGINE = MergeTree
+ORDER BY (tenant_id, data_source, commit_hash)
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 

--- a/src/ingestion/tests/e2e/metrics/git_squash_content_identity.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_squash_content_identity.test.yaml
@@ -1,0 +1,201 @@
+spec_version: 1
+description: >
+  A squash re-applies its branch's whole span as one step: the branch makes
+  A to B then B to C, the squash makes A to C. Content identity is the object
+  id a change PRODUCED, so the squash's copy of work already collected folds
+  away instead of counting a second time.
+
+  Each case owns a month, so every period assertion is isolated without a
+  repository dimension.
+
+  October — partial coverage, the case content identity alone cannot reach.
+  Four commits belonged to the request; two were collected before the branch
+  was squashed and deleted, two never arrived. The squash therefore stays
+  counted (it is the only record of the lost pair), and its rows are suppressed
+  per PATH: src/app.rs and src/util.rs are already carried by a collected
+  commit, src/new.rs is not.
+    * sp-c1  src/app.rs  A0 to A1  +10/-2
+    * sp-c2  src/util.rs add U1    +5
+    * sp-s   src/app.rs  A0 to A3  +30/-6   suppressed (sp-c1 carries the path)
+             src/util.rs add U1    +5       suppressed (sp-c2 carries the path)
+             src/new.rs  add N1    +7       the lost commits' only record
+    Lines +22/-2 over three commits. Sizes {12, 5, 7} — the squash's own size
+    follows the suppression down to 7 — so the median reads 7.
+    What is knowingly lost: a lost commit's delta on src/app.rs. Counting
+    sp-c1's ten lines twice is the alternative.
+
+  November — a squash pushed with NO pull request, so no membership edge
+  exists and history is rewritten beyond recovery.
+    * sn-b1  src/svc.rs  S0 to S1  +8/-1
+    * sn-b2  src/svc.rs  S1 to S2  +4/-2
+    * sn-s   src/svc.rs  S0 to S2  +12/-3   folds into sn-b2, same content S2
+    Lines +12/-3 over three commits, and the squash's size reads 0.
+    Branch scope heals through the content: sn-b2's content sits on the
+    default branch, so it reads `default`. sn-b1's S1 exists nowhere but the
+    branch — a squash carries the span's end, not its steps — so it stays
+    `non_default`. That split is the honest state, not the ideal one.
+
+  December — a deletion's identity is the content it REMOVED. One path is
+  deleted, re-added with different content, and deleted again: two removals of
+  two contents, both counted.
+    * di-c1  src/old.rs  delete X0  -5
+    * di-c2  src/old.rs  add Y0     +6
+    * di-c3  src/old.rs  delete Y0  -6
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_github.branches:
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: sq-br-partial, repository: "https://github.com/acme/squash-partial.git", name: main, head_sha: sp-s, is_default: true}
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: sq-br-nopr, repository: "https://github.com/acme/squash-nopr.git", name: main, head_sha: sn-s, is_default: true}
+
+  bronze_github.commits:
+    # October: the two collected branch commits and the squash.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: sp-c1, repository: "https://github.com/acme/squash-partial.git", sha: sp-c1, authored_date: "2026-10-01T09:00:00Z", committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 10, deletions: 2, is_in_default_branch: false}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: sp-c2, repository: "https://github.com/acme/squash-partial.git", sha: sp-c2, authored_date: "2026-10-01T10:00:00Z", committed_date: "2026-10-01T10:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 5, deletions: 0, is_in_default_branch: false}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: sp-s, repository: "https://github.com/acme/squash-partial.git", sha: sp-s, authored_date: "2026-10-01T12:00:00Z", committed_date: "2026-10-01T12:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 42, deletions: 6, is_in_default_branch: true}
+    # November: no request, so nothing links the squash to its originals.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: sn-b1, repository: "https://github.com/acme/squash-nopr.git", sha: sn-b1, authored_date: "2026-11-02T09:00:00Z", committed_date: "2026-11-02T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 8, deletions: 1, is_in_default_branch: false}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: sn-b2, repository: "https://github.com/acme/squash-nopr.git", sha: sn-b2, authored_date: "2026-11-02T10:00:00Z", committed_date: "2026-11-02T10:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 4, deletions: 2, is_in_default_branch: false}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: sn-s, repository: "https://github.com/acme/squash-nopr.git", sha: sn-s, authored_date: "2026-11-02T11:00:00Z", committed_date: "2026-11-02T11:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 12, deletions: 3, is_in_default_branch: true}
+    # December: delete, re-add with other content, delete again.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: di-c1, repository: "https://github.com/acme/delete-identity.git", sha: di-c1, authored_date: "2026-12-03T09:00:00Z", committed_date: "2026-12-03T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 0, deletions: 5, is_in_default_branch: true}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: di-c2, repository: "https://github.com/acme/delete-identity.git", sha: di-c2, authored_date: "2026-12-03T10:00:00Z", committed_date: "2026-12-03T10:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 6, deletions: 0, is_in_default_branch: true}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: di-c3, repository: "https://github.com/acme/delete-identity.git", sha: di-c3, authored_date: "2026-12-03T11:00:00Z", committed_date: "2026-12-03T11:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 0, deletions: 6, is_in_default_branch: true}
+
+  bronze_github.file_changes:
+    # October. The squash's src/app.rs span ends at A3, which no collected
+    # commit produced — nothing folds it, and only the path suppression keeps
+    # sp-c1's ten lines from counting twice.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: sp-f-c1, repository: "https://github.com/acme/squash-partial.git", sha: sp-c1, filename: src/app.rs, status: modified, additions: 10, deletions: 2, pre_image_oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00, post_image_oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: sp-f-c2, repository: "https://github.com/acme/squash-partial.git", sha: sp-c2, filename: src/util.rs, status: added, additions: 5, deletions: 0, pre_image_oid: null, post_image_oid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb01}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: sp-f-s-app, repository: "https://github.com/acme/squash-partial.git", sha: sp-s, filename: src/app.rs, status: modified, additions: 30, deletions: 6, pre_image_oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00, post_image_oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa03}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: sp-f-s-util, repository: "https://github.com/acme/squash-partial.git", sha: sp-s, filename: src/util.rs, status: added, additions: 5, deletions: 0, pre_image_oid: null, post_image_oid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb01}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: sp-f-s-new, repository: "https://github.com/acme/squash-partial.git", sha: sp-s, filename: src/new.rs, status: added, additions: 7, deletions: 0, pre_image_oid: null, post_image_oid: cccccccccccccccccccccccccccccccccccccc01}
+    # November. The squash ends where sn-b2 ended, so it folds on content.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: sn-f-b1, repository: "https://github.com/acme/squash-nopr.git", sha: sn-b1, filename: src/svc.rs, status: modified, additions: 8, deletions: 1, pre_image_oid: dddddddddddddddddddddddddddddddddddddd00, post_image_oid: dddddddddddddddddddddddddddddddddddddd01}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: sn-f-b2, repository: "https://github.com/acme/squash-nopr.git", sha: sn-b2, filename: src/svc.rs, status: modified, additions: 4, deletions: 2, pre_image_oid: dddddddddddddddddddddddddddddddddddddd01, post_image_oid: dddddddddddddddddddddddddddddddddddddd02}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: sn-f-s, repository: "https://github.com/acme/squash-nopr.git", sha: sn-s, filename: src/svc.rs, status: modified, additions: 12, deletions: 3, pre_image_oid: dddddddddddddddddddddddddddddddddddddd00, post_image_oid: dddddddddddddddddddddddddddddddddddddd02}
+    # December. Two removals, two contents.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: di-f-c1, repository: "https://github.com/acme/delete-identity.git", sha: di-c1, filename: src/old.rs, status: removed, additions: 0, deletions: 5, pre_image_oid: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee00, post_image_oid: null}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: di-f-c2, repository: "https://github.com/acme/delete-identity.git", sha: di-c2, filename: src/old.rs, status: added, additions: 6, deletions: 0, pre_image_oid: null, post_image_oid: ffffffffffffffffffffffffffffffffffffff00}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: di-f-c3, repository: "https://github.com/acme/delete-identity.git", sha: di-c3, filename: src/old.rs, status: removed, additions: 0, deletions: 6, pre_image_oid: ffffffffffffffffffffffffffffffffffffff00, post_image_oid: null}
+
+  bronze_github.pull_requests:
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: sp-pr, repo_full_name: acme/squash-partial, id: 51, number: 51, author_login: erin, base_ref: main, created_at: "2026-10-01T08:00:00Z", updated_at: "2026-10-01T12:00:00Z", closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: sp-s}
+
+  bronze_github.pull_request_diff_stats:
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: sp-ds, repo_full_name: acme/squash-partial, pull_number: 51, additions: 42, deletions: 6, author_email: erin@example.com}
+
+  bronze_github.pull_request_commits:
+    # Four commits belonged to the branch. Only the first two were collected —
+    # the request's own list is what still knows the other two existed.
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: sp-lnk-c1, sha: sp-c1, pull_number: 51, repo_full_name: acme/squash-partial, author_email: erin@example.com, is_merge: false}
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: sp-lnk-c2, sha: sp-c2, pull_number: 51, repo_full_name: acme/squash-partial, author_email: erin@example.com, is_merge: false}
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: sp-lnk-c3, sha: sp-c3, pull_number: 51, repo_full_name: acme/squash-partial, author_email: erin@example.com, is_merge: false}
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: sp-lnk-c4, sha: sp-c4, pull_number: 51, repo_full_name: acme/squash-partial, author_email: erin@example.com, is_merge: false}
+
+cases:
+  - name: A partly collected branch's squash counts only the paths no collected commit carries
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-31"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: period}
+          - metric_key: git.lines_added
+            views:
+              - {view: period}
+              - {view: breakdown, dimensions: [branch_scope]}
+          - metric_key: git.lines_removed
+            views:
+              - {view: period}
+          - metric_key: git.commit_size
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      # The squash stays counted: the two commits it alone records are real
+      # work, and dropping it would lose them.
+      - {metric: git.commits, view: period, find: {entity_id: erin@example.com}, equal: {value: 3}}
+      # 10 (sp-c1) + 5 (sp-c2) + 7 (the squash's own new path). The squash's
+      # copies of src/app.rs and src/util.rs are suppressed; counting them
+      # would read 52.
+      - {metric: git.lines_added, view: period, find: {entity_id: erin@example.com}, equal: {value: 22}}
+      - {metric: git.lines_removed, view: period, find: {entity_id: erin@example.com}, equal: {value: 2}}
+      # The squash's own size follows the suppression: 42 reported less the 35
+      # suppressed lines is 7, so the sizes are {12, 5, 7}.
+      - {metric: git.commit_size, view: period, find: {entity_id: erin@example.com}, equal: {value: 7}}
+      # The request merged into the default branch, so its commits landed.
+      - {metric: git.lines_added, view: breakdown, find: {entity_id: erin@example.com, dimensions: {key: branch_scope, value: default}}, equal: {value: 22}}
+      - {metric: git.lines_added, view: breakdown, assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'branch_scope' && d.value == 'non_default'))"}
+
+  - name: A squash with no request folds into the branch commit it ends on
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-11-01", to: "2026-11-30"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: period}
+          - metric_key: git.lines_added
+            views:
+              - {view: period}
+              - {view: breakdown, dimensions: [branch_scope]}
+          - metric_key: git.lines_removed
+            views:
+              - {view: period}
+              - {view: breakdown, dimensions: [branch_scope]}
+          - metric_key: git.commit_size
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      # Nothing links the squash to its originals, so it still counts as a
+      # commit — only its lines fold.
+      - {metric: git.commits, view: period, find: {entity_id: erin@example.com}, equal: {value: 3}}
+      # 8 + 4: the squash's span ends on content sn-b2 already produced, so it
+      # adds nothing. A pair-keyed identity would read 20.
+      - {metric: git.lines_added, view: period, find: {entity_id: erin@example.com}, equal: {value: 12}}
+      - {metric: git.lines_removed, view: period, find: {entity_id: erin@example.com}, equal: {value: 3}}
+      # Sizes {9, 6, 0} — the squash introduces no content of its own.
+      - {metric: git.commit_size, view: period, find: {entity_id: erin@example.com}, equal: {value: 6}}
+      # sn-b2's content is on the default branch, so it landed. sn-b1's
+      # intermediate version is not, and no signal can heal it.
+      - {metric: git.lines_added, view: breakdown, find: {entity_id: erin@example.com, dimensions: {key: branch_scope, value: default}}, equal: {value: 4}}
+      - {metric: git.lines_added, view: breakdown, find: {entity_id: erin@example.com, dimensions: {key: branch_scope, value: non_default}}, equal: {value: 8}}
+      - {metric: git.lines_removed, view: breakdown, find: {entity_id: erin@example.com, dimensions: {key: branch_scope, value: default}}, equal: {value: 2}}
+      - {metric: git.lines_removed, view: breakdown, find: {entity_id: erin@example.com, dimensions: {key: branch_scope, value: non_default}}, equal: {value: 1}}
+
+  - name: Two removals of two contents at one path both count
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-12-01", to: "2026-12-31"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: period}
+          - metric_key: git.lines_added
+            views:
+              - {view: period}
+          - metric_key: git.lines_removed
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      - {metric: git.commits, view: period, find: {entity_id: erin@example.com}, equal: {value: 3}}
+      - {metric: git.lines_added, view: period, find: {entity_id: erin@example.com}, equal: {value: 6}}
+      # 5 + 6. A deletion keyed on its post-image alone would carry no
+      # identity, collapse both removals into one and read 5.
+      - {metric: git.lines_removed, view: period, find: {entity_id: erin@example.com}, equal: {value: 11}}


### PR DESCRIPTION
**Why:** a squash re-applies a branch's whole span as one step — the branch makes A→B then B→C, the squash makes A→C — so the dedup key on the (pre, post) object-id pair read it as a third, unseen change. Where the squash stayed counted (no pull request, or a branch only partly collected before it was squashed and deleted), the branch's lines counted twice; and a squash pushed without a pull request left its originals labelled as never having landed.

**What changed:**
- Content identity is now the object id a change **produced**, shared by a new macro. A squash that ends where the branch ended folds into it. A deletion keeps the id it removed, so removals of different content at one path stay distinct.
- New `git_superseded_file_changes`: when only part of a branch was collected the squash stays counted (it is the only record of the lost commits), but its rows are suppressed **per path** for paths a collected commit already carries. The squash's own size follows the suppression.
- `git_default_branch_commits` also heals through content: a commit whose change sits on a default-branch commit at the same path reads `default`, which is the only signal available when there is no pull request.

**Out of scope / known limits** (documented in the models): a lost commit's delta on a path a collected commit also touched cannot be recovered — undercounting it is the deliberate trade against double-counting the collected commit; and content can only heal what survived onto the default branch, so a path's intermediate versions stay `non_default`.

**Verified:** new `git_squash_content_identity` spec covers the partial-coverage squash (+22/−2 over 3 commits, sizes {12, 5, 7}), the no-request squash (+12/−3, scope split 4/8) and the two-content deletion (−11). Full git + github suite: 27 passed, no existing expectation changed. `dbt parse` clean.

Served numbers for `lines_added`, `lines_removed`, `code_lines`, `test_change_share`, `commit_size` and the branch-scope splits shift on the next gold build wherever these cases occur.