### PR TITLE
fix(observability): exporter-up stat reads the present, not the time range

### DIFF
--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -319,7 +319,7 @@ dashboards:
              ]}, "overrides": []},
              "options": {"colorMode": "background", "reduceOptions": {"calcs": ["lastNotNull"]}},
              "targets": [
-               {"refId": "A", "legendFormat": "{{pod}}", "expr": "nginx_up{job=\"gateway-nginx\"}"}
+               {"refId": "A", "legendFormat": "{{pod}}", "instant": true, "range": false, "expr": "nginx_up{job=\"gateway-nginx\"}"}
              ]}
           ]
         }


### PR DESCRIPTION
**Why.** After a gateway redeploy the Exporter up panel shows the replaced pods as up alongside the live ones: dead pods never publish `nginx_up=0`, their series just stop, and the panel's range query + `lastNotNull` resurrects the final `1` from anywhere in the dashboard's window.

**What changed.** The target becomes an instant query (`instant: true, range: false`), so only series with samples inside the datasource's staleness lookback exist — replaced pods disappear within minutes instead of lingering for the whole range.

**Verified.** Against a live stand right after a gateway redeploy: the instant query returns exactly the two current pods; the range+last form returns four, including two destroyed ones. Mirror pair in the operator gitops repo.