### PR TITLE
fix(people): include manager in team state

### DIFF
--- a/src/frontend/src/components/portal/team-state-view.test.tsx
+++ b/src/frontend/src/components/portal/team-state-view.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@tanstack/react-router", async () => {
 
 import { portalRouter } from "@/test/portal-router";
 
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
@@ -92,7 +92,8 @@ function metric(
 
 // Roster entity ids: person UUIDs, the same key the metric grid returns.
 const LABELS = ["a", "b", "c", "d"];
-const IDS = LABELS.map(pid);
+const MEMBER_LABELS = ["boss", ...LABELS];
+const MEMBER_IDS = MEMBER_LABELS.map(pid);
 
 beforeEach(() => {
   mocks.personId = pid("boss");
@@ -103,15 +104,15 @@ beforeEach(() => {
   // git.commits is a real headline key (GROUPS card.preview) — the view
   // only renders columns from that set.
   mocks.grid.byKey = new Map([
-    ["git.commits", metric("git.commits", [[pid("a"), 10], [pid("b"), 20], [pid("c"), 30], [pid("d"), 40]], { label: "Commits" })],
+    ["git.commits", metric("git.commits", [[pid("boss"), 50], [pid("a"), 10], [pid("b"), 20], [pid("c"), 30], [pid("d"), 40]], { label: "Commits" })],
     // a ratio metric: must roll up as MEDIAN, not a summed percentage
-    ["collab.focus_time_pct", metric("collab.focus_time_pct", [[pid("a"), 40], [pid("b"), 50], [pid("c"), 60], [pid("d"), 70]], {
+    ["collab.focus_time_pct", metric("collab.focus_time_pct", [[pid("boss"), 80], [pid("a"), 40], [pid("b"), 50], [pid("c"), 60], [pid("d"), 70]], {
       computation: "avg",
       label: "Focus Time",
       format: "percent",
     } as never)],
     // ingested nowhere → its column must disappear, not paint zeros
-    ["tasks.closed", metric("tasks.closed", IDS.map((id) => [id, null]), { label: "Tasks closed" })],
+    ["tasks.closed", metric("tasks.closed", MEMBER_IDS.map((id) => [id, null]), { label: "Tasks closed" })],
   ]);
   mocks.grid.previousByKey = new Map();
   act(() => {
@@ -124,19 +125,18 @@ describe("TeamStateView", () => {
   it("renders the scope header and every member row", () => {
     render(<TeamStateView />);
     expect(screen.getByText("boss's team")).toBeInTheDocument();
-    expect(screen.getByText(/4 people · state & attention/)).toBeInTheDocument();
-    // Names come from identity now — the roster is the member list.
-    for (const label of LABELS) {
+    expect(screen.getByText(/5 people · state & attention/)).toBeInTheDocument();
+    for (const label of MEMBER_LABELS) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
   });
 
   it("sums counters into a team total and medians ratios — never the reverse", () => {
     render(<TeamStateView />);
-    expect(screen.getByText("100")).toBeInTheDocument();
+    expect(screen.getByText("150")).toBeInTheDocument();
     expect(screen.getAllByText("team total").length).toBeGreaterThan(0);
-    // median of 40,50,60,70 = 55%, NOT the 220% a sum would fabricate
-    expect(screen.getByText("55%")).toBeInTheDocument();
+    // median of 40,50,60,70,80 = 60%, NOT the 300% a sum would fabricate
+    expect(screen.getAllByText("60%").length).toBeGreaterThan(0);
     expect(screen.getAllByText("team median").length).toBeGreaterThan(0);
   });
 
@@ -147,18 +147,30 @@ describe("TeamStateView", () => {
 
   it("keeps the steady attention note when nobody diverges", () => {
     render(<TeamStateView />);
-    expect(screen.getByText("All 4 people are in their usual range this period.")).toBeInTheDocument();
+    expect(screen.getByText("All 5 people are in their usual range this period.")).toBeInTheDocument();
     expect(screen.getByText("Nothing stands out this period.")).toBeInTheDocument();
   });
 
-  it("gates on the empty roster with the People-specific label", () => {
-    mocks.tree = person("boss"); // a manager with nobody under them
+  it("includes the manager in needs attention", () => {
+    mocks.grid.byKey.set(
+      "git.commits",
+      metric("git.commits", [[pid("boss"), 0], [pid("a"), 10], [pid("b"), 20], [pid("c"), 30], [pid("d"), 40]], { label: "Commits" }),
+    );
+
+    render(<TeamStateView />);
+
+    expect(screen.getByText(/1 of 5 people stands out this period/)).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: /Commits/, expanded: false }),
+    );
+    expect(screen.getAllByText("boss")).toHaveLength(2);
+  });
+
+  it("shows a manager with no reports as a one-person scope", () => {
+    mocks.tree = person("boss");
     mocks.roster = peopleFromIdentityTree(mocks.tree);
     render(<TeamStateView />);
-    expect(
-      screen.getByText(
-        "No people in the current scope. Pick a different scope at the top of the page.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/1 people · state & attention/)).toBeInTheDocument();
+    expect(screen.getByText("boss")).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/portal/team-state-view.tsx
+++ b/src/frontend/src/components/portal/team-state-view.tsx
@@ -52,17 +52,18 @@ export function TeamStateView() {
   const orgScope = useOrgScope();
   const { pivot, roster } = orgScope;
 
-  // The roster IS the member list: identity owns who is on the team and
-  // every metric for them comes from `/v1/metric-results`. There is no second
-  // source to reconcile — the legacy per-member batch this used to call was
-  // removed upstream with the rest of the old metric UI.
+  // INVARIANT: People evaluates the selected manager with the reports-only org scope.
   const members = useMemo<TeamMember[]>(
-    () =>
-      (roster ?? []).map((entry) => ({
+    () => [
+      ...(pivot
+        ? [{ person_id: pivot.person_id, name: personDisplayName(pivot) }]
+        : []),
+      ...(roster ?? []).map((entry) => ({
         person_id: entry.person_id,
         name: personDisplayName(entry),
       })),
-    [roster],
+    ],
+    [pivot, roster],
   );
   const memberIds = useMemo(
     () => members.map((m) => normalizePersonId(m.person_id)),
@@ -215,7 +216,7 @@ export function TeamStateView() {
           {teamName ? `${teamName}'s team` : "Team"}
         </h1>
         <p className="text-sm text-muted-foreground">
-          {orgScope.count} people · state &amp; attention
+          {members.length} people · state &amp; attention
         </p>
       </div>
 


### PR DESCRIPTION
**Why.** Team-state views omitted the selected manager from metrics, attention analysis, member grid, and people counts.

**What changed.** Include the selected manager alongside scoped reports throughout the People roster view.

**Verified.** Frontend unit suite, TypeScript typecheck, and focused ESLint passed.