### PR TITLE
feat(observability): one log-level knob reaches every gears service

### DIFF
--- a/src/backend/services/analytics/helm/templates/configmap.yaml
+++ b/src/backend/services/analytics/helm/templates/configmap.yaml
@@ -23,7 +23,9 @@ data:
 
     logging:
       default:
-        console_level: info
+        # The install-wide knob: global.observability.logs.level — the same
+        # value the platform CM publishes as INSIGHT_LOG_LEVEL.
+        console_level: {{ ((((.Values.global).observability).logs).level) | default "info" }}
 
     opentelemetry:
       resource:

--- a/src/backend/services/authenticator/helm/templates/configmap.yaml
+++ b/src/backend/services/authenticator/helm/templates/configmap.yaml
@@ -28,7 +28,9 @@ data:
 
     logging:
       default:
-        console_level: info
+        # The install-wide knob: global.observability.logs.level — the same
+        # value the platform CM publishes as INSIGHT_LOG_LEVEL.
+        console_level: {{ ((((.Values.global).observability).logs).level) | default "info" }}
 
     opentelemetry:
       resource:

--- a/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
+++ b/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
@@ -11,7 +11,9 @@ data:
 
     logging:
       default:
-        console_level: info
+        # The install-wide knob: global.observability.logs.level — the same
+        # value the platform CM publishes as INSIGHT_LOG_LEVEL.
+        console_level: {{ ((((.Values.global).observability).logs).level) | default "info" }}
 
     opentelemetry:
       resource:

--- a/src/backend/services/identity-resolution/helm/templates/configmap.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/configmap.yaml
@@ -22,7 +22,9 @@ data:
 
     logging:
       default:
-        console_level: info
+        # The install-wide knob: global.observability.logs.level — the same
+        # value the platform CM publishes as INSIGHT_LOG_LEVEL.
+        console_level: {{ ((((.Values.global).observability).logs).level) | default "info" }}
 
     opentelemetry:
       resource:

--- a/src/backend/services/identity-resolution/helm/tests/test_umbrella_log_level_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_umbrella_log_level_contract.py
@@ -1,0 +1,53 @@
+"""One log-level knob across the install (insight#2488, AC-2).
+
+The umbrella publishes `global.observability.logs.level` twice: as
+INSIGHT_LOG_LEVEL in the platform ConfigMap and as `logging.default.
+console_level` in every gears service's rendered config. These tests hold the
+two surfaces to the same value, so no service can grow a level knob of its
+own without failing here.
+"""
+
+from __future__ import annotations
+
+import re
+
+from conftest import TENANT, UMBRELLA, UMBRELLA_BASE, render
+
+GEARS_SERVICES = 5  # identity-resolution, analytics, authenticator, previews, git-cli-proxy
+
+
+def rendered_console_levels(stdout: str) -> list[str]:
+    return re.findall(r"console_level:\s*(\S+)", stdout)
+
+
+def rendered_platform_level(stdout: str) -> str:
+    match = re.search(r'INSIGHT_LOG_LEVEL:\s*"?(\w+)"?', stdout)
+    assert match, "the platform ConfigMap should publish INSIGHT_LOG_LEVEL"
+    return match.group(1)
+
+
+def test_the_one_knob_reaches_every_service_config(umbrella_deps) -> None:
+    code, out, err = render(
+        UMBRELLA,
+        *UMBRELLA_BASE,
+        "--set",
+        f"global.tenantDefaultId={TENANT}",
+        "--set",
+        "global.observability.logs.level=debug",
+    )
+    assert code == 0, err
+
+    levels = rendered_console_levels(out)
+    assert len(levels) >= GEARS_SERVICES, (
+        f"expected a console_level from each of the {GEARS_SERVICES} gears services, found {len(levels)}"
+    )
+    assert set(levels) == {"debug"}, f"a service kept a level of its own: {levels}"
+    assert rendered_platform_level(out) == "debug"
+
+
+def test_the_default_is_info_on_both_surfaces(umbrella_deps) -> None:
+    code, out, err = render(UMBRELLA, *UMBRELLA_BASE, "--set", f"global.tenantDefaultId={TENANT}")
+    assert code == 0, err
+
+    assert set(rendered_console_levels(out)) == {"info"}
+    assert rendered_platform_level(out) == "info"

--- a/src/backend/services/previews/helm/templates/configmap.yaml
+++ b/src/backend/services/previews/helm/templates/configmap.yaml
@@ -21,7 +21,9 @@ data:
 
     logging:
       default:
-        console_level: info
+        # The install-wide knob: global.observability.logs.level — the same
+        # value the platform CM publishes as INSIGHT_LOG_LEVEL.
+        console_level: {{ ((((.Values.global).observability).logs).level) | default "info" }}
 
     gears:
       api-gateway:


### PR DESCRIPTION
Part of #2488 (AC-2, testing scenario 5).

**Why.** The umbrella publishes `INSIGHT_LOG_LEVEL` from `global.observability.logs.level`, but nothing reads it: every gears service's rendered config hardcodes `console_level: info`, so the documented knob is dead and each service effectively carries its own.

**What changed.** The five gears services' configmap templates render `console_level` from `global.observability.logs.level` (default `info`), making it the single install-wide knob — the same value on both surfaces. Pods already roll on its change via the existing checksum annotation. **A contract test enforces the parity:** rendering the umbrella with a non-default level must show that level in every service config and in `INSIGHT_LOG_LEVEL`, so a service growing a knob of its own fails the gate.

**Out of scope.** The rest of #2488 — one line format, required fields, leak checks, Python/SPA emitters, frontend sourcemaps (#2436).

**Verified.** New contract tests pass; the full identity-resolution helm contract suite (45 tests) passes; `RUST_LOG` remains what the toolkit documents it as — an upper-bound cap, not a second knob.