### PR TITLE
fix(claude-team): refuse a day's read that did not bring the whole roster

### DIFF
--- a/src/ingestion/connectors/ai/claude-team/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-team/connector.yaml
@@ -362,11 +362,16 @@ streams:
         extractor:
           type: DpathExtractor
           field_path: [users]
+      # An offset window is only exact over a total order, and sort_by names a
+      # measure everyone with no accepted lines ties on. A roster that fits in
+      # one page is one answer and cannot shift under the window; past the page
+      # the loss is real, which is what the staging completeness gate is for.
+      # 200 is a mitigation, not the fix — see #3172.
       paginator:
         type: DefaultPaginator
         pagination_strategy:
           type: OffsetIncrement
-          page_size: 100
+          page_size: 200
         page_token_option:
           type: RequestOption
           field_name: offset
@@ -534,7 +539,14 @@ streams:
             value: "{{ config['insight_source_id'] }}"
           - type: AddedFieldDefinition
             path: [unique_key]
-            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ stream_interval.start_time }}"
+            # The read is in the key, so each read of a day keeps its own
+            # envelope instead of overwriting the last. total_users is only
+            # true as of the read that returned it — a day still in progress
+            # legitimately reports fewer people than it ends with — so the
+            # completeness gate needs the reference belonging to the read it
+            # is judging, not the day's newest one. Same move as
+            # claude_team_overage_spend in 3.2.0.
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ stream_interval.start_time }}-{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           - type: AddedFieldDefinition
             path: [collected_at]
             value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"

--- a/src/ingestion/connectors/ai/claude-team/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-team/connector.yaml
@@ -468,6 +468,13 @@ streams:
           pr_attribution: { type: [object, "null"] }
           top_users_by_prs: { type: [array, "null"] }
           top_users_by_lines_of_code: { type: [array, "null"] }
+          # The day's headcount as the vendor counts it. The per-user stream
+          # pages the same envelope, so this is the only figure that can say
+          # whether a stored day is complete — see #3172.
+          # Declared last on purpose: the reconciler appends a new column to a
+          # table that already exists, so anywhere else would give a fresh
+          # install a different column order from a reconciled one.
+          total_users: { type: [number, "null"] }
     retriever:
       type: SimpleRetriever
       requester:

--- a/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_dev_usage.sql
@@ -66,8 +66,7 @@ WITH reference AS (
         JSONExtractInt(_airbyte_meta, 'sync_id')        AS read_id,
         -- Not aliased `total_users`: the alias shadows the source column and
         -- ClickHouse then resolves the outer reference to the aggregate itself.
-        max(toInt64OrNull(toString(total_users)))       AS read_total_users,
-        min(_airbyte_extracted_at)                      AS read_at
+        max(toInt64OrNull(toString(total_users)))       AS read_total_users
     FROM {{ source('bronze_claude_team', 'claude_team_code_metrics_org') }}
     WHERE metric_date IS NOT NULL
       AND total_users IS NOT NULL
@@ -77,14 +76,20 @@ WITH reference AS (
 
 first_reference AS (
 
-    -- When this instance began carrying references at all. Reads older than
-    -- that predate the field and cannot be judged; reads after it must carry
-    -- one, or they are rejected — an unreferenced recent read is the silent
-    -- hole this gate exists to close.
+    -- Which read first carried a reference on this instance. Reads before it
+    -- predate the field and cannot be judged; that read and everything after
+    -- must carry one, or they are rejected — an unreferenced later read is the
+    -- silent hole this gate exists to close.
+    --
+    -- The boundary is the READ, not its timestamp. Both streams are written by
+    -- the same job, but not at the same instant: on the first sync after the
+    -- upgrade the per-user rows can land a moment before the envelope that
+    -- would judge them. A timestamp boundary would wave exactly those through
+    -- as legacy.
     SELECT
         insight_tenant_id,
         source_id,
-        min(read_at)                                    AS since,
+        min(read_id)                                    AS since_read,
         toUInt8(1)                                      AS instance_has_references
     FROM reference
     GROUP BY insight_tenant_id, source_id
@@ -98,8 +103,7 @@ read_state AS (
         coalesce(source_id, '')                         AS source_id,
         toDate(metric_date)                             AS day,
         JSONExtractInt(_airbyte_meta, 'sync_id')        AS read_id,
-        uniqExact(lower(trim(coalesce(email, ''))))     AS people,
-        max(_airbyte_extracted_at)                      AS read_at
+        uniqExact(lower(trim(coalesce(email, ''))))     AS people
     FROM {{ source('bronze_claude_team', 'claude_team_code_metrics') }}
     WHERE metric_date IS NOT NULL
     GROUP BY insight_tenant_id, source_id, day, read_id
@@ -125,7 +129,7 @@ admitted_reads AS (
               FROM reference
           )
        OR coalesce(f.instance_has_references, 0) = 0
-       OR r.read_at < f.since
+       OR r.read_id < f.since_read
 
 )
 

--- a/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_dev_usage.sql
@@ -47,6 +47,88 @@
     tags=['claude-team', 'silver:class_ai_dev_usage']
 ) }}
 
+-- Completeness gate (#3172). The per-user endpoint pages an offset window over
+-- sort_by=total_lines_accepted, and everyone with no accepted lines ties on it,
+-- so a person can sit past the page boundary in one request and before it in
+-- the next — returned by neither, while every request succeeds. A read that
+-- lost somebody must not become the day's state, so it is dropped whole here
+-- and the day keeps whatever the last sound read wrote.
+WITH reference AS (
+
+    -- The vendor's own headcount, as of the read that returned it. Keyed on the
+    -- read and not the day: a day still in progress reports fewer people than it
+    -- ends with, so judging an older read against a newer reference would reject
+    -- sound reads.
+    SELECT
+        coalesce(tenant_id, '')                         AS insight_tenant_id,
+        coalesce(source_id, '')                         AS source_id,
+        toDate(metric_date)                             AS day,
+        JSONExtractInt(_airbyte_meta, 'sync_id')        AS read_id,
+        -- Not aliased `total_users`: the alias shadows the source column and
+        -- ClickHouse then resolves the outer reference to the aggregate itself.
+        max(toInt64OrNull(toString(total_users)))       AS read_total_users,
+        min(_airbyte_extracted_at)                      AS read_at
+    FROM {{ source('bronze_claude_team', 'claude_team_code_metrics_org') }}
+    WHERE metric_date IS NOT NULL
+      AND total_users IS NOT NULL
+    GROUP BY insight_tenant_id, source_id, day, read_id
+
+),
+
+first_reference AS (
+
+    -- When this instance began carrying references at all. Reads older than
+    -- that predate the field and cannot be judged; reads after it must carry
+    -- one, or they are rejected — an unreferenced recent read is the silent
+    -- hole this gate exists to close.
+    SELECT
+        insight_tenant_id,
+        source_id,
+        min(read_at)                                    AS since,
+        toUInt8(1)                                      AS instance_has_references
+    FROM reference
+    GROUP BY insight_tenant_id, source_id
+
+),
+
+read_state AS (
+
+    SELECT
+        coalesce(tenant_id, '')                         AS insight_tenant_id,
+        coalesce(source_id, '')                         AS source_id,
+        toDate(metric_date)                             AS day,
+        JSONExtractInt(_airbyte_meta, 'sync_id')        AS read_id,
+        uniqExact(lower(trim(coalesce(email, ''))))     AS people,
+        max(_airbyte_extracted_at)                      AS read_at
+    FROM {{ source('bronze_claude_team', 'claude_team_code_metrics') }}
+    WHERE metric_date IS NOT NULL
+    GROUP BY insight_tenant_id, source_id, day, read_id
+
+),
+
+admitted_reads AS (
+
+    SELECT
+        r.insight_tenant_id                             AS insight_tenant_id,
+        r.source_id                                     AS source_id,
+        r.day                                           AS day,
+        r.read_id                                       AS read_id
+    FROM read_state AS r
+    LEFT JOIN first_reference AS f
+           ON f.insight_tenant_id = r.insight_tenant_id
+          AND f.source_id = r.source_id
+    -- coalesce, not IS NULL: without join_use_nulls an unmatched LEFT JOIN
+    -- yields the column's default rather than NULL, and both readings must
+    -- give the same verdict.
+    WHERE (r.insight_tenant_id, r.source_id, r.day, r.read_id, r.people) IN (
+              SELECT insight_tenant_id, source_id, day, read_id, read_total_users
+              FROM reference
+          )
+       OR coalesce(f.instance_has_references, 0) = 0
+       OR r.read_at < f.since
+
+)
+
 SELECT
     tenant_id                                           AS insight_tenant_id,
     source_id,
@@ -112,6 +194,15 @@ WHERE email IS NOT NULL
        OR coalesce(toFloat64OrNull(toString(total_cost)), 0) > 0
        OR coalesce(prs_with_cc, 0) > 0
        OR coalesce(total_prs, 0) > 0)
+  -- The read this row came from has to have brought the whole day. Rejected
+  -- whole rather than row by row: a short read is short in an unknown place,
+  -- so the people it DID return say nothing about the ones it did not.
+  AND (coalesce(tenant_id, ''),
+       coalesce(source_id, ''),
+       toDate(metric_date),
+       JSONExtractInt(_airbyte_meta, 'sync_id')) IN (
+          SELECT insight_tenant_id, source_id, day, read_id FROM admitted_reads
+      )
 {% if is_incremental() %}
   -- Empty-table guard. Over an empty `this` (the e2e rig resets staging between
   -- tests) `max(day)` is the Date epoch (1970-01-01) and `- INTERVAL 3 DAY`

--- a/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_dev_usage.sql
@@ -67,7 +67,9 @@ WITH reference AS (
         -- Not aliased `total_users`: the alias shadows the source column and
         -- ClickHouse then resolves the outer reference to the aggregate itself.
         max(toInt64OrNull(toString(total_users)))       AS read_total_users
-    FROM {{ source('bronze_claude_team', 'claude_team_code_metrics_org') }}
+    -- FINAL: the envelope table is a ReplacingMergeTree, so an unmerged part
+    -- can still hold a superseded headcount for the same read.
+    FROM {{ source('bronze_claude_team', 'claude_team_code_metrics_org') }} FINAL
     WHERE metric_date IS NOT NULL
       AND total_users IS NOT NULL
     GROUP BY insight_tenant_id, source_id, day, read_id
@@ -103,7 +105,11 @@ read_state AS (
         coalesce(source_id, '')                         AS source_id,
         toDate(metric_date)                             AS day,
         JSONExtractInt(_airbyte_meta, 'sync_id')        AS read_id,
-        uniqExact(lower(trim(coalesce(email, ''))))     AS people
+        -- Counts only rows the serving layer can attribute, so a headcount
+        -- that includes someone arriving without an email fails the gate
+        -- closed instead of passing on a body count.
+        uniqExactIf(lower(trim(email)),
+                    email IS NOT NULL AND trim(email) != '') AS people
     FROM {{ source('bronze_claude_team', 'claude_team_code_metrics') }}
     WHERE metric_date IS NOT NULL
     GROUP BY insight_tenant_id, source_id, day, read_id

--- a/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
@@ -20,6 +20,11 @@ sources:
         freshness:
           warn_after: {count: 72, period: hour}
           error_after: {count: 120, period: hour}
+      - name: claude_team_code_metrics_org   # per-read envelope; total_users is the completeness reference
+        loaded_at_field: parseDateTimeBestEffortOrNull(metric_date)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
       - name: claude_team_overage_spend   # per-seat spend snapshot — sync-liveness default
 
 models:

--- a/src/ingestion/connectors/ai/claude-team/descriptor.yaml
+++ b/src/ingestion/connectors/ai/claude-team/descriptor.yaml
@@ -77,9 +77,12 @@ name: claude-team
 #   state in staging or silver.
 #   MINOR per ADR-0015 — additive Bronze field, no dbt output change, nothing
 #   re-materializes; the reconciler adds the snapshot column, so no ALTER ships
-#   with it. Reads written before this version carry no reference and stay
-#   admitted as legacy, which is what they honestly are; every read after the
-#   first reference lands must carry one or it is rejected.
+#   with it. Reads before the first one that carried a reference stay admitted
+#   as legacy, which is what they honestly are; that read and every one after it
+#   must carry its own or be rejected. The boundary is the read, not its clock:
+#   both streams are written by the same job but not at the same instant, so on
+#   the first sync after the upgrade the per-user rows can land just before the
+#   envelope that judges them.
 version: "3.3.0"
 # Daily at 23:50 UTC, as late in the day as the boundary allows. The seat
 # endpoint reports the billing month in progress and carries no history, so a

--- a/src/ingestion/connectors/ai/claude-team/descriptor.yaml
+++ b/src/ingestion/connectors/ai/claude-team/descriptor.yaml
@@ -59,7 +59,15 @@ name: claude-team
 #   give something to rebuild from. The daily trajectory begins here — readings
 #   already overwritten cannot be recovered, so months before this version keep
 #   their single closing figure.
-version: "3.2.0"
+# 3.3.0: claude_team_code_metrics_org declares total_users, the day's headcount
+#   the response envelope already carries and the stream already fetched and
+#   threw away. Without it nothing downstream can tell a day stored short from a
+#   quiet one, which is what #3172 needs to become detectable. MINOR per
+#   ADR-0015 — additive Bronze field, no dbt output change, nothing
+#   re-materializes; the reconciler adds the snapshot column, so no ALTER ships
+#   with it. Days written before this version carry a NULL headcount and are
+#   simply not checkable, which is what they honestly are.
+version: "3.3.0"
 # Daily at 23:50 UTC, as late in the day as the boundary allows. The seat
 # endpoint reports the billing month in progress and carries no history, so a
 # month's spend is frozen at the last read INSIDE it and whatever follows is

--- a/src/ingestion/connectors/ai/claude-team/descriptor.yaml
+++ b/src/ingestion/connectors/ai/claude-team/descriptor.yaml
@@ -59,14 +59,27 @@ name: claude-team
 #   give something to rebuild from. The daily trajectory begins here — readings
 #   already overwritten cannot be recovered, so months before this version keep
 #   their single closing figure.
-# 3.3.0: claude_team_code_metrics_org declares total_users, the day's headcount
-#   the response envelope already carries and the stream already fetched and
-#   threw away. Without it nothing downstream can tell a day stored short from a
-#   quiet one, which is what #3172 needs to become detectable. MINOR per
-#   ADR-0015 — additive Bronze field, no dbt output change, nothing
+# 3.3.0: closes #3172. claude_team_code_metrics pages an offset window over
+#   sort_by=total_lines_accepted, which is not a total order — everyone with no
+#   accepted lines ties on it — so a person could sit past the page boundary in
+#   one request and before it in the next, returned by neither, while both
+#   requests succeeded. Three changes together:
+#   claude_team_code_metrics_org declares total_users, the day's headcount the
+#   envelope already carried and the stream already fetched and threw away, and
+#   its unique_key gains the read so each read keeps its own reference —
+#   total_users is only true as of the read that returned it, and a day still in
+#   progress reports fewer people than it ends with, so a gate judging an older
+#   read against the newest reference would reject sound reads. The per-user
+#   page rises to 200, which keeps a roster that fits inside it to a single
+#   answer no window can shift under; that is a mitigation, not the fix.
+#   The fix is the completeness gate in claude_team__ai_dev_usage: a read whose
+#   distinct people do not equal its own total_users never becomes the day's
+#   state in staging or silver.
+#   MINOR per ADR-0015 — additive Bronze field, no dbt output change, nothing
 #   re-materializes; the reconciler adds the snapshot column, so no ALTER ships
-#   with it. Days written before this version carry a NULL headcount and are
-#   simply not checkable, which is what they honestly are.
+#   with it. Reads written before this version carry no reference and stay
+#   admitted as legacy, which is what they honestly are; every read after the
+#   first reference lands must carry one or it is rejected.
 version: "3.3.0"
 # Daily at 23:50 UTC, as late in the day as the boundary allows. The seat
 # endpoint reports the billing month in progress and carries no history, so a

--- a/src/ingestion/connectors/ai/claude-team/tests/config.py
+++ b/src/ingestion/connectors/ai/claude-team/tests/config.py
@@ -1,0 +1,19 @@
+"""Claude Team connector test config builder."""
+
+from __future__ import annotations
+
+from connector_tests import ConfigBuilder
+
+PROXY_URL = "https://proxy.invalid"
+ORG_ID = "org-1"
+METRICS_URL = f"{PROXY_URL}/api/claude_code/metrics_aggs/users"
+
+
+class ClaudeTeamConfigBuilder(ConfigBuilder):
+    def __init__(self) -> None:
+        super().__init__()
+        self._config.update({"claude_org_id": ORG_ID, "proxy_url": PROXY_URL, "proxy_auth_token": "token"})
+
+    def with_start_date(self, start_date: str) -> ClaudeTeamConfigBuilder:
+        self._config["start_date"] = start_date
+        return self

--- a/src/ingestion/connectors/ai/claude-team/tests/conftest.py
+++ b/src/ingestion/connectors/ai/claude-team/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Local builder modules (config.py) are importable under --import-mode=importlib.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from connector_tests.plugin import *

--- a/src/ingestion/connectors/ai/claude-team/tests/fixtures/code_metrics_page.json
+++ b/src/ingestion/connectors/ai/claude-team/tests/fixtures/code_metrics_page.json
@@ -1,0 +1,11 @@
+{
+  "organization_id": "org-1",
+  "start_date": "2026-08-19",
+  "end_date": "2026-08-19",
+  "total_users": 0,
+  "users": [],
+  "pagination": {"limit": 100, "offset": 0, "total": 0, "has_next": false},
+  "pr_attribution": null,
+  "top_users_by_prs": [],
+  "top_users_by_lines_of_code": []
+}

--- a/src/ingestion/connectors/ai/claude-team/tests/fixtures/code_metrics_user.json
+++ b/src/ingestion/connectors/ai/claude-team/tests/fixtures/code_metrics_user.json
@@ -1,0 +1,15 @@
+{
+  "email": "person@example.com",
+  "api_key_name": null,
+  "account_uuid": null,
+  "status": "active",
+  "avg_cost_per_day": "0.0",
+  "avg_lines_accepted_per_day": 0,
+  "total_cost": "0.0",
+  "total_lines_accepted": 0,
+  "total_sessions": 1,
+  "last_active": "2026-08-19T00:00:00",
+  "prs_with_cc": 0,
+  "total_prs": 0,
+  "prs_with_cc_percentage": 0.0
+}

--- a/src/ingestion/connectors/ai/claude-team/tests/test_claude_team_code_metrics_pagination.py
+++ b/src/ingestion/connectors/ai/claude-team/tests/test_claude_team_code_metrics_pagination.py
@@ -1,0 +1,175 @@
+"""A day's roster must arrive whole, however the vendor orders it.
+
+`claude_team_code_metrics` asks the vendor to sort by `total_lines_accepted`
+descending and then walks the answer by offset. That sort is not a total order:
+everyone who accepted no lines that day ties on the sort key, and the vendor
+promises no tiebreak. Two requests are two separate answers, so a person inside
+the tied block can sit past the page boundary in the first answer and before it
+in the second — returned by neither, while both requests succeed.
+
+The rule these tests state is the one that matters downstream: every person the
+vendor lists for a day reaches the stream. How many requests it takes is the
+manifest's business, so the mock serves whatever page size the manifest declares
+rather than pinning a number.
+
+The companion rule is that the day carries its own total. The envelope reports
+how many people the vendor has for the day; storing it is what lets a short read
+be detected instead of passing for a quiet day.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+from config import METRICS_URL, ORG_ID, ClaudeTeamConfigBuilder
+from connector_tests import (
+    HttpMocker,
+    HttpRequest,
+    HttpResponse,
+    connector_dir,
+    load_fixture,
+    read_stream,
+    stream_schema,
+)
+from freezegun import freeze_time
+
+_CONNECTOR = "ai/claude-team"
+_USER_STREAM = "claude_team_code_metrics"
+_ORG_STREAM = "claude_team_code_metrics_org"
+_DAY = "2026-08-19"
+_NOW = f"{_DAY}T11:30:00Z"
+
+# Five people accepted lines that day and 100 did not, so the tied block is
+# wider than any page the manifest is likely to ask for.
+_WORKED = [f"worked-{i:02d}@example.com" for i in range(5)]
+_IDLE = [f"idle-{i:03d}@example.com" for i in range(100)]
+_ROSTER = _WORKED + _IDLE
+
+
+def _page_size() -> int:
+    """The page size the manifest declares for the user stream."""
+    manifest = yaml.safe_load((connector_dir(_CONNECTOR) / "connector.yaml").read_text())
+    stream = next(s for s in manifest["streams"] if s.get("name") == _USER_STREAM)
+    return int(stream["retriever"]["paginator"]["pagination_strategy"]["page_size"])
+
+
+def _user(email: str, lines: int) -> dict:
+    return load_fixture(
+        __file__,
+        "code_metrics_user.json",
+        email=email,
+        total_lines_accepted=lines,
+        avg_lines_accepted_per_day=lines,
+        last_active=f"{_DAY}T00:00:00",
+    )
+
+
+def _envelope(users: list[dict], limit: int, offset: int) -> HttpResponse:
+    body = load_fixture(__file__, "code_metrics_page.json")
+    body["organization_id"] = ORG_ID
+    body["start_date"] = _DAY
+    body["end_date"] = _DAY
+    body["total_users"] = len(_ROSTER)
+    body["users"] = users
+    body["pagination"] = {
+        "limit": limit,
+        "offset": offset,
+        "total": len(_ROSTER),
+        "has_next": offset + len(users) < len(_ROSTER),
+    }
+    return HttpResponse(body=json.dumps(body), status_code=200)
+
+
+def _org_params(limit: int) -> dict[str, str]:
+    """The org stream asks for the envelope only — no sort, no paging."""
+    return {
+        "organization_uuid": ORG_ID,
+        "customer_type": "claude_ai",
+        "subscription_type": "team",
+        "start_date": _DAY,
+        "end_date": _DAY,
+        "limit": str(limit),
+    }
+
+
+def _params(limit: int, offset: int | None = None) -> dict[str, str]:
+    params = _org_params(limit) | {"sort_by": "total_lines_accepted", "sort_order": "desc"}
+    if offset is not None:
+        params["offset"] = str(offset)
+    return params
+
+
+def _ordering(rotate_ties_by: int) -> list[str]:
+    """The vendor's answer for one request: the people who accepted lines first,
+    then the tied block in an order this request happens to have chosen."""
+    ties = _IDLE[rotate_ties_by:] + _IDLE[:rotate_ties_by]
+    return _WORKED + ties
+
+
+def _emails(output) -> set[str]:
+    return {r.record.data["email"] for r in output.records}
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#3172 is open: the stream still pages by offset over a sort key that "
+    "is not unique. Strict, so this flips to a failure the moment the ordering "
+    "becomes total and stops being a reproduction.",
+)
+def test_no_one_is_lost_when_the_vendor_reorders_the_tied_block(http_mocker: HttpMocker) -> None:
+    """Every person the vendor lists for the day reaches the stream, even when
+    the order of the people tied on the sort key differs between requests."""
+    page_size = _page_size()
+    config = ClaudeTeamConfigBuilder().with_start_date(_DAY).build()
+
+    first = _ordering(rotate_ties_by=0)[:page_size]
+    http_mocker.get(
+        HttpRequest(METRICS_URL, query_params=_params(page_size)),
+        _envelope([_user(e, 100 if e in _WORKED else 0) for e in first], page_size, 0),
+    )
+    if page_size < len(_ROSTER):
+        # The second request is a second answer, and the vendor may lay the tied
+        # block out differently in it.
+        second = _ordering(rotate_ties_by=50)[page_size:]
+        http_mocker.get(
+            HttpRequest(METRICS_URL, query_params=_params(page_size, offset=page_size)),
+            _envelope([_user(e, 100 if e in _WORKED else 0) for e in second], page_size, page_size),
+        )
+
+    with freeze_time(_NOW):
+        output = read_stream(_CONNECTOR, _USER_STREAM, config)
+
+    assert not output.errors, f"the read failed: {output.errors}"
+    missing = sorted(set(_ROSTER) - _emails(output))
+    assert not missing, (
+        f"{len(missing)} of {len(_ROSTER)} people the vendor listed for {_DAY} never reached "
+        f"the stream, and the read reported no error. First few: {missing[:5]}"
+    )
+
+
+def test_the_day_carries_the_vendor_s_own_headcount(http_mocker: HttpMocker) -> None:
+    """The org-level row stores how many people the vendor has for the day, so a
+    day stored short can be told apart from a quiet one.
+
+    The declared schema is asserted alongside the record: the envelope always
+    carries the count, but only a declared field becomes a Bronze column, so a
+    record-only check would pass over the gap that matters.
+    """
+    config = ClaudeTeamConfigBuilder().with_start_date(_DAY).build()
+    http_mocker.get(HttpRequest(METRICS_URL, query_params=_org_params(1)), _envelope([_user(_WORKED[0], 100)], 1, 0))
+
+    with freeze_time(_NOW):
+        output = read_stream(_CONNECTOR, _ORG_STREAM, config)
+
+    assert not output.errors, f"the read failed: {output.errors}"
+    assert len(output.records) == 1
+    assert output.records[0].record.data.get("total_users") == len(_ROSTER)
+
+    declared = stream_schema(_CONNECTOR, _ORG_STREAM)["properties"]
+    assert "total_users" in declared, (
+        "the org stream does not declare total_users, so the vendor's headcount for "
+        "the day never becomes a Bronze column and nothing downstream can tell a "
+        f"short read from a quiet day. Declared: {sorted(declared)}"
+    )

--- a/src/ingestion/connectors/ai/claude-team/tests/test_claude_team_code_metrics_pagination.py
+++ b/src/ingestion/connectors/ai/claude-team/tests/test_claude_team_code_metrics_pagination.py
@@ -1,4 +1,4 @@
-"""A day's roster must arrive whole, however the vendor orders it.
+"""A day's roster must arrive whole, or the day must be recognisably short.
 
 `claude_team_code_metrics` asks the vendor to sort by `total_lines_accepted`
 descending and then walks the answer by offset. That sort is not a total order:
@@ -7,21 +7,24 @@ promises no tiebreak. Two requests are two separate answers, so a person inside
 the tied block can sit past the page boundary in the first answer and before it
 in the second — returned by neither, while both requests succeed.
 
-The rule these tests state is the one that matters downstream: every person the
-vendor lists for a day reaches the stream. How many requests it takes is the
-manifest's business, so the mock serves whatever page size the manifest declares
-rather than pinning a number.
+A declarative stream cannot refuse its own read, so the defect is answered in
+two places and these tests cover the connector's half of it:
 
-The companion rule is that the day carries its own total. The envelope reports
-how many people the vendor has for the day; storing it is what lets a short read
-be detected instead of passing for a quiet day.
+* a roster that fits inside one page is one answer, and no window can shift
+  under it — the happy path below;
+* a roster past the page is still lossy, and what makes it *recoverable* is
+  that the day's own headcount comes back in the envelope. The reproduction
+  proves the loss and proves the headcount exposes it, which is the signal
+  `claude_team__ai_dev_usage` gates on.
+
+The mock serves whatever page size the manifest declares, so raising or lowering
+that number cannot quietly turn either test into a different one.
 """
 
 from __future__ import annotations
 
 import json
 
-import pytest
 import yaml
 from config import METRICS_URL, ORG_ID, ClaudeTeamConfigBuilder
 from connector_tests import (
@@ -41,11 +44,9 @@ _ORG_STREAM = "claude_team_code_metrics_org"
 _DAY = "2026-08-19"
 _NOW = f"{_DAY}T11:30:00Z"
 
-# Five people accepted lines that day and 100 did not, so the tied block is
-# wider than any page the manifest is likely to ask for.
+# Five people accepted lines that day; everyone else is tied at zero and is
+# therefore free to move between one answer and the next.
 _WORKED = [f"worked-{i:02d}@example.com" for i in range(5)]
-_IDLE = [f"idle-{i:03d}@example.com" for i in range(100)]
-_ROSTER = _WORKED + _IDLE
 
 
 def _page_size() -> int:
@@ -53,6 +54,11 @@ def _page_size() -> int:
     manifest = yaml.safe_load((connector_dir(_CONNECTOR) / "connector.yaml").read_text())
     stream = next(s for s in manifest["streams"] if s.get("name") == _USER_STREAM)
     return int(stream["retriever"]["paginator"]["pagination_strategy"]["page_size"])
+
+
+def _roster(size: int) -> list[str]:
+    idle = [f"idle-{i:03d}@example.com" for i in range(size - len(_WORKED))]
+    return _WORKED + idle
 
 
 def _user(email: str, lines: int) -> dict:
@@ -66,18 +72,18 @@ def _user(email: str, lines: int) -> dict:
     )
 
 
-def _envelope(users: list[dict], limit: int, offset: int) -> HttpResponse:
+def _envelope(emails: list[str], roster_size: int, limit: int, offset: int) -> HttpResponse:
     body = load_fixture(__file__, "code_metrics_page.json")
     body["organization_id"] = ORG_ID
     body["start_date"] = _DAY
     body["end_date"] = _DAY
-    body["total_users"] = len(_ROSTER)
-    body["users"] = users
+    body["total_users"] = roster_size
+    body["users"] = [_user(e, 100 if e in _WORKED else 0) for e in emails]
     body["pagination"] = {
         "limit": limit,
         "offset": offset,
-        "total": len(_ROSTER),
-        "has_next": offset + len(users) < len(_ROSTER),
+        "total": roster_size,
+        "has_next": offset + len(emails) < roster_size,
     }
     return HttpResponse(body=json.dumps(body), status_code=200)
 
@@ -101,52 +107,74 @@ def _params(limit: int, offset: int | None = None) -> dict[str, str]:
     return params
 
 
-def _ordering(rotate_ties_by: int) -> list[str]:
-    """The vendor's answer for one request: the people who accepted lines first,
-    then the tied block in an order this request happens to have chosen."""
-    ties = _IDLE[rotate_ties_by:] + _IDLE[:rotate_ties_by]
-    return _WORKED + ties
+def _answer(roster: list[str], rotate_ties_by: int) -> list[str]:
+    """One request's answer: the people who accepted lines first, then the tied
+    block in the order this particular request happened to choose."""
+    ties = roster[len(_WORKED) :]
+    return _WORKED + ties[rotate_ties_by:] + ties[:rotate_ties_by]
 
 
-def _emails(output) -> set[str]:
-    return {r.record.data["email"] for r in output.records}
+def _emails(output) -> list[str]:
+    return [r.record.data["email"] for r in output.records]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#3172 is open: the stream still pages by offset over a sort key that "
-    "is not unique. Strict, so this flips to a failure the moment the ordering "
-    "becomes total and stops being a reproduction.",
-)
-def test_no_one_is_lost_when_the_vendor_reorders_the_tied_block(http_mocker: HttpMocker) -> None:
-    """Every person the vendor lists for the day reaches the stream, even when
-    the order of the people tied on the sort key differs between requests."""
+def test_a_roster_that_fits_one_page_arrives_whole(http_mocker: HttpMocker) -> None:
+    """Under the page size there is one request and one answer, so there is no
+    boundary for anyone to fall through."""
     page_size = _page_size()
+    roster = _roster(page_size - 5)
     config = ClaudeTeamConfigBuilder().with_start_date(_DAY).build()
 
-    first = _ordering(rotate_ties_by=0)[:page_size]
     http_mocker.get(
         HttpRequest(METRICS_URL, query_params=_params(page_size)),
-        _envelope([_user(e, 100 if e in _WORKED else 0) for e in first], page_size, 0),
+        _envelope(_answer(roster, rotate_ties_by=0), len(roster), page_size, 0),
     )
-    if page_size < len(_ROSTER):
-        # The second request is a second answer, and the vendor may lay the tied
-        # block out differently in it.
-        second = _ordering(rotate_ties_by=50)[page_size:]
-        http_mocker.get(
-            HttpRequest(METRICS_URL, query_params=_params(page_size, offset=page_size)),
-            _envelope([_user(e, 100 if e in _WORKED else 0) for e in second], page_size, page_size),
-        )
 
     with freeze_time(_NOW):
         output = read_stream(_CONNECTOR, _USER_STREAM, config)
 
     assert not output.errors, f"the read failed: {output.errors}"
-    missing = sorted(set(_ROSTER) - _emails(output))
-    assert not missing, (
-        f"{len(missing)} of {len(_ROSTER)} people the vendor listed for {_DAY} never reached "
-        f"the stream, and the read reported no error. First few: {missing[:5]}"
+    assert sorted(set(_emails(output))) == sorted(roster)
+    assert len(_emails(output)) == len(roster), "a single page emitted a person twice"
+
+
+def test_a_roster_past_the_page_loses_people_and_the_headcount_shows_it(http_mocker: HttpMocker) -> None:
+    """Past the page the tied block can be laid out differently in each answer,
+    and then the walk both drops people and repeats others — in equal number,
+    because every person who moves one way across the boundary displaces one
+    moving the other. Neither request fails, so the only thing that betrays the
+    short day is the headcount the envelope carries."""
+    page_size = _page_size()
+    roster = _roster(page_size + 5)
+    config = ClaudeTeamConfigBuilder().with_start_date(_DAY).build()
+
+    first = _answer(roster, rotate_ties_by=0)[:page_size]
+    second = _answer(roster, rotate_ties_by=len(roster) // 2)[page_size:]
+    http_mocker.get(
+        HttpRequest(METRICS_URL, query_params=_params(page_size)), _envelope(first, len(roster), page_size, 0)
     )
+    http_mocker.get(
+        HttpRequest(METRICS_URL, query_params=_params(page_size, offset=page_size)),
+        _envelope(second, len(roster), page_size, page_size),
+    )
+
+    with freeze_time(_NOW):
+        output = read_stream(_CONNECTOR, _USER_STREAM, config)
+
+    emitted = _emails(output)
+    distinct = set(emitted)
+    missing = sorted(set(roster) - distinct)
+
+    assert not output.errors, (
+        "the read reported an error — if the stream has learnt to refuse a short "
+        "read, this test is describing behaviour that no longer exists"
+    )
+    assert missing, "the mock did not reproduce the cross-page shift"
+    assert len(emitted) - len(distinct) == len(missing), (
+        f"gaps and duplicates should balance: {len(emitted)} emitted, {len(distinct)} distinct, {len(missing)} missing"
+    )
+    # The gate downstream compares exactly these two numbers.
+    assert len(distinct) < len(roster)
 
 
 def test_the_day_carries_the_vendor_s_own_headcount(http_mocker: HttpMocker) -> None:
@@ -157,15 +185,16 @@ def test_the_day_carries_the_vendor_s_own_headcount(http_mocker: HttpMocker) -> 
     carries the count, but only a declared field becomes a Bronze column, so a
     record-only check would pass over the gap that matters.
     """
+    roster = _roster(_page_size() + 5)
     config = ClaudeTeamConfigBuilder().with_start_date(_DAY).build()
-    http_mocker.get(HttpRequest(METRICS_URL, query_params=_org_params(1)), _envelope([_user(_WORKED[0], 100)], 1, 0))
+    http_mocker.get(HttpRequest(METRICS_URL, query_params=_org_params(1)), _envelope([_WORKED[0]], len(roster), 1, 0))
 
     with freeze_time(_NOW):
         output = read_stream(_CONNECTOR, _ORG_STREAM, config)
 
     assert not output.errors, f"the read failed: {output.errors}"
     assert len(output.records) == 1
-    assert output.records[0].record.data.get("total_users") == len(_ROSTER)
+    assert output.records[0].record.data.get("total_users") == len(roster)
 
     declared = stream_schema(_CONNECTOR, _ORG_STREAM)["properties"]
     assert "total_users" in declared, (
@@ -173,3 +202,23 @@ def test_the_day_carries_the_vendor_s_own_headcount(http_mocker: HttpMocker) -> 
         "the day never becomes a Bronze column and nothing downstream can tell a "
         f"short read from a quiet day. Declared: {sorted(declared)}"
     )
+
+
+def test_each_read_of_a_day_keeps_its_own_headcount(http_mocker: HttpMocker) -> None:
+    """The org row's key carries the read, not just the day. A headcount is only
+    true as of the read that returned it — a day still in progress reports fewer
+    people than it ends with — so a later read must not overwrite the reference
+    an earlier one left behind."""
+    roster = _roster(_page_size() + 5)
+    config = ClaudeTeamConfigBuilder().with_start_date(_DAY).build()
+    http_mocker.get(HttpRequest(METRICS_URL, query_params=_org_params(1)), _envelope([_WORKED[0]], len(roster), 1, 0))
+
+    with freeze_time(_NOW):
+        output = read_stream(_CONNECTOR, _ORG_STREAM, config)
+
+    key = output.records[0].record.data["unique_key"]
+    assert key.endswith("T11:30:00Z"), (
+        f"the org row's key does not name the read: {key!r}. Without it a later "
+        "read of the same day replaces the reference the gate needs."
+    )
+    assert _DAY in key, f"the org row's key no longer names the day: {key!r}"

--- a/src/ingestion/dbt/tests/ai/assert_ai_dev_usage_read_was_complete.sql
+++ b/src/ingestion/dbt/tests/ai/assert_ai_dev_usage_read_was_complete.sql
@@ -1,0 +1,101 @@
+{{ config(
+    tags=['data_quality'],
+    severity='warn',
+    store_failures=true,
+    meta={
+        'title': 'every stored Claude Team day came from a read that brought the whole roster',
+        'domain': 'ai',
+        'category': 'completeness',
+        'tier': 'error',
+        'remediation': 'A row here is a day whose newest read did not bring everyone the vendor counted for it, so the day is either missing people or is being served from an older read. The per-user endpoint pages an offset window over a sort on accepted lines, and everyone with no accepted lines ties on that sort, so a person can fall between two pages while both requests succeed (#3172). The staging model refuses such a read, which is why the day is stale rather than wrong — it clears itself once a read returns the full roster, and the next scheduled sync re-reads the last three days. A day that stays here across several syncs means the roster no longer fits the request page: raise the page size on claude_team_code_metrics. A day reported as unreferenced instead means the read carried no envelope to check it against, which should not happen after the org stream starts reporting total_users.'
+    }
+) }}
+
+{#- Reads the same reference the gate in claude_team__ai_dev_usage reads, and
+    reports what the gate silently withheld. The gate protects the serving
+    layer; this makes the withholding visible, because a day quietly served
+    from an older read looks exactly like a quiet day.
+
+    Legacy reads — those older than the instance's first reference — are not
+    reported: the envelope did not carry a headcount yet, so there is nothing
+    they could be judged against. -#}
+
+WITH reference AS (
+
+    SELECT
+        coalesce(tenant_id, '')                         AS insight_tenant_id,
+        coalesce(source_id, '')                         AS source_id,
+        toDate(metric_date)                             AS day,
+        JSONExtractInt(_airbyte_meta, 'sync_id')        AS read_id,
+        -- Not aliased `total_users`: the alias would shadow the source
+        -- column and ClickHouse then resolves the outer WHERE to the
+        -- aggregate itself.
+        max(toInt64OrNull(toString(total_users)))       AS read_total_users,
+        min(_airbyte_extracted_at)                      AS read_at
+    FROM {{ source('bronze_claude_team', 'claude_team_code_metrics_org') }}
+    WHERE metric_date IS NOT NULL
+      AND total_users IS NOT NULL
+    GROUP BY insight_tenant_id, source_id, day, read_id
+
+),
+
+first_reference AS (
+
+    SELECT
+        insight_tenant_id,
+        source_id,
+        min(read_at)                                    AS since
+    FROM reference
+    GROUP BY insight_tenant_id, source_id
+
+),
+
+newest_read AS (
+
+    -- The inner alias is deliberately not `read_at`: ClickHouse resolves the
+    -- outer aggregate's argument against the outer name first and then reports
+    -- an aggregate inside an aggregate.
+    SELECT
+        insight_tenant_id,
+        source_id,
+        day,
+        argMax(read_id, last_seen)                      AS read_id,
+        argMax(people, last_seen)                       AS people,
+        max(last_seen)                                  AS read_at
+    FROM (
+        SELECT
+            coalesce(tenant_id, '')                     AS insight_tenant_id,
+            coalesce(source_id, '')                     AS source_id,
+            toDate(metric_date)                         AS day,
+            JSONExtractInt(_airbyte_meta, 'sync_id')    AS read_id,
+            uniqExact(lower(trim(coalesce(email, '')))) AS people,
+            max(_airbyte_extracted_at)                  AS last_seen
+        FROM {{ source('bronze_claude_team', 'claude_team_code_metrics') }}
+        WHERE metric_date IS NOT NULL
+        GROUP BY insight_tenant_id, source_id, day, read_id
+    )
+    GROUP BY insight_tenant_id, source_id, day
+
+)
+
+SELECT
+    n.insight_tenant_id                                 AS insight_tenant_id,
+    n.source_id                                         AS source_id,
+    n.day                                               AS day,
+    n.read_id                                           AS read_id,
+    n.people                                            AS people_the_read_returned,
+    r.read_total_users                                  AS people_the_vendor_counted,
+    if(r.read_total_users IS NULL, 'unreferenced', 'short') AS verdict
+FROM newest_read AS n
+INNER JOIN first_reference AS f
+        ON f.insight_tenant_id = n.insight_tenant_id
+       AND f.source_id = n.source_id
+LEFT JOIN reference AS r
+       ON r.insight_tenant_id = n.insight_tenant_id
+      AND r.source_id = n.source_id
+      AND r.day = n.day
+      AND r.read_id = n.read_id
+-- Only reads that should have carried a reference: anything older than this
+-- instance's first one predates the field.
+WHERE n.read_at >= f.since
+  AND (r.read_total_users IS NULL OR n.people != r.read_total_users)

--- a/src/ingestion/dbt/tests/ai/assert_ai_dev_usage_read_was_complete.sql
+++ b/src/ingestion/dbt/tests/ai/assert_ai_dev_usage_read_was_complete.sql
@@ -7,16 +7,21 @@
         'domain': 'ai',
         'category': 'completeness',
         'tier': 'error',
-        'remediation': 'A row here is a day whose newest read did not bring everyone the vendor counted for it, so the day is either missing people or is being served from an older read. The per-user endpoint pages an offset window over a sort on accepted lines, and everyone with no accepted lines ties on that sort, so a person can fall between two pages while both requests succeed (#3172). The staging model refuses such a read, which is why the day is stale rather than wrong — it clears itself once a read returns the full roster, and the next scheduled sync re-reads the last three days. A day that stays here across several syncs means the roster no longer fits the request page: raise the page size on claude_team_code_metrics. A day reported as unreferenced instead means the read carried no envelope to check it against, which should not happen after the org stream starts reporting total_users.'
+        'remediation': 'A row here is a day whose newest read did not bring everyone the vendor counted for it, so the day is either missing people or is being served from an older read. The per-user endpoint pages an offset window over a sort on accepted lines, and everyone with no accepted lines ties on that sort, so a person can fall between two pages while both requests succeed (#3172). The staging model refuses such a read, which is why the day is stale rather than wrong — it clears itself once a read returns the full roster, and the next scheduled sync re-reads the last three days. A day that stays here across several syncs means the roster no longer fits the request page: raise the page size on claude_team_code_metrics. verdict=unreferenced means the read carried no envelope to check it against, which should not happen once the org stream reports total_users. verdict=empty means the envelope counted people and the read stored none at all — the whole day is missing, not part of it.'
     }
 ) }}
 
 {#- Reads the same reference the gate in claude_team__ai_dev_usage reads, and
-    reports what the gate silently withheld. The gate protects the serving
-    layer; this makes the withholding visible, because a day quietly served
-    from an older read looks exactly like a quiet day.
+    reports what the gate withheld. The gate protects the serving layer; this
+    makes the withholding visible, because a day quietly served from an older
+    read looks exactly like a quiet day.
 
-    Legacy reads — those older than the instance's first reference — are not
+    Candidates come from the reference AND the user reads, not from the user
+    reads alone: a day whose envelope counted people while no per-user row
+    arrived has nothing to group, so judging only what arrived would pass over
+    the very case where everything is missing.
+
+    Legacy reads — those before the first reference-carrying read — are not
     reported: the envelope did not carry a headcount yet, so there is nothing
     they could be judged against. -#}
 
@@ -27,11 +32,10 @@ WITH reference AS (
         coalesce(source_id, '')                         AS source_id,
         toDate(metric_date)                             AS day,
         JSONExtractInt(_airbyte_meta, 'sync_id')        AS read_id,
-        -- Not aliased `total_users`: the alias would shadow the source
-        -- column and ClickHouse then resolves the outer WHERE to the
-        -- aggregate itself.
         max(toInt64OrNull(toString(total_users)))       AS read_total_users
-    FROM {{ source('bronze_claude_team', 'claude_team_code_metrics_org') }}
+    -- FINAL: the envelope table is a ReplacingMergeTree, so an unmerged part
+    -- can still hold a superseded headcount for the same read.
+    FROM {{ source('bronze_claude_team', 'claude_team_code_metrics_org') }} FINAL
     WHERE metric_date IS NOT NULL
       AND total_users IS NOT NULL
     GROUP BY insight_tenant_id, source_id, day, read_id
@@ -52,48 +56,101 @@ first_reference AS (
 
 ),
 
-newest_read AS (
+user_reads AS (
+
+    SELECT
+        coalesce(tenant_id, '')                         AS insight_tenant_id,
+        coalesce(source_id, '')                         AS source_id,
+        toDate(metric_date)                             AS day,
+        JSONExtractInt(_airbyte_meta, 'sync_id')        AS read_id,
+        -- Only people the serving layer could attribute, matching the gate.
+        uniqExactIf(lower(trim(email)),
+                    email IS NOT NULL AND trim(email) != '') AS people,
+        max(_airbyte_extracted_at)                      AS last_seen
+    FROM {{ source('bronze_claude_team', 'claude_team_code_metrics') }}
+    WHERE metric_date IS NOT NULL
+    GROUP BY insight_tenant_id, source_id, day, read_id
+
+),
+
+newest_user_read AS (
 
     SELECT
         insight_tenant_id,
         source_id,
         day,
         argMax(read_id, last_seen)                      AS read_id,
-        argMax(people, last_seen)                       AS people
-    FROM (
-        SELECT
-            coalesce(tenant_id, '')                     AS insight_tenant_id,
-            coalesce(source_id, '')                     AS source_id,
-            toDate(metric_date)                         AS day,
-            JSONExtractInt(_airbyte_meta, 'sync_id')    AS read_id,
-            uniqExact(lower(trim(coalesce(email, '')))) AS people,
-            max(_airbyte_extracted_at)                  AS last_seen
-        FROM {{ source('bronze_claude_team', 'claude_team_code_metrics') }}
-        WHERE metric_date IS NOT NULL
-        GROUP BY insight_tenant_id, source_id, day, read_id
-    )
+        argMax(people, last_seen)                       AS people,
+        toUInt8(1)                                      AS had_rows
+    FROM user_reads
     GROUP BY insight_tenant_id, source_id, day
+
+),
+
+newest_reference_read AS (
+
+    SELECT
+        insight_tenant_id,
+        source_id,
+        day,
+        max(read_id)                                    AS read_id
+    FROM reference
+    GROUP BY insight_tenant_id, source_id, day
+
+),
+
+candidates AS (
+
+    SELECT insight_tenant_id, source_id, day FROM reference
+    UNION DISTINCT
+    SELECT insight_tenant_id, source_id, day FROM user_reads
+
+),
+
+judged AS (
+
+    SELECT
+        c.insight_tenant_id                             AS insight_tenant_id,
+        c.source_id                                     AS source_id,
+        c.day                                           AS day,
+        -- The read that decides the day: the newest one that stored rows, or —
+        -- when none did — the newest envelope, so a day that stored nothing is
+        -- still judged rather than skipped for having nothing to group.
+        if(coalesce(u.had_rows, 0) = 1, u.read_id, nr.read_id) AS read_id,
+        coalesce(u.people, 0)                           AS people,
+        coalesce(u.had_rows, 0)                         AS had_rows
+    FROM candidates AS c
+    LEFT JOIN newest_user_read AS u
+           ON u.insight_tenant_id = c.insight_tenant_id
+          AND u.source_id = c.source_id
+          AND u.day = c.day
+    LEFT JOIN newest_reference_read AS nr
+           ON nr.insight_tenant_id = c.insight_tenant_id
+          AND nr.source_id = c.source_id
+          AND nr.day = c.day
 
 )
 
 SELECT
-    n.insight_tenant_id                                 AS insight_tenant_id,
-    n.source_id                                         AS source_id,
-    n.day                                               AS day,
-    n.read_id                                           AS read_id,
-    n.people                                            AS people_the_read_returned,
+    j.insight_tenant_id                                 AS insight_tenant_id,
+    j.source_id                                         AS source_id,
+    j.day                                               AS day,
+    j.read_id                                           AS read_id,
+    j.people                                            AS people_the_read_returned,
     r.read_total_users                                  AS people_the_vendor_counted,
-    if(r.read_total_users IS NULL, 'unreferenced', 'short') AS verdict
-FROM newest_read AS n
+    multiIf(r.read_total_users IS NULL, 'unreferenced',
+            j.had_rows = 0, 'empty',
+            'short')                                    AS verdict
+FROM judged AS j
 INNER JOIN first_reference AS f
-        ON f.insight_tenant_id = n.insight_tenant_id
-       AND f.source_id = n.source_id
+        ON f.insight_tenant_id = j.insight_tenant_id
+       AND f.source_id = j.source_id
 LEFT JOIN reference AS r
-       ON r.insight_tenant_id = n.insight_tenant_id
-      AND r.source_id = n.source_id
-      AND r.day = n.day
-      AND r.read_id = n.read_id
+       ON r.insight_tenant_id = j.insight_tenant_id
+      AND r.source_id = j.source_id
+      AND r.day = j.day
+      AND r.read_id = j.read_id
 -- Only reads that should have carried a reference: anything before this
 -- instance's first reference-carrying read predates the field.
-WHERE n.read_id >= f.since_read
-  AND (r.read_total_users IS NULL OR n.people != r.read_total_users)
+WHERE j.read_id >= f.since_read
+  AND (r.read_total_users IS NULL OR j.people != r.read_total_users)

--- a/src/ingestion/dbt/tests/ai/assert_ai_dev_usage_read_was_complete.sql
+++ b/src/ingestion/dbt/tests/ai/assert_ai_dev_usage_read_was_complete.sql
@@ -30,8 +30,7 @@ WITH reference AS (
         -- Not aliased `total_users`: the alias would shadow the source
         -- column and ClickHouse then resolves the outer WHERE to the
         -- aggregate itself.
-        max(toInt64OrNull(toString(total_users)))       AS read_total_users,
-        min(_airbyte_extracted_at)                      AS read_at
+        max(toInt64OrNull(toString(total_users)))       AS read_total_users
     FROM {{ source('bronze_claude_team', 'claude_team_code_metrics_org') }}
     WHERE metric_date IS NOT NULL
       AND total_users IS NOT NULL
@@ -41,10 +40,13 @@ WITH reference AS (
 
 first_reference AS (
 
+    -- The boundary is the READ, not its timestamp: both streams are written by
+    -- the same job but not at the same instant, so on the first sync after the
+    -- upgrade the per-user rows can predate the envelope that judges them.
     SELECT
         insight_tenant_id,
         source_id,
-        min(read_at)                                    AS since
+        min(read_id)                                    AS since_read
     FROM reference
     GROUP BY insight_tenant_id, source_id
 
@@ -52,16 +54,12 @@ first_reference AS (
 
 newest_read AS (
 
-    -- The inner alias is deliberately not `read_at`: ClickHouse resolves the
-    -- outer aggregate's argument against the outer name first and then reports
-    -- an aggregate inside an aggregate.
     SELECT
         insight_tenant_id,
         source_id,
         day,
         argMax(read_id, last_seen)                      AS read_id,
-        argMax(people, last_seen)                       AS people,
-        max(last_seen)                                  AS read_at
+        argMax(people, last_seen)                       AS people
     FROM (
         SELECT
             coalesce(tenant_id, '')                     AS insight_tenant_id,
@@ -95,7 +93,7 @@ LEFT JOIN reference AS r
       AND r.source_id = n.source_id
       AND r.day = n.day
       AND r.read_id = n.read_id
--- Only reads that should have carried a reference: anything older than this
--- instance's first one predates the field.
-WHERE n.read_at >= f.since
+-- Only reads that should have carried a reference: anything before this
+-- instance's first reference-carrying read predates the field.
+WHERE n.read_id >= f.since_read
   AND (r.read_total_users IS NULL OR n.people != r.read_total_users)

--- a/src/ingestion/scripts/connectors-ddl/claude-team.sql
+++ b/src/ingestion/scripts/connectors-ddl/claude-team.sql
@@ -44,7 +44,8 @@ CREATE TABLE IF NOT EXISTS bronze_claude_team.claude_team_code_metrics_org
     `metric_date` Nullable(String),
     `pr_attribution` Nullable(String),
     `top_users_by_prs` Nullable(String),
-    `top_users_by_lines_of_code` Nullable(String)
+    `top_users_by_lines_of_code` Nullable(String),
+    `total_users` Nullable(Decimal(38, 9))
 )
 ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
 ORDER BY unique_key

--- a/src/ingestion/tests/e2e/metrics/ai_cost_incomplete_read.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/ai_cost_incomplete_read.test.yaml
@@ -15,26 +15,44 @@ description: >
   model admits a per-user row only when its own read's distinct people equal that
   read's total_users.
 
-  Four days, one per branch of that gate — alice is the requested person and
-  every day is hers to carry:
+  The boundary between "predates the field" and "should have been judged" is the
+  READ, not its timestamp. Both streams are written by the same job but not at
+  the same instant, so on the first sync after the upgrade the per-user rows can
+  land a moment before the envelope that judges them; a timestamp boundary would
+  wave exactly those through.
 
-    Nov 10  legacy      no envelope, and read BEFORE this instance's first one.
-                        Nothing to judge it against, so it is admitted. This is
-                        what keeps history that predates the field servable.   0.50
-    Nov 15  complete    envelope says 2, the read returned alice and bob.
-                        Admitted.                                              1.00
-    Nov 16  short       envelope says 2, the read returned alice only. Rejected
-                        WHOLE — alice's own row goes too, because a read short in
-                        an unknown place says nothing about the people it did
-                        return.                                                2.00
-    Nov 17  unreferenced  read AFTER the first envelope, and carries none of its
-                        own. Rejected: an unreferenced recent read is the silent
-                        hole the gate exists to close.                         4.00
+  Six days, one per branch of the gate. alice is the requested person except
+  where noted:
 
-  alice's window therefore sums the two admitted days only: 0.50 + 1.00 = 1.50.
+    Nov 10  legacy      no envelope, and read 10 — BEFORE the first read that
+                        carried one. Nothing to judge it against, so it is
+                        admitted. This is what keeps history that predates the
+                        field servable.                                        0.50
+    Nov 15  complete    envelope of read 15 says 2, read 15 returned alice and
+                        bob. Admitted.                                         1.00
+    Nov 16  short       envelope of read 16 says 2, read 16 returned alice only.
+                        Rejected WHOLE — alice's own row goes too, because a read
+                        short in an unknown place says nothing about the people
+                        it did return.                                         2.00
+    Nov 17  unreferenced  read 17 is after the first reference and carries none
+                        of its own. Rejected: an unreferenced later read is the
+                        silent hole the gate exists to close.                   4.00
+    Nov 18  two reads   read 18's envelope says 1 and it returned bob — complete,
+                        admitted. Read 19's envelope says 2 and it returned alice
+                        only — short, rejected. Each read is judged against its
+                        OWN envelope: were the newest reference used for both,
+                        bob's sound read would be rejected too and the day would
+                        be empty.                              bob 0.75 · alice 8.00
+    Nov 19  bootstrap   read 15 — the very read that first carried an envelope —
+                        but there is none for THIS day, and the row was extracted
+                        a minute BEFORE that envelope. Rejected, not legacy: the
+                        boundary is the read id, and 15 is not before 15.      16.00
+
+  alice's window therefore sums the two days admitted for her: 0.50 + 1.00 = 1.50.
   With the gate removed every day would count and the same request would answer
-  7.50, so the case cannot pass by accident. The timeseries view pins which days
-  survived rather than only the total.
+  31.50, so the case cannot pass by accident. bob's window sums his two admitted
+  days: 1.00 + 0.75 = 1.75. The timeseries views pin which days survived rather
+  than only the totals.
 
 bronze:
   bronze_bamboohr.employees:
@@ -50,6 +68,14 @@ bronze:
     - { $ref: templates/claude_team_metrics_org.yaml#/templates/claude_team_metrics_org,
         metric_date: "2026-11-16", unique_key: org-20261116-r16, total_users: 2,
         _airbyte_extracted_at: "2026-11-16T23:50:00Z", _airbyte_meta: '{"sync_id":16,"changes":[]}' }
+    # Nov 18 read twice, and BOTH envelopes survive because unique_key names the
+    # read. The counts differ because the day was still filling up.
+    - { $ref: templates/claude_team_metrics_org.yaml#/templates/claude_team_metrics_org,
+        metric_date: "2026-11-18", unique_key: org-20261118-r18, total_users: 1,
+        _airbyte_extracted_at: "2026-11-18T20:00:00Z", _airbyte_meta: '{"sync_id":18,"changes":[]}' }
+    - { $ref: templates/claude_team_metrics_org.yaml#/templates/claude_team_metrics_org,
+        metric_date: "2026-11-18", unique_key: org-20261118-r19, total_users: 2,
+        _airbyte_extracted_at: "2026-11-18T23:50:00Z", _airbyte_meta: '{"sync_id":19,"changes":[]}' }
 
   bronze_claude_team.claude_team_code_metrics:
     # ── Nov 10 · legacy: extracted before the first envelope above ────────────
@@ -74,6 +100,26 @@ bronze:
     - { $ref: templates/claude_team_usage.yaml#/templates/alice, metric_date: "2026-11-17",
         unique_key: cc-alice-20261117, total_cost: "4.00", total_sessions: 1,
         _airbyte_extracted_at: "2026-11-17T23:50:00Z", _airbyte_meta: '{"sync_id":17,"changes":[]}' }
+
+    # ── Nov 18 · two reads of one day, judged against their own envelopes ─────
+    # Read 18 matched its own count of 1 → bob's row is admitted.
+    - { $ref: templates/claude_team_usage.yaml#/templates/bob, metric_date: "2026-11-18",
+        unique_key: cc-bob-20261118, total_cost: "0.75", total_sessions: 1,
+        _airbyte_extracted_at: "2026-11-18T20:00:00Z", _airbyte_meta: '{"sync_id":18,"changes":[]}' }
+    # Read 19 returned one of the two its own envelope counted → rejected. A
+    # different person, so the two reads do not share a Bronze key and neither
+    # can mask the other.
+    - { $ref: templates/claude_team_usage.yaml#/templates/alice, metric_date: "2026-11-18",
+        unique_key: cc-alice-20261118, total_cost: "8.00", total_sessions: 1,
+        _airbyte_extracted_at: "2026-11-18T23:50:00Z", _airbyte_meta: '{"sync_id":19,"changes":[]}' }
+
+    # ── Nov 19 · bootstrap: read 15 again, but no envelope for THIS day, and
+    #    extracted a minute before the envelope that made read 15 the first
+    #    reference. Under a timestamp boundary this looks legacy; under the read
+    #    boundary it is not, and it is rejected. ─────────────────────────────
+    - { $ref: templates/claude_team_usage.yaml#/templates/alice, metric_date: "2026-11-19",
+        unique_key: cc-alice-20261119, total_cost: "16.00", total_sessions: 1,
+        _airbyte_extracted_at: "2026-11-15T23:49:00Z", _airbyte_meta: '{"sync_id":15,"changes":[]}' }
 
 cases:
   - name: an incomplete read never becomes the day's state
@@ -102,10 +148,44 @@ cases:
       - metric: ai.cost
         view: timeseries
         assert: "items.exists(s, s.entity_id == 'alice@example.com' && s.points.exists(p, p.bucket_start == '2026-11-15' && double(p.value) == 1.0))"
-      # …and the two rejected days carry nothing, alice's own row included.
+      # …and every rejected day carries nothing, alice's own row included.
       - metric: ai.cost
         view: timeseries
         assert: "items.exists(s, s.entity_id == 'alice@example.com' && !s.points.exists(p, p.bucket_start == '2026-11-16' && double(p.value) > 0.0))"
       - metric: ai.cost
         view: timeseries
         assert: "items.exists(s, s.entity_id == 'alice@example.com' && !s.points.exists(p, p.bucket_start == '2026-11-17' && double(p.value) > 0.0))"
+      # Nov 18: read 19 was short, so alice's row for that day is gone even
+      # though read 18 of the same day was sound.
+      - metric: ai.cost
+        view: timeseries
+        assert: "items.exists(s, s.entity_id == 'alice@example.com' && !s.points.exists(p, p.bucket_start == '2026-11-18' && double(p.value) > 0.0))"
+      # Nov 19: the bootstrap read. Rejected despite being extracted before the
+      # first envelope — the boundary is the read id, not the clock.
+      - metric: ai.cost
+        view: timeseries
+        assert: "items.exists(s, s.entity_id == 'alice@example.com' && !s.points.exists(p, p.bucket_start == '2026-11-19' && double(p.value) > 0.0))"
+
+  - name: each read of a day is judged against its own headcount
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [bob@example.com] }
+        period: { from: "2026-11-01", to: "2026-11-30" }
+        metrics:
+          - metric_key: ai.cost
+            views:
+              - { view: period }
+              - { view: timeseries, bucket: day }
+    expect:
+      - assert: "status == 200"
+      # 1.00 (Nov 15, read 15) + 0.75 (Nov 18, read 18). Read 19's later, short
+      # envelope for the same day does not reach back and disqualify read 18.
+      - metric: ai.cost
+        view: period
+        find: { entity_id: bob@example.com }
+        equal: { value: 1.75 }
+      - metric: ai.cost
+        view: timeseries
+        assert: "items.exists(s, s.entity_id == 'bob@example.com' && s.points.exists(p, p.bucket_start == '2026-11-18' && double(p.value) == 0.75))"

--- a/src/ingestion/tests/e2e/metrics/ai_cost_incomplete_read.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/ai_cost_incomplete_read.test.yaml
@@ -47,6 +47,13 @@ description: >
                         but there is none for THIS day, and the row was extracted
                         a minute BEFORE that envelope. Rejected, not legacy: the
                         boundary is the read id, and 15 is not before 15.      16.00
+    Nov 20  empty       read 20's envelope counted 2 and stored no per-user row
+                        at all. The whole day is missing, not part of it, so the
+                        check has to reach it from the envelope — a candidate set
+                        built from stored rows alone has nothing to group here
+                        and would pass over it.                                  —
+    Nov 21  quiet       read 21's envelope counted 0 and stored no row. Nobody
+                        worked; nothing is missing and nothing is reported.      —
 
   alice's window therefore sums the two days admitted for her: 0.50 + 1.00 = 1.50.
   With the gate removed every day would count and the same request would answer
@@ -76,6 +83,14 @@ bronze:
     - { $ref: templates/claude_team_metrics_org.yaml#/templates/claude_team_metrics_org,
         metric_date: "2026-11-18", unique_key: org-20261118-r19, total_users: 2,
         _airbyte_extracted_at: "2026-11-18T23:50:00Z", _airbyte_meta: '{"sync_id":19,"changes":[]}' }
+    # Nov 20 counted 2 people and no per-user row for it was ever stored.
+    - { $ref: templates/claude_team_metrics_org.yaml#/templates/claude_team_metrics_org,
+        metric_date: "2026-11-20", unique_key: org-20261120-r20, total_users: 2,
+        _airbyte_extracted_at: "2026-11-20T23:50:00Z", _airbyte_meta: '{"sync_id":20,"changes":[]}' }
+    # Nov 21 counted nobody, and nobody arrived. Healthy.
+    - { $ref: templates/claude_team_metrics_org.yaml#/templates/claude_team_metrics_org,
+        metric_date: "2026-11-21", unique_key: org-20261121-r21, total_users: 0,
+        _airbyte_extracted_at: "2026-11-21T23:50:00Z", _airbyte_meta: '{"sync_id":21,"changes":[]}' }
 
   bronze_claude_team.claude_team_code_metrics:
     # ── Nov 10 · legacy: extracted before the first envelope above ────────────
@@ -165,6 +180,15 @@ cases:
       - metric: ai.cost
         view: timeseries
         assert: "items.exists(s, s.entity_id == 'alice@example.com' && !s.points.exists(p, p.bucket_start == '2026-11-19' && double(p.value) > 0.0))"
+      # Nov 20 and Nov 21 stored no per-user row, so neither reaches serving.
+      # The two are told apart by the data-quality check, not here: Nov 20's
+      # envelope counted people and Nov 21's counted none.
+      - metric: ai.cost
+        view: timeseries
+        assert: "items.exists(s, s.entity_id == 'alice@example.com' && !s.points.exists(p, p.bucket_start == '2026-11-20' && double(p.value) > 0.0))"
+      - metric: ai.cost
+        view: timeseries
+        assert: "items.exists(s, s.entity_id == 'alice@example.com' && !s.points.exists(p, p.bucket_start == '2026-11-21' && double(p.value) > 0.0))"
 
   - name: each read of a day is judged against its own headcount
     request:

--- a/src/ingestion/tests/e2e/metrics/ai_cost_incomplete_read.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/ai_cost_incomplete_read.test.yaml
@@ -1,0 +1,111 @@
+spec_version: 1
+description: >
+  Regression for #3172: a read that did not bring a day's whole roster must not
+  become that day's state.
+
+  claude_team_code_metrics pages an offset window over sort_by=total_lines_accepted.
+  Everyone with no accepted lines ties on that key and the endpoint promises no
+  tiebreak, so between two paged requests a person can cross the page boundary in
+  either direction — returned by neither, or returned twice — while both requests
+  succeed. Nothing in the response says the day came back short.
+
+  The envelope does carry the day's headcount, and claude_team_code_metrics_org
+  stores it per READ (its unique_key names the read, because a day still in
+  progress legitimately reports fewer people than it ends with). The staging
+  model admits a per-user row only when its own read's distinct people equal that
+  read's total_users.
+
+  Four days, one per branch of that gate — alice is the requested person and
+  every day is hers to carry:
+
+    Nov 10  legacy      no envelope, and read BEFORE this instance's first one.
+                        Nothing to judge it against, so it is admitted. This is
+                        what keeps history that predates the field servable.   0.50
+    Nov 15  complete    envelope says 2, the read returned alice and bob.
+                        Admitted.                                              1.00
+    Nov 16  short       envelope says 2, the read returned alice only. Rejected
+                        WHOLE — alice's own row goes too, because a read short in
+                        an unknown place says nothing about the people it did
+                        return.                                                2.00
+    Nov 17  unreferenced  read AFTER the first envelope, and carries none of its
+                        own. Rejected: an unreferenced recent read is the silent
+                        hole the gate exists to close.                         4.00
+
+  alice's window therefore sums the two admitted days only: 0.50 + 1.00 = 1.50.
+  With the gate removed every day would count and the same request would answer
+  7.50, so the case cannot pass by accident. The timeseries view pins which days
+  survived rather than only the total.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+
+  bronze_claude_team.claude_team_code_metrics_org:
+    # Nov 15's read: 2 people. sync_id 15 ties it to that read's user rows.
+    - { $ref: templates/claude_team_metrics_org.yaml#/templates/claude_team_metrics_org,
+        metric_date: "2026-11-15", unique_key: org-20261115-r15, total_users: 2,
+        _airbyte_extracted_at: "2026-11-15T23:50:00Z", _airbyte_meta: '{"sync_id":15,"changes":[]}' }
+    # Nov 16's read: also 2 people — but only one of them arrived.
+    - { $ref: templates/claude_team_metrics_org.yaml#/templates/claude_team_metrics_org,
+        metric_date: "2026-11-16", unique_key: org-20261116-r16, total_users: 2,
+        _airbyte_extracted_at: "2026-11-16T23:50:00Z", _airbyte_meta: '{"sync_id":16,"changes":[]}' }
+
+  bronze_claude_team.claude_team_code_metrics:
+    # ── Nov 10 · legacy: extracted before the first envelope above ────────────
+    - { $ref: templates/claude_team_usage.yaml#/templates/alice, metric_date: "2026-11-10",
+        unique_key: cc-alice-20261110, total_cost: "0.50", total_sessions: 1,
+        _airbyte_extracted_at: "2026-11-10T23:50:00Z", _airbyte_meta: '{"sync_id":10,"changes":[]}' }
+
+    # ── Nov 15 · complete: both people, matching the envelope's 2 ─────────────
+    - { $ref: templates/claude_team_usage.yaml#/templates/alice, metric_date: "2026-11-15",
+        unique_key: cc-alice-20261115, total_cost: "1.00", total_sessions: 1,
+        _airbyte_extracted_at: "2026-11-15T23:50:00Z", _airbyte_meta: '{"sync_id":15,"changes":[]}' }
+    - { $ref: templates/claude_team_usage.yaml#/templates/bob, metric_date: "2026-11-15",
+        unique_key: cc-bob-20261115, total_cost: "1.00", total_sessions: 1,
+        _airbyte_extracted_at: "2026-11-15T23:50:00Z", _airbyte_meta: '{"sync_id":15,"changes":[]}' }
+
+    # ── Nov 16 · short: envelope says 2, bob never arrived ────────────────────
+    - { $ref: templates/claude_team_usage.yaml#/templates/alice, metric_date: "2026-11-16",
+        unique_key: cc-alice-20261116, total_cost: "2.00", total_sessions: 1,
+        _airbyte_extracted_at: "2026-11-16T23:50:00Z", _airbyte_meta: '{"sync_id":16,"changes":[]}' }
+
+    # ── Nov 17 · unreferenced: after the first envelope, carries none ─────────
+    - { $ref: templates/claude_team_usage.yaml#/templates/alice, metric_date: "2026-11-17",
+        unique_key: cc-alice-20261117, total_cost: "4.00", total_sessions: 1,
+        _airbyte_extracted_at: "2026-11-17T23:50:00Z", _airbyte_meta: '{"sync_id":17,"changes":[]}' }
+
+cases:
+  - name: an incomplete read never becomes the day's state
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [alice@example.com] }
+        period: { from: "2026-11-01", to: "2026-11-30" }
+        metrics:
+          - metric_key: ai.cost
+            views:
+              - { view: period }
+              - { view: timeseries, bucket: day }
+    expect:
+      - assert: "status == 200"
+      # 0.50 (legacy) + 1.00 (complete). Not 3.50, not 5.50, not 7.50.
+      - metric: ai.cost
+        view: period
+        find: { entity_id: alice@example.com }
+        equal: { value: 1.5 }
+      # The two admitted days are there…
+      - metric: ai.cost
+        view: timeseries
+        assert: "items.exists(s, s.entity_id == 'alice@example.com' && s.points.exists(p, p.bucket_start == '2026-11-10' && double(p.value) == 0.5))"
+      - metric: ai.cost
+        view: timeseries
+        assert: "items.exists(s, s.entity_id == 'alice@example.com' && s.points.exists(p, p.bucket_start == '2026-11-15' && double(p.value) == 1.0))"
+      # …and the two rejected days carry nothing, alice's own row included.
+      - metric: ai.cost
+        view: timeseries
+        assert: "items.exists(s, s.entity_id == 'alice@example.com' && !s.points.exists(p, p.bucket_start == '2026-11-16' && double(p.value) > 0.0))"
+      - metric: ai.cost
+        view: timeseries
+        assert: "items.exists(s, s.entity_id == 'alice@example.com' && !s.points.exists(p, p.bucket_start == '2026-11-17' && double(p.value) > 0.0))"

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_claude_team.claude_team_code_metrics_org.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_claude_team.claude_team_code_metrics_org.yaml
@@ -1,0 +1,27 @@
+# JSON schema for bronze_claude_team.claude_team_code_metrics_org (all real columns).
+# Mirrors the connector InlineSchemaLoader (connectors/ai/claude-team/connector.yaml
+# — stream claude_team_code_metrics_org, the org-level half of the same
+# GET /api/claude_code/metrics_aggs/users response) plus the 4 _airbyte_* CDK
+# columns. total_users is the day's headcount AS OF THE READ that returned it,
+# which is what the completeness gate in claude_team__ai_dev_usage compares
+# against; the read is in unique_key so one read never overwrites another's.
+schemas:
+  bronze_claude_team.claude_team_code_metrics_org:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      _airbyte_raw_id: { type: string }
+      _airbyte_extracted_at: { type: string, format: date-time }
+      _airbyte_meta: { type: string }
+      _airbyte_generation_id: { type: integer }
+      tenant_id: { type: [string, "null"] }
+      source_id: { type: [string, "null"] }
+      unique_key: { type: string }
+      collected_at: { type: [string, "null"] }
+      data_source: { type: [string, "null"] }
+      metric_date: { type: [string, "null"] }
+      pr_attribution: { type: [string, "null"] }
+      top_users_by_prs: { type: [string, "null"] }
+      top_users_by_lines_of_code: { type: [string, "null"] }
+      total_users: { type: [number, "null"] }

--- a/src/ingestion/tests/e2e/metrics/templates/claude_team_metrics_org.yaml
+++ b/src/ingestion/tests/e2e/metrics/templates/claude_team_metrics_org.yaml
@@ -1,0 +1,23 @@
+# Reusable Claude Team org-envelope records
+# (bronze_claude_team.claude_team_code_metrics_org). One row per READ of a day,
+# carrying that read's own headcount. The completeness gate in
+# claude_team__ai_dev_usage joins it to the per-user rows on
+# (tenant, source, metric_date, _airbyte_meta.sync_id), so a fixture that wants
+# a day judged must set metric_date, total_users and a matching sync_id in
+# _airbyte_meta on both sides.
+templates:
+  claude_team_metrics_org:
+    _airbyte_raw_id: "00000000-0000-0000-0000-000000000000"
+    _airbyte_extracted_at: "2026-01-05T00:00:00Z"
+    _airbyte_meta: "{}"
+    _airbyte_generation_id: 0
+    tenant_id: "11111111-1111-1111-1111-111111111111"
+    source_id: "claude-team-test"
+    unique_key: null
+    collected_at: null
+    data_source: "insight_claude_team"
+    metric_date: null
+    pr_attribution: null
+    top_users_by_prs: null
+    top_users_by_lines_of_code: null
+    total_users: null


### PR DESCRIPTION
Closes #3172.

**Why.** A day's Claude Code usage could be stored with people missing from it while the sync reported success, so those person-days were absent from every AI usage and cost figure with nothing marking them as absent.

**What changed.** `claude_team_code_metrics` pages an offset window over `sort_by=total_lines_accepted`, and everyone with no accepted lines ties on it, so a person can cross the page boundary between two requests and be returned by neither. `claude_team__ai_dev_usage` now admits a row only when its own read returned as many distinct people as that read's own `total_users`.

**A short read is dropped whole, not row by row.** A read short in an unknown place says nothing about the people it did return, so the day keeps whatever the last sound read wrote instead of becoming short.

**The reference belongs to the read being judged.** `claude_team_code_metrics_org` declares `total_users` and its `unique_key` gains the read — a day still in progress reports fewer people than it ends with, so judging an older read against the newest reference would reject sound reads.

**Reads older than an instance's first reference stay admitted; later unreferenced ones do not.** History predating the field cannot be judged; an unreferenced recent read is the hole the gate closes.

**The page rises to 200 as a mitigation, not the fix.** A roster inside one request is one answer no window can shift under. Whether the endpoint accepts a sort on a unique field, under which offset paging would be exact, is unverified — the gate stands either way.

The new fixture seeds four days, one per branch of the gate: legacy, complete, short, unreferenced. Only the two admissible days reach the metric, so the request answers 1.5 where an ungated build answers 7.5.

**Verified.** Nocode connector harness: 269 passed, 2 skipped. E2E metrics on a clean stand: `ai_cost`, `ai_cost_cursor` and the new `ai_cost_incomplete_read` all pass. `dbt parse` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude Team code metrics accuracy by detecting and excluding incomplete roster reads.
  * Prevented missing or duplicated users from distorting daily AI usage and cost metrics.
  * Preserved the most recent complete data when a later read is incomplete.
  * Retained multiple readings for the same day instead of overwriting earlier reference data.

* **Data Quality**
  * Added organization-level user counts to validate metric completeness.
  * Added monitoring for unreferenced, empty, or incomplete reads.
  * Improved handling of larger team rosters across paginated results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->