### PR TITLE
fix(metrics): recognise a squash result reported under a shortened hash

### DIFF
--- a/src/ingestion/dbt/macros/git_merge_result_match.sql
+++ b/src/ingestion/dbt/macros/git_merge_result_match.sql
@@ -1,0 +1,21 @@
+{# Join condition matching a merged pull request to the commit its merge
+   produced, for the two models that need that commit: git_derived_commits and
+   git_superseded_file_changes.
+
+   WORKAROUND: the reported hash is RESOLVED against the collected commit, not
+   compared to it. Bitbucket Cloud answers `merge_commit.hash` with a
+   12-character prefix where GitHub answers the full 40, so an equality join
+   matches no Bitbucket result at all. #3161
+
+   Scoped to the request's own repository: a prefix is a weak key, and a commit
+   in another repository that happens to share it is another author's work.
+   The caller decides what to do when more than one commit matches — both
+   callers refuse to mark anything. #}
+{% macro git_merge_result_match(request, commit) -%}
+{{ commit }}.tenant_id = {{ request }}.tenant_id
+        AND {{ commit }}.source_id = {{ request }}.source_id
+        AND {{ commit }}.project_key = {{ request }}.project_key
+        AND {{ commit }}.repo_slug = {{ request }}.repo_slug
+        AND {{ commit }}.data_source = {{ request }}.data_source
+        AND startsWith({{ commit }}.commit_hash, {{ request }}.merge_commit_hash)
+{%- endmacro %}

--- a/src/ingestion/gold/git_derived_commits.sql
+++ b/src/ingestion/gold/git_derived_commits.sql
@@ -23,7 +23,9 @@
 --   completes, which never loses work or per-author credit — the content
 --   dedup on file oids still folds the overlapping lines). The result hash
 --   is never marked when it is itself a linked commit: a fast-forward merge
---   promotes an original, which stays authored.
+--   promotes an original, which stays authored. Nor when the result commit
+--   was never collected in that repository — there is then nothing for the
+--   evidence build to exclude.
 --
 -- * patch_duplicate: a commit whose diff content (patch id) an earlier commit
 --   IN THE SAME REPOSITORY already carries — a rebase copy or a cherry-pick.
