### PR TITLE
feat(analytics): add token-authenticated SQL API

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -76,6 +76,8 @@ AI_ASSIST_MODEL=claude-sonnet-5
 # both the browser and Docker containers can reach. Pin it only when that
 # address is unsuitable for your machine.
 MCP_ENABLED=false
+SQL_API_ENABLED=false
+SQL_API_TOKEN=
 MCP_PUBLIC_URL=
 MCP_MAX_CONCURRENT_QUERIES=16
 CLICKHOUSE_MCP_PASSWORD=

--- a/charts/insight/README.md
+++ b/charts/insight/README.md
@@ -2,6 +2,9 @@
 
 Single canonical unit of delivery for the Insight platform.
 
+For token-authenticated, read-only SQL execution, see the
+[SQL query API guide](../../deploy/SQL_QUERY_API.md).
+
 - **Chart**: `insight`
 - **Version**: see `Chart.yaml` → `version`
 - **App version**: see `Chart.yaml` → `appVersion` (matches image tags)

--- a/charts/insight/templates/clickhouse-migrate-job.yaml
+++ b/charts/insight/templates/clickhouse-migrate-job.yaml
@@ -109,7 +109,9 @@ spec:
                   optional: true
             - name: MCP_ENABLED
               value: {{ .Values.global.mcp.enabled | quote }}
-            {{- if .Values.global.mcp.enabled }}
+            - name: SQL_API_ENABLED
+              value: {{ .Values.global.sqlApi.enabled | quote }}
+            {{- if or .Values.global.mcp.enabled .Values.global.sqlApi.enabled }}
             - name: CLICKHOUSE_MCP_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/insight/values.schema.json
+++ b/charts/insight/values.schema.json
@@ -88,6 +88,12 @@
         "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
         "storageClass":     { "type": "string" },
         "observability":    { "$ref": "#/definitions/observability" },
