### PR TITLE
fix(observability): stamp OTLP metric streams with their pod identity

### DIFF
--- a/deploy/gitops/system/alloy/values.yaml
+++ b/deploy/gitops/system/alloy/values.yaml
@@ -120,10 +120,47 @@ alloy:
           endpoint = "0.0.0.0:4318"
         }
         output {
-          metrics = [otelcol.processor.filter.drop_probe_routes.input]
+          metrics = [otelcol.processor.k8sattributes.pods.input]
+          traces  = [otelcol.processor.k8sattributes.pods.input]
+        }
+      }
+
+      // Two replicas of one service export identical resource identities, so
+      // their cumulative counters collide into one stored series and every
+      // scrape reads as a counter reset. Stamp each stream with its pod.
+      otelcol.processor.k8sattributes "pods" {
+        // Refuse readiness until the pod cache syncs — telemetry accepted
+        // before it would miss k8s.pod.name and collide again.
+        wait_for_metadata = true
+        extract {
+          metadata = ["k8s.pod.name"]
+        }
+        pod_association {
+          source {
+            from = "connection"
+          }
+        }
+        output {
+          metrics = [otelcol.processor.transform.instance_from_pod.input]
           traces  = [otelcol.exporter.otlp.to_tempo.input]
         }
       }
+
+      // service.instance.id is what otelcol.exporter.prometheus turns into
+      // the `instance` label.
+      otelcol.processor.transform "instance_from_pod" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            "set(attributes[\"service.instance.id\"], attributes[\"k8s.pod.name\"]) where attributes[\"service.instance.id\"] == nil",
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.filter.drop_probe_routes.input]
+        }
+      }
+
 
       // Liveness/readiness probes out of the RED metrics: they are traffic
       // nobody sent, and the toolkit records them with a coarser bucket set


### PR DESCRIPTION
**Why.** Every service runs two replicas, and the toolkit builds its OTel resource from static config only — no `service.instance.id` — so both pods' cumulative counters collide into one stored series. PromQL reads every alternation as a counter reset and `rate()` reports roughly counter÷interval, a value that grows with the counter: the RED rate panels climb forever instead of showing traffic. (#3152 removed the same collision between the two in-process recorders; the replica collision remained.)

**What changed.** The Alloy OTLP pipeline gains `otelcol.processor.k8sattributes` (pod identity from the connection's pod IP) and a transform that sets `service.instance.id` from `k8s.pod.name` where absent; `otelcol.exporter.prometheus` then emits it as the `instance` label, separating the replicas' series. Traces route through the same processor, so spans carry the pod too. **Pipeline over per-chart env plumbing:** one change covers every current and future service, and services that someday set their own `service.instance.id` win (`where … == nil`).

**Verified.** Both rendered configs pass `alloy validate`. The k8sattributes pod lookup reuses the RBAC the same release already holds for log discovery. Mirror pair in the operator gitops repo.

**Out of scope.** Purging the corrupted series window from VictoriaMetrics; existing dashboards need no change (`sum by` folds the new label).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Observability data now includes pod-level attribution for both metrics and traces.
  - Metrics automatically populate the service instance identifier from the originating pod when it is not already set.
  - Existing metric filtering and remote storage workflows remain in place, while traces continue to be delivered to the tracing backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->