### PR TITLE
fix(observability): loki compactor actually enforces retention

### DIFF
--- a/deploy/gitops/system/loki/values.yaml
+++ b/deploy/gitops/system/loki/values.yaml
@@ -37,6 +37,11 @@ loki:
           period: 24h
   storage:
     type: filesystem
+  # INVARIANT: retention_period alone deletes nothing — only the compactor
+  # enforces it; without this block the store grows until the PVC fills.
+  compactor:
+    retention_enabled: true
+    delete_request_store: filesystem
   limits_config:
     # Keep logs cheap: 7d retention for the whole store. Per-stream
     # retention (e.g. shorter for the chatty `namespace=airbyte`) is a


### PR DESCRIPTION
**Why.** `retention_period: 168h` is configured but Loki only deletes through the compactor, which was never enabled — the store grows until its PVC fills (the gap #2183 recorded).

**What changed.** `compactor.retention_enabled: true` + `delete_request_store: filesystem`.

**Verified.** `helm template` with the pinned chart (18.11.4) renders the compactor block into the Loki config. Mirror pair in the operator gitops repo.