+        "sqlApi": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
         "mcp": {
           "type": "object",
           "properties": {

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -93,6 +93,8 @@ credentials:
 global:
   imagePullSecrets: [] # pull-secrets for a private registry
   storageClass: "" # empty = default StorageClass of the cluster
+  sqlApi:
+    enabled: false
   mcp:
     enabled: false
     # Public origin of this Insight instance, for example https://insight.example.com.
@@ -563,6 +565,9 @@ analytics:
     credentialsSecret: insight-mcp-creds
     clickhouseUser: insight_mcp
     clickhousePasswordKey: clickhouse-password
+  sqlApi:
+    tokenSecret: insight-sql-api-creds
+    tokenKey: token
   externalSources: []
   # Explaining a metric with an LLM. Off everywhere until an operator turns it
   # on, and turning it on without `tokenEncryptionKey` stops the service at

--- a/deploy/SQL_QUERY_API.md
+++ b/deploy/SQL_QUERY_API.md
@@ -1,0 +1,88 @@
+# SQL query API
+
+`POST /api/sql/query` executes SQL without saving a query. It uses the same
+read-only ClickHouse account, grants, SQL validation, and per-pod concurrency
+budget as MCP. Saved-query endpoints and MCP OAuth are unchanged.
+
+## Enable
+
+Create two operator-managed Kubernetes Secrets in the release namespace:
+
+- `insight-mcp-creds`, key `clickhouse-password`: the existing SQL explorer
+  ClickHouse password. Reuse this Secret if MCP is already configured.
+- `insight-sql-api-creds`, key `token`: a separate, cryptographically random
+  instance token. Generate at least 32 random bytes, for example with
+  `openssl rand -hex 32`, and store it in your secret manager. Never commit
+  plaintext credentials; SealedSecrets can carry them in GitOps.
+
+Enable the endpoint in Helm values:
+
+```yaml
+global:
+  sqlApi:
+    enabled: true
+analytics:
+  sqlApi:
+    tokenSecret: insight-sql-api-creds
+    tokenKey: token
+```
+
+MCP does not need to be enabled. The existing `analytics.mcp` values configure
+the shared listener, ClickHouse credentials, and concurrency budget. When either
+feature is enabled, database provisioning creates the read-only explorer access.
+Leave `global.mcp.enabled` and `global.mcp.publicUrl` unchanged.
+
+Inherit gateway route defaults. A custom `gateway.gateway.routes` list replaces
+the complete default list and must explicitly include `/api/sql/query` with
+`auth: instance_token`, upstream `http://{{ .Release.Name }}-analytics:8086`,
+`timeoutMs: 40000`, and `sqlApiOnly: true`.
+
+For Docker Compose, set `SQL_API_ENABLED=true`, `SQL_API_TOKEN`, and
+`CLICKHOUSE_MCP_PASSWORD` in your untracked environment file. Restart analytics
+after changing the token. In Kubernetes, update the token Secret and roll the
+analytics Deployment: environment-injected secrets are read only at startup.
+During a rolling rotation, old and new pods may temporarily accept different tokens.
+
+## Query
+
+With `INSIGHT_SQL_TOKEN` supplied by your secret manager:
+
+```bash
+curl --fail-with-body https://insight.example.com/api/sql/query \
+  -H "Authorization: Bearer ${INSIGHT_SQL_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  --data '{"sql":"SELECT 1 AS answer"}'
+```
+
+```json
+{
+  "columns": [{"name": "answer", "type": "UInt8"}],
+  "rows": [{"answer": 1}],
+  "row_count": 1,
+  "truncated": false
+}
+```
+
+Discover available relations through `system.databases`, `system.tables`, and
+`system.columns`. The same grants cover bronze, staging, silver, the configured
+gold database, identity, and config. No new grants are introduced by this API.
+
+Only one SELECT/WITH statement is accepted. Multiple CTEs, subqueries, joins,
+and unions are allowed. Query SETTINGS/FORMAT and external table functions are
+rejected. SQL is capped at 64 KiB and the request body at 128 KiB. The shared
+executor caps ClickHouse response bytes at 5 MiB; database row, memory, scan,
+and execution-time limits remain in force. Exceeding a limit fails the query;
+results are not silently truncated.
+
+Responses use canonical problem JSON for errors: 400 for invalid requests/SQL,
+401 for missing or invalid tokens, 429 for capacity or size limits, 504 for query
+timeouts, and 500 for backend failures. Responses are marked `Cache-Control:
+no-store`. Database details and the token are not returned in errors.
+
+## Access scope
+
+The instance token grants all SQL explorer access, not access on behalf of an
+individual user. There are no personal role checks, per-user revocation, or
+automatic tenant-row filters on this endpoint. Distribute it only to trusted
+operators authorized to access the entire allowed dataset, and require HTTPS.
+Revoke access by rotating the token or disabling `global.sqlApi.enabled`.

--- a/deploy/SQL_QUERY_API.md
+++ b/deploy/SQL_QUERY_API.md
@@ -74,8 +74,11 @@ gold database, identity, and config. No new grants are introduced by this API.
 Only one SELECT/WITH statement is accepted. Multiple CTEs, subqueries, joins,
 and unions are allowed. Query SETTINGS/FORMAT and external table functions are
 rejected. SQL is capped at 64 KiB and the request body at 128 KiB. The shared
-executor caps ClickHouse response bytes at 5 MiB; database row, memory, scan,
-and execution-time limits remain in force. Exceeding a limit fails the query;
+executor caps ClickHouse response bytes at 5 MiB. Shared API and MCP database
+limits allow scanning 10 million rows / 1 GiB and returning 5,000 rows / 5 MiB,
+with 512 MiB query memory, two threads, and a 30-second execution timeout.
+The scan limits apply when database provisioning runs, including on upgrades.
+Exceeding a limit fails the query;
 results are not silently truncated.
 
 Responses use canonical problem JSON for errors: 400 for invalid requests/SQL,

--- a/deploy/SQL_QUERY_API.md
+++ b/deploy/SQL_QUERY_API.md
@@ -15,6 +15,10 @@ Create two operator-managed Kubernetes Secrets in the release namespace:
   `openssl rand -hex 32`, and store it in your secret manager. Never commit
   plaintext credentials; SealedSecrets can carry them in GitOps.
 
+Token strength is the operator's responsibility. Startup checks length and
+character validity, not randomness; never use a memorable phrase or repeated
+characters as the token. Rate limiting is not a substitute for a random secret.
+
 Enable the endpoint in Helm values:
 
 ```yaml
@@ -75,8 +79,11 @@ and execution-time limits remain in force. Exceeding a limit fails the query;
 results are not silently truncated.
 
 Responses use canonical problem JSON for errors: 400 for invalid requests/SQL,
-401 for missing or invalid tokens, 429 for capacity or size limits, 504 for query
-timeouts, and 500 for backend failures. Responses are marked `Cache-Control:
+401 for missing or invalid tokens, 413 for oversized bodies or SQL, 429 for
+query capacity, result-size, or database resource limits, 504 for query timeouts,
+and 500 for other backend failures. Recognized database exceptions are classified
+using [ClickHouse's numeric error codes](https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp);
+unrecognized exceptions remain generic backend failures. Responses are marked `Cache-Control:
 no-store`. Database details and the token are not returned in errors.
 
 ## Access scope

--- a/deploy/compose/gateway/routes.yaml
+++ b/deploy/compose/gateway/routes.yaml
@@ -9,6 +9,10 @@ defaults:
     - X-Real-IP
     - Forwarded
 routes:
+  - prefix: /api/sql/query
+    upstream: http://analytics:8086
+    auth: instance_token
+    timeout_ms: 40000
   - prefix: /mcp
     upstream: http://analytics:8086
     auth: bearer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -264,6 +264,8 @@ services:
       APP__gears__analytics__config__ai_assist__admin_only: "${AI_ASSIST_ADMIN_ONLY:-true}"
       APP__gears__analytics__config__ai_assist__model: "${AI_ASSIST_MODEL:-claude-sonnet-5}"
       APP__gears__analytics__config__mcp__enabled: "${MCP_ENABLED:-false}"
+      APP__gears__analytics__config__sql_api__enabled: "${SQL_API_ENABLED:-false}"
+      APP__gears__analytics__config__sql_api__token: "${SQL_API_TOKEN:-}"
       APP__gears__analytics__config__mcp__public_url: "${MCP_PUBLIC_URL:-}"
       APP__gears__analytics__config__mcp__allow_insecure_private_network: "true"
       APP__gears__analytics__config__mcp__max_concurrent_queries: "${MCP_MAX_CONCURRENT_QUERIES:-16}"
@@ -775,6 +777,7 @@ services:
       # Grant-less `presentation` user's password (#1964), provisioned on seed.
       CLICKHOUSE_PRESENTATION_PASSWORD: "${CLICKHOUSE_PRESENTATION_PASSWORD:-presentation-local}"
       MCP_ENABLED: "${MCP_ENABLED:-false}"
+      SQL_API_ENABLED: "${SQL_API_ENABLED:-false}"
       CLICKHOUSE_MCP_PASSWORD: "${CLICKHOUSE_MCP_PASSWORD:-}"
       # apply-ch-migrations.sh runs `dbt run` from /ingestion/dbt. The
       # ingestion tree is bind-mounted read-only (below), so redirect dbt's

--- a/docs/components/backend/gateway/DESIGN.md
+++ b/docs/components/backend/gateway/DESIGN.md
@@ -203,7 +203,7 @@ Runs once at startup, not as a runtime watcher. Does not decide routing policy -
 The commodity edge: routing, proxying, streaming, WebSocket upgrades, timeouts, rate limiting -- the code nobody should hand-write in Rust.
 
 ##### Responsibility scope
-Longest-prefix `location` matching; an access-phase Lua exchange on every `/api/` location; plain proxy for `/auth/` (with a coarse per-IP `limit_req` flood guard); SPA at `/`; `proxy_buffering off` where streaming matters; WebSocket upgrade pass-through (auth runs once at upgrade, JWT frozen for the socket's life); `/internal/` returns 404; HSTS on every response.
+Longest-prefix `location` matching for session-authenticated routes, with an access-phase Lua exchange; exact matching for explicitly configured bearer and instance-token routes (see 3.8); plain proxy for `/auth/` (with a coarse per-IP `limit_req` flood guard); SPA at `/`; `proxy_buffering off` where streaming matters; WebSocket upgrade pass-through (auth runs once at upgrade, JWT frozen for the socket's life); `/internal/` returns 404; HSTS on every response.
 
 Access-phase Lua exchange semantics the design hangs on: authenticator `200` = allow (JWT read from the `X-Gateway-Jwt` response header); `401` = deny with that status (never cached); anything else (authenticator unreachable / timeout / 5xx) = fail closed, shaped to a `503`. The Lua cosocket calls the authenticator without the request body, so uploads are not buffered twice; the response body and any `Set-Cookie` are discarded -- fine, the design never sets cookies on `/api/*`.
 
@@ -331,8 +331,8 @@ defaults:
   strip_prefix: false
   websocket: false
   # Operator-extensible deny-list of request headers. The hardcoded
-  # gateway-reserved set (Authorization, X-Correlation-Id,
-  # X-Forwarded-*, gateway cookies) is always stripped in addition.
+  # Auth mode owns Authorization/cookies; correlation and forwarding
+  # headers are always replaced by gateway-authored values.
   strip_request_headers:
     - X-Real-IP
     - Forwarded
@@ -355,16 +355,16 @@ Validation rules (enforced by the configurator in CI, before nginx ever sees the
 
 - `version` must be a known schema version.
 - `prefix` unique across the table; no two routes share an exact prefix.
-- `prefix` must start with `/api/`.
+- `auth` defaults to `session`, whose `prefix` must start with `/api/`. `bearer` is restricted to exact `/mcp`; `instance_token` is restricted to exact `/api/sql/query`.
 - `upstream` must be a valid URL with hostname and port.
 - `timeout_ms >= 0`; `0` only allowed when `websocket: true`.
-- `strip_request_headers` entries must be valid HTTP header names; reserved gateway headers (`Authorization`, `X-Correlation-Id`, `X-Forwarded-*`, gateway cookies) **MUST NOT** appear in this list -- they are stripped unconditionally. There is no tenant selector anymore: the JWT carries a single signed `tenant_id`, so an inbound `X-Tenant-ID`/`X-Insight-Tenant-Id` is not authority and downstream ignores it (deployments may strip it for hygiene).
+- `strip_request_headers` entries must be valid HTTP header names; reserved gateway headers (`Authorization`, `X-Correlation-Id`, `X-Forwarded-*`, gateway cookies) **MUST NOT** appear in this list -- their treatment is owned by the selected auth mode and the common hygiene block. There is no tenant selector: session JWTs carry a single signed `tenant_id`, while the instance-token SQL API has instance-wide scope. An inbound `X-Tenant-ID`/`X-Insight-Tenant-Id` is not authority (deployments may strip it for hygiene).
 
 **Why the defaults strip `X-Real-IP` and `Forwarded` -- and how backends still get the client IP.** Those two are *inbound, client-writable* identity headers: the gateway never sets them, so any value arriving upstream could only have come from the browser -- an attacker sending `Forwarded: for=1.2.3.4` would spoof IP-based audit trails, rate-limit keys, or geo logic in any backend that reads them. Stripping them leaves exactly **one source of client-IP truth**: the `X-Forwarded-For` chain, which the gateway strips from the client unconditionally (reserved set) and re-writes itself (hygiene block item 5), resolving the true peer address via `set_real_ip_from` trust of the ingress hops. Backends read client IP from that header and nothing else; the authenticator's session records (`ip` captured at login) rely on the same chain. Same trust model as the tenant claim: an unsigned inbound header is never authority — only the signed gateway JWT is. If an upstream ever genuinely needs `X-Real-IP`, the configurator emits it gateway-written (`$remote_addr` after real-ip resolution) as a hygiene-block addition -- do not remove it from the strip list, which would reintroduce the client-writable variant.
 
 ### 3.9 Generated Location Hygiene Block
 
-Every generated `/api/` location gets, without exception (this is what closes the deleted spec's header-hygiene and auth-bypass risks by construction):
+Every generated `auth: session` location gets the following block. Explicit non-session modes preserve the common header hygiene but use their own downstream authentication boundary, as described below.
 
 1. `auth_request` to the internal exchange location, with `auth_request_set` capturing `X-Gateway-Jwt`.
 2. `Authorization` set to the captured JWT -- replacing anything the browser sent.
@@ -375,7 +375,11 @@ Every generated `/api/` location gets, without exception (this is what closes th
 7. Per-route `proxy_read_timeout` from `timeout_ms`; WebSocket upgrade boilerplate when `websocket: true`; `proxy_buffering off`.
 8. `error_page` wiring for the fail-closed exits (3.12).
 
-CI proof: a poisoned-request snapshot test per generated route (forged `Authorization`, junk cookies, junk correlation id sent in; assert what the upstream stub receives), and a no-cookie-means-401 assertion on every `/api/` route.
+`auth: instance_token` forwards `Authorization` unchanged to analytics, where the SQL API validates the configured instance token on every request. It does not invoke the session exchange or advertise MCP OAuth. Its Lua handler strips all cookies and replaces the correlation and forwarding context; operator header stripping, proxy timeouts, and response handling still apply. This mode grants instance-wide SQL explorer access, not a user or tenant identity. Helm renders the route only when `global.sqlApi.enabled` is true.
+
+`auth: bearer` similarly forwards bearer credentials for `/mcp`, where analytics verifies the MCP OAuth token. This is separate from instance-token authentication.
+
+CI proof: poisoned-request and no-cookie-means-401 assertions cover session routes. Route-generator tests separately assert exact matching, the instance-token handler, common proxy hygiene, and absence of session exchange/MCP OAuth on the SQL API route. Analytics tests cover missing, malformed, and valid instance tokens.
 
 ### 3.10 Subrequest Contract
 
@@ -520,7 +524,7 @@ One OpenResty Deployment behind the single ingress backend, per the edge chain f
 
 **Why**: In the deleted Rust Router, auth was structural (every request passed the middleware chain by construction); in nginx it is per-location config. The containment is this rule: a route missing auth means a JWT-less request downstream and a 401 -- an availability bug caught by the first smoke test, never a breach. This is what zero trust means here: no service trusts network position, headers, or another service's word; only the signature.
 
-**Consequences**: CI asserts every `/api/` route returns 401 without a cookie; downstream verification ships as one shared middleware so a new service gets the boundary by adding a dependency.
+**Consequences**: CI asserts every session-authenticated `/api/` route returns 401 without a cookie; downstream verification ships as one shared middleware so a new service gets the boundary by adding a dependency. Explicit bearer and instance-token routes use the separate boundaries in 3.9.
 
 **Realized (step 07)**: The algorithm is **ES256** (§9.6, ECDSA P-256) — smaller signatures (~64 B vs RSA's ~256 B) and faster verify, both paid on every downstream request. Downstream verification is entirely **plugin-native**: Rust services enable host auth via the **upstream `cf-gears-oidc-authn-plugin`** (the insight-local fork and the bespoke `authverify` crate are both **deleted**), which verifies signature / `iss` / `aud` / `exp` / the required `tenant_id` and maps the signed claims straight to a `SecurityContext` via configured `claim_mapping` (`sub`→`subject_id`, `tenant_id`→`subject_tenant_id`, `sub_type`→`subject_type`, `roles`→`token_scopes`). There is **no tenant selector**: the JWT carries a single signed `tenant_id`, so the `X-Tenant-ID`/`X-Insight-Tenant-Id` header trust paths are gone (a tenant from the outside world never passes). analytics adopts the plugin (its `auth_disabled` trust path deleted). identity-resolution verifies JWTs the same way via the upstream `cf-gears-oidc-authn-plugin` (pinned to ES256) against the authenticator's JWKS, reading the caller from `sub` and the tenant from the single `tenant_id` claim, and fails closed when the token is absent or invalid. The plugin resolves the JWKS via OIDC **discovery** (`{issuer}/.well-known/openid-configuration` → `jwks_uri`) over **https only**; in production the issuer is a real https origin, and in dev/e2e a self-signed TLS front serves the authenticator's well-known endpoints (trusted via `http_client.custom_ca_certificate_paths`). Proven end-to-end by `services/gateway/tests/step07/` (the §D scenarios).
 

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -153,6 +153,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.11.0",
  "sqlparser",
+ "subtle",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/src/backend/services/analytics/Cargo.toml
+++ b/src/backend/services/analytics/Cargo.toml
@@ -77,6 +77,7 @@ base64 = { workspace = true }
 aes-gcm = { workspace = true }
 zeroize = { workspace = true }
 sha2 = { workspace = true }
+subtle = { workspace = true }
 hex = { workspace = true }
 secrecy = { workspace = true }
 csv = { workspace = true }

--- a/src/backend/services/analytics/helm/templates/configmap.yaml
+++ b/src/backend/services/analytics/helm/templates/configmap.yaml
@@ -140,6 +140,8 @@ data:
       analytics:
         config:
           visibility_policy: {{ .Values.visibilityPolicy | default "org_chart" | quote }}
+          sql_api:
+            enabled: {{ .Values.global.sqlApi.enabled }}
           mcp:
             enabled: {{ .Values.global.mcp.enabled }}
             bind_addr: "0.0.0.0:{{ .Values.mcp.port }}"

--- a/src/backend/services/analytics/helm/templates/deployment.yaml
+++ b/src/backend/services/analytics/helm/templates/deployment.yaml
@@ -69,18 +69,25 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-            {{- if .Values.global.mcp.enabled }}
+            {{- if or .Values.global.mcp.enabled .Values.global.sqlApi.enabled }}
             - name: mcp
               containerPort: {{ .Values.mcp.port }}
               protocol: TCP
             {{- end }}
-          {{- if .Values.global.mcp.enabled }}
+          {{- if or .Values.global.mcp.enabled .Values.global.sqlApi.enabled }}
           env:
             - name: APP__gears__analytics__config__mcp__clickhouse_password
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "mcp.credentialsSecret is required when MCP is enabled" .Values.mcp.credentialsSecret | quote }}
-                  key: {{ required "mcp.clickhousePasswordKey is required when MCP is enabled" .Values.mcp.clickhousePasswordKey | quote }}
+                  name: {{ required "mcp.credentialsSecret is required when a SQL explorer is enabled" .Values.mcp.credentialsSecret | quote }}
+                  key: {{ required "mcp.clickhousePasswordKey is required when a SQL explorer is enabled" .Values.mcp.clickhousePasswordKey | quote }}
+            {{- if .Values.global.sqlApi.enabled }}
+            - name: APP__gears__analytics__config__sql_api__token
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "sqlApi.tokenSecret is required when SQL API is enabled" .Values.sqlApi.tokenSecret | quote }}
+                  key: {{ required "sqlApi.tokenKey is required when SQL API is enabled" .Values.sqlApi.tokenKey | quote }}
+            {{- end }}
           {{- end }}
           # Gateway-JWT verification (NGINX_BFF R1): the plugin's verification
           # config is nested/list-shaped and rendered into the ConfigMap from

--- a/src/backend/services/analytics/helm/templates/service.yaml
+++ b/src/backend/services/analytics/helm/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if .Values.global.mcp.enabled }}
+    {{- if or .Values.global.mcp.enabled .Values.global.sqlApi.enabled }}
     - port: {{ .Values.mcp.port }}
       targetPort: mcp
       protocol: TCP

--- a/src/backend/services/analytics/helm/values.yaml
+++ b/src/backend/services/analytics/helm/values.yaml
@@ -1,6 +1,8 @@
 replicaCount: 1
 
 global:
+  sqlApi:
+    enabled: false
   mcp:
     enabled: false
     publicUrl: ""
@@ -15,6 +17,10 @@ image:
 service:
   type: ClusterIP
   port: 8081
+
+sqlApi:
+  tokenSecret: insight-sql-api-creds
+  tokenKey: token
 
 mcp:
   port: 8086

--- a/src/backend/services/analytics/src/config.rs
+++ b/src/backend/services/analytics/src/config.rs
@@ -18,14 +18,16 @@ const REDACTED_SECRET: &str = "<redacted>";
 
 pub(crate) fn redacted_yaml(config: &toolkit::bootstrap::AppConfig) -> anyhow::Result<String> {
     let mut redacted = config.clone();
-    if let Some(password) = redacted
-        .gears
-        .get_mut("analytics")
-        .and_then(|gear| gear.get_mut("config"))
-        .and_then(|config| config.get_mut("mcp"))
-        .and_then(|mcp| mcp.get_mut("clickhouse_password"))
-    {
-        *password = serde_json::Value::String(REDACTED_SECRET.to_owned());
+    for (section, key) in [("mcp", "clickhouse_password"), ("sql_api", "token")] {
+        if let Some(secret) = redacted
+            .gears
+            .get_mut("analytics")
+            .and_then(|gear| gear.get_mut("config"))
+            .and_then(|config| config.get_mut(section))
+            .and_then(|section| section.get_mut(key))
+        {
+            *secret = serde_json::Value::String(REDACTED_SECRET.to_owned());
+        }
     }
     redacted.to_yaml()
 }
@@ -65,6 +67,13 @@ pub struct McpConfig {
     pub max_concurrent_queries: usize,
     pub clickhouse_user: String,
     pub clickhouse_password: SecretString,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct SqlApiConfig {
+    pub enabled: bool,
+    pub token: SecretString,
 }
 
 impl Default for McpConfig {
@@ -133,6 +142,7 @@ pub struct GearConfig {
     pub reports: ReportsConfig,
 
     pub mcp: McpConfig,
+    pub sql_api: SqlApiConfig,
 
     pub external_sources: Vec<ExternalSourceConfig>,
 }
@@ -154,6 +164,7 @@ impl Default for GearConfig {
             ai_assist: AiAssistConfig::default(),
             reports: ReportsConfig::default(),
             mcp: McpConfig::default(),
+            sql_api: SqlApiConfig::default(),
             external_sources: Vec::new(),
         }
     }
@@ -336,12 +347,14 @@ mod tests {
     #[test]
     fn printed_config_redacts_mcp_clickhouse_password() -> anyhow::Result<()> {
         let password = "mcp-password-that-must-not-print";
+        let token = "synthetic-sql-api-token-that-must-not-print";
         let mut config = toolkit::bootstrap::AppConfig::default();
         config.gears.insert(
             "analytics".to_owned(),
             serde_json::json!({
                 "config": {
-                    "mcp": { "clickhouse_password": password }
+                    "mcp": { "clickhouse_password": password },
+                    "sql_api": { "token": token }
                 }
             }),
         );
@@ -350,6 +363,7 @@ mod tests {
 
         assert!(printed.contains(REDACTED_SECRET));
         assert!(!printed.contains(password));
+        assert!(!printed.contains(token));
         Ok(())
     }
 

--- a/src/backend/services/analytics/src/gear.rs
+++ b/src/backend/services/analytics/src/gear.rs
@@ -47,8 +47,9 @@ impl Gear for AnalyticsApiGear {
     async fn init(&self, ctx: &GearCtx) -> anyhow::Result<()> {
         let cfg: GearConfig = ctx.config()?;
         validate_reports_config(&cfg.reports)?;
-        crate::mcp::validate_config(&cfg.mcp)?;
+        crate::sql_explorer::validate_config(&cfg.mcp, &cfg.sql_api)?;
         let mcp = cfg.mcp.clone();
+        let sql_api = cfg.sql_api.clone();
         let mcp_clickhouse_url = cfg.clickhouse_url.clone();
         let mcp_clickhouse_database = cfg.clickhouse_database.clone();
         let report_temp_dir = cfg.reports.temp_dir.clone();
@@ -129,9 +130,10 @@ impl Gear for AnalyticsApiGear {
             .set(Arc::new(state))
             .map_err(|_| anyhow::anyhow!("{} gear already initialized", Self::MODULE_NAME))?;
 
-        if mcp.enabled {
-            crate::mcp::start(
+        if mcp.enabled || sql_api.enabled {
+            crate::sql_explorer::start(
                 &mcp,
+                &sql_api,
                 &mcp_clickhouse_url,
                 &mcp_clickhouse_database,
                 ctx.cancellation_token().child_token(),
@@ -252,7 +254,7 @@ pub fn check_config(app: &toolkit::bootstrap::AppConfig) -> anyhow::Result<()> {
         );
     }
     ExternalSourceRegistry::new(&cfg.external_sources)?;
-    crate::mcp::validate_config(&cfg.mcp)?;
+    crate::sql_explorer::validate_config(&cfg.mcp, &cfg.sql_api)?;
     if cfg.ai_assist.enabled {
         if cfg.ai_assist.max_concurrent == 0 {
             anyhow::bail!(

--- a/src/backend/services/analytics/src/gear.rs
+++ b/src/backend/services/analytics/src/gear.rs
@@ -130,16 +130,14 @@ impl Gear for AnalyticsApiGear {
             .set(Arc::new(state))
             .map_err(|_| anyhow::anyhow!("{} gear already initialized", Self::MODULE_NAME))?;
 
-        if mcp.enabled || sql_api.enabled {
-            crate::sql_explorer::start(
-                &mcp,
-                &sql_api,
-                &mcp_clickhouse_url,
-                &mcp_clickhouse_database,
-                ctx.cancellation_token().child_token(),
-            )
-            .await?;
-        }
+        crate::sql_explorer::start(
+            &mcp,
+            &sql_api,
+            &mcp_clickhouse_url,
+            &mcp_clickhouse_database,
+            ctx.cancellation_token().child_token(),
+        )
+        .await?;
 
         // INVARIANT: periodic and never gating boot — the stamp lands after
         // boot (post-install migrate hook) and a later in-place bump must

--- a/src/backend/services/analytics/src/main.rs
+++ b/src/backend/services/analytics/src/main.rs
@@ -35,6 +35,7 @@ mod gear;
 mod infra;
 mod mcp;
 mod migration;
+mod sql_explorer;
 
 // System gears — linked via inventory for the REST host + auth pipeline.
 // `oidc-authn-plugin` verifies the ES256 gateway JWT against the authenticator's

--- a/src/backend/services/analytics/src/mcp.rs
+++ b/src/backend/services/analytics/src/mcp.rs
@@ -1,4 +1,3 @@
-use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -18,19 +17,13 @@ use rmcp::transport::streamable_http_server::{
 };
 use rmcp::{ServerHandler, tool, tool_handler, tool_router};
 use schemars::JsonSchema;
-use secrecy::ExposeSecret as _;
-use serde::{Deserialize, Serialize};
-use sha2::{Digest as _, Sha256};
-use tokio::sync::{Mutex, RwLock, Semaphore};
+use serde::Deserialize;
+use tokio::sync::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 
 use crate::config::McpConfig;
-use crate::domain::query_gate::validate_mcp_sql;
+use crate::sql_explorer::executor::{MAX_REQUEST_BODY_BYTES, QueryExecutor};
 
-const MAX_REQUEST_BODY_BYTES: usize = 128 * 1024;
-const MAX_SQL_BYTES: usize = 64 * 1024;
-const MAX_RESULT_BYTES: usize = 5 * 1024 * 1024;
-const FETCH_TIMEOUT: Duration = Duration::from_secs(35);
 const MAX_JWKS_BYTES: usize = 1024 * 1024;
 const JWKS_REFRESH_COOLDOWN: Duration = Duration::from_secs(5);
 const MCP_SCOPE: &str = "mcp:query";
@@ -39,27 +32,6 @@ const MCP_SCOPE: &str = "mcp:query";
 struct QuerySqlRequest {
     /// One ClickHouse SELECT or WITH statement. Multiple CTEs and nested queries are allowed.
     sql: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct ResultColumn {
-    name: String,
-    #[serde(rename = "type")]
-    data_type: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct ClickHouseJsonResult {
-    meta: Vec<ResultColumn>,
-    data: Vec<serde_json::Map<String, serde_json::Value>>,
-}
-
-#[derive(Debug, Serialize)]
-struct QuerySqlResult {
-    columns: Vec<ResultColumn>,
-    rows: Vec<serde_json::Map<String, serde_json::Value>>,
-    row_count: usize,
-    truncated: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -108,134 +80,28 @@ enum AuthFailure {
     Unavailable,
 }
 
-#[derive(Debug, thiserror::Error)]
-enum QueryFailure {
-    #[error("query capacity is exhausted")]
-    Busy,
-    #[error("query result exceeded the response limit")]
-    ResultTooLarge,
-    #[error("query timed out")]
-    Timeout,
-    #[error("ClickHouse query failed: {0}")]
-    ClickHouse(#[from] clickhouse::error::Error),
-    #[error("ClickHouse returned an invalid JSON response: {0}")]
-    InvalidResponse(#[from] serde_json::Error),
-    #[error("query result processing task failed: {0}")]
-    ProcessingTask(#[from] tokio::task::JoinError),
-}
-
-impl QueryFailure {
-    fn public_message(&self) -> &'static str {
-        match self {
-            Self::Busy => "the SQL explorer is busy; retry shortly",
-            Self::ResultTooLarge => "query result exceeded the response limit",
-            Self::Timeout => "query timed out",
-            Self::ClickHouse(_) | Self::InvalidResponse(_) | Self::ProcessingTask(_) => {
-                "query execution failed"
-            }
-        }
-    }
-}
-
 #[derive(Clone)]
 struct SqlExplorer {
-    client: insight_clickhouse::Client,
-    query_slots: Arc<Semaphore>,
+    executor: QueryExecutor,
     tool_router: ToolRouter<Self>,
 }
 
 impl SqlExplorer {
-    fn new(client: insight_clickhouse::Client, max_concurrent_queries: usize) -> Self {
+    fn new(executor: QueryExecutor) -> Self {
         Self {
-            client,
-            query_slots: Arc::new(Semaphore::new(max_concurrent_queries)),
+            executor,
             tool_router: Self::tool_router(),
         }
     }
 
-    async fn execute(&self, sql: &str) -> Result<QuerySqlResult, QueryFailure> {
-        let permit = self
-            .query_slots
-            .clone()
-            .try_acquire_owned()
-            .map_err(|_| QueryFailure::Busy)?;
-
-        let mut query = self.client.query(sql).fetch_bytes("JSON")?;
-
-        let fetch = async {
-            let mut bytes = Vec::new();
-            while let Some(chunk) = query.next().await? {
-                let next_len = bytes.len().saturating_add(chunk.len());
-                if next_len > MAX_RESULT_BYTES {
-                    return Err(QueryFailure::ResultTooLarge);
-                }
-                bytes.extend_from_slice(&chunk);
-            }
-            Ok::<_, QueryFailure>(bytes)
-        };
-
-        let bytes = tokio::time::timeout(FETCH_TIMEOUT, fetch)
-            .await
-            .map_err(|_| QueryFailure::Timeout)??;
-        // INVARIANT: query capacity also bounds CPU-heavy result decoding.
-        let result = tokio::task::spawn_blocking(move || {
-            serde_json::from_slice::<ClickHouseJsonResult>(&bytes)
-        })
-        .await??;
-        drop(permit);
-
-        let row_count = result.data.len();
-        Ok(QuerySqlResult {
-            columns: result.meta,
-            rows: result.data,
-            row_count,
-            truncated: false,
-        })
-    }
-
     async fn run_query_sql(&self, sql: String) -> CallToolResult {
-        if sql.len() > MAX_SQL_BYTES {
-            return tool_error(format!(
-                "SQL exceeds the {MAX_SQL_BYTES}-byte request limit"
-            ));
-        }
-        if let Err(reason) = validate_mcp_sql(&sql) {
-            return tool_error(reason);
-        }
-
-        let started = Instant::now();
-        let query_hash = hex::encode(Sha256::digest(sql.as_bytes()));
-        match self.execute(&sql).await {
-            Ok(result) => {
-                tracing::info!(
-                    query_hash,
-                    duration_ms = started.elapsed().as_millis(),
-                    rows = result.row_count,
-                    outcome = "success",
-                    "MCP SQL query completed"
-                );
-                match tokio::task::spawn_blocking(move || serde_json::to_value(result)).await {
-                    Ok(Ok(value)) => CallToolResult::structured(value),
-                    Ok(Err(error)) => {
-                        tracing::error!(query_hash, %error, "failed to serialize MCP SQL result");
-                        tool_error("query result serialization failed")
-                    }
-                    Err(error) => {
-                        tracing::error!(query_hash, %error, "MCP result serialization task failed");
-                        tool_error("query result serialization failed")
-                    }
-                }
-            }
-            Err(error) => {
-                tracing::warn!(
-                    query_hash,
-                    duration_ms = started.elapsed().as_millis(),
-                    error = %error,
-                    outcome = "error",
-                    "MCP SQL query failed"
-                );
-                tool_error(error.public_message())
-            }
+        match self
+            .executor
+            .query(sql, |value| Ok(CallToolResult::structured(value)))
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => tool_error(error.public_message()),
         }
     }
 }
@@ -268,24 +134,12 @@ impl ServerHandler for SqlExplorer {
     }
 }
 
-pub async fn start(
+pub(crate) fn router(
     config: &McpConfig,
-    clickhouse_url: &str,
-    clickhouse_database: &str,
+    executor: QueryExecutor,
     cancellation_token: CancellationToken,
-) -> anyhow::Result<()> {
-    let bind_addr: SocketAddr = config.bind_addr.parse()?;
-    let listener = tokio::net::TcpListener::bind(bind_addr).await?;
-
-    let client = insight_clickhouse::Client::new(
-        insight_clickhouse::Config::new(clickhouse_url, clickhouse_database)
-            .with_auth(
-                &config.clickhouse_user,
-                config.clickhouse_password.expose_secret(),
-            )
-            .without_query_timeout(),
-    );
-    let explorer = SqlExplorer::new(client, config.max_concurrent_queries);
+) -> anyhow::Result<Router> {
+    let explorer = SqlExplorer::new(executor);
     let service: StreamableHttpService<SqlExplorer, LocalSessionManager> =
         StreamableHttpService::new(
             move || Ok(explorer.clone()),
@@ -295,42 +149,12 @@ pub async fn start(
                 .with_json_response(true)
                 .with_allowed_hosts(["localhost"])
                 .with_max_request_body_bytes(MAX_REQUEST_BODY_BYTES)
-                .with_cancellation_token(cancellation_token.child_token()),
+                .with_cancellation_token(cancellation_token),
         );
     let auth = TokenVerifier::new(&config.public_url, config.allow_insecure_private_network)?;
-    let router = Router::new()
+    Ok(Router::new()
         .nest_service("/mcp", service)
-        .layer(middleware::from_fn_with_state(auth, authenticate));
-
-    tracing::info!(%bind_addr, "MCP SQL explorer listening");
-    tokio::spawn(async move {
-        let result = axum::serve(listener, router)
-            .with_graceful_shutdown(cancellation_token.cancelled_owned())
-            .await;
-        if let Err(error) = result {
-            tracing::error!(%error, "MCP SQL explorer stopped unexpectedly");
-        }
-    });
-
-    Ok(())
-}
-
-pub fn validate_config(config: &McpConfig) -> anyhow::Result<()> {
-    if !config.enabled {
-        return Ok(());
-    }
-    config.bind_addr.parse::<SocketAddr>()?;
-    validate_public_url(&config.public_url, config.allow_insecure_private_network)?;
-    if config.max_concurrent_queries == 0 {
-        anyhow::bail!("MCP max concurrent queries must be greater than zero");
-    }
-    if config.clickhouse_user.trim().is_empty() {
-        anyhow::bail!("MCP ClickHouse user is empty");
-    }
-    if config.clickhouse_password.expose_secret().is_empty() {
-        anyhow::bail!("MCP ClickHouse password is empty");
-    }
-    Ok(())
+        .layer(middleware::from_fn_with_state(auth, authenticate)))
 }
 
 async fn authenticate(
@@ -490,7 +314,7 @@ impl TokenVerifier {
     }
 }
 
-fn validate_public_url(
+pub(crate) fn validate_public_url(
     public_url: &str,
     allow_insecure_private_network: bool,
 ) -> anyhow::Result<()> {
@@ -532,489 +356,4 @@ fn tool_error(message: impl Into<String>) -> CallToolResult {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    use axum::Json;
-    use axum::body::Body;
-    use axum::http::{HeaderValue, Request, Response, StatusCode};
-    use axum::routing::{any, get};
-    use base64::Engine as _;
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
-    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
-    use p256::SecretKey;
-    use p256::elliptic_curve::Generate as _;
-    use p256::elliptic_curve::sec1::ToSec1Point as _;
-    use p256::pkcs8::{EncodePrivateKey as _, LineEnding};
-    use secrecy::SecretString;
-    use serde_json::{Value, json};
-    use tokio::task::JoinHandle;
-    use tokio_util::sync::CancellationToken;
-    use tower::ServiceExt as _;
-
-    use super::{
-        MAX_RESULT_BYTES, MAX_SQL_BYTES, McpConfig, QueryFailure, QuerySqlRequest, SqlExplorer,
-        TokenVerifier, bearer_token, start, validate_config, validate_public_url,
-    };
-
-    struct SigningMaterial {
-        key: EncodingKey,
-        jwks: Value,
-    }
-
-    fn signing_material() -> anyhow::Result<SigningMaterial> {
-        let secret = SecretKey::generate();
-        let pem = secret.to_pkcs8_pem(LineEnding::LF)?;
-        let key = EncodingKey::from_ec_pem(pem.as_bytes())?;
-        let point = secret.public_key().to_sec1_point(false);
-        let x = point
-            .x()
-            .ok_or_else(|| anyhow::anyhow!("public key has no x coordinate"))?;
-        let y = point
-            .y()
-            .ok_or_else(|| anyhow::anyhow!("public key has no y coordinate"))?;
-
-        Ok(SigningMaterial {
-            key,
-            jwks: json!({
-                "keys": [{
-                    "kty": "EC",
-                    "crv": "P-256",
-                    "use": "sig",
-                    "alg": "ES256",
-                    "kid": "test-key",
-                    "x": B64.encode(x),
-                    "y": B64.encode(y),
-                }]
-            }),
-        })
-    }
-
-    fn claims(issuer: &str) -> anyhow::Result<Value> {
-        let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-
-        Ok(json!({
-            "sub": "test-user",
-            "tenant_id": "test-tenant",
-            "roles": "user admin",
-            "sub_type": "user",
-            "sid": "test-session",
-            "iss": issuer,
-            "aud": format!("{issuer}/mcp"),
-            "scope": "openid mcp:query",
-            "iat": now,
-            "exp": now + 600,
-            "jti": "test-token",
-        }))
-    }
-
-    fn sign(material: &SigningMaterial, claims: &Value) -> anyhow::Result<String> {
-        let mut header = Header::new(Algorithm::ES256);
-        header.kid = Some("test-key".to_owned());
-
-        Ok(encode(&header, claims, &material.key)?)
-    }
-
-    async fn spawn_app(app: axum::Router) -> anyhow::Result<(String, JoinHandle<()>)> {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
-        let address = listener.local_addr()?;
-        let server = tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
-        });
-
-        Ok((format!("http://{address}"), server))
-    }
-
-    async fn spawn_clickhouse(
-        status: StatusCode,
-        body: Vec<u8>,
-    ) -> anyhow::Result<(SqlExplorer, JoinHandle<()>)> {
-        let app = axum::Router::new().fallback(any(move || {
-            let body = body.clone();
-            async move {
-                Response::builder()
-                    .status(status)
-                    .body(Body::from(body))
-                    .unwrap_or_else(|_| Response::new(Body::empty()))
-            }
-        }));
-        let (url, server) = spawn_app(app).await?;
-        let client = insight_clickhouse::Client::new(insight_clickhouse::Config::new(url, "gold"));
-
-        Ok((SqlExplorer::new(client, 1), server))
-    }
-
-    fn mcp_config() -> McpConfig {
-        McpConfig {
-            enabled: true,
-            bind_addr: "127.0.0.1:0".to_owned(),
-            public_url: "http://localhost:3000".to_owned(),
-            allow_insecure_private_network: false,
-            max_concurrent_queries: 2,
-            clickhouse_user: "test_mcp".to_owned(),
-            clickhouse_password: SecretString::from("test-password".to_owned()),
-        }
-    }
-
-    fn assert_tool_error_contains(result: &rmcp::model::CallToolResult, expected: &str) {
-        assert_eq!(result.is_error, Some(true));
-        let encoded = serde_json::to_string(result).unwrap_or_default();
-        assert!(
-            encoded.contains(expected),
-            "expected {expected:?} in {encoded}"
-        );
-    }
-
-    #[tokio::test]
-    async fn query_sql_returns_structured_clickhouse_json() -> anyhow::Result<()> {
-        let body = serde_json::to_vec(&json!({
-            "meta": [{"name": "answer", "type": "UInt8"}],
-            "data": [{"answer": 1}],
-            "rows": 1
-        }))?;
-        let (explorer, server) = spawn_clickhouse(StatusCode::OK, body).await?;
-
-        let result = explorer
-            .run_query_sql("SELECT 1 AS answer".to_owned())
-            .await;
-
-        assert_eq!(result.is_error, Some(false));
-        assert_eq!(
-            result
-                .structured_content
-                .as_ref()
-                .and_then(|value| value["row_count"].as_u64()),
-            Some(1)
-        );
-        assert_eq!(
-            result
-                .structured_content
-                .as_ref()
-                .map(|value| &value["rows"][0]["answer"]),
-            Some(&json!(1))
-        );
-        let info = rmcp::ServerHandler::get_info(&explorer);
-        assert_eq!(info.server_info.name, "insight-sql-explorer");
-        let direct = explorer
-            .query_sql(rmcp::handler::server::wrapper::Parameters(
-                QuerySqlRequest {
-                    sql: "SELECT 1 AS answer".to_owned(),
-                },
-            ))
-            .await;
-        assert_eq!(direct.is_error, Some(false));
-        server.abort();
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn query_sql_rejects_invalid_and_oversized_input() {
-        let client = insight_clickhouse::Client::new(insight_clickhouse::Config::new(
-            "http://127.0.0.1:1",
-            "gold",
-        ));
-        let explorer = SqlExplorer::new(client, 1);
-
-        let invalid = explorer
-            .run_query_sql("DROP TABLE gold.events".to_owned())
-            .await;
-        assert_tool_error_contains(&invalid, "SELECT or WITH");
-        let oversized = explorer.run_query_sql("x".repeat(MAX_SQL_BYTES + 1)).await;
-        assert_tool_error_contains(&oversized, "request limit");
-    }
-
-    #[tokio::test]
-    async fn query_execution_reports_busy_backend_and_response_failures() -> anyhow::Result<()> {
-        let client = insight_clickhouse::Client::new(insight_clickhouse::Config::new(
-            "http://127.0.0.1:1",
-            "gold",
-        ));
-        let busy = SqlExplorer::new(client, 0).execute("SELECT 1").await;
-        assert!(matches!(busy, Err(QueryFailure::Busy)));
-
-        let (invalid, invalid_server) =
-            spawn_clickhouse(StatusCode::OK, b"not-json".to_vec()).await?;
-        assert!(matches!(
-            invalid.execute("SELECT 1").await,
-            Err(QueryFailure::InvalidResponse(_))
-        ));
-        invalid_server.abort();
-
-        let (failed, failed_server) =
-            spawn_clickhouse(StatusCode::INTERNAL_SERVER_ERROR, Vec::new()).await?;
-        assert!(matches!(
-            failed.execute("SELECT 1").await,
-            Err(QueryFailure::ClickHouse(_))
-        ));
-        failed_server.abort();
-
-        let (large, large_server) =
-            spawn_clickhouse(StatusCode::OK, vec![b'x'; MAX_RESULT_BYTES + 1]).await?;
-        assert!(matches!(
-            large.execute("SELECT 1").await,
-            Err(QueryFailure::ResultTooLarge)
-        ));
-        large_server.abort();
-        Ok(())
-    }
-
-    #[test]
-    fn configuration_requires_a_complete_safe_origin_and_credentials() {
-        let mut config = mcp_config();
-        assert!(validate_config(&config).is_ok());
-        assert!(validate_config(&McpConfig::default()).is_ok());
-
-        config.bind_addr = "not-an-address".to_owned();
-        assert!(validate_config(&config).is_err());
-        config = mcp_config();
-        config.max_concurrent_queries = 0;
-        assert!(validate_config(&config).is_err());
-        config = mcp_config();
-        config.clickhouse_user = "  ".to_owned();
-        assert!(validate_config(&config).is_err());
-        config = mcp_config();
-        config.clickhouse_password = SecretString::from(String::new());
-        assert!(validate_config(&config).is_err());
-
-        assert!(validate_public_url("https://insight.example", false).is_ok());
-        assert!(validate_public_url("http://127.0.0.1:3000", false).is_ok());
-        assert!(validate_public_url("http://10.0.0.2:3000", true).is_ok());
-        for invalid in [
-            "http://insight.example",
-            "https://user@insight.example",
-            "https://insight.example/path",
-            "https://insight.example?query=true",
-            "https://insight.example#fragment",
-        ] {
-            assert!(
-                validate_public_url(invalid, false).is_err(),
-                "should reject {invalid}"
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn start_accepts_valid_configuration_and_cancellation() -> anyhow::Result<()> {
-        let cancellation = CancellationToken::new();
-
-        start(
-            &mcp_config(),
-            "http://127.0.0.1:1",
-            "gold",
-            cancellation.clone(),
-        )
-        .await?;
-        cancellation.cancel();
-        tokio::task::yield_now().await;
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn verifier_accepts_admin_tokens_and_rejects_other_claims() -> anyhow::Result<()> {
-        let material = signing_material()?;
-        let app = axum::Router::new().route(
-            "/.well-known/jwks.json",
-            get({
-                let jwks = material.jwks.clone();
-                move || {
-                    let jwks = jwks.clone();
-                    async move { Json(jwks) }
-                }
-            }),
-        );
-        let (issuer, server) = spawn_app(app).await?;
-        let verifier = TokenVerifier::new(&issuer, false)?;
-
-        let valid = sign(&material, &claims(&issuer)?)?;
-        assert!(verifier.verify(&valid).await.is_ok());
-
-        let mut insufficient = claims(&issuer)?;
-        insufficient["roles"] = json!("user");
-        let insufficient = sign(&material, &insufficient)?;
-        assert!(matches!(
-            verifier.verify(&insufficient).await,
-            Err(super::AuthFailure::InsufficientScope)
-        ));
-
-        let mut future_issued = claims(&issuer)?;
-        future_issued["iat"] = json!(future_issued["exp"].as_u64().unwrap_or_default() + 1);
-        let future_issued = sign(&material, &future_issued)?;
-        assert!(matches!(
-            verifier.verify(&future_issued).await,
-            Err(super::AuthFailure::InsufficientScope)
-        ));
-
-        assert!(matches!(
-            verifier.verify("not-a-token").await,
-            Err(super::AuthFailure::Unauthorized)
-        ));
-        let token_without_kid = encode(
-            &Header::new(Algorithm::ES256),
-            &claims(&issuer)?,
-            &material.key,
-        )?;
-        assert!(matches!(
-            verifier.verify(&token_without_kid).await,
-            Err(super::AuthFailure::Unauthorized)
-        ));
-        let wrong_algorithm = encode(
-            &Header::new(Algorithm::HS256),
-            &claims(&issuer)?,
-            &EncodingKey::from_secret(b"test-secret"),
-        )?;
-        assert!(matches!(
-            verifier.verify(&wrong_algorithm).await,
-            Err(super::AuthFailure::Unauthorized)
-        ));
-        server.abort();
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn auth_middleware_returns_oauth_challenges() -> anyhow::Result<()> {
-        let material = signing_material()?;
-        let app = axum::Router::new().route(
-            "/.well-known/jwks.json",
-            get({
-                let jwks = material.jwks.clone();
-                move || {
-                    let jwks = jwks.clone();
-                    async move { Json(jwks) }
-                }
-            }),
-        );
-        let (issuer, server) = spawn_app(app).await?;
-        let verifier = TokenVerifier::new(&issuer, false)?;
-        let protected = axum::Router::new()
-            .route("/", get(|| async { StatusCode::NO_CONTENT }))
-            .layer(axum::middleware::from_fn_with_state(
-                verifier.clone(),
-                super::authenticate,
-            ));
-
-        let missing = protected
-            .clone()
-            .oneshot(Request::get("/").body(Body::empty())?)
-            .await?;
-        assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
-        assert!(
-            missing
-                .headers()
-                .contains_key(axum::http::header::WWW_AUTHENTICATE)
-        );
-
-        let valid = sign(&material, &claims(&issuer)?)?;
-        let allowed = protected
-            .clone()
-            .oneshot(
-                Request::get("/")
-                    .header("authorization", format!("Bearer {valid}"))
-                    .body(Body::empty())?,
-            )
-            .await?;
-        assert_eq!(allowed.status(), StatusCode::NO_CONTENT);
-
-        let mut claims = claims(&issuer)?;
-        claims["scope"] = json!("openid");
-        let denied = sign(&material, &claims)?;
-        let denied = protected
-            .oneshot(
-                Request::get("/")
-                    .header("authorization", format!("Bearer {denied}"))
-                    .body(Body::empty())?,
-            )
-            .await?;
-        assert_eq!(denied.status(), StatusCode::FORBIDDEN);
-        server.abort();
-        Ok(())
-    }
-
-    #[test]
-    fn bearer_tokens_are_strictly_parsed() {
-        let mut headers = axum::http::HeaderMap::new();
-        headers.insert(
-            axum::http::header::AUTHORIZATION,
-            "Bearer token"
-                .parse()
-                .unwrap_or(HeaderValue::from_static("")),
-        );
-        assert_eq!(bearer_token(&headers), Some("token"));
-
-        for value in ["bearer token", "Bearer ", "Bearer two tokens"] {
-            headers.insert(
-                axum::http::header::AUTHORIZATION,
-                value.parse().unwrap_or(HeaderValue::from_static("")),
-            );
-            assert_eq!(bearer_token(&headers), None);
-        }
-    }
-
-    #[tokio::test]
-    async fn concurrent_jwks_misses_share_one_refresh() -> anyhow::Result<()> {
-        let requests = Arc::new(AtomicUsize::new(0));
-        let app = axum::Router::new().route(
-            "/.well-known/jwks.json",
-            get({
-                let requests = requests.clone();
-                move || {
-                    let requests = requests.clone();
-                    async move {
-                        requests.fetch_add(1, Ordering::SeqCst);
-                        Json(serde_json::json!({ "keys": [] }))
-                    }
-                }
-            }),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
-        let address = listener.local_addr()?;
-        let server = tokio::spawn(async move { axum::serve(listener, app).await });
-        let verifier = TokenVerifier::new(&format!("http://{address}"), false)?;
-
-        let (first, second) = tokio::join!(verifier.cached_jwks(), verifier.cached_jwks());
-
-        assert!(first.is_ok());
-        assert!(second.is_ok());
-        assert_eq!(requests.load(Ordering::SeqCst), 1);
-        assert!(verifier.refresh_jwks(Some("missing-key")).await.is_ok());
-        assert!(verifier.refresh_jwks(Some("missing-key")).await.is_ok());
-        assert_eq!(requests.load(Ordering::SeqCst), 1);
-        server.abort();
-        Ok(())
-    }
-
-    #[test]
-    fn backend_failures_have_a_generic_public_message() {
-        let clickhouse_failure = QueryFailure::ClickHouse(clickhouse::error::Error::BadResponse(
-            "private backend diagnostic".to_owned(),
-        ));
-        let parse_error = serde_json::Error::io(std::io::Error::other("private JSON diagnostic"));
-        let json_failure = QueryFailure::InvalidResponse(parse_error);
-
-        assert_eq!(
-            clickhouse_failure.public_message(),
-            "query execution failed"
-        );
-        assert_eq!(json_failure.public_message(), "query execution failed");
-        assert!(
-            !clickhouse_failure
-                .public_message()
-                .contains("private backend diagnostic")
-        );
-        assert!(!json_failure.public_message().contains("JSON"));
-    }
-
-    #[test]
-    fn bounded_query_failures_have_stable_public_messages() {
-        assert_eq!(
-            QueryFailure::Busy.public_message(),
-            "the SQL explorer is busy; retry shortly"
-        );
-        assert_eq!(
-            QueryFailure::ResultTooLarge.public_message(),
-            "query result exceeded the response limit"
-        );
-        assert_eq!(QueryFailure::Timeout.public_message(), "query timed out");
-    }
-}
+mod tests;

--- a/src/backend/services/analytics/src/mcp/tests.rs
+++ b/src/backend/services/analytics/src/mcp/tests.rs
@@ -1,0 +1,490 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::Json;
+use axum::body::Body;
+use axum::http::{HeaderValue, Request, Response, StatusCode};
+use axum::routing::{any, get};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use p256::SecretKey;
+use p256::elliptic_curve::Generate as _;
+use p256::elliptic_curve::sec1::ToSec1Point as _;
+use p256::pkcs8::{EncodePrivateKey as _, LineEnding};
+use secrecy::SecretString;
+use serde_json::{Value, json};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt as _;
+
+use crate::config::SqlApiConfig;
+use crate::sql_explorer::executor::{MAX_RESULT_BYTES, MAX_SQL_BYTES, QueryExecutor, QueryFailure};
+use crate::sql_explorer::{start, validate_config};
+
+use super::{
+    McpConfig, QuerySqlRequest, SqlExplorer, TokenVerifier, bearer_token, validate_public_url,
+};
+
+struct SigningMaterial {
+    key: EncodingKey,
+    jwks: Value,
+}
+
+fn signing_material() -> anyhow::Result<SigningMaterial> {
+    let secret = SecretKey::generate();
+    let pem = secret.to_pkcs8_pem(LineEnding::LF)?;
+    let key = EncodingKey::from_ec_pem(pem.as_bytes())?;
+    let point = secret.public_key().to_sec1_point(false);
+    let x = point
+        .x()
+        .ok_or_else(|| anyhow::anyhow!("public key has no x coordinate"))?;
+    let y = point
+        .y()
+        .ok_or_else(|| anyhow::anyhow!("public key has no y coordinate"))?;
+
+    Ok(SigningMaterial {
+        key,
+        jwks: json!({
+            "keys": [{
+                "kty": "EC",
+                "crv": "P-256",
+                "use": "sig",
+                "alg": "ES256",
+                "kid": "test-key",
+                "x": B64.encode(x),
+                "y": B64.encode(y),
+            }]
+        }),
+    })
+}
+
+fn claims(issuer: &str) -> anyhow::Result<Value> {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+
+    Ok(json!({
+        "sub": "test-user",
+        "tenant_id": "test-tenant",
+        "roles": "user admin",
+        "sub_type": "user",
+        "sid": "test-session",
+        "iss": issuer,
+        "aud": format!("{issuer}/mcp"),
+        "scope": "openid mcp:query",
+        "iat": now,
+        "exp": now + 600,
+        "jti": "test-token",
+    }))
+}
+
+fn sign(material: &SigningMaterial, claims: &Value) -> anyhow::Result<String> {
+    let mut header = Header::new(Algorithm::ES256);
+    header.kid = Some("test-key".to_owned());
+
+    Ok(encode(&header, claims, &material.key)?)
+}
+
+async fn spawn_app(app: axum::Router) -> anyhow::Result<(String, JoinHandle<()>)> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    Ok((format!("http://{address}"), server))
+}
+
+async fn spawn_clickhouse(
+    status: StatusCode,
+    body: Vec<u8>,
+) -> anyhow::Result<(SqlExplorer, JoinHandle<()>)> {
+    let app = axum::Router::new().fallback(any(move || {
+        let body = body.clone();
+        async move {
+            Response::builder()
+                .status(status)
+                .body(Body::from(body))
+                .unwrap_or_else(|_| Response::new(Body::empty()))
+        }
+    }));
+    let (url, server) = spawn_app(app).await?;
+    let client = insight_clickhouse::Client::new(insight_clickhouse::Config::new(url, "gold"));
+
+    Ok((SqlExplorer::new(QueryExecutor::new(client, 1)), server))
+}
+
+fn mcp_config() -> McpConfig {
+    McpConfig {
+        enabled: true,
+        bind_addr: "127.0.0.1:0".to_owned(),
+        public_url: "http://localhost:3000".to_owned(),
+        allow_insecure_private_network: false,
+        max_concurrent_queries: 2,
+        clickhouse_user: "test_mcp".to_owned(),
+        clickhouse_password: SecretString::from("test-password".to_owned()),
+    }
+}
+
+fn assert_tool_error_contains(result: &rmcp::model::CallToolResult, expected: &str) {
+    assert_eq!(result.is_error, Some(true));
+    let encoded = serde_json::to_string(result).unwrap_or_default();
+    assert!(
+        encoded.contains(expected),
+        "expected {expected:?} in {encoded}"
+    );
+}
+
+#[tokio::test]
+async fn query_sql_returns_structured_clickhouse_json() -> anyhow::Result<()> {
+    let body = serde_json::to_vec(&json!({
+        "meta": [{"name": "answer", "type": "UInt8"}],
+        "data": [{"answer": 1}],
+        "rows": 1
+    }))?;
+    let (explorer, server) = spawn_clickhouse(StatusCode::OK, body).await?;
+
+    let result = explorer
+        .run_query_sql("SELECT 1 AS answer".to_owned())
+        .await;
+
+    assert_eq!(result.is_error, Some(false));
+    assert_eq!(
+        result
+            .structured_content
+            .as_ref()
+            .and_then(|value| value["row_count"].as_u64()),
+        Some(1)
+    );
+    assert_eq!(
+        result
+            .structured_content
+            .as_ref()
+            .map(|value| &value["rows"][0]["answer"]),
+        Some(&json!(1))
+    );
+    let info = rmcp::ServerHandler::get_info(&explorer);
+    assert_eq!(info.server_info.name, "insight-sql-explorer");
+    let direct = explorer
+        .query_sql(rmcp::handler::server::wrapper::Parameters(
+            QuerySqlRequest {
+                sql: "SELECT 1 AS answer".to_owned(),
+            },
+        ))
+        .await;
+    assert_eq!(direct.is_error, Some(false));
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_sql_rejects_invalid_and_oversized_input() {
+    let client = insight_clickhouse::Client::new(insight_clickhouse::Config::new(
+        "http://127.0.0.1:1",
+        "gold",
+    ));
+    let explorer = SqlExplorer::new(QueryExecutor::new(client, 1));
+
+    let invalid = explorer
+        .run_query_sql("DROP TABLE gold.events".to_owned())
+        .await;
+    assert_tool_error_contains(&invalid, "SELECT or WITH");
+    let oversized = explorer.run_query_sql("x".repeat(MAX_SQL_BYTES + 1)).await;
+    assert_tool_error_contains(&oversized, "request limit");
+}
+
+#[tokio::test]
+async fn query_execution_reports_busy_backend_and_response_failures() -> anyhow::Result<()> {
+    let client = insight_clickhouse::Client::new(insight_clickhouse::Config::new(
+        "http://127.0.0.1:1",
+        "gold",
+    ));
+    let busy = SqlExplorer::new(QueryExecutor::new(client, 0))
+        .executor
+        .execute("SELECT 1")
+        .await;
+    assert!(matches!(busy, Err(QueryFailure::Busy)));
+
+    let (invalid, invalid_server) = spawn_clickhouse(StatusCode::OK, b"not-json".to_vec()).await?;
+    assert!(matches!(
+        invalid.executor.execute("SELECT 1").await,
+        Err(QueryFailure::InvalidResponse(_))
+    ));
+    invalid_server.abort();
+
+    let (failed, failed_server) =
+        spawn_clickhouse(StatusCode::INTERNAL_SERVER_ERROR, Vec::new()).await?;
+    assert!(matches!(
+        failed.executor.execute("SELECT 1").await,
+        Err(QueryFailure::ClickHouse(_))
+    ));
+    failed_server.abort();
+
+    let (large, large_server) =
+        spawn_clickhouse(StatusCode::OK, vec![b'x'; MAX_RESULT_BYTES + 1]).await?;
+    assert!(matches!(
+        large.executor.execute("SELECT 1").await,
+        Err(QueryFailure::ResultTooLarge)
+    ));
+    large_server.abort();
+    Ok(())
+}
+
+#[test]
+fn configuration_requires_a_complete_safe_origin_and_credentials() {
+    let mut config = mcp_config();
+    assert!(validate_config(&config, &SqlApiConfig::default()).is_ok());
+    assert!(validate_config(&McpConfig::default(), &SqlApiConfig::default()).is_ok());
+
+    config.bind_addr = "not-an-address".to_owned();
+    assert!(validate_config(&config, &SqlApiConfig::default()).is_err());
+    config = mcp_config();
+    config.max_concurrent_queries = 0;
+    assert!(validate_config(&config, &SqlApiConfig::default()).is_err());
+    config = mcp_config();
+    config.clickhouse_user = "  ".to_owned();
+    assert!(validate_config(&config, &SqlApiConfig::default()).is_err());
+    config = mcp_config();
+    config.clickhouse_password = SecretString::from(String::new());
+    assert!(validate_config(&config, &SqlApiConfig::default()).is_err());
+
+    assert!(validate_public_url("https://insight.example", false).is_ok());
+    assert!(validate_public_url("http://127.0.0.1:3000", false).is_ok());
+    assert!(validate_public_url("http://10.0.0.2:3000", true).is_ok());
+    for invalid in [
+        "http://insight.example",
+        "https://user@insight.example",
+        "https://insight.example/path",
+        "https://insight.example?query=true",
+        "https://insight.example#fragment",
+    ] {
+        assert!(
+            validate_public_url(invalid, false).is_err(),
+            "should reject {invalid}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn start_accepts_valid_configuration_and_cancellation() -> anyhow::Result<()> {
+    let cancellation = CancellationToken::new();
+
+    start(
+        &mcp_config(),
+        &SqlApiConfig::default(),
+        "http://127.0.0.1:1",
+        "gold",
+        cancellation.clone(),
+    )
+    .await?;
+    cancellation.cancel();
+    tokio::task::yield_now().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn verifier_accepts_admin_tokens_and_rejects_other_claims() -> anyhow::Result<()> {
+    let material = signing_material()?;
+    let app = axum::Router::new().route(
+        "/.well-known/jwks.json",
+        get({
+            let jwks = material.jwks.clone();
+            move || {
+                let jwks = jwks.clone();
+                async move { Json(jwks) }
+            }
+        }),
+    );
+    let (issuer, server) = spawn_app(app).await?;
+    let verifier = TokenVerifier::new(&issuer, false)?;
+
+    let valid = sign(&material, &claims(&issuer)?)?;
+    assert!(verifier.verify(&valid).await.is_ok());
+
+    let mut insufficient = claims(&issuer)?;
+    insufficient["roles"] = json!("user");
+    let insufficient = sign(&material, &insufficient)?;
+    assert!(matches!(
+        verifier.verify(&insufficient).await,
+        Err(super::AuthFailure::InsufficientScope)
+    ));
+
+    let mut future_issued = claims(&issuer)?;
+    future_issued["iat"] = json!(future_issued["exp"].as_u64().unwrap_or_default() + 1);
+    let future_issued = sign(&material, &future_issued)?;
+    assert!(matches!(
+        verifier.verify(&future_issued).await,
+        Err(super::AuthFailure::InsufficientScope)
+    ));
+
+    assert!(matches!(
+        verifier.verify("not-a-token").await,
+        Err(super::AuthFailure::Unauthorized)
+    ));
+    let token_without_kid = encode(
+        &Header::new(Algorithm::ES256),
+        &claims(&issuer)?,
+        &material.key,
+    )?;
+    assert!(matches!(
+        verifier.verify(&token_without_kid).await,
+        Err(super::AuthFailure::Unauthorized)
+    ));
+    let wrong_algorithm = encode(
+        &Header::new(Algorithm::HS256),
+        &claims(&issuer)?,
+        &EncodingKey::from_secret(b"test-secret"),
+    )?;
+    assert!(matches!(
+        verifier.verify(&wrong_algorithm).await,
+        Err(super::AuthFailure::Unauthorized)
+    ));
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn auth_middleware_returns_oauth_challenges() -> anyhow::Result<()> {
+    let material = signing_material()?;
+    let app = axum::Router::new().route(
+        "/.well-known/jwks.json",
+        get({
+            let jwks = material.jwks.clone();
+            move || {
+                let jwks = jwks.clone();
+                async move { Json(jwks) }
+            }
+        }),
+    );
+    let (issuer, server) = spawn_app(app).await?;
+    let verifier = TokenVerifier::new(&issuer, false)?;
+    let protected = axum::Router::new()
+        .route("/", get(|| async { StatusCode::NO_CONTENT }))
+        .layer(axum::middleware::from_fn_with_state(
+            verifier.clone(),
+            super::authenticate,
+        ));
+
+    let missing = protected
+        .clone()
+        .oneshot(Request::get("/").body(Body::empty())?)
+        .await?;
+    assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+    assert!(
+        missing
+            .headers()
+            .contains_key(axum::http::header::WWW_AUTHENTICATE)
+    );
+
+    let valid = sign(&material, &claims(&issuer)?)?;
+    let allowed = protected
+        .clone()
+        .oneshot(
+            Request::get("/")
+                .header("authorization", format!("Bearer {valid}"))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(allowed.status(), StatusCode::NO_CONTENT);
+
+    let mut claims = claims(&issuer)?;
+    claims["scope"] = json!("openid");
+    let denied = sign(&material, &claims)?;
+    let denied = protected
+        .oneshot(
+            Request::get("/")
+                .header("authorization", format!("Bearer {denied}"))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+    server.abort();
+    Ok(())
+}
+
+#[test]
+fn bearer_tokens_are_strictly_parsed() {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        "Bearer token"
+            .parse()
+            .unwrap_or(HeaderValue::from_static("")),
+    );
+    assert_eq!(bearer_token(&headers), Some("token"));
+
+    for value in ["bearer token", "Bearer ", "Bearer two tokens"] {
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            value.parse().unwrap_or(HeaderValue::from_static("")),
+        );
+        assert_eq!(bearer_token(&headers), None);
+    }
+}
+
+#[tokio::test]
+async fn concurrent_jwks_misses_share_one_refresh() -> anyhow::Result<()> {
+    let requests = Arc::new(AtomicUsize::new(0));
+    let app = axum::Router::new().route(
+        "/.well-known/jwks.json",
+        get({
+            let requests = requests.clone();
+            move || {
+                let requests = requests.clone();
+                async move {
+                    requests.fetch_add(1, Ordering::SeqCst);
+                    Json(serde_json::json!({ "keys": [] }))
+                }
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let server = tokio::spawn(async move { axum::serve(listener, app).await });
+    let verifier = TokenVerifier::new(&format!("http://{address}"), false)?;
+
+    let (first, second) = tokio::join!(verifier.cached_jwks(), verifier.cached_jwks());
+
+    assert!(first.is_ok());
+    assert!(second.is_ok());
+    assert_eq!(requests.load(Ordering::SeqCst), 1);
+    assert!(verifier.refresh_jwks(Some("missing-key")).await.is_ok());
+    assert!(verifier.refresh_jwks(Some("missing-key")).await.is_ok());
+    assert_eq!(requests.load(Ordering::SeqCst), 1);
+    server.abort();
+    Ok(())
+}
+
+#[test]
+fn backend_failures_have_a_generic_public_message() {
+    let clickhouse_failure = QueryFailure::ClickHouse(clickhouse::error::Error::BadResponse(
+        "private backend diagnostic".to_owned(),
+    ));
+    let parse_error = serde_json::Error::io(std::io::Error::other("private JSON diagnostic"));
+    let json_failure = QueryFailure::InvalidResponse(parse_error);
+
+    assert_eq!(
+        clickhouse_failure.public_message(),
+        "query execution failed"
+    );
+    assert_eq!(json_failure.public_message(), "query execution failed");
+    assert!(
+        !clickhouse_failure
+            .public_message()
+            .contains("private backend diagnostic")
+    );
+    assert!(!json_failure.public_message().contains("JSON"));
+}
+
+#[test]
+fn bounded_query_failures_have_stable_public_messages() {
+    assert_eq!(
+        QueryFailure::Busy.public_message(),
+        "the SQL explorer is busy; retry shortly"
+    );
+    assert_eq!(
+        QueryFailure::ResultTooLarge.public_message(),
+        "query result exceeded the response limit"
+    );
+    assert_eq!(QueryFailure::Timeout.public_message(), "query timed out");
+}

--- a/src/backend/services/analytics/src/mcp/tests.rs
+++ b/src/backend/services/analytics/src/mcp/tests.rs
@@ -201,13 +201,13 @@ async fn query_execution_reports_busy_backend_and_response_failures() -> anyhow:
     ));
     let busy = SqlExplorer::new(QueryExecutor::new(client, 0))
         .executor
-        .execute("SELECT 1")
+        .query("SELECT 1".to_owned(), Ok)
         .await;
     assert!(matches!(busy, Err(QueryFailure::Busy)));
 
     let (invalid, invalid_server) = spawn_clickhouse(StatusCode::OK, b"not-json".to_vec()).await?;
     assert!(matches!(
-        invalid.executor.execute("SELECT 1").await,
+        invalid.executor.query("SELECT 1".to_owned(), Ok).await,
         Err(QueryFailure::InvalidResponse(_))
     ));
     invalid_server.abort();
@@ -215,7 +215,7 @@ async fn query_execution_reports_busy_backend_and_response_failures() -> anyhow:
     let (failed, failed_server) =
         spawn_clickhouse(StatusCode::INTERNAL_SERVER_ERROR, Vec::new()).await?;
     assert!(matches!(
-        failed.executor.execute("SELECT 1").await,
+        failed.executor.query("SELECT 1".to_owned(), Ok).await,
         Err(QueryFailure::ClickHouse(_))
     ));
     failed_server.abort();
@@ -223,7 +223,7 @@ async fn query_execution_reports_busy_backend_and_response_failures() -> anyhow:
     let (large, large_server) =
         spawn_clickhouse(StatusCode::OK, vec![b'x'; MAX_RESULT_BYTES + 1]).await?;
     assert!(matches!(
-        large.executor.execute("SELECT 1").await,
+        large.executor.query("SELECT 1".to_owned(), Ok).await,
         Err(QueryFailure::ResultTooLarge)
     ));
     large_server.abort();

--- a/src/backend/services/analytics/src/sql_explorer/api.rs
+++ b/src/backend/services/analytics/src/sql_explorer/api.rs
@@ -9,7 +9,7 @@ use secrecy::ExposeSecret as _;
 use serde::Deserialize;
 use sha2::{Digest as _, Sha256};
 use subtle::ConstantTimeEq as _;
-use toolkit_canonical_errors::{CanonicalError, resource_error};
+use toolkit_canonical_errors::{CanonicalError, Http, resource_error};
 
 use super::executor::{MAX_REQUEST_BODY_BYTES, QueryExecutor, QueryFailure};
 use crate::config::SqlApiConfig;
@@ -86,9 +86,7 @@ async fn query(
 ) -> Result<Response, CanonicalError> {
     let Json(request) = body.map_err(|error| {
         if error.status() == StatusCode::PAYLOAD_TOO_LARGE {
-            SqlQueryError::resource_exhausted("Request body exceeds limit")
-                .with_quota_violation("request", "request body exceeds limit")
-                .create()
+            oversized_input("body", "Request body exceeds limit")
         } else {
             invalid_request("Expected a JSON object containing only a sql string")
         }
@@ -106,12 +104,18 @@ fn invalid_request(reason: &str) -> CanonicalError {
         .create()
 }
 
+fn oversized_input(field: &str, reason: &str) -> CanonicalError {
+    SqlQueryError::invalid_argument()
+        .with_field_violation(field, reason, "TOO_LARGE")
+        .with_override(Http::status_code(413))
+        .create()
+}
+
 fn query_error(error: &QueryFailure) -> CanonicalError {
     match error {
-        QueryFailure::InvalidSql(_) | QueryFailure::SqlTooLarge => {
-            invalid_request(error.public_message())
-        }
-        QueryFailure::Busy | QueryFailure::ResultTooLarge => {
+        QueryFailure::InvalidSql(_) => invalid_request(&error.public_message()),
+        QueryFailure::SqlTooLarge => oversized_input("sql", &error.public_message()),
+        QueryFailure::Busy | QueryFailure::ResultTooLarge | QueryFailure::ResourceLimit => {
             SqlQueryError::resource_exhausted("Query exceeded resource limits")
                 .with_quota_violation("sql_explorer", error.public_message())
                 .create()

--- a/src/backend/services/analytics/src/sql_explorer/api.rs
+++ b/src/backend/services/analytics/src/sql_explorer/api.rs
@@ -1,0 +1,126 @@
+use axum::extract::{DefaultBodyLimit, Request, State, rejection::JsonRejection};
+use axum::http::header::{AUTHORIZATION, CACHE_CONTROL, CONTENT_TYPE, WWW_AUTHENTICATE};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
+use secrecy::ExposeSecret as _;
+use serde::Deserialize;
+use sha2::{Digest as _, Sha256};
+use subtle::ConstantTimeEq as _;
+use toolkit_canonical_errors::{CanonicalError, resource_error};
+
+use super::executor::{MAX_REQUEST_BODY_BYTES, QueryExecutor, QueryFailure};
+use crate::config::SqlApiConfig;
+
+#[resource_error("gts.cf.insight.analytics_api.sql_query.v1~")]
+struct SqlQueryError;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct QueryRequest {
+    sql: String,
+}
+
+pub(super) fn router(config: &SqlApiConfig, executor: QueryExecutor) -> Router {
+    let token_hash: [u8; 32] = Sha256::digest(config.token.expose_secret().as_bytes()).into();
+    Router::new()
+        .route("/api/sql/query", post(query))
+        .with_state(executor)
+        .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES))
+        .layer(middleware::from_fn_with_state(token_hash, authenticate))
+}
+
+async fn authenticate(
+    State(expected): State<[u8; 32]>,
+    headers: HeaderMap,
+    request: Request,
+    next: Next,
+) -> Response {
+    let mut response = if valid_token(&headers, &expected) {
+        next.run(request).await
+    } else {
+        let mut response = CanonicalError::unauthenticated()
+            .with_reason("INVALID_INSTANCE_TOKEN")
+            .create()
+            .into_response();
+        response
+            .headers_mut()
+            .insert(WWW_AUTHENTICATE, HeaderValue::from_static("Bearer"));
+        response
+    };
+    response
+        .headers_mut()
+        .insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    response
+}
+
+fn valid_token(headers: &HeaderMap, expected: &[u8; 32]) -> bool {
+    if headers.get_all(AUTHORIZATION).iter().count() != 1 {
+        return false;
+    }
+    let Some(value) = headers.get(AUTHORIZATION).and_then(|v| v.to_str().ok()) else {
+        return false;
+    };
+    let Some((scheme, token)) = value.split_once(' ') else {
+        return false;
+    };
+    if !scheme.eq_ignore_ascii_case("bearer")
+        || token.is_empty()
+        || token.len() > 1024
+        || !token.bytes().all(|b| b.is_ascii_graphic())
+    {
+        return false;
+    }
+    let actual: [u8; 32] = Sha256::digest(token.as_bytes()).into();
+    bool::from(actual.ct_eq(expected))
+}
+
+async fn query(
+    State(executor): State<QueryExecutor>,
+    body: Result<Json<QueryRequest>, JsonRejection>,
+) -> Result<Response, CanonicalError> {
+    let Json(request) = body.map_err(|error| {
+        if error.status() == StatusCode::PAYLOAD_TOO_LARGE {
+            SqlQueryError::resource_exhausted("Request body exceeds limit")
+                .with_quota_violation("request", "request body exceeds limit")
+                .create()
+        } else {
+            invalid_request("Expected a JSON object containing only a sql string")
+        }
+    })?;
+    let bytes = executor
+        .query(request.sql, |result| serde_json::to_vec(&result))
+        .await
+        .map_err(|error| query_error(&error))?;
+    Ok(([(CONTENT_TYPE, "application/json")], bytes).into_response())
+}
+
+fn invalid_request(reason: &str) -> CanonicalError {
+    SqlQueryError::invalid_argument()
+        .with_field_violation("sql", reason, "INVALID")
+        .create()
+}
+
+fn query_error(error: &QueryFailure) -> CanonicalError {
+    match error {
+        QueryFailure::InvalidSql(_) | QueryFailure::SqlTooLarge => {
+            invalid_request(error.public_message())
+        }
+        QueryFailure::Busy | QueryFailure::ResultTooLarge => {
+            SqlQueryError::resource_exhausted("Query exceeded resource limits")
+                .with_quota_violation("sql_explorer", error.public_message())
+                .create()
+        }
+        QueryFailure::Timeout => SqlQueryError::deadline_exceeded("Query timed out").create(),
+        QueryFailure::ClickHouse(_)
+        | QueryFailure::InvalidResponse(_)
+        | QueryFailure::ProcessingTask(_) => {
+            CanonicalError::internal("query execution failed").create()
+        }
+    }
+}

--- a/src/backend/services/analytics/src/sql_explorer/api/tests.rs
+++ b/src/backend/services/analytics/src/sql_explorer/api/tests.rs
@@ -122,14 +122,68 @@ async fn busy_and_backend_errors_use_generic_http_errors() -> R {
 
 #[tokio::test]
 async fn oversized_requests_are_bounded() -> R {
-    let body = json!({"sql":"x".repeat(MAX_REQUEST_BODY_BYTES)}).to_string();
-    let response = send(
-        app("http://127.0.0.1:1", 1),
-        Some(&format!("Bearer {TOKEN}")),
-        &body,
-    )
-    .await?;
-    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    for size in [
+        super::super::executor::MAX_SQL_BYTES + 1,
+        MAX_REQUEST_BODY_BYTES,
+    ] {
+        let body = json!({"sql":"x".repeat(size)}).to_string();
+        let response = send(
+            app("http://127.0.0.1:1", 1),
+            Some(&format!("Bearer {TOKEN}")),
+            &body,
+        )
+        .await?;
+        assert_eq!(
+            response.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "size: {size}"
+        );
+        let problem: Value = serde_json::from_slice(&to_bytes(response.into_body(), 4096).await?)?;
+        assert_eq!(problem["status"], 413, "size: {size}");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn database_exception_codes_map_to_timeout_and_resource_responses() -> R {
+    for (code, expected) in [
+        (159, StatusCode::GATEWAY_TIMEOUT),
+        (209, StatusCode::GATEWAY_TIMEOUT),
+        (158, StatusCode::TOO_MANY_REQUESTS),
+        (191, StatusCode::TOO_MANY_REQUESTS),
+        (201, StatusCode::TOO_MANY_REQUESTS),
+        (202, StatusCode::TOO_MANY_REQUESTS),
+        (241, StatusCode::TOO_MANY_REQUESTS),
+        (290, StatusCode::TOO_MANY_REQUESTS),
+        (307, StatusCode::TOO_MANY_REQUESTS),
+        (396, StatusCode::TOO_MANY_REQUESTS),
+        (9999, StatusCode::INTERNAL_SERVER_ERROR),
+    ] {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+        let upstream = Router::new().route(
+            "/",
+            post(move || async move {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Code: {code}. DB::Exception: synthetic-internal-detail"),
+                )
+            }),
+        );
+        let server = tokio::spawn(async move { axum::serve(listener, upstream).await });
+        let response = send(
+            app(&format!("http://{address}"), 1),
+            Some(&format!("Bearer {TOKEN}")),
+            r#"{"sql":"SELECT 1"}"#,
+        )
+        .await?;
+        assert_eq!(response.status(), expected, "code: {code}");
+        let bytes = to_bytes(response.into_body(), 4096).await?;
+        let problem: Value = serde_json::from_slice(&bytes)?;
+        assert_eq!(problem["status"], expected.as_u16(), "code: {code}");
+        assert!(!String::from_utf8(bytes.to_vec())?.contains("synthetic-internal-detail"));
+        server.abort();
+    }
     Ok(())
 }
 

--- a/src/backend/services/analytics/src/sql_explorer/api/tests.rs
+++ b/src/backend/services/analytics/src/sql_explorer/api/tests.rs
@@ -1,0 +1,146 @@
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use axum::routing::post;
+use secrecy::SecretString;
+use serde_json::{Value, json};
+use tower::ServiceExt as _;
+
+use super::*;
+
+const TOKEN: &str = "synthetic-test-token-not-a-real-secret";
+type R = Result<(), Box<dyn std::error::Error>>;
+
+fn app(url: &str, capacity: usize) -> Router {
+    let config = SqlApiConfig {
+        enabled: true,
+        token: SecretString::from(TOKEN.to_owned()),
+    };
+    let client = insight_clickhouse::Client::new(insight_clickhouse::Config::new(url, "gold"));
+    router(&config, QueryExecutor::new(client, capacity))
+}
+
+async fn send(
+    app: Router,
+    token: Option<&str>,
+    body: &str,
+) -> Result<Response, Box<dyn std::error::Error>> {
+    let mut request = Request::post("/api/sql/query").header(CONTENT_TYPE, "application/json");
+    if let Some(token) = token {
+        request = request.header(AUTHORIZATION, token);
+    }
+    Ok(app
+        .oneshot(request.body(Body::from(body.to_owned()))?)
+        .await?)
+}
+
+#[tokio::test]
+async fn invalid_credentials_never_execute_queries() -> R {
+    for token in [
+        None,
+        Some("Bearer wrong"),
+        Some("Basic wrong"),
+        Some("Bearer "),
+        Some("Bearer two tokens"),
+    ] {
+        let response = send(app("http://127.0.0.1:1", 1), token, "{}").await?;
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "credential: {token:?}"
+        );
+        assert_eq!(response.headers()[WWW_AUTHENTICATE], "Bearer");
+        assert_eq!(response.headers()[CACHE_CONTROL], "no-store");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn request_and_sql_validation_precede_database_calls() -> R {
+    let auth = format!("bEaReR {TOKEN}");
+    for body in [
+        "{}",
+        "{",
+        r#"{"sql":1}"#,
+        r#"{"sql":"SELECT 1","extra":true}"#,
+        r#"{"sql":"DROP TABLE gold.events"}"#,
+        r#"{"sql":"SELECT 1; SELECT 2"}"#,
+    ] {
+        let response = send(app("http://127.0.0.1:1", 1), Some(&auth), body).await?;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "body: {body}");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_returns_the_shared_result_contract() -> R {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let upstream = Router::new().route(
+        "/",
+        post(|| async {
+            Json(json!({"meta":[{"name":"answer","type":"UInt8"}],"data":[{"answer":1}]}))
+        }),
+    );
+    let server = tokio::spawn(async move { axum::serve(listener, upstream).await });
+    let response = send(
+        app(&format!("http://{address}"), 1),
+        Some(&format!("Bearer {TOKEN}")),
+        r#"{"sql":"SELECT 1 AS answer"}"#,
+    )
+    .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[CACHE_CONTROL], "no-store");
+    let body: Value = serde_json::from_slice(&to_bytes(response.into_body(), 4096).await?)?;
+    assert_eq!(
+        body,
+        json!({"columns":[{"name":"answer","type":"UInt8"}],"rows":[{"answer":1}],"row_count":1,"truncated":false})
+    );
+    server.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn busy_and_backend_errors_use_generic_http_errors() -> R {
+    for (capacity, expected) in [
+        (0, StatusCode::TOO_MANY_REQUESTS),
+        (1, StatusCode::INTERNAL_SERVER_ERROR),
+    ] {
+        let response = send(
+            app("http://127.0.0.1:1", capacity),
+            Some(&format!("Bearer {TOKEN}")),
+            r#"{"sql":"SELECT 1"}"#,
+        )
+        .await?;
+        assert_eq!(response.status(), expected);
+        let bytes = to_bytes(response.into_body(), 4096).await?;
+        let body = String::from_utf8(bytes.to_vec())?;
+        assert!(!body.contains("127.0.0.1"));
+        assert!(!body.contains(TOKEN));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn oversized_requests_are_bounded() -> R {
+    let body = json!({"sql":"x".repeat(MAX_REQUEST_BODY_BYTES)}).to_string();
+    let response = send(
+        app("http://127.0.0.1:1", 1),
+        Some(&format!("Bearer {TOKEN}")),
+        &body,
+    )
+    .await?;
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    Ok(())
+}
+
+#[test]
+fn duplicate_authorization_headers_are_rejected() -> R {
+    let mut headers = HeaderMap::new();
+    headers.append(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {TOKEN}"))?,
+    );
+    headers.append(AUTHORIZATION, HeaderValue::from_static("Bearer wrong"));
+    assert!(!valid_token(&headers, &Sha256::digest(TOKEN).into()));
+    Ok(())
+}

--- a/src/backend/services/analytics/src/sql_explorer/executor.rs
+++ b/src/backend/services/analytics/src/sql_explorer/executor.rs
@@ -37,16 +37,18 @@ pub(crate) struct QuerySqlResult {
 pub(crate) enum QueryFailure {
     #[error("{0}")]
     InvalidSql(String),
-    #[error("SQL exceeds the 65536-byte request limit")]
+    #[error("SQL exceeds the {}-byte request limit", MAX_SQL_BYTES)]
     SqlTooLarge,
-    #[error("query capacity is exhausted")]
+    #[error("the SQL explorer is busy; retry shortly")]
     Busy,
     #[error("query result exceeded the response limit")]
     ResultTooLarge,
+    #[error("query exceeded database resource limits")]
+    ResourceLimit,
     #[error("query timed out")]
     Timeout,
     #[error("ClickHouse query failed: {0}")]
-    ClickHouse(#[from] clickhouse::error::Error),
+    ClickHouse(clickhouse::error::Error),
     #[error("ClickHouse returned an invalid JSON response: {0}")]
     InvalidResponse(#[from] serde_json::Error),
     #[error("query result processing task failed: {0}")]
@@ -54,18 +56,45 @@ pub(crate) enum QueryFailure {
 }
 
 impl QueryFailure {
-    pub(crate) fn public_message(&self) -> &str {
+    pub(crate) fn public_message(&self) -> String {
         match self {
-            Self::InvalidSql(reason) => reason,
-            Self::SqlTooLarge => "SQL exceeds the 65536-byte request limit",
-            Self::Busy => "the SQL explorer is busy; retry shortly",
-            Self::ResultTooLarge => "query result exceeded the response limit",
-            Self::Timeout => "query timed out",
+            Self::InvalidSql(_)
+            | Self::SqlTooLarge
+            | Self::Busy
+            | Self::ResultTooLarge
+            | Self::ResourceLimit
+            | Self::Timeout => self.to_string(),
             Self::ClickHouse(_) | Self::InvalidResponse(_) | Self::ProcessingTask(_) => {
-                "query execution failed"
+                "query execution failed".to_owned()
             }
         }
     }
+}
+
+impl From<clickhouse::error::Error> for QueryFailure {
+    fn from(error: clickhouse::error::Error) -> Self {
+        if matches!(error, clickhouse::error::Error::TimedOut) {
+            return Self::Timeout;
+        }
+        let code = match &error {
+            clickhouse::error::Error::BadResponse(message) => exception_code(message),
+            _ => None,
+        };
+        match code {
+            Some(159 | 209) => Self::Timeout,
+            Some(158 | 191 | 201 | 202 | 241 | 290 | 307 | 396) => Self::ResourceLimit,
+            _ => Self::ClickHouse(error),
+        }
+    }
+}
+
+fn exception_code(message: &str) -> Option<u16> {
+    message
+        .strip_prefix("Code: ")?
+        .split('.')
+        .next()?
+        .parse()
+        .ok()
 }
 
 #[derive(Clone)]
@@ -89,19 +118,6 @@ impl QueryExecutor {
             client,
             query_slots: Arc::new(Semaphore::new(max_concurrent_queries)),
         }
-    }
-
-    #[cfg(test)]
-    pub(crate) async fn execute(&self, sql: &str) -> Result<QuerySqlResult, QueryFailure> {
-        let permit = self
-            .query_slots
-            .clone()
-            .try_acquire_owned()
-            .map_err(|_| QueryFailure::Busy)?;
-        // INVARIANT: the permit bounds database work and result decoding.
-        let result = self.execute_admitted(sql).await;
-        drop(permit);
-        result
     }
 
     async fn execute_admitted(&self, sql: &str) -> Result<QuerySqlResult, QueryFailure> {

--- a/src/backend/services/analytics/src/sql_explorer/executor.rs
+++ b/src/backend/services/analytics/src/sql_explorer/executor.rs
@@ -1,0 +1,194 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use tokio::sync::Semaphore;
+
+use crate::domain::query_gate::validate_mcp_sql;
+
+pub(crate) const MAX_REQUEST_BODY_BYTES: usize = 128 * 1024;
+pub(crate) const MAX_SQL_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_RESULT_BYTES: usize = 5 * 1024 * 1024;
+const FETCH_TIMEOUT: Duration = Duration::from_secs(35);
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ResultColumn {
+    name: String,
+    #[serde(rename = "type")]
+    data_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClickHouseJsonResult {
+    meta: Vec<ResultColumn>,
+    data: Vec<serde_json::Map<String, serde_json::Value>>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct QuerySqlResult {
+    columns: Vec<ResultColumn>,
+    rows: Vec<serde_json::Map<String, serde_json::Value>>,
+    row_count: usize,
+    truncated: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum QueryFailure {
+    #[error("{0}")]
+    InvalidSql(String),
+    #[error("SQL exceeds the 65536-byte request limit")]
+    SqlTooLarge,
+    #[error("query capacity is exhausted")]
+    Busy,
+    #[error("query result exceeded the response limit")]
+    ResultTooLarge,
+    #[error("query timed out")]
+    Timeout,
+    #[error("ClickHouse query failed: {0}")]
+    ClickHouse(#[from] clickhouse::error::Error),
+    #[error("ClickHouse returned an invalid JSON response: {0}")]
+    InvalidResponse(#[from] serde_json::Error),
+    #[error("query result processing task failed: {0}")]
+    ProcessingTask(#[from] tokio::task::JoinError),
+}
+
+impl QueryFailure {
+    pub(crate) fn public_message(&self) -> &str {
+        match self {
+            Self::InvalidSql(reason) => reason,
+            Self::SqlTooLarge => "SQL exceeds the 65536-byte request limit",
+            Self::Busy => "the SQL explorer is busy; retry shortly",
+            Self::ResultTooLarge => "query result exceeded the response limit",
+            Self::Timeout => "query timed out",
+            Self::ClickHouse(_) | Self::InvalidResponse(_) | Self::ProcessingTask(_) => {
+                "query execution failed"
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct QueryExecutor {
+    client: insight_clickhouse::Client,
+    query_slots: Arc<Semaphore>,
+}
+
+impl std::fmt::Debug for QueryExecutor {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("QueryExecutor")
+            .field("query_slots", &self.query_slots)
+            .finish_non_exhaustive()
+    }
+}
+
+impl QueryExecutor {
+    pub(crate) fn new(client: insight_clickhouse::Client, max_concurrent_queries: usize) -> Self {
+        Self {
+            client,
+            query_slots: Arc::new(Semaphore::new(max_concurrent_queries)),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn execute(&self, sql: &str) -> Result<QuerySqlResult, QueryFailure> {
+        let permit = self
+            .query_slots
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| QueryFailure::Busy)?;
+        // INVARIANT: the permit bounds database work and result decoding.
+        let result = self.execute_admitted(sql).await;
+        drop(permit);
+        result
+    }
+
+    async fn execute_admitted(&self, sql: &str) -> Result<QuerySqlResult, QueryFailure> {
+        let mut query = self.client.query(sql).fetch_bytes("JSON")?;
+
+        let fetch = async {
+            let mut bytes = Vec::new();
+            while let Some(chunk) = query.next().await? {
+                let next_len = bytes.len().saturating_add(chunk.len());
+                if next_len > MAX_RESULT_BYTES {
+                    return Err(QueryFailure::ResultTooLarge);
+                }
+                bytes.extend_from_slice(&chunk);
+            }
+            Ok::<_, QueryFailure>(bytes)
+        };
+
+        let bytes = tokio::time::timeout(FETCH_TIMEOUT, fetch)
+            .await
+            .map_err(|_| QueryFailure::Timeout)??;
+        // INVARIANT: query capacity also bounds CPU-heavy result decoding.
+        let result = tokio::task::spawn_blocking(move || {
+            serde_json::from_slice::<ClickHouseJsonResult>(&bytes)
+        })
+        .await??;
+
+        let row_count = result.data.len();
+        Ok(QuerySqlResult {
+            columns: result.meta,
+            rows: result.data,
+            row_count,
+            truncated: false,
+        })
+    }
+
+    pub(crate) async fn query<T, F>(&self, sql: String, encode: F) -> Result<T, QueryFailure>
+    where
+        T: Send + 'static,
+        F: FnOnce(serde_json::Value) -> Result<T, serde_json::Error> + Send + 'static,
+    {
+        if sql.len() > MAX_SQL_BYTES {
+            return Err(QueryFailure::SqlTooLarge);
+        }
+        // INVARIANT: capacity bounds SQL parsing, database work, and result conversion together.
+        let _permit = self
+            .query_slots
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| QueryFailure::Busy)?;
+        let sql = tokio::task::spawn_blocking(move || {
+            validate_mcp_sql(&sql).map_err(QueryFailure::InvalidSql)?;
+            Ok::<_, QueryFailure>(sql)
+        })
+        .await??;
+
+        let started = Instant::now();
+        let query_hash = hex::encode(Sha256::digest(sql.as_bytes()));
+        let result = self.execute_admitted(&sql).await;
+        match result {
+            Ok(result) => {
+                tracing::info!(
+                    query_hash,
+                    duration_ms = started.elapsed().as_millis(),
+                    rows = result.row_count,
+                    outcome = "success",
+                    "SQL explorer query completed"
+                );
+                let value =
+                    tokio::task::spawn_blocking(move || encode(serde_json::to_value(result)?))
+                        .await;
+                match value {
+                    Ok(Ok(value)) => Ok(value),
+                    Ok(Err(error)) => {
+                        tracing::error!(query_hash, %error, "SQL result serialization failed");
+                        Err(QueryFailure::InvalidResponse(error))
+                    }
+                    Err(error) => {
+                        tracing::error!(query_hash, %error, "SQL result processing failed");
+                        Err(QueryFailure::ProcessingTask(error))
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::warn!(query_hash, duration_ms = started.elapsed().as_millis(),
+                    %error, outcome = "error", "SQL explorer query failed");
+                Err(error)
+            }
+        }
+    }
+}

--- a/src/backend/services/analytics/src/sql_explorer/mod.rs
+++ b/src/backend/services/analytics/src/sql_explorer/mod.rs
@@ -1,0 +1,87 @@
+use std::net::SocketAddr;
+
+use axum::Router;
+use secrecy::ExposeSecret as _;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::{McpConfig, SqlApiConfig};
+
+mod api;
+pub(crate) mod executor;
+
+#[cfg(test)]
+mod tests;
+
+pub(crate) fn validate_config(mcp: &McpConfig, api: &SqlApiConfig) -> anyhow::Result<()> {
+    if !mcp.enabled && !api.enabled {
+        return Ok(());
+    }
+    mcp.bind_addr.parse::<SocketAddr>()?;
+    if mcp.enabled {
+        crate::mcp::validate_public_url(&mcp.public_url, mcp.allow_insecure_private_network)?;
+    }
+    anyhow::ensure!(
+        mcp.max_concurrent_queries > 0,
+        "SQL explorer concurrency must be positive"
+    );
+    anyhow::ensure!(
+        !mcp.clickhouse_user.trim().is_empty(),
+        "SQL explorer ClickHouse user is empty"
+    );
+    anyhow::ensure!(
+        !mcp.clickhouse_password.expose_secret().is_empty(),
+        "SQL explorer ClickHouse password is empty"
+    );
+    if api.enabled {
+        let token = api.token.expose_secret();
+        anyhow::ensure!(
+            token.len() >= 32 && token.len() <= 1024 && token.bytes().all(|b| b.is_ascii_graphic()),
+            "SQL API token must contain 32 to 1024 printable ASCII characters without whitespace"
+        );
+    }
+    Ok(())
+}
+
+pub(crate) async fn start(
+    mcp: &McpConfig,
+    api: &SqlApiConfig,
+    clickhouse_url: &str,
+    clickhouse_database: &str,
+    cancellation: CancellationToken,
+) -> anyhow::Result<()> {
+    validate_config(mcp, api)?;
+    if !mcp.enabled && !api.enabled {
+        return Ok(());
+    }
+    let client = insight_clickhouse::Client::new(
+        insight_clickhouse::Config::new(clickhouse_url, clickhouse_database)
+            .with_auth(
+                &mcp.clickhouse_user,
+                mcp.clickhouse_password.expose_secret(),
+            )
+            .without_query_timeout(),
+    );
+    let executor = executor::QueryExecutor::new(client, mcp.max_concurrent_queries);
+    let mut router = Router::new();
+    if mcp.enabled {
+        router = router.merge(crate::mcp::router(
+            mcp,
+            executor.clone(),
+            cancellation.child_token(),
+        )?);
+    }
+    if api.enabled {
+        router = router.merge(api::router(api, executor));
+    }
+    let listener = tokio::net::TcpListener::bind(&mcp.bind_addr).await?;
+    tracing::info!(bind_addr = %mcp.bind_addr, "SQL explorer listening");
+    tokio::spawn(async move {
+        if let Err(error) = axum::serve(listener, router)
+            .with_graceful_shutdown(cancellation.cancelled_owned())
+            .await
+        {
+            tracing::error!(%error, "SQL explorer stopped unexpectedly");
+        }
+    });
+    Ok(())
+}

--- a/src/backend/services/analytics/src/sql_explorer/tests.rs
+++ b/src/backend/services/analytics/src/sql_explorer/tests.rs
@@ -3,6 +3,37 @@ use secrecy::SecretString;
 use super::*;
 
 #[test]
+fn database_error_classification_requires_an_exact_leading_code() {
+    use super::executor::QueryFailure;
+
+    for message in [
+        "",
+        "TIMEOUT_EXCEEDED",
+        "Code: not-a-number",
+        "Code: 159x.",
+        "Code: 65536.",
+        "unexpected Code: 159.",
+        "Code: 9999. nested Code: 159.",
+    ] {
+        let failure = QueryFailure::from(clickhouse::error::Error::BadResponse(message.to_owned()));
+        assert!(
+            matches!(failure, QueryFailure::ClickHouse(_)),
+            "message: {message}"
+        );
+    }
+    assert!(matches!(
+        QueryFailure::from(clickhouse::error::Error::BadResponse(
+            "Code: 159".to_owned()
+        )),
+        QueryFailure::Timeout
+    ));
+    assert!(matches!(
+        QueryFailure::from(clickhouse::error::Error::TimedOut),
+        QueryFailure::Timeout
+    ));
+}
+
+#[test]
 fn api_only_startup_requires_credentials_but_not_oauth_metadata() {
     let mut mcp = McpConfig::default();
     let mut api = SqlApiConfig::default();

--- a/src/backend/services/analytics/src/sql_explorer/tests.rs
+++ b/src/backend/services/analytics/src/sql_explorer/tests.rs
@@ -1,0 +1,74 @@
+use secrecy::SecretString;
+
+use super::*;
+
+#[test]
+fn api_only_startup_requires_credentials_but_not_oauth_metadata() {
+    let mut mcp = McpConfig::default();
+    let mut api = SqlApiConfig::default();
+    assert!(validate_config(&mcp, &api).is_ok());
+    api.enabled = true;
+    assert!(validate_config(&mcp, &api).is_err());
+    mcp.clickhouse_password = SecretString::from("synthetic-db-password".to_owned());
+    for token in ["", "short", "synthetic-token-with-a-space-in it"] {
+        api.token = SecretString::from(token.to_owned());
+        assert!(validate_config(&mcp, &api).is_err(), "token case: {token}");
+    }
+    api.token = SecretString::from("synthetic-test-token-not-a-real-secret".to_owned());
+    assert!(validate_config(&mcp, &api).is_ok());
+    mcp.enabled = true;
+    assert!(validate_config(&mcp, &api).is_err());
+    mcp.public_url = "https://insight.example.com".to_owned();
+    assert!(validate_config(&mcp, &api).is_ok());
+}
+
+#[tokio::test]
+async fn cloned_executors_share_capacity_and_release_it_after_completion()
+-> Result<(), Box<dyn std::error::Error>> {
+    use std::sync::Arc;
+
+    use axum::routing::post;
+    use axum::{Json, Router};
+    use serde_json::json;
+    use tokio::sync::Notify;
+
+    use super::executor::{QueryExecutor, QueryFailure};
+
+    let entered = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let handler_entered = entered.clone();
+    let handler_release = release.clone();
+    let upstream = Router::new().route(
+        "/",
+        post(move || {
+            let entered = handler_entered.clone();
+            let release = handler_release.clone();
+            async move {
+                entered.notify_one();
+                release.notified().await;
+                Json(json!({"meta":[],"data":[]}))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let server = tokio::spawn(async move { axum::serve(listener, upstream).await });
+    let client = insight_clickhouse::Client::new(insight_clickhouse::Config::new(
+        format!("http://{address}"),
+        "gold",
+    ));
+    let executor = QueryExecutor::new(client, 1);
+    let other = executor.clone();
+    let running = tokio::spawn(async move { other.query("SELECT 1".to_owned(), Ok).await });
+    tokio::time::timeout(std::time::Duration::from_secs(5), entered.notified()).await?;
+    let result = executor.query("SELECT 2".to_owned(), Ok).await;
+    assert!(matches!(result, Err(QueryFailure::Busy)));
+    release.notify_one();
+    running.await??;
+    let result = executor
+        .query("DROP TABLE gold.example".to_owned(), Ok)
+        .await;
+    assert!(matches!(result, Err(QueryFailure::InvalidSql(_))));
+    server.abort();
+    Ok(())
+}

--- a/src/backend/services/analytics/src/sql_explorer/tests.rs
+++ b/src/backend/services/analytics/src/sql_explorer/tests.rs
@@ -45,6 +45,14 @@ fn api_only_startup_requires_credentials_but_not_oauth_metadata() {
         api.token = SecretString::from(token.to_owned());
         assert!(validate_config(&mcp, &api).is_err(), "token case: {token}");
     }
+    for (length, accepted) in [(32, true), (1024, true), (1025, false)] {
+        api.token = SecretString::from("a".repeat(length));
+        assert_eq!(
+            validate_config(&mcp, &api).is_ok(),
+            accepted,
+            "token length: {length}"
+        );
+    }
     api.token = SecretString::from("synthetic-test-token-not-a-real-secret".to_owned());
     assert!(validate_config(&mcp, &api).is_ok());
     mcp.enabled = true;

--- a/src/backend/services/gateway/helm/templates/configmap.yaml
+++ b/src/backend/services/gateway/helm/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
         {{- end }}
     routes:
       {{- range .Values.gateway.routes }}
-      {{- if or (not (.mcpOnly | default false)) $.Values.global.mcp.enabled }}
+      {{- if and (or (not (.mcpOnly | default false)) $.Values.global.mcp.enabled) (or (not (.sqlApiOnly | default false)) $.Values.global.sqlApi.enabled) }}
       - prefix: {{ .prefix }}
         upstream: {{ tpl .upstream $ | quote }}
         {{- with .auth }}

--- a/src/backend/services/gateway/helm/values.yaml
+++ b/src/backend/services/gateway/helm/values.yaml
@@ -1,4 +1,6 @@
 global:
+  sqlApi:
+    enabled: false
   mcp:
     enabled: false
     publicUrl: ""
@@ -57,6 +59,11 @@ gateway:
   # `/v1/metrics` before proxying (the app services host at `/v1/*`, unaware of
   # the platform prefix).
   routes:
+    - prefix: /api/sql/query
+      upstream: 'http://{{ .Release.Name }}-analytics:8086'
+      auth: instance_token
+      timeoutMs: 40000
+      sqlApiOnly: true
     - prefix: /mcp
       upstream: 'http://{{ .Release.Name }}-analytics:8086'
       auth: bearer

--- a/src/backend/services/gateway/lua/gateway.lua
+++ b/src/backend/services/gateway/lua/gateway.lua
@@ -161,4 +161,9 @@ function _M.pass_bearer()
     set_request_context()
 end
 
+function _M.pass_instance_token()
+    ngx.req.clear_header("Cookie")
+    set_request_context()
+end
+
 return _M

--- a/src/backend/tools/routegen/src/emit.rs
+++ b/src/backend/tools/routegen/src/emit.rs
@@ -467,7 +467,9 @@ fn emit_api_location(
     writeln!(c, "        # route: {} -> {}", route.prefix, route.upstream)?;
     match route.auth {
         Authentication::Session => writeln!(c, "        location {} {{", route.prefix)?,
-        Authentication::Bearer => writeln!(c, "        location = {} {{", route.prefix)?,
+        Authentication::Bearer | Authentication::InstanceToken => {
+            writeln!(c, "        location = {} {{", route.prefix)?;
+        }
     }
     match route.auth {
         Authentication::Session => {
@@ -475,6 +477,11 @@ fn emit_api_location(
         }
         Authentication::Bearer => {
             c.push_str("            access_by_lua_block { require(\"gateway\").pass_bearer() }\n");
+        }
+        Authentication::InstanceToken => {
+            c.push_str(
+                "            access_by_lua_block { require(\"gateway\").pass_instance_token() }\n",
+            );
         }
     }
     if route.strip_prefix {
@@ -486,7 +493,9 @@ fn emit_api_location(
     }
     writeln!(c, "            proxy_pass {scheme}://{ident};")?;
     match route.auth {
-        Authentication::Session => c.push_str("            proxy_set_header Host $host;\n"),
+        Authentication::Session | Authentication::InstanceToken => {
+            c.push_str("            proxy_set_header Host $host;\n");
+        }
         Authentication::Bearer => c.push_str("            proxy_set_header Host localhost;\n"),
     }
     // 5. gateway-authored forwarding headers (client-supplied are cleared in Lua)

--- a/src/backend/tools/routegen/src/schema.rs
+++ b/src/backend/tools/routegen/src/schema.rs
@@ -45,6 +45,7 @@ pub enum Authentication {
     #[default]
     Session,
     Bearer,
+    InstanceToken,
 }
 
 impl Default for Defaults {

--- a/src/backend/tools/routegen/src/validate.rs
+++ b/src/backend/tools/routegen/src/validate.rs
@@ -81,7 +81,10 @@ pub fn validate(config: &RouteConfig) -> Result<(), ValidationErrors> {
             Authentication::Bearer if p != "/mcp" => errors.push(format!(
                 "bearer-authenticated route prefix '{p}' must be exactly '/mcp'"
             )),
-            Authentication::Session | Authentication::Bearer => {}
+            Authentication::InstanceToken if p != "/api/sql/query" => errors.push(format!(
+                "instance-token route prefix '{p}' must be exactly '/api/sql/query'"
+            )),
+            Authentication::Session | Authentication::Bearer | Authentication::InstanceToken => {}
         }
 
         match parse_upstream(&route.upstream) {

--- a/src/backend/tools/routegen/src/validate.rs
+++ b/src/backend/tools/routegen/src/validate.rs
@@ -96,6 +96,11 @@ pub fn validate(config: &RouteConfig) -> Result<(), ValidationErrors> {
         }
 
         let resolved = route.resolve(&config.defaults);
+        if resolved.auth == Authentication::InstanceToken && resolved.strip_prefix {
+            errors.push(format!(
+                "instance-token route '{p}' must not enable strip_prefix"
+            ));
+        }
         if resolved.timeout_ms == 0 && !resolved.websocket {
             errors.push(format!(
                 "route '{p}': timeout_ms 0 is only allowed with websocket: true"

--- a/src/backend/tools/routegen/tests/golden.rs
+++ b/src/backend/tools/routegen/tests/golden.rs
@@ -54,6 +54,23 @@ fn instance_token_route_bypasses_session_and_mcp_oauth() {
     assert!(conf.contains("require(\"gateway\").pass_instance_token()"));
     assert!(!conf.contains("require(\"gateway\").pass_bearer()"));
     assert!(!conf.contains("require(\"gateway\").exchange()"));
+    let sql_location = conf
+        .split("location = /api/sql/query {")
+        .nth(1)
+        .unwrap()
+        .split("        }\n")
+        .next()
+        .unwrap();
+    for directive in [
+        "proxy_set_header Host $host;",
+        "proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;",
+        "proxy_set_header X-Forwarded-Proto $scheme;",
+        "proxy_connect_timeout 5s;",
+        "proxy_read_timeout 30s;",
+        "proxy_buffering off;",
+    ] {
+        assert!(sql_location.contains(directive), "missing: {directive}");
+    }
     for path in ["/mcp", "/api/analytics", "/api/sql/query/extra"] {
         assert!(
             generate(
@@ -70,7 +87,7 @@ fn instance_token_route_bypasses_session_and_mcp_oauth() {
 /// 3.9): the Lua exchange, no browser Authorization survives, the session cookie
 /// is stripped in Lua, a fresh correlation id, and gateway-authored forwarding.
 #[test]
-fn every_api_location_has_the_hygiene_block() {
+fn every_session_location_has_the_hygiene_block() {
     let conf = generate(&fixture("full.routes.yaml"), &Settings::default()).unwrap();
     // One access_by_lua per /api route (3 routes in the fixture).
     assert_eq!(

--- a/src/backend/tools/routegen/tests/golden.rs
+++ b/src/backend/tools/routegen/tests/golden.rs
@@ -46,6 +46,26 @@ fn golden_strip_prefix() {
     assert_golden("stripprefix.routes.yaml", "stripprefix.nginx.conf");
 }
 
+#[test]
+fn instance_token_route_bypasses_session_and_mcp_oauth() {
+    let routes = "version: 1\nroutes:\n  - prefix: /api/sql/query\n    upstream: http://analytics:8086\n    auth: instance_token\n";
+    let conf = generate(routes, &Settings::default()).unwrap();
+    assert!(conf.contains("location = /api/sql/query {"));
+    assert!(conf.contains("require(\"gateway\").pass_instance_token()"));
+    assert!(!conf.contains("require(\"gateway\").pass_bearer()"));
+    assert!(!conf.contains("require(\"gateway\").exchange()"));
+    for path in ["/mcp", "/api/analytics", "/api/sql/query/extra"] {
+        assert!(
+            generate(
+                &routes.replace("/api/sql/query", path),
+                &Settings::default()
+            )
+            .is_err(),
+            "path: {path}"
+        );
+    }
+}
+
 /// Every generated `/api/` location must carry the full hygiene block (DESIGN
 /// 3.9): the Lua exchange, no browser Authorization survives, the session cookie
 /// is stripped in Lua, a fresh correlation id, and gateway-authored forwarding.

--- a/src/backend/tools/routegen/tests/golden.rs
+++ b/src/backend/tools/routegen/tests/golden.rs
@@ -47,6 +47,29 @@ fn golden_strip_prefix() {
 }
 
 #[test]
+fn instance_token_routes_reject_effective_prefix_stripping() {
+    for (defaults, route, accepted) in [
+        ("", "", true),
+        ("", "    strip_prefix: true\n", false),
+        ("defaults:\n  strip_prefix: true\n", "", false),
+        (
+            "defaults:\n  strip_prefix: true\n",
+            "    strip_prefix: false\n",
+            true,
+        ),
+    ] {
+        let routes = format!(
+            "version: 1\n{defaults}routes:\n  - prefix: /api/sql/query\n    upstream: http://analytics:8086\n    auth: instance_token\n{route}"
+        );
+        let result = generate(&routes, &Settings::default());
+        assert_eq!(result.is_ok(), accepted, "route configuration: {routes}");
+        if let Err(error) = result {
+            assert!(error.to_string().contains("must not enable strip_prefix"));
+        }
+    }
+}
+
+#[test]
 fn instance_token_route_bypasses_session_and_mcp_oauth() {
     let routes = "version: 1\nroutes:\n  - prefix: /api/sql/query\n    upstream: http://analytics:8086\n    auth: instance_token\n";
     let conf = generate(routes, &Settings::default()).unwrap();

--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -67,7 +67,7 @@ SQL
 echo "=== Provisioning presentation access (role + grant-less user) (#1963/#1964) ==="
 bash "$SCRIPT_DIR/bootstrap-db/provision-presentation-access.sh"
 
-if [[ "${MCP_ENABLED:-false}" == "true" ]]; then
+if [[ "${MCP_ENABLED:-false}" == "true" || "${SQL_API_ENABLED:-false}" == "true" ]]; then
   echo "=== Provisioning MCP SQL explorer access ==="
   bash "$SCRIPT_DIR/bootstrap-db/provision-mcp-access.sh"
 else

--- a/src/ingestion/scripts/bootstrap-db/provision-mcp-access.sh
+++ b/src/ingestion/scripts/bootstrap-db/provision-mcp-access.sh
@@ -33,8 +33,8 @@ CREATE USER IF NOT EXISTS insight_mcp IDENTIFIED BY '${CLICKHOUSE_MCP_PASSWORD}'
   max_result_rows = 5000,
   max_result_bytes = 5242880,
   result_overflow_mode = 'throw',
-  max_rows_to_read = 1000000,
-  max_bytes_to_read = 268435456;
+  max_rows_to_read = 10000000,
+  max_bytes_to_read = 1073741824;
 ALTER USER insight_mcp IDENTIFIED BY '${CLICKHOUSE_MCP_PASSWORD}' SETTINGS
   readonly = 1,
   max_execution_time = 30,
@@ -43,8 +43,8 @@ ALTER USER insight_mcp IDENTIFIED BY '${CLICKHOUSE_MCP_PASSWORD}' SETTINGS
   max_result_rows = 5000,
   max_result_bytes = 5242880,
   result_overflow_mode = 'throw',
-  max_rows_to_read = 1000000,
-  max_bytes_to_read = 268435456;
+  max_rows_to_read = 10000000,
+  max_bytes_to_read = 1073741824;
 GRANT insight_mcp_ro TO insight_mcp;
 ALTER USER insight_mcp DEFAULT ROLE insight_mcp_ro;
 SQL


### PR DESCRIPTION
**Why.** Scripts need direct SQL access without saving queries or using an MCP client.

**What changed.** Add an independently enabled SQL endpoint backed by the shared MCP executor, with instance-token authentication and Helm/Compose configuration.

**Access.** The shared token grants instance-wide explorer access. Personal authorization remains available through MCP OAuth.

**Verified.** 860 tests passed; 69 existing tests ignored. Clippy, formatting, and Helm rendering passed. Deployed execution not tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional, token-authenticated SQL Query API for read-only queries.
  - Added SQL API configuration for Docker Compose and Kubernetes deployments.
  - Added gateway routing, request limits, structured results, and sanitized error responses.
  - Added support for enabling the SQL API independently of MCP.

- **Documentation**
  - Added setup, authentication, usage, response, limits, and access guidance for the SQL Query API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->