@@ -51,6 +53,7 @@ collected_branch_commits AS (
         source_id,
         project_key,
         repo_slug,
+        data_source,
         commit_hash
     FROM {{ ref('class_git_commits') }} FINAL
     WHERE is_merge_commit = 0
@@ -73,11 +76,22 @@ pull_request_links AS (
     FROM {{ ref('class_git_pull_requests_commits') }} FINAL
     GROUP BY tenant_id, source_id, project_key, repo_slug, pr_id
 ),
-merge_results AS (
-    SELECT DISTINCT
+-- The result commit each merged request produced, resolved to a collected
+-- commit rather than compared to one.
+--
+-- WORKAROUND: Bitbucket Cloud answers `merge_commit.hash` with a 12-character
+-- prefix where GitHub answers the full 40, so an equality join marks no
+-- Bitbucket result at all. #3161
+--
+-- SAFETY: marking a commit removes its lines along with itself, so a prefix
+-- that names more than one collected commit marks neither. Over-counting the
+-- request is recoverable; deleting an unrelated author's work is not.
+resolved_merge_results AS (
+    SELECT
         prs.tenant_id AS tenant_id,
         prs.data_source AS data_source,
-        prs.merge_commit_hash AS commit_hash
+        groupUniqArray(result.commit_hash) AS candidates,
+        any(links.linked_hashes) AS linked_hashes
     FROM {{ ref('class_git_pull_requests') }} AS prs FINAL
     INNER JOIN pull_request_links AS links
         ON links.tenant_id = prs.tenant_id
@@ -85,10 +99,33 @@ merge_results AS (
         AND links.project_key = prs.project_key
         AND links.repo_slug = prs.repo_slug
         AND links.pr_id = prs.pr_id
+    INNER JOIN collected_branch_commits AS result
+        ON result.tenant_id = prs.tenant_id
+        AND result.source_id = prs.source_id
+        AND result.project_key = prs.project_key
+        AND result.repo_slug = prs.repo_slug
+        AND result.data_source = prs.data_source
+        AND startsWith(result.commit_hash, prs.merge_commit_hash)
     WHERE prs.state = 'MERGED'
       AND prs.merge_commit_hash != ''
       AND links.collected_branch_commit_count = length(links.linked_hashes)
-      AND NOT has(links.linked_hashes, prs.merge_commit_hash)
+    GROUP BY
+        prs.tenant_id,
+        prs.source_id,
+        prs.project_key,
+        prs.repo_slug,
+        prs.pr_id,
+        prs.data_source
+    HAVING length(candidates) = 1
+),
+merge_results AS (
+    SELECT DISTINCT
+        tenant_id,
+        data_source,
+        arrayElement(candidates, 1) AS commit_hash
+    FROM resolved_merge_results
+    -- A fast-forward merge promotes an original, which stays authored.
+    WHERE NOT has(linked_hashes, arrayElement(candidates, 1))
 ),
 -- One row per commit per repository: patch ids rank within a repository, so a
 -- duplicate patch in an unrelated repository is untouched. A hash present in

--- a/src/ingestion/gold/git_derived_commits.sql
+++ b/src/ingestion/gold/git_derived_commits.sql
@@ -23,9 +23,7 @@
 --   completes, which never loses work or per-author credit — the content
 --   dedup on file oids still folds the overlapping lines). The result hash
 --   is never marked when it is itself a linked commit: a fast-forward merge
---   promotes an original, which stays authored. Nor when the result commit
---   was never collected in that repository — there is then nothing for the
---   evidence build to exclude.
+--   promotes an original, which stays authored.
 --
 -- * patch_duplicate: a commit whose diff content (patch id) an earlier commit
 --   IN THE SAME REPOSITORY already carries — a rebase copy or a cherry-pick.
@@ -76,12 +74,25 @@ pull_request_links AS (
     FROM {{ ref('class_git_pull_requests_commits') }} FINAL
     GROUP BY tenant_id, source_id, project_key, repo_slug, pr_id
 ),
+-- The requests that produced a result commit at all. Narrowed before the
+-- resolution below, whose prefix test is a residual predicate: the join's only
+-- equi key is the repository, so every row that reaches it is compared against
+-- that repository's whole commit set.
+merged_requests AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        data_source,
+        pr_id,
+        merge_commit_hash
+    FROM {{ ref('class_git_pull_requests') }} FINAL
+    WHERE state = 'MERGED'
+      AND merge_commit_hash != ''
+),
 -- The result commit each merged request produced, resolved to a collected
--- commit rather than compared to one.
---
--- WORKAROUND: Bitbucket Cloud answers `merge_commit.hash` with a 12-character
--- prefix where GitHub answers the full 40, so an equality join marks no
--- Bitbucket result at all. #3161
+-- commit rather than compared to one — see `git_merge_result_match`.
 --
 -- SAFETY: marking a commit removes its lines along with itself, so a prefix
 -- that names more than one collected commit marks neither. Over-counting the
@@ -92,7 +103,7 @@ resolved_merge_results AS (
         prs.data_source AS data_source,
         groupUniqArray(result.commit_hash) AS candidates,
         any(links.linked_hashes) AS linked_hashes
-    FROM {{ ref('class_git_pull_requests') }} AS prs FINAL
+    FROM merged_requests AS prs
     INNER JOIN pull_request_links AS links
         ON links.tenant_id = prs.tenant_id
         AND links.source_id = prs.source_id
@@ -100,15 +111,8 @@ resolved_merge_results AS (
         AND links.repo_slug = prs.repo_slug
         AND links.pr_id = prs.pr_id
     INNER JOIN collected_branch_commits AS result
-        ON result.tenant_id = prs.tenant_id
-        AND result.source_id = prs.source_id
-        AND result.project_key = prs.project_key
-        AND result.repo_slug = prs.repo_slug
-        AND result.data_source = prs.data_source
-        AND startsWith(result.commit_hash, prs.merge_commit_hash)
-    WHERE prs.state = 'MERGED'
-      AND prs.merge_commit_hash != ''
-      AND links.collected_branch_commit_count = length(links.linked_hashes)
+        ON {{ git_merge_result_match('prs', 'result') }}
+    WHERE links.collected_branch_commit_count = length(links.linked_hashes)
     GROUP BY
         prs.tenant_id,
         prs.source_id,

--- a/src/ingestion/gold/git_superseded_file_changes.sql
+++ b/src/ingestion/gold/git_superseded_file_changes.sql
@@ -36,6 +36,7 @@ collected_branch_commits AS (
         source_id,
         project_key,
         repo_slug,
+        data_source,
         commit_hash
     FROM {{ ref('class_git_commits') }} FINAL
     WHERE is_merge_commit = 0
@@ -58,25 +59,61 @@ pull_request_links AS (
     FROM {{ ref('class_git_pull_requests_commits') }} FINAL
     GROUP BY tenant_id, source_id, project_key, repo_slug, pr_id
 ),
-partly_collected_results AS (
-    SELECT DISTINCT
+-- The requests that produced a result commit at all. Narrowed before the
+-- resolution below, whose prefix test is a residual predicate: the join's only
+-- equi key is the repository, so every row that reaches it is compared against
+-- that repository's whole commit set.
+merged_requests AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        data_source,
+        pr_id,
+        merge_commit_hash
+    FROM {{ ref('class_git_pull_requests') }} FINAL
+    WHERE state = 'MERGED'
+      AND merge_commit_hash != ''
+),
+-- SAFETY: a prefix naming more than one collected commit suppresses nothing,
+-- for the same reason git_derived_commits marks nothing — see
+-- `git_merge_result_match`.
+resolved_results AS (
+    SELECT
         prs.tenant_id AS tenant_id,
         prs.data_source AS data_source,
-        prs.merge_commit_hash AS commit_hash,
-        links.linked_hashes AS linked_hashes
-    FROM {{ ref('class_git_pull_requests') }} AS prs FINAL
+        groupUniqArray(result.commit_hash) AS candidates,
+        any(links.linked_hashes) AS linked_hashes
+    FROM merged_requests AS prs
     INNER JOIN pull_request_links AS links
         ON links.tenant_id = prs.tenant_id
         AND links.source_id = prs.source_id
         AND links.project_key = prs.project_key
         AND links.repo_slug = prs.repo_slug
         AND links.pr_id = prs.pr_id
-    WHERE prs.state = 'MERGED'
-      AND prs.merge_commit_hash != ''
-      AND links.collected_branch_commit_count > 0
+    INNER JOIN collected_branch_commits AS result
+        ON {{ git_merge_result_match('prs', 'result') }}
+    WHERE links.collected_branch_commit_count > 0
       AND links.collected_branch_commit_count < length(links.linked_hashes)
-      -- A fast-forward merge promotes an original, which owns its own rows.
-      AND NOT has(links.linked_hashes, prs.merge_commit_hash)
+    GROUP BY
+        prs.tenant_id,
+        prs.source_id,
+        prs.project_key,
+        prs.repo_slug,
+        prs.pr_id,
+        prs.data_source
+    HAVING length(candidates) = 1
+),
+partly_collected_results AS (
+    SELECT DISTINCT
+        tenant_id,
+        data_source,
+        arrayElement(candidates, 1) AS commit_hash,
+        linked_hashes
+    FROM resolved_results
+    -- A fast-forward merge promotes an original, which owns its own rows.
+    WHERE NOT has(linked_hashes, arrayElement(candidates, 1))
 ),
 linked_commit_of_result AS (
     SELECT

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -168,7 +168,8 @@ models:
       tenant/data_source/commit_hash/reason. merge_result is the commit a
       merged pull request produced on its destination (a squash result or the
       last rebased copy), marked only when every linked branch commit was
-      collected; patch_duplicate is a later carrier of a patch id an earlier
+      collected and the result commit itself was collected in that repository;
+      patch_duplicate is a later carrier of a patch id an earlier
       commit in the same repository authored (a rebase copy or a cherry-pick).
       The git
       evidence build excludes these from both the commit and the line figures,

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -168,8 +168,7 @@ models:
       tenant/data_source/commit_hash/reason. merge_result is the commit a
       merged pull request produced on its destination (a squash result or the
       last rebased copy), marked only when every linked branch commit was
-      collected and the result commit itself was collected in that repository;
-      patch_duplicate is a later carrier of a patch id an earlier
+      collected; patch_duplicate is a later carrier of a patch id an earlier
       commit in the same repository authored (a rebase copy or a cherry-pick).
       The git
       evidence build excludes these from both the commit and the line figures,

--- a/src/ingestion/silver/git/mtr_git_person_weekly.sql
+++ b/src/ingestion/silver/git/mtr_git_person_weekly.sql
@@ -11,7 +11,11 @@
 -- LEFT JOINs on `week` align rows from the same activity window.
 -- For prs_merged the week is taken from the merge commit's date (when the
 -- merge_commit_hash resolves to a commit row), falling back to the PR
--- closed_on week. This avoids commit-week vs PR-close-week drift.
+-- closed_on week. This avoids commit-week vs PR-close-week drift, except for
+-- Bitbucket Cloud: its API reports `merge_commit.hash` as a 12-character
+-- prefix, the equality below resolves nothing, and every Bitbucket row takes
+-- the fallback. Correcting that here needs a resolution which cannot match two
+-- commits at once, because this join feeds an aggregate. See #3161.
 --
 -- Why anchor + LEFT JOINs instead of FULL OUTER JOIN ... USING:
 -- ClickHouse 25.3 fills unmatched per-side columns with the column's default

--- a/src/ingestion/silver/git/mtr_git_person_weekly.sql
+++ b/src/ingestion/silver/git/mtr_git_person_weekly.sql
@@ -11,11 +11,13 @@
 -- LEFT JOINs on `week` align rows from the same activity window.
 -- For prs_merged the week is taken from the merge commit's date (when the
 -- merge_commit_hash resolves to a commit row), falling back to the PR
--- closed_on week. This avoids commit-week vs PR-close-week drift, except for
--- Bitbucket Cloud: its API reports `merge_commit.hash` as a 12-character
--- prefix, the equality below resolves nothing, and every Bitbucket row takes
--- the fallback. Correcting that here needs a resolution which cannot match two
--- commits at once, because this join feeds an aggregate. See #3161.
+-- closed_on week. This avoids commit-week vs PR-close-week drift.
+--
+-- WORKAROUND: Bitbucket Cloud reports `merge_commit.hash` as a 12-character
+-- prefix, so the equality below resolves nothing and every Bitbucket row takes
+-- the fallback week. The gold path resolves it with
+-- `git_merge_result_match`; here the join feeds an aggregate, so the same
+-- change needs a form that cannot match two commits at once.
 --
 -- Why anchor + LEFT JOINs instead of FULL OUTER JOIN ... USING:
 -- ClickHouse 25.3 fills unmatched per-side columns with the column's default

--- a/src/ingestion/tests/e2e/metrics/git_squash_result_bitbucket.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_squash_result_bitbucket.test.yaml
@@ -5,8 +5,11 @@ description: >
   Bitbucket Cloud answers `merge_commit.hash` with a 12-character prefix where
   GitHub answers the full 40, so the result commit of a merged pull request has
   to be resolved against the collected commit rather than compared to it.
-  Without that, the squash counts as a third commit and its A-to-C file row
-  counts the twice-touched path's lines again.
+  Without that, the squash counts as a third commit.
+
+  The commit count is what discriminates. The line figures are pinned here too,
+  but content identity already folds a squash into the branch commit it ends
+  on, so they read the same either way.
 
   Fixtures isolate per repository:
     * squash-bb: two branch commits, the second re-touching the first's file,
@@ -14,12 +17,15 @@ description: >
       Both branch commits are linked to the request, so coverage is complete
       and the result carries no credit of its own.
     * other-bb: a commit in an unrelated repository whose hash starts with the
-      same 12 characters. Resolving a prefix has to stay inside the request's
-      own repository, or this commit loses its credit to a request it has
-      nothing to do with.
+      same 12 characters. A guard on the resolution, not a case main gets
+      wrong: resolving a prefix has to stay inside the request's own
+      repository.
     * ff-bb: a fast-forward merge under a shortened hash — the request reports
-      the prefix of a commit it also links. That commit is the work, not a copy
-      of it, so it stays authored.
+      the prefix of a commit it also links. Also a guard: that commit is the
+      work, not a copy of it, so it stays authored.
+    * ambig-bb: two commits in ONE repository share the reported prefix. The
+      prefix names neither, so nothing is marked and both keep their credit —
+      the guard against deleting an author's work on a weak key.
 
   Assertions read the `repository` breakdown so they are unaffected by any
   other fixture in the suite.
@@ -40,13 +46,18 @@ bronze:
     - { $ref: templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:bboth-1", repository: https://bitbucket.org/acme/other-bb.git, sha: 4f1c9a20d3e5aaaaaaaaaaaaaaaaaaaaaaaaaaaa, author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, additions: 4, changed_files: 1, is_in_default_branch: true }
     # ff-bb: the request reports this commit's own prefix as its merge result.
     - { $ref: templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:bbff-1", repository: https://bitbucket.org/acme/ff-bb.git, sha: 9c2b71fe40a3d5e8b6740c19af23568d1b0e7f42, author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, additions: 6, changed_files: 1, is_in_default_branch: true }
+    # ambig-bb: two commits sharing the reported prefix, plus the branch commit
+    # the request links.
+    - { $ref: templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:bbam-x", repository: https://bitbucket.org/acme/ambig-bb.git, sha: 7e3d0b91c4f2000000000000000000000000000a, author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, additions: 5, changed_files: 1, is_in_default_branch: true }
+    - { $ref: templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:bbam-y", repository: https://bitbucket.org/acme/ambig-bb.git, sha: 7e3d0b91c4f2000000000000000000000000000b, author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, additions: 7, changed_files: 1, is_in_default_branch: true }
+    - { $ref: templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:bbam-b", repository: https://bitbucket.org/acme/ambig-bb.git, sha: bbam-b, author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, additions: 3, changed_files: 1, is_in_default_branch: false }
 
   bronze_bitbucket_cloud.file_changes:
     # One path, touched twice on the branch: null-to-B then B-to-C.
     - { $ref: templates/bitbucket_git.yaml#/templates/file_change, unique_key: "fc:bbsq-b1:one.py", repository: https://bitbucket.org/acme/squash-bb.git, sha: bbsq-b1, filename: src/one.py, status: added, additions: 10, changes: 10, post_image_oid: oid-b }
     - { $ref: templates/bitbucket_git.yaml#/templates/file_change, unique_key: "fc:bbsq-b2:one.py", repository: https://bitbucket.org/acme/squash-bb.git, sha: bbsq-b2, committed_date: "2026-10-01T10:00:00Z", filename: src/one.py, additions: 8, deletions: 2, changes: 10, pre_image_oid: oid-b, post_image_oid: oid-c }
-    # The squash's own null-to-C row matches neither branch transition, so blob
-    # identity cannot fold it and the lines count again if the commit counts.
+    # The squash ends where the branch ended, so content identity folds this
+    # row into the branch commit's.
     - { $ref: templates/bitbucket_git.yaml#/templates/file_change, unique_key: "fc:bbsq-r:one.py", repository: https://bitbucket.org/acme/squash-bb.git, sha: 4f1c9a20d3e57b8f6a1c0d92e4b73a58c6d90f11, committed_date: "2026-10-01T11:00:00Z", filename: src/one.py, status: added, additions: 18, deletions: 2, changes: 20, post_image_oid: oid-c }
 
   bronze_bitbucket_cloud.pull_requests:
@@ -55,6 +66,8 @@ bronze:
     - { $ref: templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "pr:91", repo_full_name: acme/squash-bb, id: 91, author_display_name: Erin Epsilon, source_commit_sha: bbsq-b2, destination_commit_sha: dst-91, merge_commit_sha: 4f1c9a20d3e5 }
     # ff-bb: a fast-forward, so the reported result is one of the linked commits.
     - { $ref: templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "pr:92", repo_full_name: acme/ff-bb, id: 92, author_display_name: Erin Epsilon, source_commit_sha: bbff-1, destination_commit_sha: dst-92, merge_commit_sha: 9c2b71fe40a3 }
+    # ambig-bb: the reported prefix fits both bbam-x and bbam-y.
+    - { $ref: templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "pr:93", repo_full_name: acme/ambig-bb, id: 93, author_display_name: Erin Epsilon, source_commit_sha: bbam-b, destination_commit_sha: dst-93, merge_commit_sha: 7e3d0b91c4f2 }
 
   bronze_bitbucket_cloud.pull_request_commits:
     # Both branch commits are linked and both were collected, so coverage is
@@ -62,12 +75,13 @@ bronze:
     - { $ref: templates/bitbucket_git.yaml#/templates/pull_request_commit, unique_key: "prc:91:bbsq-b1", repo_full_name: acme/squash-bb, pr_id: 91, sha: bbsq-b1, author_name: Erin Epsilon, author_email: erin@example.com }
     - { $ref: templates/bitbucket_git.yaml#/templates/pull_request_commit, unique_key: "prc:91:bbsq-b2", repo_full_name: acme/squash-bb, pr_id: 91, sha: bbsq-b2, committed_date: "2026-10-01T10:00:00Z", author_name: Erin Epsilon, author_email: erin@example.com }
     - { $ref: templates/bitbucket_git.yaml#/templates/pull_request_commit, unique_key: "prc:92:bbff-1", repo_full_name: acme/ff-bb, pr_id: 92, sha: 9c2b71fe40a3d5e8b6740c19af23568d1b0e7f42, author_name: Erin Epsilon, author_email: erin@example.com }
+    - { $ref: templates/bitbucket_git.yaml#/templates/pull_request_commit, unique_key: "prc:93:bbam-b", repo_full_name: acme/ambig-bb, pr_id: 93, sha: bbam-b, author_name: Erin Epsilon, author_email: erin@example.com }
 
   bronze_bitbucket_cloud.pull_request_activity:
     - { $ref: templates/bitbucket_git.yaml#/templates/activity, unique_key: "ac:91:ev1", repo_full_name: acme/squash-bb, pr_id: 91, update_state: MERGED }
 
 cases:
-  - name: A squash result reported under a shortened hash carries no commit and no lines
+  - name: A squash result reported under a shortened hash carries no commit of its own
     request:
       url: /v1/metric-results
       method: POST
@@ -91,7 +105,7 @@ cases:
         view: breakdown
         find: { entity_id: erin@example.com, dimensions: { key: repository, value: "bitbucket-test:acme/squash-bb" } }
         equal: { value: 2 }
-      # The branch's own lines, once: 10 + 8. With the squash counted, 36.
+      # The branch's own lines, once: 10 + 8.
       - metric: git.lines_added
         view: breakdown
         find: { entity_id: erin@example.com, dimensions: { key: repository, value: "bitbucket-test:acme/squash-bb" } }
@@ -113,3 +127,8 @@ cases:
         view: breakdown
         find: { entity_id: erin@example.com, dimensions: { key: repository, value: "bitbucket-test:acme/ff-bb" } }
         equal: { value: 1 }
+      # An ambiguous prefix names neither commit, so all three still count.
+      - metric: git.commits
+        view: breakdown
+        find: { entity_id: erin@example.com, dimensions: { key: repository, value: "bitbucket-test:acme/ambig-bb" } }
+        equal: { value: 3 }

--- a/src/ingestion/tests/e2e/metrics/git_squash_result_bitbucket.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_squash_result_bitbucket.test.yaml
@@ -1,0 +1,115 @@
+spec_version: 1
+description: >
+  A squash result reported under a shortened hash is still recognised as one.
+
+  Bitbucket Cloud answers `merge_commit.hash` with a 12-character prefix where
+  GitHub answers the full 40, so the result commit of a merged pull request has
+  to be resolved against the collected commit rather than compared to it.
+  Without that, the squash counts as a third commit and its A-to-C file row
+  counts the twice-touched path's lines again.
+
+  Fixtures isolate per repository:
+    * squash-bb: two branch commits, the second re-touching the first's file,
+      and the squash result on the default branch under a 12-character hash.
+      Both branch commits are linked to the request, so coverage is complete
+      and the result carries no credit of its own.
+    * other-bb: a commit in an unrelated repository whose hash starts with the
+      same 12 characters. Resolving a prefix has to stay inside the request's
+      own repository, or this commit loses its credit to a request it has
+      nothing to do with.
+    * ff-bb: a fast-forward merge under a shortened hash — the request reports
+      the prefix of a commit it also links. That commit is the work, not a copy
+      of it, so it stays authored.
+
+  Assertions read the `repository` breakdown so they are unaffected by any
+  other fixture in the suite.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_bitbucket_cloud.commits:
+    # The branch pair. Their flag is false: at sync time they were not on the
+    # default branch, which is the normal shape for a branch that merges later.
+    - { $ref: templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:bbsq-b1", repository: https://bitbucket.org/acme/squash-bb.git, sha: bbsq-b1, author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, additions: 10, changed_files: 1, is_in_default_branch: false }
+    - { $ref: templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:bbsq-b2", repository: https://bitbucket.org/acme/squash-bb.git, sha: bbsq-b2, committed_date: "2026-10-01T10:00:00Z", author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, additions: 8, deletions: 2, changed_files: 1, is_in_default_branch: false }
+    # The squash result, on the default branch, carrying the whole branch as one
+    # commit. Its sha is full length here — only the request reports a prefix.
+    - { $ref: templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:bbsq-r", repository: https://bitbucket.org/acme/squash-bb.git, sha: 4f1c9a20d3e57b8f6a1c0d92e4b73a58c6d90f11, committed_date: "2026-10-01T11:00:00Z", author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, additions: 18, deletions: 2, changed_files: 1, is_in_default_branch: true }
+    # other-bb: same first 12 characters, unrelated repository, no request.
+    - { $ref: templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:bboth-1", repository: https://bitbucket.org/acme/other-bb.git, sha: 4f1c9a20d3e5aaaaaaaaaaaaaaaaaaaaaaaaaaaa, author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, additions: 4, changed_files: 1, is_in_default_branch: true }
+    # ff-bb: the request reports this commit's own prefix as its merge result.
+    - { $ref: templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:bbff-1", repository: https://bitbucket.org/acme/ff-bb.git, sha: 9c2b71fe40a3d5e8b6740c19af23568d1b0e7f42, author_name: Erin Epsilon, author_email: erin@example.com, committer_name: Erin Epsilon, committer_email: erin@example.com, additions: 6, changed_files: 1, is_in_default_branch: true }
+
+  bronze_bitbucket_cloud.file_changes:
+    # One path, touched twice on the branch: null-to-B then B-to-C.
+    - { $ref: templates/bitbucket_git.yaml#/templates/file_change, unique_key: "fc:bbsq-b1:one.py", repository: https://bitbucket.org/acme/squash-bb.git, sha: bbsq-b1, filename: src/one.py, status: added, additions: 10, changes: 10, post_image_oid: oid-b }
+    - { $ref: templates/bitbucket_git.yaml#/templates/file_change, unique_key: "fc:bbsq-b2:one.py", repository: https://bitbucket.org/acme/squash-bb.git, sha: bbsq-b2, committed_date: "2026-10-01T10:00:00Z", filename: src/one.py, additions: 8, deletions: 2, changes: 10, pre_image_oid: oid-b, post_image_oid: oid-c }
+    # The squash's own null-to-C row matches neither branch transition, so blob
+    # identity cannot fold it and the lines count again if the commit counts.
+    - { $ref: templates/bitbucket_git.yaml#/templates/file_change, unique_key: "fc:bbsq-r:one.py", repository: https://bitbucket.org/acme/squash-bb.git, sha: 4f1c9a20d3e57b8f6a1c0d92e4b73a58c6d90f11, committed_date: "2026-10-01T11:00:00Z", filename: src/one.py, status: added, additions: 18, deletions: 2, changes: 20, post_image_oid: oid-c }
+
+  bronze_bitbucket_cloud.pull_requests:
+    # `merge_commit_sha` is the first 12 characters of the result's sha, exactly
+    # as the vendor API reports it.
+    - { $ref: templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "pr:91", repo_full_name: acme/squash-bb, id: 91, author_display_name: Erin Epsilon, source_commit_sha: bbsq-b2, destination_commit_sha: dst-91, merge_commit_sha: 4f1c9a20d3e5 }
+    # ff-bb: a fast-forward, so the reported result is one of the linked commits.
+    - { $ref: templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "pr:92", repo_full_name: acme/ff-bb, id: 92, author_display_name: Erin Epsilon, source_commit_sha: bbff-1, destination_commit_sha: dst-92, merge_commit_sha: 9c2b71fe40a3 }
+
+  bronze_bitbucket_cloud.pull_request_commits:
+    # Both branch commits are linked and both were collected, so coverage is
+    # complete and the result commit is not the only record of the work.
+    - { $ref: templates/bitbucket_git.yaml#/templates/pull_request_commit, unique_key: "prc:91:bbsq-b1", repo_full_name: acme/squash-bb, pr_id: 91, sha: bbsq-b1, author_name: Erin Epsilon, author_email: erin@example.com }
+    - { $ref: templates/bitbucket_git.yaml#/templates/pull_request_commit, unique_key: "prc:91:bbsq-b2", repo_full_name: acme/squash-bb, pr_id: 91, sha: bbsq-b2, committed_date: "2026-10-01T10:00:00Z", author_name: Erin Epsilon, author_email: erin@example.com }
+    - { $ref: templates/bitbucket_git.yaml#/templates/pull_request_commit, unique_key: "prc:92:bbff-1", repo_full_name: acme/ff-bb, pr_id: 92, sha: 9c2b71fe40a3d5e8b6740c19af23568d1b0e7f42, author_name: Erin Epsilon, author_email: erin@example.com }
+
+  bronze_bitbucket_cloud.pull_request_activity:
+    - { $ref: templates/bitbucket_git.yaml#/templates/activity, unique_key: "ac:91:ev1", repo_full_name: acme/squash-bb, pr_id: 91, update_state: MERGED }
+
+cases:
+  - name: A squash result reported under a shortened hash carries no commit and no lines
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [erin@example.com] }
+        period: { from: "2026-10-01", to: "2026-10-02" }
+        metrics:
+          - metric_key: git.commits
+            views:
+              - { view: breakdown, dimensions: [repository] }
+          - metric_key: git.lines_added
+            views:
+              - { view: breakdown, dimensions: [repository] }
+          - metric_key: git.code_lines
+            views:
+              - { view: breakdown, dimensions: [repository] }
+    expect:
+      - assert: "status == 200"
+      # The branch pair counts; the squash result does not.
+      - metric: git.commits
+        view: breakdown
+        find: { entity_id: erin@example.com, dimensions: { key: repository, value: "bitbucket-test:acme/squash-bb" } }
+        equal: { value: 2 }
+      # The branch's own lines, once: 10 + 8. With the squash counted, 36.
+      - metric: git.lines_added
+        view: breakdown
+        find: { entity_id: erin@example.com, dimensions: { key: repository, value: "bitbucket-test:acme/squash-bb" } }
+        equal: { value: 18 }
+      # `.py` under src/ classifies as code, so the code figure follows.
+      - metric: git.code_lines
+        view: breakdown
+        find: { entity_id: erin@example.com, dimensions: { key: repository, value: "bitbucket-test:acme/squash-bb" } }
+        equal: { value: 18 }
+      # A shared prefix in another repository is another commit, and keeps its
+      # credit: resolving stays inside the request's own repository.
+      - metric: git.commits
+        view: breakdown
+        find: { entity_id: erin@example.com, dimensions: { key: repository, value: "bitbucket-test:acme/other-bb" } }
+        equal: { value: 1 }
+      # A fast-forward promotes an original. Recognising the shortened hash must
+      # not turn the work itself into a copy of itself.
+      - metric: git.commits
+        view: breakdown
+        find: { entity_id: erin@example.com, dimensions: { key: repository, value: "bitbucket-test:acme/ff-bb" } }
+        equal: { value: 1 }

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_bitbucket_cloud.pull_request_commits.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_bitbucket_cloud.pull_request_commits.yaml
@@ -2,7 +2,7 @@
 # land in bronze as JSON strings (the staging models toString() them), so they
 # are typed string here.
 schemas:
-  bronze_bitbucket_cloud.file_changes:
+  bronze_bitbucket_cloud.pull_request_commits:
     $schema: http://json-schema.org/draft-07/schema#
     type: object
     additionalProperties: false
@@ -11,20 +11,21 @@ schemas:
       source_id: { type: [string, "null"] }
       unique_key: { type: [string, "null"] }
       data_source: { type: [string, "null"] }
-      repository: { type: [string, "null"] }
+      collected_at: { type: [string, "null"] }
+      repo_full_name: { type: [string, "null"] }
+      pr_id: { type: [integer, "null"] }
+      pr_updated_on: { type: [string, "null"] }
       sha: { type: [string, "null"] }
+      message: { type: [string, "null"] }
       committed_date: { type: [string, "null"] }
-      filename: { type: [string, "null"] }
-      previous_filename: { type: [string, "null"] }
-      status: { type: [string, "null"] }
-      additions: { type: [integer, "null"] }
-      deletions: { type: [integer, "null"] }
-      changes: { type: [integer, "null"] }
-      is_binary: { type: [boolean, "null"] }
-      pre_image_oid: { type: [string, "null"] }
-      post_image_oid: { type: [string, "null"] }
-      patch: { type: [string, "null"] }
-      patch_truncated: { type: [boolean, "null"] }
+      parent_shas: { type: [string, "null"] }
+      is_merge: { type: [boolean, "null"] }
+      author_name: { type: [string, "null"] }
+      author_email: { type: [string, "null"] }
+      author_uuid: { type: [string, "null"] }
+      author_account_id: { type: [string, "null"] }
+      author_nickname: { type: [string, "null"] }
+      author_display_name: { type: [string, "null"] }
       _airbyte_raw_id: { type: string }
       _airbyte_extracted_at: { type: string, format: date-time }
       _airbyte_meta: { type: string }

--- a/src/ingestion/tests/e2e/metrics/templates/bitbucket_git.yaml
+++ b/src/ingestion/tests/e2e/metrics/templates/bitbucket_git.yaml
@@ -64,6 +64,18 @@ templates:
     merge_commit_sha: null
     participants: "[]"
 
+  pull_request_commit:
+    $ref: "#/templates/base"
+    repo_full_name: acme/platform
+    pr_id: null
+    sha: null
+    message: change
+    committed_date: "2026-10-01T09:00:00Z"
+    parent_shas: "[\"parent\"]"
+    is_merge: false
+    author_name: null
+    author_email: null
+
   diffstat:
     $ref: "#/templates/base"
     repo_full_name: acme/platform


### PR DESCRIPTION
Closes #3161.

**Why.** On Bitbucket a squash-merged pull request's result commit is never recognised as one, so it counts beside the branch commits it replaced and inflates every commit-based git metric.

**What changed.** The reported hash is resolved against the collected commit instead of compared to it — Bitbucket answers `merge_commit.hash` with a 12-character prefix, GitHub with the full 40 — in `git_derived_commits` and in `git_superseded_file_changes`, through the shared `git_merge_result_match`.

**Both call sites, not one.** #3160's partial-coverage suppression matches the reported hash too, so fixing only the first would leave complete coverage working on Bitbucket and partial coverage silently not.

**A prefix matching more than one collected commit marks neither.** Marking removes a commit's lines along with itself, so over-counting a request is the safer failure.

**`mtr_git_person_weekly` keeps the mismatch.** Its join feeds an aggregate and needs a form that cannot match two commits at once; documented in the model rather than changed here.

`git_squash_result_bitbucket` reads 2 commits where the unfixed model reads 3, and pins three boundaries the resolution introduces: a shared prefix in another repository keeps its own credit, a fast-forward under a shortened hash stays authored, and an ambiguous prefix marks nothing — weakening that guard to `length(candidates) >= 1` fails the spec. The line figures are pinned but do not discriminate: since #3160 content identity already folds a squash into the branch commit it ends on.

**Verified.** `dbt parse` clean; `-k git_` 21 passed. `git_commits_per_active_day` fails here and on plain `upstream/main` alike — pre-existing, arriving with #3135.
