### PR TITLE
feat(datasets): answer dataset questions through POST /v1/query

### DIFF
--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -109,6 +109,18 @@ traceability = "DOCS-ONLY"
 
 [[systems.artifacts]]
 kind = "PRD"
+path = "docs/domain/query-engine/PRD.md"
+name = "Query Engine PRD"
+traceability = "DOCS-ONLY"
+
+[[systems.artifacts]]
+kind = "DESIGN"
+path = "docs/domain/query-engine/DESIGN.md"
+name = "Query Engine Design"
+traceability = "DOCS-ONLY"
+
+[[systems.artifacts]]
+kind = "PRD"
 path = "docs/domain/datasets/PRD.md"
 name = "Data Sets PRD"
 traceability = "DOCS-ONLY"

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -2365,6 +2365,306 @@
         ],
         "type": "object"
       },
+      "Query": {
+        "additionalProperties": false,
+        "properties": {
+          "aggregates": {
+            "items": {
+              "$ref": "#/components/schemas/QueryAggregate"
+            },
+            "type": "array"
+          },
+          "dataset": {
+            "type": "string"
+          },
+          "filters": {
+            "description": "Row filters, narrowing the scan before aggregation.",
+            "items": {
+              "$ref": "#/components/schemas/QueryFilter"
+            },
+            "type": "array"
+          },
+          "group_by": {
+            "items": {
+              "$ref": "#/components/schemas/QueryGroupAxis"
+            },
+            "type": "array"
+          },
+          "limit": {
+            "description": "Row ceiling; a query over the cap is refused rather than clipped.",
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "order": {
+            "items": {
+              "$ref": "#/components/schemas/QueryOrder"
+            },
+            "type": "array"
+          },
+          "time": {
+            "$ref": "#/components/schemas/QueryTime",
+            "description": "The window every scan is bounded by, and the width of its buckets."
+          }
+        },
+        "required": [
+          "dataset",
+          "aggregates",
+          "time"
+        ],
+        "type": "object"
+      },
+      "QueryAggregate": {
+        "oneOf": [
+          {
+            "properties": {
+              "filter": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/QueryFilter",
+                    "description": "Restricts this fold to the rows one filter selects."
+                  }
+                ]
+              },
+              "fn": {
+                "enum": [
+                  "count"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "What the answer column is called.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "fn"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "filter": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/QueryFilter",
+                    "description": "Restricts this fold to the rows one filter selects."
+                  }
+                ]
+              },
+              "fn": {
+                "enum": [
+                  "sum"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "What the answer column is called.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "field",
+              "fn"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "filter": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/QueryFilter",
+                    "description": "Restricts this fold to the rows one filter selects."
+                  }
+                ]
+              },
+              "fn": {
+                "enum": [
+                  "avg"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "What the answer column is called.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "field",
+              "fn"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "filter": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/QueryFilter",
+                    "description": "Restricts this fold to the rows one filter selects."
+                  }
+                ]
+              },
+              "fn": {
+                "enum": [
+                  "min"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "What the answer column is called.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "field",
+              "fn"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "filter": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/QueryFilter",
+                    "description": "Restricts this fold to the rows one filter selects."
+                  }
+                ]
+              },
+              "fn": {
+                "enum": [
+                  "max"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "What the answer column is called.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "field",
+              "fn"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "QueryAnswer": {
+        "properties": {
+          "columns": {
+            "items": {
+              "$ref": "#/components/schemas/QueryAnswerColumn"
+            },
+            "type": "array"
+          },
+          "flags": {
+            "$ref": "#/components/schemas/QueryAnswerFlags"
+          },
+          "rows": {
+            "items": {
+              "items": {},
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "columns",
+          "rows",
+          "flags"
+        ],
+        "type": "object"
+      },
+      "QueryAnswerColumn": {
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/QueryColumnKind"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/QueryColumnType"
+          }
+        },
+        "required": [
+          "name",
+          "kind",
+          "type"
+        ],
+        "type": "object"
+      },
+      "QueryAnswerFlags": {
+        "properties": {
+          "truncated": {
+            "description": "More groups matched than the limit admits; the rows are the first\n`limit` of them in the answer's order.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "truncated"
+        ],
+        "type": "object"
+      },
+      "QueryColumnKind": {
+        "enum": [
+          "dimension",
+          "label",
+          "bucket",
+          "aggregate"
+        ],
+        "type": "string"
+      },
+      "QueryColumnType": {
+        "enum": [
+          "text",
+          "number",
+          "date"
+        ],
+        "type": "string"
+      },
       "QueryDataset": {
         "properties": {
           "dimensions": {
@@ -2376,6 +2676,10 @@
           },
           "key": {
             "type": "string"
+          },
+          "limits": {
+            "$ref": "#/components/schemas/QueryLimits",
+            "description": "The bounds a request against this dataset must stay inside."
           },
           "measurables": {
             "description": "The columns an aggregate may fold.",
@@ -2396,7 +2700,8 @@
           "key",
           "time_fields",
           "dimensions",
-          "measurables"
+          "measurables",
+          "limits"
         ],
         "type": "object"
       },
@@ -2463,6 +2768,427 @@
         "required": [
           "field",
           "default"
+        ],
+        "type": "object"
+      },
+      "QueryDirection": {
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "QueryFilter": {
+        "oneOf": [
+          {
+            "properties": {
+              "field": {
+                "description": "A declared dimension or measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "eq"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/QueryFilterValue"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared dimension or measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "in"
+                ],
+                "type": "string"
+              },
+              "values": {
+                "description": "At least one value, and at most the contract's cap.",
+                "items": {
+                  "$ref": "#/components/schemas/QueryFilterValue"
+                },
+                "maxItems": 256,
+                "minItems": 1,
+                "type": "array"
+              }
+            },
+            "required": [
+              "field",
+              "values",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "gt"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/QueryFilterValue"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "gte"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/QueryFilterValue"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "lt"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/QueryFilterValue"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "lte"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/QueryFilterValue"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "high": {
+                "$ref": "#/components/schemas/QueryFilterValue",
+                "description": "Inclusive upper bound."
+              },
+              "low": {
+                "$ref": "#/components/schemas/QueryFilterValue",
+                "description": "Inclusive lower bound."
+              },
+              "op": {
+                "enum": [
+                  "between"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "field",
+              "low",
+              "high",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared dimension or measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "not_null"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "field",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "SQL `LIKE`: `%` matches any run, `_` one character.",
+            "properties": {
+              "field": {
+                "description": "A declared dimension of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "like"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "maxLength": 256,
+                "type": "string"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "An RE2 regular expression, unanchored.",
+            "properties": {
+              "field": {
+                "description": "A declared dimension of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "match"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "maxLength": 256,
+                "type": "string"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "QueryFilterValue": {
+        "description": "A filter value: text, a number, or a boolean",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "format": "double",
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "QueryGrain": {
+        "enum": [
+          "day",
+          "week",
+          "month"
+        ],
+        "type": "string"
+      },
+      "QueryGroupAxis": {
+        "oneOf": [
+          {
+            "properties": {
+              "axis": {
+                "enum": [
+                  "dimension"
+                ],
+                "type": "string"
+              },
+              "field": {
+                "description": "A declared dimension of the dataset.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "field",
+              "axis"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "The time bucket as a group axis; its width is `time.grain`.",
+            "properties": {
+              "axis": {
+                "enum": [
+                  "time"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "axis"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "QueryLimits": {
+        "description": "The contract's request bounds, identical for every dataset.",
+        "properties": {
+          "default_limit": {
+            "description": "Rows a query gets when it sets no ceiling of its own.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_aggregates": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_filter_values": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_filters": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_group_axes": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_limit": {
+            "description": "Rows a query may ask for at most; over it the query is refused, not clipped.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_name_chars": {
+            "description": "Longest an aggregate's name may be, in characters.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_order_terms": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "max_filters",
+          "max_filter_values",
+          "max_aggregates",
+          "max_group_axes",
+          "max_order_terms",
+          "max_name_chars",
+          "default_limit",
+          "max_limit"
+        ],
+        "type": "object"
+      },
+      "QueryOrder": {
+        "additionalProperties": false,
+        "properties": {
+          "by": {
+            "description": "A column the answer reports: a grouped dimension, `time`, or an aggregate name.",
+            "type": "string"
+          },
+          "dir": {
+            "$ref": "#/components/schemas/QueryDirection"
+          }
+        },
+        "required": [
+          "by"
+        ],
+        "type": "object"
+      },
+      "QueryTime": {
+        "additionalProperties": false,
+        "properties": {
+          "field": {
+            "description": "A declared time field; the dataset's default when omitted.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "from": {
+            "description": "Inclusive first day, UTC.",
+            "format": "date",
+            "type": "string"
+          },
+          "grain": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/QueryGrain",
+                "description": "Bucket width. Required with an `{\"axis\": \"time\"}` axis, refused without one."
+              }
+            ]
+          },
+          "to": {
+            "description": "Inclusive last day, UTC.",
+            "format": "date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "from",
+          "to"
         ],
         "type": "object"
       },
@@ -6755,6 +7481,100 @@
           }
         ],
         "summary": "Run a saved query"
+      }
+    },
+    "/v1/query": {
+      "post": {
+        "operationId": "analytics_api.query.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Query"
+              }
+            }
+          },
+          "description": "The question to answer",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryAnswer"
+                }
+              }
+            },
+            "description": "A typed table"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "415": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Answer a query over a declared dataset"
       }
     },
     "/v1/reports/export": {

--- a/docs/domain/query-engine/DESIGN.md
+++ b/docs/domain/query-engine/DESIGN.md
@@ -1,5 +1,5 @@
 ---
-version: 2.1
+version: 2.2
 status: proposed
 date: 2026-09-08
 ---
@@ -27,8 +27,8 @@ date: 2026-09-08
   - [3.7 Database schemas & tables](#37-database-schemas--tables)
   - [3.8 Deployment Topology](#38-deployment-topology)
 - [4. Additional context](#4-additional-context)
-  - [Capability semantics](#capability-semantics)
-  - [Saved queries](#saved-queries)
+  - [Capability status and proposed semantics](#capability-status-and-proposed-semantics)
+  - [Saved queries (specified, not implemented)](#saved-queries-specified-not-implemented)
   - [Non-goals](#non-goals)
 - [5. Traceability](#5-traceability)
 
@@ -38,52 +38,57 @@ date: 2026-09-08
 
 ### 1.1 Architectural Vision
 
-One question contract over declared datasets. Each question compiles to one bounded,
-parameterised ClickHouse scan per dataset and answers a typed table. The rules the schema
-does not carry — session tenancy, duplicate-free reads, NULL folding, UTC day boundaries,
-caps — are compiler steps applied to every question and pinned by rendered-SQL tests.
+The engine validates a structured request against a dataset declaration, compiles one
+parameterized ClickHouse query, and returns a typed table. The compiler applies session
+tenancy, dataset read discipline, null-preserving aggregation, UTC boundaries, ordering,
+and row limits. The executor bounds fetched bytes, timeout, and concurrent scans.
 
-Three pure layers around one I/O shell. *Declarations*: what may be asked, validated at
-build time against the warehouse column snapshot. *Validation*: bind a request or refuse it
-with every violation named. *Compilation*: SQL text with engine-owned identifiers, caller
-values bound. The shell runs the statement under a byte ceiling and a concurrency permit and
-assembles the answer. Realises [PRD.md](PRD.md); migration in [MIGRATION.md](MIGRATION.md).
+Validation, compilation, and answer assembly are pure domain operations. The API handles
+authorization and orchestration; infrastructure executes the query. Dataset declarations
+and their snapshot validation belong to the [dataset registry](../datasets/DESIGN.md).
+
+**Implemented**: single-dataset queries, basic and pattern filters, dimension and time
+grouping, conditional count/sum/avg/min/max, ordering, truncation, and administrator access.
+
+**Planned**: constructor UI, advanced query operations, saved queries, and access policies.
+Section 3 defines the supported contract; Section 4 preserves proposed extension semantics.
+See [PRD.md](PRD.md) for requirements and [MIGRATION.md](MIGRATION.md) for migration.
 
 ### 1.2 Architecture Drivers
 
-**ADRs**: none yet; the first is expected with access policies.
+**ADRs**: none. Access-policy design remains open.
 
 #### Functional Drivers
 
 | Requirement | Design Response |
 |-------------|------------------|
 | `cpt-insightspec-qe-fr-ask` | request → plan → compile → one scan; no metric definition in the path |
-| `cpt-insightspec-qe-fr-group` | a labelled dimension answers `<field>_label` beside its value; every stable column declared |
+| `cpt-insightspec-qe-fr-group` | a labelled dimension answers `<field>_label` beside its value; grouping restricted to declared dimensions |
 | `cpt-insightspec-qe-fr-filter` | tagged filter variants; patterns bound as parameters, `match` compiled at validation; operator/target mismatch refused |
-| `cpt-insightspec-qe-fr-fold` | `OrNull` folds; `count` alone reports 0 |
+| `cpt-insightspec-qe-fr-fold` | `OrNull` aggregates; `count` alone reports 0 |
 | `cpt-insightspec-qe-fr-bounds` | window cap; `LIMIT limit + 1` with `flags.truncated`; chunked byte ceiling; semaphore |
-| `cpt-insightspec-qe-fr-refusal` | whole plan checked first; one `Violation {field, reason, detail}` per problem |
-| `cpt-insightspec-qe-fr-boolean` | `any`/`all`/`not` variants → parenthesised predicates |
-| `cpt-insightspec-qe-fr-relative-window` | resolved at plan time; answer reports `resolved_window` |
-| `cpt-insightspec-qe-fr-derived` | `classify` → one `multiIf`; `time_part` → date-part function in the query zone |
-| `cpt-insightspec-qe-fr-richer-folds` | more fold and window variants over the same plan (§4) |
-| `cpt-insightspec-qe-fr-time-intelligence` | zone, week start, fiscal start as compiler inputs to every boundary |
-| `cpt-insightspec-qe-fr-rows` | sibling row-level shape over the same predicates, keyed on `row_identity` |
-| `cpt-insightspec-qe-fr-saved` | stored request re-planned on every read |
-| `cpt-insightspec-qe-fr-cross-dataset` | one scan per dataset aligned on conformed dimensions; lookups joined on a unique key |
-| `cpt-insightspec-qe-fr-funnels` | aggregate families over ClickHouse `windowFunnel`, `retention` |
+| `cpt-insightspec-qe-fr-refusal` | semantic violations collected after dataset resolution; deserialization fails separately |
+| `cpt-insightspec-qe-fr-boolean` | planned: `any`/`all`/`not` variants → parenthesised predicates |
+| `cpt-insightspec-qe-fr-relative-window` | planned: resolved at plan time; answer reports `resolved_window` |
+| `cpt-insightspec-qe-fr-derived` | planned: `classify` → one `multiIf`; `time_part` → date-part function in the query zone |
+| `cpt-insightspec-qe-fr-richer-folds` | planned: advanced aggregates and window operations over the same plan (§4) |
+| `cpt-insightspec-qe-fr-time-intelligence` | planned: zone, week start, fiscal start as compiler inputs to every boundary |
+| `cpt-insightspec-qe-fr-rows` | planned: row-level results keyed on `row_identity`; route remains undecided |
+| `cpt-insightspec-qe-fr-saved` | planned: stored request re-planned on every read |
+| `cpt-insightspec-qe-fr-cross-dataset` | planned: one scan per dataset aligned on conformed dimensions; lookups joined on a unique key |
+| `cpt-insightspec-qe-fr-funnels` | planned: aggregate families over ClickHouse `windowFunnel`, `retention` |
 | `cpt-insightspec-qe-fr-admin-gate` | `require_admin` before every query and discovery handler |
-| `cpt-insightspec-qe-fr-access-policies` | policy predicates bound from the caller context at plan time, before any capability |
+| `cpt-insightspec-qe-fr-access-policies` | planned: policy predicates bound from the caller context at plan time, before any capability |
 
 #### NFR Allocation
 
 | NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
 |--------|-------------|--------------|-----------------|----------------------|
-| `cpt-insightspec-qe-nfr-correctness` | correct by construction | compiler | tenancy predicate first; `FINAL` per read discipline; `OrNull` folds; `toDate(x, 'UTC')`; no `=` on nullable keys | rendered-SQL goldens; stand reconciliations |
+| `cpt-insightspec-qe-nfr-correctness` | consistent query semantics | compiler | tenancy predicate first; `FINAL` per read discipline; `OrNull` aggregates; `toDate(x, 'UTC')` | rendered-SQL goldens; stand reconciliations |
 | `cpt-insightspec-qe-nfr-bounded` | bounded cost | validation, executor, handler | 731-day window; 10 000 rows; 16 MiB chunked ceiling; 8-permit semaphore → 429 | unit tests per cap; stand 400/429 cases |
-| `cpt-insightspec-qe-nfr-latency` | interactive latency | gold datasets, compiler | flat pre-joined relations; one scan; partitioned by month, sorted by tenant | stand timing; ClickHouse query log |
+| `cpt-insightspec-qe-nfr-latency` | interactive latency | gold datasets, compiler | flat pre-joined relations; one scan; partitioned by month, sorted by tenant | planned benchmark; reference workload not yet defined |
 | `cpt-insightspec-qe-nfr-contract` | stable contract | contract DTOs | tagged unions with `deny_unknown_fields`; OpenAPI generated from types; CI drift gate | drift check; stand schema generation |
-| `cpt-insightspec-qe-nfr-person-data` | person columns classified | declarations, executor | person columns named in the declaration; no engine store or cache; gate then policies govern reads | declaration tests; no persistence in the engine |
+| `cpt-insightspec-qe-nfr-person-data` | personal-data handling | declarations, executor | admin gate and no result store; classification and policies planned | authorization tests; inspect persistence boundaries |
 
 ### 1.3 Architecture Layers
 
@@ -109,46 +114,46 @@ ingestion (dbt) ─────────────────────�
 
 ### 2.1 Design Principles
 
-#### A contract, not SQL, from callers
+#### Structured query contract
 
 - [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-contract`
 
-Callers send a small typed document. Only engine-owned identifiers reach SQL text; every
-caller value binds. This is what makes tenancy, read discipline, NULL semantics, caps and
-row policies enforceable without a SQL parser.
+Callers select typed operations over declared fields. SQL identifiers are resolved from the
+plan; caller values are bound as parameters. Requests cannot override tenant scoping or
+read discipline.
 
-#### Declarations are the truth
+#### Declared fields
 
 - [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-declarations`
 
-What may be asked is declared per dataset and validated against the column snapshot at build
-time. Every stable-valued column is a dimension. A request cannot name what no declaration
-does.
+Requests may reference only fields exposed by the selected dataset. Shipped declarations
+are validated against an embedded column snapshot; this is not a live-schema check.
 
-#### Refuse by name
+#### Structured validation errors
 
 - [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-refusals`
 
-Check the whole request, then report every violation with field, machine reason and
-admissible set. Server faults (unusable declarations, warehouse errors) are 500s, never
-dressed as request errors.
+After deserialization and dataset resolution, validation collects independent semantic
+violations with field paths, reason codes, and available choices. Malformed requests and
+unknown datasets fail earlier. Unusable declarations and warehouse failures are server errors.
 
-#### Correct by construction
+#### Shared compiler rules
 
 - [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-correctness`
 
-Rules the schema does not carry live in the compiler, pinned by exact rendered-SQL tests.
+Compiler tests verify tenant predicates, read discipline, aggregate null behavior, and
+time boundaries. Prepared-data deduplication and attribution remain dataset responsibilities.
 
 ### 2.2 Constraints
 
-#### Tenancy binds from the session
+#### Session tenant
 
 - [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-tenancy`
 
 First predicate of every scan is the tenant from the security context. No request member
 names a tenant; unknown members are refused.
 
-#### Admin-only until access policies land
+#### Initial administrator restriction
 
 - [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-admin-gate`
 
@@ -156,13 +161,23 @@ Datasets carry person columns and declare no access policy yet: `POST /v1/query`
 `GET /v1/datasets` routes refuse non-administrators. The change declaring the first policy
 must specify what replaces the minimum-peer suppression of the metric surfaces.
 
-#### Bounded on every axis
+#### Execution limits
 
 - [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-bounds`
 
-Window ≤ 731 days inside the `Date` range; rows ≤ 10 000 plus one fetched to flag
-truncation; answer ≤ 16 MiB enforced while receiving; 8 scans in flight per process; filter,
-aggregate, axis, order counts and pattern lengths capped by contract constants.
+| Limit | Value |
+|---|---|
+| Inclusive time window | 731 days, within the supported `Date` range |
+| Result rows | Default 1,000; maximum 10,000; fetch one extra to detect truncation |
+| Fetched response bytes | 16 MiB, checked while receiving chunks |
+| Concurrent scans | Eight per process |
+| Permit acquisition | Two seconds, then a retryable capacity error |
+| Top-level filters / values per membership filter | 32 / 256 |
+| Aggregates / grouping axes / ordering terms | 16 / 4 / 4 |
+| Aggregate-name / pattern length | 64 / 256 characters |
+
+Constants live in `contract/dto.rs`, `api/query.rs`, and `infra/query.rs`. The byte cap applies
+to fetched warehouse data, not the size of the final serialized HTTP response.
 
 #### Gold relations only
 
@@ -177,15 +192,15 @@ bronze, no silver, no query-time joins beyond a future declared lookup, no write
 
 - **Authentication**: gateway and identity establish the session; the engine trusts the
   `SecurityContext` it receives and never authenticates.
-- **Data protection**: TLS and tenant isolation inherited from the platform; person columns
-  classified in declarations; column masking arrives with access policies.
+- **Data protection**: TLS and tenant isolation inherited from the platform; personal-field
+  classification and column masking are planned with access policies.
 - **Threats**: injection via operands — mitigated by binding every caller value; over-broad
   exposure before policies — mitigated by the admin gate; resource exhaustion — mitigated by
   the caps above; malformed regex — compiled at validation.
-- **Audit**: latency and error class recorded per question; who-asked-what audit is open
+- **Audit**: latency and error class recorded per query; caller/query audit remains open
   and tracked under access policies.
-- **Capacity and recovery**: the engine holds no state; capacity is the warehouse's and
-  ingestion's concern; recovery is redeploy.
+- **Capacity and recovery**: no durable query state. In-process concurrency is bounded;
+  warehouse capacity and query shape still affect latency. Recovery follows the service.
 
 ## 3. Technical Architecture
 
@@ -227,13 +242,13 @@ request ─▶ api (gate) ─▶ validation ─▶ compile ─▶ executor ─�
 
 ##### Why this component exists
 
-A request is untrusted until every reference resolves and every rule holds.
+Resolves field references and checks operations before SQL compilation.
 
 ##### Responsibility scope
 
 Bind filters, axes, aggregates, order, window to the declaration; check operand types and
 operator/target pairs; compile `match` patterns; enforce caps; build answer columns (value,
-label, bucket, aggregate) with sources; return a `QueryPlan` or every `Violation`.
+label, bucket, aggregate) with sources; return a `QueryPlan` or collected `Violation` values.
 
 ##### Responsibility boundaries
 
@@ -250,11 +265,11 @@ No SQL, no connection. `PlanError` separates a refused request from unusable dec
 
 ##### Why this component exists
 
-Apply the correctness rules once, to every question.
+Compiles validated plans with consistent query semantics.
 
 ##### Responsibility scope
 
-Render one statement: positional aliases; `FINAL` per read discipline; `OrNull` folds;
+Render one statement: positional aliases; `FINAL` per read discipline; `OrNull` aggregates;
 `toDate(x, 'UTC')`; dimension values via `toString` and the absent sentinel; every caller
 value as `?`; tenancy, window, filters in that order; `GROUP BY` group columns;
 deterministic `ORDER BY`; `LIMIT limit + 1`.
@@ -274,7 +289,7 @@ Never sees a raw request or a connection; no authorization logic.
 
 ##### Why this component exists
 
-One place talks to the warehouse for questions, so every bound is enforced there.
+Centralizes warehouse execution and bounded response collection.
 
 ##### Responsibility scope
 
@@ -297,13 +312,13 @@ Does not interpret the request; a ceiling breach is a typed error the handler ma
 
 ##### Why this component exists
 
-HTTP edge: authorization, extraction, error envelopes.
+Exposes query execution through the analytics API.
 
 ##### Responsibility scope
 
-`POST /v1/query`: admin gate, permit, plan, compile, fetch, assemble; refusals →
-field-violation envelope, byte ceiling → `limit` violation, exhaustion → 429, else 500.
-`GET /v1/datasets`, `GET /v1/datasets/{key}`: admin gate, describe.
+`POST /v1/query`: authorize, plan, compile, acquire a permit, fetch, release the permit,
+and assemble the result. Section 3.3 defines errors. Dataset discovery is owned by the
+datasets API; the query contract supplies its limits metadata.
 
 ##### Responsibility boundaries
 
@@ -315,13 +330,13 @@ No business logic, no SQL.
 - `cpt-insightspec-qe-component-executor` — calls
 - `cpt-insightspec-qe-component-constructor` — serves
 
-#### Constructor page
+#### Constructor page (planned)
 
 - [ ] `p2` - **ID**: `cpt-insightspec-qe-component-constructor`
 
 ##### Why this component exists
 
-Administrators ask questions without writing JSON.
+Provides query composition and result rendering for administrators.
 
 ##### Responsibility scope
 
@@ -331,25 +346,26 @@ beside its input and the truncation flag.
 
 ##### Responsibility boundaries
 
-No metric semantics, no invented labels, no persistence.
+Uses dataset metadata and query errors; owns no metric semantics or persistence.
+Not implemented in this change.
 
 ##### Related components (by ID)
 
 - `cpt-insightspec-qe-component-api` — calls
 
-#### Access policies
+#### Access policies (needs design)
 
 - [ ] `p2` - **ID**: `cpt-insightspec-qe-component-access-policies`
 
 ##### Why this component exists
 
-Row visibility is enforced where rows are planned, from facts identity supplies.
+Extends administrator-only access with dataset, row, and column policies.
 
 ##### Responsibility scope
 
 Per dataset: dataset access (roles or allow list); row policies (dimension bound to a caller
 attribute: visible people, team repositories); column policies (dropped or masked per role).
-Applied at plan time before any capability. *Needs design* (§4).
+Proposed enforcement occurs at plan time. Section 4 records unresolved decisions.
 
 ##### Responsibility boundaries
 
@@ -368,138 +384,66 @@ Never decides who the caller is; refuses when a needed fact is missing.
 - **PRD interface**: `cpt-insightspec-qe-interface-query`
 - **Technology**: REST/OpenAPI, JSON, RFC 9457 problem envelopes
 - **Location**: [openapi.json](../../components/backend/analytics/openapi.json) — the
-  authority for what is accepted today
+  authority for the supported wire schema
 
 **Endpoints Overview**:
 
 | Method | Path | Description | Stability |
 |--------|------|-------------|-----------|
-| `POST` | `/v1/query` | answer one question over a declared dataset | unstable (admin-only) |
+| `POST` | `/v1/query` | Execute a query over one dataset | unstable (admin-only) |
 
 Discovery — `GET /v1/datasets` — belongs to the [dataset registry](../datasets/DESIGN.md);
 the engine contributes only the request bounds each description carries.
 
-The request below is the design target; §4 says which members are shipped. Today's accepted
-members: `dataset`, `filters`, `group_by`, `aggregates` (with `filter`), `time` with
-`field`/`from`/`to`/`grain` (day, week, month), `order`, `limit`. Everything else is refused
-as unknown until its change lands.
+#### Supported request
 
-```jsonc
-POST /v1/query
-{
-  "dataset": "…",                       // or "saved": "<saved-query name>"
+| Member | Contract |
+|---|---|
+| `dataset` | One registered dataset key |
+| `filters` | Optional list, combined with AND |
+| `group_by` | Optional dimension or time axes |
+| `aggregates` | One or more named count, sum, avg, min, or max operations; each may have one filter |
+| `time` | Required inclusive `from` and `to`; optional declared `field` and day/week/month `grain` |
+| `order` | Optional result-column names with ascending or descending direction |
+| `limit` | Optional row limit, subject to declared bounds |
 
-  // Every list below is a discriminated union: the tag (`op`, `axis`, `fn`)
-  // selects the variant, and a variant carries exactly the operands it takes.
-  // An operand belonging to another variant is refused at deserialization, so
-  // no arity or "required together" rule is checked at runtime.
+`op`, `axis`, and `fn` select tagged variants. Unknown members and operands belonging to
+another variant are rejected during deserialization. The OpenAPI document is the complete
+wire schema; semantic validation additionally checks dataset fields, types, and limits.
 
-  "filters": [
-    { "op": "eq",       "field": "…", "value": … },
-    { "op": "in",       "field": "…", "values": [ … ] },
-    { "op": "gt",       "field": "…", "value": … },
-    { "op": "gte",      "field": "…", "value": … },
-    { "op": "lt",       "field": "…", "value": … },
-    { "op": "lte",      "field": "…", "value": … },
-    { "op": "between",  "field": "…", "low": …, "high": … },
-    { "op": "not_null", "field": "…" },
-    { "op": "like",     "field": "…", "value": "%/tests/%", "case_insensitive": false },
-    { "op": "match",    "field": "…", "value": "\\.(test|spec)\\.", "case_insensitive": false },
-    // Boolean groups nest any filter, including other groups. The top-level
-    // list is an implicit `all`.
-    { "op": "any", "filters": [ … ] },
-    { "op": "all", "filters": [ … ] },
-    { "op": "not", "filter": { … } }
-  ],
+#### Supported operations
 
-  "group_by": [
-    { "axis": "dimension", "field": "…" },
-    { "axis": "bin_width", "field": "…", "width": 10 },
-    { "axis": "bin_edges", "field": "…", "edges": [ … ] },
-    { "axis": "bin_count", "field": "…", "count": 20 },
-    { "axis": "time" },                                 // the time bucket as a group axis
-    { "axis": "time_part", "part": "hour|day_of_week|day_of_month|week_of_year|month_of_year|quarter_of_year" },
-    // A derived dimension: the first matching case names the group, `else`
-    // catches the rest. Cases take any filter shape over the named field.
-    { "axis": "classify", "name": "…", "field": "…",
-      "cases": [ { "label": "tests", "filter": { "op": "match", "value": "…" } } ],
-      "else": "other" }
-  ],
+- Filters: `eq`, `in`, `gt`, `gte`, `lt`, `lte`, `between`, `not_null`, `like`, `match`.
+- Dimensions compare as their string result values. Ordered comparisons require measurables;
+  pattern filters require dimensions. Membership lists must be non-empty.
+- `like` uses `%` and `_`; `match` uses unanchored RE2 patterns validated before execution.
+  Both are case-sensitive; a case-insensitive request option is planned.
+- `count` counts rows without a field. Other aggregates require a measurable and preserve null
+  for no observations. Conditional aggregates treat an unknown predicate as a non-match.
+- Time windows use UTC dates and inclusive endpoints. The time field defaults to the dataset
+  default. `time.grain` is required with a time axis and rejected without one. Buckets are
+  day, Monday-start week, or month. No dense fill is implemented.
+- Grouped dimensions with declared labels return a separate `<field>_label` column.
+- Ordering defaults to ascending and includes grouping tie-breakers. Fetching `limit + 1`
+  detects truncation.
 
-  "aggregates": [
-    // Every variant also takes the optional members `filter` (a conditional
-    // fold, one filter variant above), `fill` (zero|null — what an empty
-    // bucket reports on a dense axis) and `per_period` (last|first|min|max —
-    // semi-additive: fold inside each period first).
-    { "fn": "count",          "name": "…" },            // folds rows, reads no column
-    { "fn": "count_distinct", "name": "…", "field": "…", "approx": false },   // approx: HyperLogLog, cheap over wide columns
-    { "fn": "sum",            "name": "…", "field": "…" },
-    { "fn": "avg",            "name": "…", "field": "…" },
-    { "fn": "min",            "name": "…", "field": "…" },
-    { "fn": "max",            "name": "…", "field": "…" },
-    { "fn": "median",         "name": "…", "field": "…" },
-    { "fn": "quantile",       "name": "…", "field": "…", "q": 0.9 },
-    { "fn": "stddev",         "name": "…", "field": "…" }
-  ],
+#### Result and errors
 
-  "expressions": [ { "name": "…", "expr": "a / nullif(b, 0) * 100" } ],   // over aggregate names only
+Results contain `columns`, positional `rows`, and `flags.truncated`. Current column kinds are
+dimension, label, bucket, and aggregate; column types are text, number, and date.
+Cursors, freshness metadata, resolved relative
+windows, expression columns, and window columns are planned extensions.
 
-  "windows": [
-    // `of` is an aggregate or expression name; `over` names the partition
-    // dimensions. Only a moving average carries a frame.
-    { "fn": "running_sum", "name": "…", "of": "…", "over": ["…"] },
-    { "fn": "moving_avg",  "name": "…", "of": "…", "over": ["…"], "frame": 3 },
-    { "fn": "rank",        "name": "…", "of": "…", "over": ["…"] },
-    { "fn": "delta",       "name": "…", "of": "…", "over": ["…"] },
-    { "fn": "pct_change",  "name": "…", "of": "…", "over": ["…"] },
-    { "fn": "share",       "name": "…", "of": "…", "over": ["…"] }   // this row's part of its partition's total, 0..1
-  ],
+| Condition | Response |
+|---|---|
+| Semantic validation failure | 400 with field paths, reason codes, and explanations |
+| Non-administrator | Permission denial |
+| Fetched response exceeds byte cap | 400 with an `OUT_OF_RANGE` violation on `limit` |
+| Permit acquisition times out | 429 with retry metadata |
+| Unusable declarations, fetch failure, or assembly failure | 500 |
 
-  // The filter variants above, over aggregate and expression names.
-  "having": [ { "op": "gt", "target": "…", "value": … } ],
-
-  "time": {
-    "field": "…",                       // defaults to the dataset's declared default
-    // Exactly one of `from`/`to` or `relative`. A relative window resolves
-    // against the request's day in `timezone`, so a saved query stays current.
-    "from": "2026-01-01", "to": "2026-03-31",
-    "relative": { "last": 12, "unit": "day|week|month|quarter|year", "include_current": false },
-    //           or { "period": "this|previous", "unit": "…", "to_date": true }
-    "grain": "day|week|month|quarter|year",
-    "timezone": "Europe/Berlin",        // bucket boundaries in this zone; default UTC
-    "week_start": "monday|sunday",
-    "fiscal_year_start": "04-01",       // month-day; shifts quarter and year buckets and periods
-    "to_date": true,                    // clip every bucket at the equivalent point of the last one
-    "fill": "dense|sparse"              // dense: every bucket in range appears; sparse: only buckets with rows
-  },
-
-  "compare": { "offset": "period|month|quarter|year", "aligned": true },
-
-  "top": { "n": 5, "by": "…", "per": ["…"], "remainder": true },
-
-  "totals": [ [], ["team"] ],           // grouping sets: [] = grand total
-
-  "order": [ { "by": "…", "dir": "asc|desc" } ],
-  "limit": 1000,
-  "cursor": "…"
-}
-```
-
-Answer:
-
-```jsonc
-{
-  "columns": [ { "name": "…", "kind": "dimension|label|bucket|aggregate|expression|window|total_marker", "type": "…" } ],
-  "rows":    [ [ … ], … ],
-  "flags":   {
-    "truncated": true,          // more groups matched than `limit` admits; rows are the first `limit` in order
-    "incomplete_period": true,  // the window's last bucket is not over yet
-    "data_through": "2026-03-30T22:10:00Z",   // the newest event time the scanned relation holds
-    "resolved_window": { "from": "…", "to": "…" }  // what a relative window became, so a chart can label it
-  },
-  "next_cursor": "…"
-}
-```
+Deserialization failures occur before semantic planning and do not use its collected
+violation list. A rejected plan performs no warehouse query.
 
 ### 3.4 Internal Dependencies
 
@@ -510,13 +454,6 @@ Answer:
 | toolkit canonical errors | resource-scoped builders | violation, permission, quota envelopes |
 | toolkit security | `SecurityContext` | the tenant every scan binds |
 
-**Dependency Rules** (per project conventions):
-- No circular dependencies
-- Always use SDK modules for inter-module communication
-- No cross-category sideways deps except through contracts
-- Only integration/adapter modules talk to external systems
-- `SecurityContext` must be propagated across all in-process calls
-
 ### 3.5 External Dependencies
 
 #### ClickHouse
@@ -524,18 +461,11 @@ Answer:
 | Dependency Module | Interface Used | Purpose |
 |-------------------|---------------|---------|
 | executor | HTTP query, positional bindings, `JSONEachRow` | runs the scan |
-| declarations | column snapshot dumped at build time | validates datasets offline |
-
-**Dependency Rules** (per project conventions):
-- No circular dependencies
-- Always use SDK modules for inter-module communication
-- No cross-category sideways deps except through contracts
-- Only integration/adapter modules talk to external systems
-- `SecurityContext` must be propagated across all in-process calls
+| declarations | embedded column snapshot | validates datasets offline |
 
 ### 3.6 Interactions & Sequences
 
-#### Answer a question
+#### Execute a query
 
 **ID**: `cpt-insightspec-qe-seq-answer`
 
@@ -552,14 +482,17 @@ sequenceDiagram
     Validation ->> Declarations: dataset(key)
     Validation -->> API: QueryPlan | violations
     API ->> Compiler: compile(plan, tenant)
-    API ->> Executor: fetch (permit, byte ceiling)
+    API ->> API: Acquire scan permit
+    API ->> Executor: Fetch under byte ceiling
     Executor ->> ClickHouse: statement
     ClickHouse -->> Executor: rows
+    API ->> API: Release scan permit
     API ->> Answer: assemble
     API -->> Constructor: QueryAnswer | problem+json
 ```
 
-**Description**: a refusal returns before any connection is touched.
+**Description**: semantic validation completes before warehouse execution. The permit covers
+fetching and decoding, and is released before answer assembly.
 
 ### 3.7 Database schemas & tables
 
@@ -575,79 +508,65 @@ hook's `dbt run --select tag:gold`.
 
 ## 4. Additional context
 
-### Capability semantics
+### Capability status and proposed semantics
 
-Each capability: request shape, answer shape, null rule, cap, refusal. Refusals are typed
-violations naming the field.
-
-Inventory. *Shipped*: served today. *Specified*: shape settled, awaits its change. *Needs
-design*: sketch; the section says what is open. Nothing leaves this table without a note.
+**Implemented** capabilities are accepted by the current API. **Specified, not implemented**
+capabilities retain their proposed semantics below. **Needs design** identifies unresolved
+architecture. Proposed request members are rejected until implemented.
 
 | Capability | Status |
 |---|---|
-| Filters: `eq`, `in`, comparisons, `between`, `not_null` | shipped |
-| Pattern filters: `like`, `match` | shipped |
-| Boolean filter groups: `any`, `all`, `not` | specified |
-| Case-insensitive patterns | specified |
-| Dimension and time group axes | shipped |
-| Date-part axes | specified |
-| Bins as dimensions | specified |
-| Derived dimensions (`classify`) | specified |
-| `count`, `sum`, `avg`, `min`, `max` with a conditional filter | shipped |
-| `count_distinct` (exact and approximate), `median`, `quantile`, `stddev` | specified |
-| Expressions over aggregate names | specified |
-| Windows: running sum, moving average, rank, delta, percent change | specified |
-| Share of total | specified |
-| `having` | specified |
-| Top groups with remainder | specified |
-| Dense fill | specified |
-| Fixed window, UTC, day/week/month grain | shipped |
-| Relative windows | specified |
-| Timezone, week start, to-date, compare windows | specified |
-| Fiscal calendars | specified |
-| Grouping sets and totals | specified |
-| Semi-additive aggregates | specified |
-| Truncation flag | shipped |
-| Cursors | specified |
+| Filters: `eq`, `in`, comparisons, `between`, `not_null` | implemented |
+| Pattern filters: `like`, `match` | implemented |
+| Boolean filter groups: `any`, `all`, `not` | specified, not implemented |
+| Case-insensitive patterns | specified, not implemented |
+| Dimension and time group axes | implemented |
+| Date-part axes | specified, not implemented |
+| Bins as dimensions | specified, not implemented |
+| Derived dimensions (`classify`) | specified, not implemented |
+| `count`, `sum`, `avg`, `min`, `max` with a conditional filter | implemented |
+| `count_distinct` (exact and approximate), `median`, `quantile`, `stddev` | specified, not implemented |
+| Expressions over aggregate names | specified, not implemented |
+| Windows: running sum, moving average, rank, delta, percent change | specified, not implemented |
+| Share of total | specified, not implemented |
+| `having` | specified, not implemented |
+| Top groups with remainder | specified, not implemented |
+| Dense fill | specified, not implemented |
+| Fixed window, UTC, day/week/month grain | implemented |
+| Relative windows | specified, not implemented |
+| Timezone, week start, to-date, compare windows | specified, not implemented |
+| Fiscal calendars | specified, not implemented |
+| Grouping sets and totals | specified, not implemented |
+| Semi-additive aggregates | specified, not implemented |
+| Truncation flag | implemented |
+| Cursors | specified, not implemented |
 | Rows behind a cell (drilldown shape) | needs design |
 | Multiple datasets in one query over conformed dimensions | needs design |
 | Runtime-defined datasets | [datasets](../datasets/DESIGN.md) |
 | Discovery of what can be asked | [datasets](../datasets/DESIGN.md) |
-| Freshness (`data_through`) | specified |
-| Saved queries | specified |
+| Freshness (`data_through`) | specified, not implemented |
+| Saved queries | specified, not implemented |
 | Access policies: dataset, row, column | needs design |
 | Enrichment lookups (customer-declared dimensions) | needs design |
 | Funnels and retention | needs design |
 
-#### Filters and having
+#### Post-aggregation filters (specified)
 
-Row filters narrow the scan before aggregation; `having` narrows groups after it over
-aggregate and expression names. Unknown field or target → refused with the admissible set.
-Values always bind.
+`having` filters groups by aggregate or expression names after aggregation. Unknown targets
+produce violations listing available names. Operands remain bound parameters.
 
-Arity is enforced by shape: each operator is a variant with exactly its operands, so "two
-values for `eq`" cannot be expressed. Only `in` has a length to check: 1 to the cap.
-
-A dimension compares as the text the answer reports: `eq`, `in`, `not_null`, `like`
-(`%`, `_`), `match` (RE2, unanchored). Patterns bind, are length-capped, and `match` is
-compiled at validation. Ordered tests on a dimension and patterns on a measurable are refused
-naming the operator.
-
-Every stable-valued column is a dimension, `file_path` and `commit_hash` included; caps
-bound a wide group-by like a narrow one.
-
-#### Boolean filter logic
+#### Boolean filter logic (specified)
 
 Top-level `filters` is an implicit `all`. `any`, `all`, `not` are filter variants: nest
 anywhere a filter may appear. Compile to parenthesised predicates, never reordered. Caps:
 total filters and nesting depth. Empty groups refused. `case_insensitive` → `ILIKE` or a
 case-insensitive regex; default case-sensitive.
 
-#### Multiple aggregates and conformed dimensions
+#### Aggregate naming and cross-dataset alignment
 
-`count` folds rows (no field); the others read a measurable. Names are unique, snake_case,
-and also unique against group columns. Several datasets in one request align on shared group
-axes; see *Multiple datasets*. Caps: datasets per query, aggregates per query.
+`count` counts rows without a field; numeric aggregates read a measurable. Names are unique, snake_case,
+and also unique against group columns. Cross-dataset alignment is not implemented; proposed
+behavior and open decisions appear under *Multiple datasets in one query*.
 
 #### Expressions
 
@@ -659,7 +578,9 @@ propagates; division by zero is NULL via `nullif`.
 
 Over the answer's buckets after aggregation, partitioned by named dimensions: running sum,
 moving average with a bounded frame, rank, delta, percent change. Refused over a sparse axis
-unless fill is dense. First bucket's delta is NULL.
+unless fill is dense. The first bucket's delta is null. Proposed variants are `running_sum`,
+`moving_avg`, `rank`, `delta`, and `pct_change`, with `name`, `of`, and partition dimensions
+in `over`. Only `moving_avg` accepts a bounded `frame`.
 
 #### Top groups and the remainder
 
@@ -677,22 +598,26 @@ null) says what an empty bucket reports. Sparse is the default.
 
 Boundaries in the query's timezone with its week start. `to_date` clips every bucket at the
 point the last one reached. `compare.aligned` shifts by whole periods keeping the day count.
-The answer flags an incomplete final bucket.
+`flags.incomplete_period` identifies an incomplete final bucket. Proposed time grains add
+quarter and year; `compare.offset` selects period, month, quarter, or year.
 
 Windows are fixed (`from`/`to`) or relative: last N units (optionally including the current
 one) or a calendar period (`this`/`previous` unit, `to_date`). Resolved at plan time in the
 query zone; the answer reports `resolved_window`. Same span cap. `fiscal_year_start` shifts
-quarter and year buckets and periods; tenant settings supply defaults.
+quarter and year buckets and periods; tenant settings supply defaults. Proposed members
+include `relative.last`, `unit`, `include_current`, or `period` with `to_date`; fixed and
+relative windows are mutually exclusive. The proposed timezone default is UTC.
 
 #### Grouping sets and totals
 
 `totals` lists grouping sets; `[]` is the grand total. Total rows carry a marker column and
-sort after detail rows.
+sort after detail rows, using the proposed `total_marker` column kind.
 
 #### Bins as dimensions
 
 Numeric or temporal field binned by fixed `width`, explicit `edges`, or a `count` of equal
-buckets. A bin is an ordinary group axis. Distributions are one bin axis plus a count.
+buckets, using `bin_width`, `bin_edges`, or `bin_count` axis variants. A bin is a group axis;
+a distribution combines a bin axis with a count.
 
 #### Date parts as axes
 
@@ -710,7 +635,7 @@ length. Same `name` twice is a duplicate.
 
 `count_distinct` over a dimension; exact by default, `approx: true` uses HyperLogLog and the
 column type says so. Empty group → 0. `median`, `quantile`, `stddev` fold measurables and
-report NULL over nothing.
+return null over no observations; `quantile` takes a `q` parameter.
 
 #### Share of total
 
@@ -725,15 +650,16 @@ and headcount shapes.
 #### Cursors over grouped answers
 
 An answer past `limit` returns a keyset cursor over its own order, made total with the group
-columns. Bound to the query fingerprint; a cursor with a different query is refused.
+columns. The request carries `cursor`; the response returns `next_cursor`. Cursors are bound
+to the query fingerprint; reuse with a different query is rejected.
 
-#### Freshness
+#### Freshness (specified)
 
 `flags.data_through`: newest event time the scanned relation holds for the tenant.
 
-#### Access policies
+#### Access policies (needs design)
 
-*Needs design.* Identity supplies the caller context (subject, roles, visible people, team
+**Needs design.** Identity supplies the caller context (subject, roles, visible people, team
 memberships, tenant settings); the engine enforces declared policies at plan time. Three
 kinds: dataset access (roles or allow list); row policy (dimension ← caller attribute, e.g.
 `author_email ← visible_people`, `repository ← team_repositories`), applied to every scan
@@ -744,34 +670,35 @@ until the first policy lands.
 
 #### Enrichment lookups
 
-*Needs design.* Customer relation keyed on a conformed dimension (repository → product,
+**Needs design.** Customer relation keyed on a conformed dimension (repository → product,
 person → cost centre), declared as a lookup, joined at plan time; its columns become
 dimensions on every dataset sharing the key. Non-unique key refused (fan-out); unmatched key
 → absent sentinel. Open: upload/sync path; tenant- vs per-user scope.
 
 #### Funnels and retention
 
-*Needs design.* Aggregate families over datasets declaring an actor key and event time,
+**Needs design.** Aggregate families over datasets declaring an actor key and event time,
 backed by `windowFunnel`, `retention`, `sequenceMatch`. Funnel: ordered step filters plus a
 window → actors reaching each step. Retention: entry filter, return filter, period. Group by
 any dimension. Open: strict vs any-order steps; exposing a step's actor set for drilldown.
 
 #### Rows behind a cell
 
-*Needs design.* Row-level shape over the same dataset, filters and window: declared columns
-instead of groups and folds, `row_identity` as page key, cursors, sort by any reported
+**Needs design.** Row-level shape over the same dataset, filters and window: declared columns
+instead of groups and aggregates, `row_identity` as page key, cursors, sort by any reported
 column. Open: mode of `POST /v1/query` or sibling route (preference: sibling); how a cell's
 group values become filters.
 
 #### Multiple datasets in one query
 
-*Needs design.* Several datasets with conformed dimensions; one scan each, aligned on shared
+**Needs design.** Several datasets with conformed dimensions; one scan each, aligned on shared
 axes. Open: declaring conformance; refusing mismatched grains; making fan-out impossible.
 Row-level joins stay out.
 
-### Saved queries
+### Saved queries (specified, not implemented)
 
-A saved query is a named request with a dataset and a version. Read re-runs validation; a
+A saved query is a named request with a dataset and a version, selected through the proposed
+`saved` request member instead of `dataset`. Read re-runs validation; a
 dataset change that invalidates it is a refusal naming the field, never a reinterpretation.
 On run, a request may *replace* `time`, `order`, `limit`, `cursor`, `top`, `totals`,
 `fill`, `compare`; may *append* `filters` (AND-ed); may not touch `dataset`, `group_by`,
@@ -785,10 +712,12 @@ shipped set of saved queries.
 - OData or GraphQL as the native contract.
 - Chart-type-specific endpoints; a chart the contract cannot feed is a contract gap.
 - Path analysis and sessionization.
-- Joins to relations nobody declared: that is the SQL console, admin-only.
 
 ## 5. Traceability
 
 - **PRD**: [PRD.md](PRD.md)
 - **Migration map**: [MIGRATION.md](MIGRATION.md)
 - **Contract**: [openapi.json](../../components/backend/analytics/openapi.json)
+
+**Revision 2.2**: separated the supported API from proposed extensions, consolidated query
+semantics and limits, and clarified validation, execution, and authorization boundaries.

--- a/docs/domain/query-engine/DESIGN.md
+++ b/docs/domain/query-engine/DESIGN.md
@@ -1,0 +1,794 @@
+---
+version: 2.1
+status: proposed
+date: 2026-09-08
+---
+
+# Technical Design — Query Engine
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-design-query-engine`
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+  - [3.8 Deployment Topology](#38-deployment-topology)
+- [4. Additional context](#4-additional-context)
+  - [Capability semantics](#capability-semantics)
+  - [Saved queries](#saved-queries)
+  - [Non-goals](#non-goals)
+- [5. Traceability](#5-traceability)
+
+<!-- /toc -->
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+One question contract over declared datasets. Each question compiles to one bounded,
+parameterised ClickHouse scan per dataset and answers a typed table. The rules the schema
+does not carry — session tenancy, duplicate-free reads, NULL folding, UTC day boundaries,
+caps — are compiler steps applied to every question and pinned by rendered-SQL tests.
+
+Three pure layers around one I/O shell. *Declarations*: what may be asked, validated at
+build time against the warehouse column snapshot. *Validation*: bind a request or refuse it
+with every violation named. *Compilation*: SQL text with engine-owned identifiers, caller
+values bound. The shell runs the statement under a byte ceiling and a concurrency permit and
+assembles the answer. Realises [PRD.md](PRD.md); migration in [MIGRATION.md](MIGRATION.md).
+
+### 1.2 Architecture Drivers
+
+**ADRs**: none yet; the first is expected with access policies.
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+|-------------|------------------|
+| `cpt-insightspec-qe-fr-ask` | request → plan → compile → one scan; no metric definition in the path |
+| `cpt-insightspec-qe-fr-group` | a labelled dimension answers `<field>_label` beside its value; every stable column declared |
+| `cpt-insightspec-qe-fr-filter` | tagged filter variants; patterns bound as parameters, `match` compiled at validation; operator/target mismatch refused |
+| `cpt-insightspec-qe-fr-fold` | `OrNull` folds; `count` alone reports 0 |
+| `cpt-insightspec-qe-fr-bounds` | window cap; `LIMIT limit + 1` with `flags.truncated`; chunked byte ceiling; semaphore |
+| `cpt-insightspec-qe-fr-refusal` | whole plan checked first; one `Violation {field, reason, detail}` per problem |
+| `cpt-insightspec-qe-fr-boolean` | `any`/`all`/`not` variants → parenthesised predicates |
+| `cpt-insightspec-qe-fr-relative-window` | resolved at plan time; answer reports `resolved_window` |
+| `cpt-insightspec-qe-fr-derived` | `classify` → one `multiIf`; `time_part` → date-part function in the query zone |
+| `cpt-insightspec-qe-fr-richer-folds` | more fold and window variants over the same plan (§4) |
+| `cpt-insightspec-qe-fr-time-intelligence` | zone, week start, fiscal start as compiler inputs to every boundary |
+| `cpt-insightspec-qe-fr-rows` | sibling row-level shape over the same predicates, keyed on `row_identity` |
+| `cpt-insightspec-qe-fr-saved` | stored request re-planned on every read |
+| `cpt-insightspec-qe-fr-cross-dataset` | one scan per dataset aligned on conformed dimensions; lookups joined on a unique key |
+| `cpt-insightspec-qe-fr-funnels` | aggregate families over ClickHouse `windowFunnel`, `retention` |
+| `cpt-insightspec-qe-fr-admin-gate` | `require_admin` before every query and discovery handler |
+| `cpt-insightspec-qe-fr-access-policies` | policy predicates bound from the caller context at plan time, before any capability |
+
+#### NFR Allocation
+
+| NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
+|--------|-------------|--------------|-----------------|----------------------|
+| `cpt-insightspec-qe-nfr-correctness` | correct by construction | compiler | tenancy predicate first; `FINAL` per read discipline; `OrNull` folds; `toDate(x, 'UTC')`; no `=` on nullable keys | rendered-SQL goldens; stand reconciliations |
+| `cpt-insightspec-qe-nfr-bounded` | bounded cost | validation, executor, handler | 731-day window; 10 000 rows; 16 MiB chunked ceiling; 8-permit semaphore → 429 | unit tests per cap; stand 400/429 cases |
+| `cpt-insightspec-qe-nfr-latency` | interactive latency | gold datasets, compiler | flat pre-joined relations; one scan; partitioned by month, sorted by tenant | stand timing; ClickHouse query log |
+| `cpt-insightspec-qe-nfr-contract` | stable contract | contract DTOs | tagged unions with `deny_unknown_fields`; OpenAPI generated from types; CI drift gate | drift check; stand schema generation |
+| `cpt-insightspec-qe-nfr-person-data` | person columns classified | declarations, executor | person columns named in the declaration; no engine store or cache; gate then policies govern reads | declaration tests; no persistence in the engine |
+
+### 1.3 Architecture Layers
+
+```text
+constructor ──HTTP──▶ gateway ──▶ analytics service
+                                   ├─ api     gate · extract · respond
+                                   ├─ domain  declarations · validation · compile · answer
+                                   └─ infra   bounded fetch · metrics ──▶ ClickHouse gold
+ingestion (dbt) ─────────────────────────────────────────────────────▶ ClickHouse gold
+```
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-tech-layers`
+
+| Layer | Responsibility | Technology |
+|-------|---------------|------------|
+| Presentation | constructor: form → request; answer → table and chart | React, TanStack Query |
+| Application | handlers: admin gate, extraction, error envelopes | Rust, axum, canonical errors |
+| Domain | declarations, validation, compilation, answer assembly | Rust, pure functions |
+| Infrastructure | bounded ClickHouse fetch, metrics, identity client | Rust, clickhouse client |
+| Data | gold datasets from silver class relations | dbt, ClickHouse MergeTree |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### A contract, not SQL, from callers
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-contract`
+
+Callers send a small typed document. Only engine-owned identifiers reach SQL text; every
+caller value binds. This is what makes tenancy, read discipline, NULL semantics, caps and
+row policies enforceable without a SQL parser.
+
+#### Declarations are the truth
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-declarations`
+
+What may be asked is declared per dataset and validated against the column snapshot at build
+time. Every stable-valued column is a dimension. A request cannot name what no declaration
+does.
+
+#### Refuse by name
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-refusals`
+
+Check the whole request, then report every violation with field, machine reason and
+admissible set. Server faults (unusable declarations, warehouse errors) are 500s, never
+dressed as request errors.
+
+#### Correct by construction
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-correctness`
+
+Rules the schema does not carry live in the compiler, pinned by exact rendered-SQL tests.
+
+### 2.2 Constraints
+
+#### Tenancy binds from the session
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-tenancy`
+
+First predicate of every scan is the tenant from the security context. No request member
+names a tenant; unknown members are refused.
+
+#### Admin-only until access policies land
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-admin-gate`
+
+Datasets carry person columns and declare no access policy yet: `POST /v1/query` and both
+`GET /v1/datasets` routes refuse non-administrators. The change declaring the first policy
+must specify what replaces the minimum-peer suppression of the metric surfaces.
+
+#### Bounded on every axis
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-bounds`
+
+Window ≤ 731 days inside the `Date` range; rows ≤ 10 000 plus one fetched to flag
+truncation; answer ≤ 16 MiB enforced while receiving; 8 scans in flight per process; filter,
+aggregate, axis, order counts and pattern lengths capped by contract constants.
+
+#### Gold relations only
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-gold-only`
+
+A declaration binds an `insight.*` relation whose columns exist in the embedded snapshot. No
+bronze, no silver, no query-time joins beyond a future declared lookup, no writes.
+
+#### Security and operations dispositions
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-constraint-inherited-platform`
+
+- **Authentication**: gateway and identity establish the session; the engine trusts the
+  `SecurityContext` it receives and never authenticates.
+- **Data protection**: TLS and tenant isolation inherited from the platform; person columns
+  classified in declarations; column masking arrives with access policies.
+- **Threats**: injection via operands — mitigated by binding every caller value; over-broad
+  exposure before policies — mitigated by the admin gate; resource exhaustion — mitigated by
+  the caps above; malformed regex — compiled at validation.
+- **Audit**: latency and error class recorded per question; who-asked-what audit is open
+  and tracked under access policies.
+- **Capacity and recovery**: the engine holds no state; capacity is the warehouse's and
+  ingestion's concern; recovery is redeploy.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: Rust types, YAML dataset declarations, JSON column snapshot.
+
+**Location**: `src/backend/services/analytics/src/domain/query/`
+
+**Core Entities**:
+
+| Entity | Description | Schema |
+|--------|-------------|--------|
+| Dataset | a declaration read from the registry: grain, dimensions with labels, measurables, time fields, read discipline — see the [dataset design](../datasets/DESIGN.md) | `domain/datasets/declaration.rs` |
+| QueryRequest | tagged request document | `contract/dto.rs` |
+| QueryPlan | request bound to its dataset; answer columns with sources | `plan.rs` |
+| CompiledQuery | statement text and positional bindings | `compile/mod.rs` |
+| QueryAnswer | typed columns, rows, flags | `contract/dto.rs`, `answer.rs` |
+| Violation | field, machine reason, sentence | `violation.rs` |
+
+**Relationships**:
+- Dataset: owned by the registry; the engine only reads it.
+- QueryRequest → QueryPlan: `validation::plan` binds or refuses.
+- QueryPlan → CompiledQuery: `compile` renders.
+- CompiledQuery → QueryAnswer: executor returns rows; `answer::assemble` maps aliases.
+
+### 3.2 Component Model
+
+```text
+request ─▶ api (gate) ─▶ validation ─▶ compile ─▶ executor ─▶ ClickHouse
+                            │                        │
+                    dataset registry               answer ─▶ response
+                     (its own design)
+```
+
+#### Validation
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-validation`
+
+##### Why this component exists
+
+A request is untrusted until every reference resolves and every rule holds.
+
+##### Responsibility scope
+
+Bind filters, axes, aggregates, order, window to the declaration; check operand types and
+operator/target pairs; compile `match` patterns; enforce caps; build answer columns (value,
+label, bucket, aggregate) with sources; return a `QueryPlan` or every `Violation`.
+
+##### Responsibility boundaries
+
+No SQL, no connection. `PlanError` separates a refused request from unusable declarations.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-ds-component-registry` — reads declarations from
+- `cpt-insightspec-qe-component-compiler` — hands the plan to
+
+#### Compiler
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-compiler`
+
+##### Why this component exists
+
+Apply the correctness rules once, to every question.
+
+##### Responsibility scope
+
+Render one statement: positional aliases; `FINAL` per read discipline; `OrNull` folds;
+`toDate(x, 'UTC')`; dimension values via `toString` and the absent sentinel; every caller
+value as `?`; tenancy, window, filters in that order; `GROUP BY` group columns;
+deterministic `ORDER BY`; `LIMIT limit + 1`.
+
+##### Responsibility boundaries
+
+Never sees a raw request or a connection; no authorization logic.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-validation` — consumes its plan
+- `cpt-insightspec-qe-component-executor` — hands the statement to
+
+#### Executor and answer
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-executor`
+
+##### Why this component exists
+
+One place talks to the warehouse for questions, so every bound is enforced there.
+
+##### Responsibility scope
+
+Bind parameters; run under a fetch timeout; collect chunks against the byte ceiling; decode
+off the async runtime; record latency and error class. `answer::assemble` maps aliases to
+columns, drops the extra row, sets `flags.truncated`.
+
+##### Responsibility boundaries
+
+Does not interpret the request; a ceiling breach is a typed error the handler maps.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-compiler` — depends on
+- `cpt-insightspec-qe-component-api` — called by
+
+#### API
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-api`
+
+##### Why this component exists
+
+HTTP edge: authorization, extraction, error envelopes.
+
+##### Responsibility scope
+
+`POST /v1/query`: admin gate, permit, plan, compile, fetch, assemble; refusals →
+field-violation envelope, byte ceiling → `limit` violation, exhaustion → 429, else 500.
+`GET /v1/datasets`, `GET /v1/datasets/{key}`: admin gate, describe.
+
+##### Responsibility boundaries
+
+No business logic, no SQL.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-validation` — calls
+- `cpt-insightspec-qe-component-executor` — calls
+- `cpt-insightspec-qe-component-constructor` — serves
+
+#### Constructor page
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-component-constructor`
+
+##### Why this component exists
+
+Administrators ask questions without writing JSON.
+
+##### Responsibility scope
+
+Read descriptions; keep a form draft; build the request (measurable operands as numbers,
+dimension operands and patterns as text); run; render table and chart; show each violation
+beside its input and the truncation flag.
+
+##### Responsibility boundaries
+
+No metric semantics, no invented labels, no persistence.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-api` — calls
+
+#### Access policies
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-component-access-policies`
+
+##### Why this component exists
+
+Row visibility is enforced where rows are planned, from facts identity supplies.
+
+##### Responsibility scope
+
+Per dataset: dataset access (roles or allow list); row policies (dimension bound to a caller
+attribute: visible people, team repositories); column policies (dropped or masked per role).
+Applied at plan time before any capability. *Needs design* (§4).
+
+##### Responsibility boundaries
+
+Never decides who the caller is; refuses when a needed fact is missing.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-validation` — extends the plan
+- `cpt-insightspec-ds-component-declarations` — policies are declared beside the dataset
+
+### 3.3 API Contracts
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-interface-query-api`
+
+- **Contracts**: `cpt-insightspec-qe-contract-caller-context`
+- **PRD interface**: `cpt-insightspec-qe-interface-query`
+- **Technology**: REST/OpenAPI, JSON, RFC 9457 problem envelopes
+- **Location**: [openapi.json](../../components/backend/analytics/openapi.json) — the
+  authority for what is accepted today
+
+**Endpoints Overview**:
+
+| Method | Path | Description | Stability |
+|--------|------|-------------|-----------|
+| `POST` | `/v1/query` | answer one question over a declared dataset | unstable (admin-only) |
+
+Discovery — `GET /v1/datasets` — belongs to the [dataset registry](../datasets/DESIGN.md);
+the engine contributes only the request bounds each description carries.
+
+The request below is the design target; §4 says which members are shipped. Today's accepted
+members: `dataset`, `filters`, `group_by`, `aggregates` (with `filter`), `time` with
+`field`/`from`/`to`/`grain` (day, week, month), `order`, `limit`. Everything else is refused
+as unknown until its change lands.
+
+```jsonc
+POST /v1/query
+{
+  "dataset": "…",                       // or "saved": "<saved-query name>"
+
+  // Every list below is a discriminated union: the tag (`op`, `axis`, `fn`)
+  // selects the variant, and a variant carries exactly the operands it takes.
+  // An operand belonging to another variant is refused at deserialization, so
+  // no arity or "required together" rule is checked at runtime.
+
+  "filters": [
+    { "op": "eq",       "field": "…", "value": … },
+    { "op": "in",       "field": "…", "values": [ … ] },
+    { "op": "gt",       "field": "…", "value": … },
+    { "op": "gte",      "field": "…", "value": … },
+    { "op": "lt",       "field": "…", "value": … },
+    { "op": "lte",      "field": "…", "value": … },
+    { "op": "between",  "field": "…", "low": …, "high": … },
+    { "op": "not_null", "field": "…" },
+    { "op": "like",     "field": "…", "value": "%/tests/%", "case_insensitive": false },
+    { "op": "match",    "field": "…", "value": "\\.(test|spec)\\.", "case_insensitive": false },
+    // Boolean groups nest any filter, including other groups. The top-level
+    // list is an implicit `all`.
+    { "op": "any", "filters": [ … ] },
+    { "op": "all", "filters": [ … ] },
+    { "op": "not", "filter": { … } }
+  ],
+
+  "group_by": [
+    { "axis": "dimension", "field": "…" },
+    { "axis": "bin_width", "field": "…", "width": 10 },
+    { "axis": "bin_edges", "field": "…", "edges": [ … ] },
+    { "axis": "bin_count", "field": "…", "count": 20 },
+    { "axis": "time" },                                 // the time bucket as a group axis
+    { "axis": "time_part", "part": "hour|day_of_week|day_of_month|week_of_year|month_of_year|quarter_of_year" },
+    // A derived dimension: the first matching case names the group, `else`
+    // catches the rest. Cases take any filter shape over the named field.
+    { "axis": "classify", "name": "…", "field": "…",
+      "cases": [ { "label": "tests", "filter": { "op": "match", "value": "…" } } ],
+      "else": "other" }
+  ],
+
+  "aggregates": [
+    // Every variant also takes the optional members `filter` (a conditional
+    // fold, one filter variant above), `fill` (zero|null — what an empty
+    // bucket reports on a dense axis) and `per_period` (last|first|min|max —
+    // semi-additive: fold inside each period first).
+    { "fn": "count",          "name": "…" },            // folds rows, reads no column
+    { "fn": "count_distinct", "name": "…", "field": "…", "approx": false },   // approx: HyperLogLog, cheap over wide columns
+    { "fn": "sum",            "name": "…", "field": "…" },
+    { "fn": "avg",            "name": "…", "field": "…" },
+    { "fn": "min",            "name": "…", "field": "…" },
+    { "fn": "max",            "name": "…", "field": "…" },
+    { "fn": "median",         "name": "…", "field": "…" },
+    { "fn": "quantile",       "name": "…", "field": "…", "q": 0.9 },
+    { "fn": "stddev",         "name": "…", "field": "…" }
+  ],
+
+  "expressions": [ { "name": "…", "expr": "a / nullif(b, 0) * 100" } ],   // over aggregate names only
+
+  "windows": [
+    // `of` is an aggregate or expression name; `over` names the partition
+    // dimensions. Only a moving average carries a frame.
+    { "fn": "running_sum", "name": "…", "of": "…", "over": ["…"] },
+    { "fn": "moving_avg",  "name": "…", "of": "…", "over": ["…"], "frame": 3 },
+    { "fn": "rank",        "name": "…", "of": "…", "over": ["…"] },
+    { "fn": "delta",       "name": "…", "of": "…", "over": ["…"] },
+    { "fn": "pct_change",  "name": "…", "of": "…", "over": ["…"] },
+    { "fn": "share",       "name": "…", "of": "…", "over": ["…"] }   // this row's part of its partition's total, 0..1
+  ],
+
+  // The filter variants above, over aggregate and expression names.
+  "having": [ { "op": "gt", "target": "…", "value": … } ],
+
+  "time": {
+    "field": "…",                       // defaults to the dataset's declared default
+    // Exactly one of `from`/`to` or `relative`. A relative window resolves
+    // against the request's day in `timezone`, so a saved query stays current.
+    "from": "2026-01-01", "to": "2026-03-31",
+    "relative": { "last": 12, "unit": "day|week|month|quarter|year", "include_current": false },
+    //           or { "period": "this|previous", "unit": "…", "to_date": true }
+    "grain": "day|week|month|quarter|year",
+    "timezone": "Europe/Berlin",        // bucket boundaries in this zone; default UTC
+    "week_start": "monday|sunday",
+    "fiscal_year_start": "04-01",       // month-day; shifts quarter and year buckets and periods
+    "to_date": true,                    // clip every bucket at the equivalent point of the last one
+    "fill": "dense|sparse"              // dense: every bucket in range appears; sparse: only buckets with rows
+  },
+
+  "compare": { "offset": "period|month|quarter|year", "aligned": true },
+
+  "top": { "n": 5, "by": "…", "per": ["…"], "remainder": true },
+
+  "totals": [ [], ["team"] ],           // grouping sets: [] = grand total
+
+  "order": [ { "by": "…", "dir": "asc|desc" } ],
+  "limit": 1000,
+  "cursor": "…"
+}
+```
+
+Answer:
+
+```jsonc
+{
+  "columns": [ { "name": "…", "kind": "dimension|label|bucket|aggregate|expression|window|total_marker", "type": "…" } ],
+  "rows":    [ [ … ], … ],
+  "flags":   {
+    "truncated": true,          // more groups matched than `limit` admits; rows are the first `limit` in order
+    "incomplete_period": true,  // the window's last bucket is not over yet
+    "data_through": "2026-03-30T22:10:00Z",   // the newest event time the scanned relation holds
+    "resolved_window": { "from": "…", "to": "…" }  // what a relative window became, so a chart can label it
+  },
+  "next_cursor": "…"
+}
+```
+
+### 3.4 Internal Dependencies
+
+| Dependency Module | Interface Used | Purpose |
+|-------------------|----------------|----------|
+| identity client | `is_admin` over the forwarded session | admin gate; later the caller context |
+| insight-clickhouse | bound query, bytes cursor | executor fetch |
+| toolkit canonical errors | resource-scoped builders | violation, permission, quota envelopes |
+| toolkit security | `SecurityContext` | the tenant every scan binds |
+
+**Dependency Rules** (per project conventions):
+- No circular dependencies
+- Always use SDK modules for inter-module communication
+- No cross-category sideways deps except through contracts
+- Only integration/adapter modules talk to external systems
+- `SecurityContext` must be propagated across all in-process calls
+
+### 3.5 External Dependencies
+
+#### ClickHouse
+
+| Dependency Module | Interface Used | Purpose |
+|-------------------|---------------|---------|
+| executor | HTTP query, positional bindings, `JSONEachRow` | runs the scan |
+| declarations | column snapshot dumped at build time | validates datasets offline |
+
+**Dependency Rules** (per project conventions):
+- No circular dependencies
+- Always use SDK modules for inter-module communication
+- No cross-category sideways deps except through contracts
+- Only integration/adapter modules talk to external systems
+- `SecurityContext` must be propagated across all in-process calls
+
+### 3.6 Interactions & Sequences
+
+#### Answer a question
+
+**ID**: `cpt-insightspec-qe-seq-answer`
+
+**Use cases**: `cpt-insightspec-qe-usecase-build-chart`, `cpt-insightspec-qe-usecase-own-category`
+
+**Actors**: `cpt-insightspec-qe-actor-admin`, `cpt-insightspec-qe-actor-constructor`
+
+```mermaid
+sequenceDiagram
+    Constructor ->> API: POST /v1/query
+    API ->> Identity: is admin?
+    Identity -->> API: yes
+    API ->> Validation: plan(request)
+    Validation ->> Declarations: dataset(key)
+    Validation -->> API: QueryPlan | violations
+    API ->> Compiler: compile(plan, tenant)
+    API ->> Executor: fetch (permit, byte ceiling)
+    Executor ->> ClickHouse: statement
+    ClickHouse -->> Executor: rows
+    API ->> Answer: assemble
+    API -->> Constructor: QueryAnswer | problem+json
+```
+
+**Description**: a refusal returns before any connection is touched.
+
+### 3.7 Database schemas & tables
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-db-relations`
+
+The engine owns no relation. It scans the one each dataset declares; their schemas, grains
+and provenance are in the [dataset design](../datasets/DESIGN.md).
+
+### 3.8 Deployment Topology
+
+Part of the analytics service; no extra deployable. Gold relations are built by the deploy
+hook's `dbt run --select tag:gold`.
+
+## 4. Additional context
+
+### Capability semantics
+
+Each capability: request shape, answer shape, null rule, cap, refusal. Refusals are typed
+violations naming the field.
+
+Inventory. *Shipped*: served today. *Specified*: shape settled, awaits its change. *Needs
+design*: sketch; the section says what is open. Nothing leaves this table without a note.
+
+| Capability | Status |
+|---|---|
+| Filters: `eq`, `in`, comparisons, `between`, `not_null` | shipped |
+| Pattern filters: `like`, `match` | shipped |
+| Boolean filter groups: `any`, `all`, `not` | specified |
+| Case-insensitive patterns | specified |
+| Dimension and time group axes | shipped |
+| Date-part axes | specified |
+| Bins as dimensions | specified |
+| Derived dimensions (`classify`) | specified |
+| `count`, `sum`, `avg`, `min`, `max` with a conditional filter | shipped |
+| `count_distinct` (exact and approximate), `median`, `quantile`, `stddev` | specified |
+| Expressions over aggregate names | specified |
+| Windows: running sum, moving average, rank, delta, percent change | specified |
+| Share of total | specified |
+| `having` | specified |
+| Top groups with remainder | specified |
+| Dense fill | specified |
+| Fixed window, UTC, day/week/month grain | shipped |
+| Relative windows | specified |
+| Timezone, week start, to-date, compare windows | specified |
+| Fiscal calendars | specified |
+| Grouping sets and totals | specified |
+| Semi-additive aggregates | specified |
+| Truncation flag | shipped |
+| Cursors | specified |
+| Rows behind a cell (drilldown shape) | needs design |
+| Multiple datasets in one query over conformed dimensions | needs design |
+| Runtime-defined datasets | [datasets](../datasets/DESIGN.md) |
+| Discovery of what can be asked | [datasets](../datasets/DESIGN.md) |
+| Freshness (`data_through`) | specified |
+| Saved queries | specified |
+| Access policies: dataset, row, column | needs design |
+| Enrichment lookups (customer-declared dimensions) | needs design |
+| Funnels and retention | needs design |
+
+#### Filters and having
+
+Row filters narrow the scan before aggregation; `having` narrows groups after it over
+aggregate and expression names. Unknown field or target → refused with the admissible set.
+Values always bind.
+
+Arity is enforced by shape: each operator is a variant with exactly its operands, so "two
+values for `eq`" cannot be expressed. Only `in` has a length to check: 1 to the cap.
+
+A dimension compares as the text the answer reports: `eq`, `in`, `not_null`, `like`
+(`%`, `_`), `match` (RE2, unanchored). Patterns bind, are length-capped, and `match` is
+compiled at validation. Ordered tests on a dimension and patterns on a measurable are refused
+naming the operator.
+
+Every stable-valued column is a dimension, `file_path` and `commit_hash` included; caps
+bound a wide group-by like a narrow one.
+
+#### Boolean filter logic
+
+Top-level `filters` is an implicit `all`. `any`, `all`, `not` are filter variants: nest
+anywhere a filter may appear. Compile to parenthesised predicates, never reordered. Caps:
+total filters and nesting depth. Empty groups refused. `case_insensitive` → `ILIKE` or a
+case-insensitive regex; default case-sensitive.
+
+#### Multiple aggregates and conformed dimensions
+
+`count` folds rows (no field); the others read a measurable. Names are unique, snake_case,
+and also unique against group columns. Several datasets in one request align on shared group
+axes; see *Multiple datasets*. Caps: datasets per query, aggregates per query.
+
+#### Expressions
+
+Arithmetic over aggregate names: four operations, parentheses, numeric literals, `nullif`.
+Parsed to an AST, rendered from the AST; a non-round-tripping string is refused. NULL
+propagates; division by zero is NULL via `nullif`.
+
+#### Windows
+
+Over the answer's buckets after aggregation, partitioned by named dimensions: running sum,
+moving average with a bounded frame, rank, delta, percent change. Refused over a sparse axis
+unless fill is dense. First bucket's delta is NULL.
+
+#### Top groups and the remainder
+
+`top` ranks groups by an aggregate within each `per` partition, keeps `n`, and with
+`remainder` folds the rest into one row with a declared label. Ties break on the group value.
+The remainder's aggregates are computed over the underlying rows or merged states, never
+from finalized scalars. `n` is capped.
+
+#### Fill and dense axes
+
+`time.fill: dense` materialises every bucket in the window; each aggregate's `fill` (zero or
+null) says what an empty bucket reports. Sparse is the default.
+
+#### Time intelligence
+
+Boundaries in the query's timezone with its week start. `to_date` clips every bucket at the
+point the last one reached. `compare.aligned` shifts by whole periods keeping the day count.
+The answer flags an incomplete final bucket.
+
+Windows are fixed (`from`/`to`) or relative: last N units (optionally including the current
+one) or a calendar period (`this`/`previous` unit, `to_date`). Resolved at plan time in the
+query zone; the answer reports `resolved_window`. Same span cap. `fiscal_year_start` shifts
+quarter and year buckets and periods; tenant settings supply defaults.
+
+#### Grouping sets and totals
+
+`totals` lists grouping sets; `[]` is the grand total. Total rows carry a marker column and
+sort after detail rows.
+
+#### Bins as dimensions
+
+Numeric or temporal field binned by fixed `width`, explicit `edges`, or a `count` of equal
+buckets. A bin is an ordinary group axis. Distributions are one bin axis plus a count.
+
+#### Date parts as axes
+
+`time_part`: hour, day of week, day of month, week of year, month of year, quarter of year,
+in the query zone with its week and fiscal start. Ordinary dimension; may sit beside `time`.
+Numeric column with a declared label form.
+
+#### Derived dimensions
+
+`classify`: ordered cases (label + filter over one field) plus `else`; first match wins.
+One `multiIf`; behaves as a group axis in filters, `top`, totals. Caps: case count, pattern
+length. Same `name` twice is a duplicate.
+
+#### Distinct counts
+
+`count_distinct` over a dimension; exact by default, `approx: true` uses HyperLogLog and the
+column type says so. Empty group → 0. `median`, `quantile`, `stddev` fold measurables and
+report NULL over nothing.
+
+#### Share of total
+
+`share` window: `of` divided by the partition's sum, 0..1; empty `over` = whole answer. Zero
+total → NULL. Composes with `top` (remainder's share is the rest) and grouping sets.
+
+#### Semi-additive aggregates
+
+`per_period` (last, first, min, max) folds inside each period first, then across; seat-day
+and headcount shapes.
+
+#### Cursors over grouped answers
+
+An answer past `limit` returns a keyset cursor over its own order, made total with the group
+columns. Bound to the query fingerprint; a cursor with a different query is refused.
+
+#### Freshness
+
+`flags.data_through`: newest event time the scanned relation holds for the tenant.
+
+#### Access policies
+
+*Needs design.* Identity supplies the caller context (subject, roles, visible people, team
+memberships, tenant settings); the engine enforces declared policies at plan time. Three
+kinds: dataset access (roles or allow list); row policy (dimension ← caller attribute, e.g.
+`author_email ← visible_people`, `repository ← team_repositories`), applied to every scan
+whatever the query selects, refused when the attribute is missing; column policy (dropped or
+masked per role). Open: where team-to-resource facts live; replacement for minimum-peer
+suppression; how a saved question records the policy it was validated under. Admin-only
+until the first policy lands.
+
+#### Enrichment lookups
+
+*Needs design.* Customer relation keyed on a conformed dimension (repository → product,
+person → cost centre), declared as a lookup, joined at plan time; its columns become
+dimensions on every dataset sharing the key. Non-unique key refused (fan-out); unmatched key
+→ absent sentinel. Open: upload/sync path; tenant- vs per-user scope.
+
+#### Funnels and retention
+
+*Needs design.* Aggregate families over datasets declaring an actor key and event time,
+backed by `windowFunnel`, `retention`, `sequenceMatch`. Funnel: ordered step filters plus a
+window → actors reaching each step. Retention: entry filter, return filter, period. Group by
+any dimension. Open: strict vs any-order steps; exposing a step's actor set for drilldown.
+
+#### Rows behind a cell
+
+*Needs design.* Row-level shape over the same dataset, filters and window: declared columns
+instead of groups and folds, `row_identity` as page key, cursors, sort by any reported
+column. Open: mode of `POST /v1/query` or sibling route (preference: sibling); how a cell's
+group values become filters.
+
+#### Multiple datasets in one query
+
+*Needs design.* Several datasets with conformed dimensions; one scan each, aligned on shared
+axes. Open: declaring conformance; refusing mismatched grains; making fan-out impossible.
+Row-level joins stay out.
+
+### Saved queries
+
+A saved query is a named request with a dataset and a version. Read re-runs validation; a
+dataset change that invalidates it is a refusal naming the field, never a reinterpretation.
+On run, a request may *replace* `time`, `order`, `limit`, `cursor`, `top`, `totals`,
+`fill`, `compare`; may *append* `filters` (AND-ed); may not touch `dataset`, `group_by`,
+`aggregates`, `expressions`, `windows`, `having`. Versioned; the metric library becomes the
+shipped set of saved queries.
+
+### Non-goals
+
+- Undeclared joins in the query; joins live in the modeled relation or a declared lookup.
+- Pivot, layout, conditional formatting.
+- OData or GraphQL as the native contract.
+- Chart-type-specific endpoints; a chart the contract cannot feed is a contract gap.
+- Path analysis and sessionization.
+- Joins to relations nobody declared: that is the SQL console, admin-only.
+
+## 5. Traceability
+
+- **PRD**: [PRD.md](PRD.md)
+- **Migration map**: [MIGRATION.md](MIGRATION.md)
+- **Contract**: [openapi.json](../../components/backend/analytics/openapi.json)

--- a/docs/domain/query-engine/MIGRATION.md
+++ b/docs/domain/query-engine/MIGRATION.md
@@ -1,0 +1,57 @@
+# Migration: current serving surface to the query engine
+
+Companion to [DESIGN.md](DESIGN.md). The design reads timeless; this file
+carries the mapping from what serves today to what the engine becomes, and is
+deleted when the migration completes.
+
+## What generalizes (machinery kept, renamed under the contract)
+
+| Today | Becomes | Notes |
+|---|---|---|
+| Values total / timeseries / rollup grains | one `query` with `group_by` + optional `{time: true}` axis | grain enum dissolves into group-axis composition |
+| Distributions endpoint (histogram, quantiles) | `bin` group axis + `quantile` aggregates | no separate surface |
+| Compare windows (previous period / month / quarter / year) | `compare.aligned` | the equal-day-count rule is already implemented and tested |
+| Group-cap "Other" folding | `top` with `remainder` | the ranking CTE, deterministic ties, and remainder fold survive as-is |
+| Rows evidence pages (keyset + server sort) | unchanged | already generic |
+| Ratio / derived metric computations | `expressions` over aggregate names | AST-rendered instead of two computation kinds |
+| Percentile / stddev metrics | `quantile` / `stddev` aggregates | per-event row discipline unchanged |
+| Seat-month/seat-day style period folds | `per_period` semi-additive aggregates | the hand-built shape becomes a contract feature |
+| Measure cache (deferred PR) | refresh engine behind saved queries | its four review findings get fixed in that role |
+| Metric definitions + seeds | saved queries + the OTB library | definitions store and versioning survive; the metric key stops being the API's spine |
+| Dry-run validation endpoint | saved-query validation | same violation-list loop |
+| Discovery catalog | dataset + saved-query catalog | advertises declarations, not metric capabilities |
+
+## What dies
+
+- **Peer comparison views and endpoint** — cohort spreads, target-vs-peers,
+  the minimum-peer floor. A dashboard wanting a spread composes queries.
+- **Capped-timeseries as a bespoke view kind** — subsumed by `top`.
+- **Person-entity machinery as the API spine** — identity resolution and
+  visibility become the declared entity policy of person-shaped datasets;
+  datasets without the declaration carry none of it.
+- **Metric-centric query shape** — requests name datasets (or saved queries), not
+  metric keys; direction/format/labels move wholly into rendering metadata.
+- **Grain/fold advertisement per metric** — the catalog describes datasets
+  and saved queries; admissibility falls out of the contract, not per-key
+  capability lists.
+
+## What stays out of scope for this rebuild
+
+- Ingestion layout and the field-catalog snapshot gate stay exactly as they
+  are; the engine consumes the same catalog the current compiler does.
+- Dataset authoring remains repository-owned (declarations in the seeds and
+  roles files); no runtime authoring surface is part of this migration.
+
+## Sequencing
+
+1. Land the current stack (store, compiler, query surface, discovery catalog,
+   families) — it is the kernel: the compiler's tenancy, null, identity, and
+   read-discipline rules transfer verbatim.
+2. Introduce `/v1/query` beside the existing surface, implementing the
+   contract capability by capability; the existing endpoints keep serving
+   until their consumers move.
+3. Re-express the OTB metrics as saved queries; the transcription corpus (105
+   metrics with exact legacy reconciliation) becomes the regression suite for
+   the new contract.
+4. Retire the metric-centric endpoints and the dead view kinds; the deferred
+   cache PR lands re-aimed at saved-query refresh.

--- a/docs/domain/query-engine/PRD.md
+++ b/docs/domain/query-engine/PRD.md
@@ -1,0 +1,626 @@
+---
+version: 1.2
+status: proposed
+date: 2026-09-08
+---
+
+# PRD — Query Engine
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Module-Specific Environment Constraints](#31-module-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 Asking a question](#51-asking-a-question)
+  - [5.2 Being told what went wrong](#52-being-told-what-went-wrong)
+  - [5.3 Questions we cannot answer yet](#53-questions-we-cannot-answer-yet)
+  - [5.4 Who is allowed to ask](#54-who-is-allowed-to-ask)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 NFR Inclusions](#61-nfr-inclusions)
+  - [6.2 NFR Exclusions](#62-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+
+<!-- /toc -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Let a person ask their own question of the data the product already collects — narrow it,
+break it down, count or add something up, watch it over time — and get a table they can turn
+into a chart. Nobody has to build that question into the product first.
+
+What can be asked about is the [data sets](../datasets/PRD.md); this document is how a
+question about one gets asked and answered. Built by [DESIGN.md](DESIGN.md). What happens to
+today's charts is in [MIGRATION.md](MIGRATION.md).
+
+### 1.2 Background / Problem Statement
+
+Every chart in the product is a pre-built metric. Someone decided in advance what it counts,
+what you can break it down by, and how far back it looks. A question nobody anticipated —
+"how much of our change volume goes into test files, by file type, on GitHub only" — needs
+new code and a release. The person with the question has to ask an engineer and wait.
+
+A page that lets people build their own charts cannot exist either, because there is nothing
+for it to offer: no list of what can be broken down, filtered or counted, no readable names,
+no idea how far back it may look.
+
+There is a SQL console, but only administrators who know the warehouse can use it. It cannot
+be opened to everyone: raw SQL cannot be made to respect who is allowed to see whose data,
+and it gives no protection against the mistakes that quietly produce a wrong number.
+
+### 1.3 Goals (Business Outcomes)
+
+- A new question takes minutes, not a release. Today: one release cycle from question to
+  chart. Target: the same working session.
+- Answers are right without the asker knowing anything about the warehouse — no double
+  counting, no invented zeroes, no data from another organisation, days that start and end
+  at the same moment for everyone.
+- When a question cannot be answered, the page says which part is wrong and what would work
+  instead.
+- A saved question either still means what it meant, or it stops and says so. It never
+  quietly starts answering something else.
+- Once we can enforce who may see whose data, the same page opens to leads, not just
+  administrators.
+- A question can be asked of any data set the product offers, including ones added after the
+  engine shipped, without the engine learning anything about them first.
+
+### 1.4 Glossary
+
+| Term | Meaning |
+|---|---|
+| **Data set** | one kind of thing you can ask about; defined and described by the [data sets](../datasets/PRD.md) |
+| **Breakdown** | splitting an answer into rows: per person, per repository, per week |
+| **Measure** | something you can count or add up: commits, lines added |
+| **Filter** | a condition that keeps only the rows you mean |
+| **Time window** | the from–to dates every question must state |
+| **Time step** | how wide each bar or point is: a day, a week, a month |
+| **Rejection** | an answer the system refuses to give, saying which part of the question is wrong |
+| **Access rule** | who may ask about a data set, and which rows their answers may include |
+| **Constructor** | the page where an administrator builds a question and sees the result |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Instance administrator
+
+**ID**: `cpt-insightspec-qe-actor-admin`
+
+**Role**: runs one installation of the product; today the only person allowed to ask.
+**Needs**: answer a new question the same day, and understand a rejection without asking an
+engineer.
+
+#### Team lead
+
+**ID**: `cpt-insightspec-qe-actor-lead`
+
+**Role**: looks at numbers about the people they are responsible for, and only those people.
+**Needs**: their limits applied automatically, and charts that keep working over time.
+
+#### Dashboard author
+
+**ID**: `cpt-insightspec-qe-actor-author`
+
+**Role**: builds charts and saved questions for other people to read.
+**Needs**: to see what can be asked — the available breakdowns, measures and limits.
+
+### 2.2 System Actors
+
+#### Constructor page
+
+**ID**: `cpt-insightspec-qe-actor-constructor`
+
+**Role**: shows what can be asked, turns a filled-in form into a question, draws the answer.
+
+#### Identity service
+
+**ID**: `cpt-insightspec-qe-actor-identity`
+
+**Role**: says who is asking, what they are allowed to do, and whose data they may see.
+
+#### Warehouse
+
+**ID**: `cpt-insightspec-qe-actor-warehouse`
+
+**Role**: stores the prepared data and answers each question.
+
+## 3. Operational Concept & Environment
+
+### 3.1 Module-Specific Environment Constraints
+
+- Reads only prepared, ready-to-query data. It never touches raw collected data and never
+  changes anything.
+- A data set can only be offered if it really exists in the warehouse; a mismatch is caught
+  when the product is built, not when someone asks.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Asking a question: filters, breakdowns including over time, counts and totals with their
+  own conditions, sorting, a row limit, a required time window.
+- Telling a caller the bounds a question must stay inside, reported alongside what each data
+  set says about itself.
+- Getting a clear answer: a table with readable names beside the values, and a note when the
+  answer was cut short.
+- Clear rejections that point at the part of the question to fix.
+- An administrator-only page for building questions.
+- A named list of what comes next, as requirements: or/not conditions, rolling time windows,
+  your own categories, unique counts, percentages of a total, running and moving figures,
+  subtotals, paging, saved questions, and enforcing access rules.
+
+### 4.2 Out of Scope
+
+- What can be asked about: how a data set is defined, described and added — the
+  [data sets](../datasets/PRD.md).
+- Letting people write SQL; the administrator SQL console stays as it is.
+- How a chart looks: chart types, layouts, formatting.
+- Step-by-step journey analysis over individual event streams.
+- Alerts and notifications about an answer.
+- Switching the existing charts over before this can do what they do
+  ([MIGRATION.md](MIGRATION.md)).
+
+## 5. Functional Requirements
+
+### 5.1 Asking a question
+
+#### Ask a data set directly
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-ask`
+
+The system **MUST** answer a question that names a data set, a time window and at least one
+thing to count, plus optional filters, breakdowns, sorting and a row limit — with nothing
+built in advance.
+
+**Rationale**: the whole point; a question should not need a release.
+
+**Actors**: `cpt-insightspec-qe-actor-admin`, `cpt-insightspec-qe-actor-constructor`
+
+#### Break down by anything, including time
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-group`
+
+The system **MUST** allow a breakdown by any offered column and by day, week or month, and
+**MUST** return the readable name beside the value it stands for.
+
+**Rationale**: a chart needs a stable value to key on and a name a person can read.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Narrow to the rows you mean
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-filter`
+
+The system **MUST** filter by exact value, a list of values, greater or less than, a range,
+"has a value", and text patterns (simple wildcards or a regular expression). It **MUST**
+reject a greater-or-less-than test on text and a text pattern on a number.
+
+**Rationale**: the asker decides what "test files" means. A comparison on the wrong kind of
+column gives a wrong answer that looks right.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Count and total, with conditions
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-fold`
+
+The system **MUST** count rows and compute totals, averages, smallest and largest, each
+optionally over just the rows a condition selects. When nothing matched, the cell **MUST** be
+blank rather than a zero — except a count, where zero is the true answer.
+
+**Rationale**: one question can answer several columns at once, and a made-up zero is a wrong
+number.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Keep every answer within safe limits
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-bounds`
+
+The system **MUST** require a time window of at most 731 days (two years), limit how many
+rows an answer holds, how large it may be and how many questions run at once, and **MUST**
+say when an answer was cut at the row limit.
+
+**Rationale**: everyone shares one warehouse, and a chart that was cut short without saying
+so is misleading.
+
+**Actors**: `cpt-insightspec-qe-actor-admin`
+
+### 5.2 Being told what went wrong
+
+#### Point at every problem at once
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-refusal`
+
+The system **MUST** check the whole question before rejecting it, and report every problem
+with the part of the question it concerns, a code a page can act on, and — where there is a
+list of valid choices — that list.
+
+**Rationale**: a page can highlight the wrong boxes; a person reads one clear message.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+### 5.3 Questions we cannot answer yet
+
+#### And, or, not
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-boolean`
+
+The system **MUST** allow conditions combined with "any of", "all of" and "not", nested as
+deeply as needed.
+
+**Rationale**: "GitHub or GitLab, but not bots" cannot be said with "and" alone.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Rolling time windows
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-relative-window`
+
+The system **MUST** accept windows stated relative to today — the last twelve weeks, this
+month, the previous quarter, the year so far — and report the actual dates it used.
+
+**Rationale**: a saved chart with fixed dates is out of date tomorrow.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Your own categories, and parts of a date
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-derived`
+
+The system **MUST** allow a breakdown by categories the asker defines with their own rules,
+and by parts of a date such as day of the week or hour.
+
+**Rationale**: everyone's definition of "test code" or "core service" differs.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### The rest of the usual chart maths
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-richer-folds`
+
+The system **MUST** offer unique counts (exact and estimated), medians and percentiles,
+spread, arithmetic between computed columns, running and moving figures, percentage of a
+total, a top-N with everything else grouped as "other", empty periods shown as gaps or
+zeroes, subtotals and grand totals, and measures counted once per period such as headcount.
+
+**Rationale**: this is what today's charts already do and what anyone building a chart
+expects.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Calendars and comparisons
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-time-intelligence`
+
+The system **MUST** work in a chosen time zone, with a chosen first day of the week and start
+of the financial year, and **MUST** compare a period against the same stretch of the period
+before it.
+
+**Rationale**: "versus last quarter" comes up in every review.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### See more, and look behind a number
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-rows`
+
+The system **MUST** let a reader page past the row limit, and **MUST** show the individual
+records behind any single figure in an answer.
+
+**Rationale**: a number nobody can open is a number nobody trusts.
+
+**Actors**: `cpt-insightspec-qe-actor-lead`
+
+#### Save a question and share it
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-saved`
+
+The system **MUST** save a question under a name, re-check it every time it is opened, let a
+reader change the dates, sorting and row limit and add their own filters, and refuse changes
+that would make it a different question.
+
+**Rationale**: a dashboard is a set of saved questions; they must break loudly rather than
+drift.
+
+**Actors**: `cpt-insightspec-qe-actor-author`, `cpt-insightspec-qe-actor-lead`
+
+#### Combine sources, and bring your own reference data
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-cross-dataset`
+
+The system **MUST** answer one question spanning several data sets that share a breakdown,
+without inflating any number, and **MUST** let a customer's own reference list — repository
+to product line, person to cost centre — be used as a breakdown everywhere it fits.
+
+**Rationale**: real questions cross sources, and product lines and cost centres are facts
+only the customer has.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Funnels and return rates
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-funnels`
+
+The system **MUST** count how many people, deals or tickets reached each step of a sequence
+within a period, and how many came back after a first action.
+
+**Rationale**: deal stages, ticket transitions and the life of a pull request are all
+funnels.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+### 5.4 Who is allowed to ask
+
+#### Administrators only, for now
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-admin-gate`
+
+The system **MUST** refuse both questions and the list of what can be asked to anyone who is
+not an administrator of the installation, until access rules exist for the data sets that
+describe people.
+
+**Rationale**: these data sets show what named people did.
+
+**Actors**: `cpt-insightspec-qe-actor-admin`, `cpt-insightspec-qe-actor-lead`
+
+#### Access rules
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-access-policies`
+
+For each data set the system **MUST** enforce who may ask about it at all, which rows may
+count towards their answers — based on facts about the asker, such as the people they manage
+or the repositories their teams own — and which columns they may see. This **MUST** apply to
+every question, no matter how it is broken down.
+
+**Rationale**: a count per repository is still a count of people's work; what a chart is
+grouped by must not change who is visible in it.
+
+**Actors**: `cpt-insightspec-qe-actor-lead`, `cpt-insightspec-qe-actor-identity`
+
+## 6. Non-Functional Requirements
+
+### 6.1 NFR Inclusions
+
+#### Right answers without expert knowledge
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-correctness`
+
+Every answer **MUST** cover only the asker's own organisation, count nothing twice, leave a
+cell blank when nothing matched, and treat a day as the same stretch of time for everyone.
+There **MUST** be no way for a question to switch any of this off.
+
+**Threshold**: no exceptions; checked by tests that compare answers which must agree.
+
+**Rationale**: this is why the product answers questions itself instead of handing out SQL.
+
+#### Predictable cost
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-bounded`
+
+A question **MUST** stay within stated limits, and be rejected rather than run when it would
+exceed them.
+
+**Threshold**: time window at most 731 days; at most 10 000 rows; at most 16 MiB per answer;
+8 questions at once per server, with the rest asked to retry shortly.
+
+**Rationale**: the warehouse is shared with everything else the product does.
+
+#### Fast enough to explore
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-nfr-latency`
+
+An ordinary question **SHOULD** come back within two seconds for 95 out of 100 asks on a
+reference installation.
+
+**Threshold**: 2 seconds at the 95th percentile, up to four breakdowns, one year of data.
+
+**Rationale**: building a chart is a back-and-forth; waiting breaks it.
+
+#### A promise that does not shift
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-contract`
+
+What can be asked and what comes back **MUST** be published in a form other software can
+check against, and anything unrecognised in a question **MUST** be rejected rather than
+ignored.
+
+**Threshold**: the published description accepts exactly what the product accepts; any
+divergence stops the build.
+
+**Rationale**: a page built against the description must not disagree with the product.
+
+#### People's data stays handled as people's data
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-person-data`
+
+Columns that identify a person **MUST** be shown only to those the access rules allow, and
+**MUST NOT** be copied or stored anywhere by this part of the product. Keeping and deleting
+that data stays where it already happens.
+
+**Threshold**: nothing stored here; person columns marked as such where data sets are
+described.
+
+**Rationale**: no second copy of people's activity with a life of its own.
+
+### 6.2 NFR Exclusions
+
+- **Working offline**: it reads live data; there is nothing to work from offline.
+- **Storing anything reliably**: it stores nothing until saved questions arrive.
+- **Signing in**: handled before a question reaches it.
+- **Uptime and recovery targets**: inherited from the service it lives in; it holds no data
+  of its own to recover.
+- **Accessibility, translation, phones**: the page is administrator-only today and follows
+  the product's usual standards; revisited when leads get access.
+- **Certifications**: none beyond the product's own.
+- **Monitoring**: speed and failures are recorded with the rest of the service; nothing
+  special is needed here.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### The question and answer format
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-interface-query`
+
+**Type**: the published request and answer format of the analytics API
+
+**Stability**: still changing while administrator-only; settles when access rules arrive
+
+**Description**: the one way to ask a data set a question, and to find out what can be asked.
+
+**Breaking Change Policy**: anything already accepted keeps its meaning; new options are
+added, never substituted.
+
+### 7.2 External Integration Contracts
+
+#### Who is asking
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-contract-caller-context`
+
+**Direction**: required from the identity service
+
+**Protocol/Format**: the asker's permissions, the people they may see, the teams they belong
+to, resolved for each question
+
+**Compatibility**: if a fact an access rule needs is missing, the question is refused — never
+answered more widely.
+
+## 8. Use Cases
+
+#### Build a chart nobody planned for
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-usecase-build-chart`
+
+**Actor**: `cpt-insightspec-qe-actor-admin`
+
+**Preconditions**:
+- The person is an administrator; data sets are available.
+
+**Main Flow**:
+1. The page lists the data sets and, for the chosen one, what can be broken down, filtered
+   and counted.
+2. The administrator picks dates, breakdowns, what to count, any filters, and asks.
+3. The product either points at what is wrong, or returns a table with readable names and a
+   note if it was cut short.
+4. The page draws the table and a chart from that answer alone.
+
+**Postconditions**:
+- A chart exists that nobody built into the product.
+
+**Alternative Flows**:
+- **Something is wrong**: each problem is shown next to the box it belongs to; nothing is
+  answered.
+- **Too many rows**: the answer is cut and says so.
+
+#### Decide for yourself what counts as test code
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-usecase-own-category`
+
+**Actor**: `cpt-insightspec-qe-actor-author`
+
+**Preconditions**:
+- File changes can be filtered by path.
+
+**Main Flow**:
+1. The author adds a second column counting only the changes whose path matches their own
+   pattern.
+2. The product checks the pattern makes sense and counts only those rows.
+
+**Postconditions**:
+- One table shows the matching lines beside the total, per file type, using the author's own
+  definition.
+
+**Alternative Flows**:
+- **The pattern is not valid**: the answer is refused, pointing at the pattern.
+
+#### A lead sees only their own team
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-usecase-lead-visibility`
+
+**Actor**: `cpt-insightspec-qe-actor-lead`
+
+**Preconditions**:
+- The data set has an access rule tying it to the people the asker may see.
+
+**Main Flow**:
+1. The lead opens a saved chart broken down by repository.
+2. The product applies the rule before counting anything, so only their people are included.
+
+**Postconditions**:
+- The same saved chart is correct for two different leads, and different for each.
+
+**Alternative Flows**:
+- **The product cannot tell who the lead may see**: the question is refused, not widened.
+
+## 9. Acceptance Criteria
+
+- [x] An administrator answers a question about each available data set from the page, with
+  nothing built in advance.
+- [x] Answers that must agree do agree on a test installation: the weeks add up to the whole
+  period; filtering to one value matches what the breakdown showed for it; a pattern matches
+  what the exact values match.
+- [x] Someone who is not an administrator is refused, both the questions and the list.
+- [x] Every refusal names the part of the question that is wrong.
+- [ ] A saved question is refused after the data behind it changes shape, instead of
+  answering something different.
+- [ ] A lead's answer includes only people they may see, however the chart is broken down.
+
+## 10. Dependencies
+
+| Dependency | Description | Criticality |
+|------------|-------------|-------------|
+| Prepared data sets | the ready-to-query tables, built with the counting rules already applied | p1 |
+| Record of what the warehouse holds | checked when the product is built, so a data set cannot promise a column that is not there | p1 |
+| Identity service | says who is an administrator today; who may see whom, later | p1 |
+| Published API description | what the page and the automated tests are built from | p1 |
+
+## 11. Assumptions
+
+- The product ships the first data sets; people add their own later, and both kinds are
+  checked and treated the same way.
+- Administrators may see everything in their own organisation; the restriction is for
+  everyone else.
+- The test installation contains data for every data set, so the checks mean something.
+- Cost depends on the dates and row limit rather than on how large the customer is; those
+  limits are the lever if an installation outgrows them.
+
+**Open questions**
+
+| Question | Owner | Resolve by |
+|---|---|---|
+| Where do we record which teams own which repositories? | product + backend | before the first access rule |
+| What protects small groups from being singled out once leads can ask? | product | before the page opens to leads |
+| Which data sets come after commits and file changes, in what order? | product | after the constructor page |
+| Who may add a data set, and what does approval look like when an assistant wrote it? | product | when own data sets start |
+| Is "show me the records behind this number" part of the same request or its own? | backend | when that work starts |
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| What people want to ask outpaces what we support | they go back to asking engineers, or to SQL | the list in DESIGN is the backlog, in priority order; the SQL console stays for administrators |
+| Access rules take longer than expected | charts stay administrator-only | access rules are the first thing after the basics; the restriction is deliberate, not a default |
+| A very broad question is slow on a large customer | exploring becomes painful | limits on dates, rows, size and how many run at once; the "cut short" note tells the asker to narrow it |
+| The data behind a saved question changes shape | wrong answers or errors | data sets are checked when the product is built; saved questions are re-checked each time they are opened |
+| Someone's own data set is wrong, slow or too revealing | bad numbers spread, or data leaks past its audience | the same checks and limits as a shipped data set; usable by its author alone until an administrator approves it and its access rules are set |

--- a/docs/domain/query-engine/PRD.md
+++ b/docs/domain/query-engine/PRD.md
@@ -1,5 +1,5 @@
 ---
-version: 1.2
+version: 1.3
 status: proposed
 date: 2026-09-08
 ---
@@ -22,10 +22,10 @@ date: 2026-09-08
   - [4.1 In Scope](#41-in-scope)
   - [4.2 Out of Scope](#42-out-of-scope)
 - [5. Functional Requirements](#5-functional-requirements)
-  - [5.1 Asking a question](#51-asking-a-question)
-  - [5.2 Being told what went wrong](#52-being-told-what-went-wrong)
-  - [5.3 Questions we cannot answer yet](#53-questions-we-cannot-answer-yet)
-  - [5.4 Who is allowed to ask](#54-who-is-allowed-to-ask)
+  - [5.1 Query execution](#51-query-execution)
+  - [5.2 Validation](#52-validation)
+  - [5.3 Planned capabilities](#53-planned-capabilities)
+  - [5.4 Authorization](#54-authorization)
 - [6. Non-Functional Requirements](#6-non-functional-requirements)
   - [6.1 NFR Inclusions](#61-nfr-inclusions)
   - [6.2 NFR Exclusions](#62-nfr-exclusions)
@@ -44,58 +44,47 @@ date: 2026-09-08
 
 ### 1.1 Purpose
 
-Let a person ask their own question of the data the product already collects — narrow it,
-break it down, count or add something up, watch it over time — and get a table they can turn
-into a chart. Nobody has to build that question into the product first.
+The query engine executes structured queries over declared datasets and returns typed tables
+for charts and analysis. Callers select filters, grouping, aggregates, ordering, and a time
+window without defining a new server-side metric.
 
-What can be asked about is the [data sets](../datasets/PRD.md); this document is how a
-question about one gets asked and answered. Built by [DESIGN.md](DESIGN.md). What happens to
-today's charts is in [MIGRATION.md](MIGRATION.md).
+[Datasets](../datasets/PRD.md) define the available data and fields. [DESIGN.md](DESIGN.md)
+defines query semantics and implementation. [MIGRATION.md](MIGRATION.md) covers the transition
+from existing metric APIs.
 
 ### 1.2 Background / Problem Statement
 
-Every chart in the product is a pre-built metric. Someone decided in advance what it counts,
-what you can break it down by, and how far back it looks. A question nobody anticipated —
-"how much of our change volume goes into test files, by file type, on GitHub only" — needs
-new code and a release. The person with the question has to ask an engineer and wait.
+Pre-built metrics couple each supported calculation to server code. Queries outside those
+combinations require development and a release.
 
-A page that lets people build their own charts cannot exist either, because there is nothing
-for it to offer: no list of what can be broken down, filtered or counted, no readable names,
-no idea how far back it may look.
-
-There is a SQL console, but only administrators who know the warehouse can use it. It cannot
-be opened to everyone: raw SQL cannot be made to respect who is allowed to see whose data,
-and it gives no protection against the mistakes that quietly produce a wrong number.
+A chart builder needs a discoverable query contract: available fields, supported operations,
+limits, and structured errors. An administrator SQL console does not provide that contract
+or automatically apply the dataset semantics required by chart consumers.
 
 ### 1.3 Goals (Business Outcomes)
 
-- A new question takes minutes, not a release. Today: one release cycle from question to
-  chart. Target: the same working session.
-- Answers are right without the asker knowing anything about the warehouse — no double
-  counting, no invented zeroes, no data from another organisation, days that start and end
-  at the same moment for everyone.
-- When a question cannot be answered, the page says which part is wrong and what would work
-  instead.
-- A saved question either still means what it meant, or it stops and says so. It never
-  quietly starts answering something else.
-- Once we can enforce who may see whose data, the same page opens to leads, not just
-  administrators.
-- A question can be asked of any data set the product offers, including ones added after the
-  engine shipped, without the engine learning anything about them first.
+- Build a supported query and chart within one working session, without a release.
+- Apply tenant isolation, dataset read rules, null semantics, and time boundaries consistently.
+- Return actionable validation errors identifying invalid inputs.
+- Preserve saved-query meaning or reject incompatible definitions.
+- Extend access to team leads after dataset access policies are enforced.
+- Query newly declared datasets without engine changes.
 
 ### 1.4 Glossary
 
 | Term | Meaning |
 |---|---|
-| **Data set** | one kind of thing you can ask about; defined and described by the [data sets](../datasets/PRD.md) |
-| **Breakdown** | splitting an answer into rows: per person, per repository, per week |
-| **Measure** | something you can count or add up: commits, lines added |
-| **Filter** | a condition that keeps only the rows you mean |
-| **Time window** | the from–to dates every question must state |
-| **Time step** | how wide each bar or point is: a day, a week, a month |
-| **Rejection** | an answer the system refuses to give, saying which part of the question is wrong |
-| **Access rule** | who may ask about a data set, and which rows their answers may include |
-| **Constructor** | the page where an administrator builds a question and sees the result |
+| Dataset | Declared queryable data with a row grain and field metadata |
+| Dimension | Declared field available for grouping and filtering |
+| Measurable | Declared numeric field available for aggregation |
+| Aggregate | Computation over rows, such as count, sum, or average |
+| Filter | Predicate selecting rows |
+| Grouping | Partitioning results by dimensions or time buckets |
+| Time window | Required inclusive start and end dates |
+| Time grain | Bucket size: initially day, week, or month |
+| Violation | Validation error with a field path, reason code, and explanation |
+| Access policy | Dataset, row, or column visibility rule |
+| Constructor | Client for composing queries and rendering results |
 
 ## 2. Actors
 
@@ -105,23 +94,22 @@ and it gives no protection against the mistakes that quietly produce a wrong num
 
 **ID**: `cpt-insightspec-qe-actor-admin`
 
-**Role**: runs one installation of the product; today the only person allowed to ask.
-**Needs**: answer a new question the same day, and understand a rejection without asking an
-engineer.
+**Role**: executes queries under the initial administrator-only access model.
+**Needs**: query composition and actionable errors without warehouse expertise.
 
 #### Team lead
 
 **ID**: `cpt-insightspec-qe-actor-lead`
 
-**Role**: looks at numbers about the people they are responsible for, and only those people.
-**Needs**: their limits applied automatically, and charts that keep working over time.
+**Role**: planned query consumer restricted to authorized people and resources.
+**Needs**: visibility policies applied independently of grouping.
 
 #### Dashboard author
 
 **ID**: `cpt-insightspec-qe-actor-author`
 
-**Role**: builds charts and saved questions for other people to read.
-**Needs**: to see what can be asked — the available breakdowns, measures and limits.
+**Role**: builds charts and, in the planned extension, saved queries.
+**Needs**: discoverable fields, operations, and limits.
 
 ### 2.2 System Actors
 
@@ -129,271 +117,248 @@ engineer.
 
 **ID**: `cpt-insightspec-qe-actor-constructor`
 
-**Role**: shows what can be asked, turns a filled-in form into a question, draws the answer.
+**Role**: composes requests, renders results, and displays validation errors.
 
 #### Identity service
 
 **ID**: `cpt-insightspec-qe-actor-identity`
 
-**Role**: says who is asking, what they are allowed to do, and whose data they may see.
+**Role**: supplies administrator checks and, later, caller attributes for access policies.
 
 #### Warehouse
 
 **ID**: `cpt-insightspec-qe-actor-warehouse`
 
-**Role**: stores the prepared data and answers each question.
+**Role**: stores prepared datasets and executes compiled queries.
 
 ## 3. Operational Concept & Environment
 
 ### 3.1 Module-Specific Environment Constraints
 
-- Reads only prepared, ready-to-query data. It never touches raw collected data and never
-  changes anything.
-- A data set can only be offered if it really exists in the warehouse; a mismatch is caught
-  when the product is built, not when someone asks.
+- Queries read prepared datasets and do not modify data.
+- Dataset declarations must pass validation before use. The dataset design documents the
+  limits of snapshot-based validation.
 
 ## 4. Scope
 
 ### 4.1 In Scope
 
-- Asking a question: filters, breakdowns including over time, counts and totals with their
-  own conditions, sorting, a row limit, a required time window.
-- Telling a caller the bounds a question must stay inside, reported alongside what each data
-  set says about itself.
-- Getting a clear answer: a table with readable names beside the values, and a note when the
-  answer was cut short.
-- Clear rejections that point at the part of the question to fix.
-- An administrator-only page for building questions.
-- A named list of what comes next, as requirements: or/not conditions, rolling time windows,
-  your own categories, unique counts, percentages of a total, running and moving figures,
-  subtotals, paging, saved questions, and enforcing access rules.
+**Initial implementation**: single-dataset queries with filters, dimension and time grouping,
+conditional aggregates, ordering, row limits, a required time window, structured errors,
+typed results, and truncation reporting. Discovery includes query limits.
+
+**Planned product scope**: a constructor UI, Boolean filter groups, relative windows, derived
+dimensions, richer aggregates, expressions, windows, totals, pagination, saved queries,
+cross-dataset analysis, and access-policy enforcement. DESIGN records each capability's status.
 
 ### 4.2 Out of Scope
 
-- What can be asked about: how a data set is defined, described and added — the
-  [data sets](../datasets/PRD.md).
-- Letting people write SQL; the administrator SQL console stays as it is.
-- How a chart looks: chart types, layouts, formatting.
-- Step-by-step journey analysis over individual event streams.
-- Alerts and notifications about an answer.
-- Switching the existing charts over before this can do what they do
-  ([MIGRATION.md](MIGRATION.md)).
+- Dataset definition and registration, owned by the datasets module.
+- User-authored SQL; the administrator SQL console remains separate.
+- Chart layout and formatting.
+- Event-path analysis and sessionization beyond the planned funnel and retention operations.
+- Alerts and notifications.
+- Replacing existing chart APIs before capability and migration requirements are met.
 
 ## 5. Functional Requirements
 
-### 5.1 Asking a question
+### 5.1 Query execution
 
-#### Ask a data set directly
+#### Structured queries
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-fr-ask`
 
-The system **MUST** answer a question that names a data set, a time window and at least one
-thing to count, plus optional filters, breakdowns, sorting and a row limit — with nothing
-built in advance.
+The system **MUST** execute a query naming a dataset, time window, and at least one
+aggregate, with optional filters, grouping, ordering, and row limit.
 
-**Rationale**: the whole point; a question should not need a release.
+**Rationale**: Supported queries must not require pre-built metrics.
 
 **Actors**: `cpt-insightspec-qe-actor-admin`, `cpt-insightspec-qe-actor-constructor`
 
-#### Break down by anything, including time
+#### Dimension and time grouping
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-fr-group`
 
-The system **MUST** allow a breakdown by any offered column and by day, week or month, and
-**MUST** return the readable name beside the value it stands for.
+The system **MUST** group by declared dimensions and by day, week, or month. For dimensions
+with a declared label, results **MUST** include the label beside the stable value.
 
-**Rationale**: a chart needs a stable value to key on and a name a person can read.
+**Rationale**: Clients need stable identifiers and readable labels.
 
 **Actors**: `cpt-insightspec-qe-actor-author`
 
-#### Narrow to the rows you mean
+#### Row filters
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-fr-filter`
 
-The system **MUST** filter by exact value, a list of values, greater or less than, a range,
-"has a value", and text patterns (simple wildcards or a regular expression). It **MUST**
-reject a greater-or-less-than test on text and a text pattern on a number.
+The system **MUST** support equality, membership, ordered comparisons, inclusive ranges,
+non-null checks, wildcard patterns, and regular expressions. It **MUST** reject operations
+incompatible with the target field, including ordered text comparisons and numeric patterns.
 
-**Rationale**: the asker decides what "test files" means. A comparison on the wrong kind of
-column gives a wrong answer that looks right.
+**Rationale**: Field-aware validation prevents misleading comparisons.
 
 **Actors**: `cpt-insightspec-qe-actor-author`
 
-#### Count and total, with conditions
+#### Conditional aggregates
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-fr-fold`
 
-The system **MUST** count rows and compute totals, averages, smallest and largest, each
-optionally over just the rows a condition selects. When nothing matched, the cell **MUST** be
-blank rather than a zero — except a count, where zero is the true answer.
+The system **MUST** support count, sum, average, minimum, and maximum, each with an optional
+filter. An aggregate over no observations **MUST** return null, except count, which returns
+zero.
 
-**Rationale**: one question can answer several columns at once, and a made-up zero is a wrong
-number.
+**Rationale**: Null distinguishes missing observations from measured zero.
 
 **Actors**: `cpt-insightspec-qe-actor-author`
 
-#### Keep every answer within safe limits
+#### Query limits
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-fr-bounds`
 
-The system **MUST** require a time window of at most 731 days (two years), limit how many
-rows an answer holds, how large it may be and how many questions run at once, and **MUST**
-say when an answer was cut at the row limit.
+The system **MUST** require a time window of at most 731 days and bound result rows,
+response size, and concurrent execution. Results **MUST** indicate row-limit truncation.
 
-**Rationale**: everyone shares one warehouse, and a chart that was cut short without saying
-so is misleading.
+**Rationale**: Resource limits protect shared capacity; truncation must remain visible.
 
 **Actors**: `cpt-insightspec-qe-actor-admin`
 
-### 5.2 Being told what went wrong
+### 5.2 Validation
 
-#### Point at every problem at once
+#### Validation errors
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-fr-refusal`
 
-The system **MUST** check the whole question before rejecting it, and report every problem
-with the part of the question it concerns, a code a page can act on, and — where there is a
-list of valid choices — that list.
+The system **MUST** validate requests before execution and report violations with field
+paths, machine-readable reasons, and valid choices where available. It **MUST** report
+independent semantic violations together when the request can be resolved.
 
-**Rationale**: a page can highlight the wrong boxes; a person reads one clear message.
+**Rationale**: Clients can identify invalid inputs without repeated trial-and-error requests.
 
 **Actors**: `cpt-insightspec-qe-actor-author`
 
-### 5.3 Questions we cannot answer yet
+### 5.3 Planned capabilities
 
-#### And, or, not
+#### Boolean filter groups
 
 - [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-boolean`
 
-The system **MUST** allow conditions combined with "any of", "all of" and "not", nested as
-deeply as needed.
+The system **MUST** support nested AND, OR, and NOT conditions.
 
-**Rationale**: "GitHub or GitLab, but not bots" cannot be said with "and" alone.
+**Rationale**: Compound selection requires more than the initial implicit AND. Nesting limits
+remain a design parameter.
 
 **Actors**: `cpt-insightspec-qe-actor-author`
 
-#### Rolling time windows
+#### Relative time windows
 
 - [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-relative-window`
 
-The system **MUST** accept windows stated relative to today — the last twelve weeks, this
-month, the previous quarter, the year so far — and report the actual dates it used.
+The system **MUST** support relative and calendar windows, including recent weeks, the
+current month, the previous quarter, and year-to-date. Results **MUST** report resolved dates.
 
-**Rationale**: a saved chart with fixed dates is out of date tomorrow.
+**Rationale**: Saved charts need windows that advance over time.
 
 **Actors**: `cpt-insightspec-qe-actor-author`
 
-#### Your own categories, and parts of a date
+#### Derived dimensions
 
 - [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-derived`
 
-The system **MUST** allow a breakdown by categories the asker defines with their own rules,
-and by parts of a date such as day of the week or hour.
+The system **MUST** group by caller-defined categories and date parts such as weekday or hour.
 
-**Rationale**: everyone's definition of "test code" or "core service" differs.
+**Rationale**: Authors need classifications beyond shipped dimensions.
 
 **Actors**: `cpt-insightspec-qe-actor-author`
 
-#### The rest of the usual chart maths
+#### Advanced aggregation
 
 - [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-richer-folds`
 
-The system **MUST** offer unique counts (exact and estimated), medians and percentiles,
-spread, arithmetic between computed columns, running and moving figures, percentage of a
-total, a top-N with everything else grouped as "other", empty periods shown as gaps or
-zeroes, subtotals and grand totals, and measures counted once per period such as headcount.
+The system **MUST** support exact and approximate distinct counts, medians, percentiles,
+dispersion, computed-column arithmetic, running and moving calculations, share of total,
+top-N with an Other group, empty-period fill, subtotals, grand totals, and per-period
+aggregation for quantities such as headcount.
 
-**Rationale**: this is what today's charts already do and what anyone building a chart
-expects.
+**Rationale**: These operations expand chart coverage beyond basic aggregates.
 
 **Actors**: `cpt-insightspec-qe-actor-author`
 
-#### Calendars and comparisons
+#### Calendars and period comparison
 
 - [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-time-intelligence`
 
-The system **MUST** work in a chosen time zone, with a chosen first day of the week and start
-of the financial year, and **MUST** compare a period against the same stretch of the period
-before it.
+The system **MUST** support a chosen timezone, week start, and fiscal-year start, and
+compare equivalent portions of successive periods.
 
-**Rationale**: "versus last quarter" comes up in every review.
+**Rationale**: Calendar settings determine comparable reporting periods.
 
 **Actors**: `cpt-insightspec-qe-actor-author`
 
-#### See more, and look behind a number
+#### Pagination and drilldown
 
 - [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-rows`
 
-The system **MUST** let a reader page past the row limit, and **MUST** show the individual
-records behind any single figure in an answer.
+The system **MUST** support pagination beyond the result row limit and retrieval of records
+contributing to a result cell.
 
-**Rationale**: a number nobody can open is a number nobody trusts.
+**Rationale**: Users need complete result traversal and supporting records.
 
 **Actors**: `cpt-insightspec-qe-actor-lead`
 
-#### Save a question and share it
+#### Saved queries
 
 - [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-saved`
 
-The system **MUST** save a question under a name, re-check it every time it is opened, let a
-reader change the dates, sorting and row limit and add their own filters, and refuse changes
-that would make it a different question.
+The system **MUST** save named queries and revalidate them on each use. Callers may change
+time windows, ordering, and limits, and add filters; changes to the query definition
+**MUST** be rejected. DESIGN specifies the proposed override contract.
 
-**Rationale**: a dashboard is a set of saved questions; they must break loudly rather than
-drift.
+**Rationale**: Revalidation and restricted overrides preserve query meaning.
 
 **Actors**: `cpt-insightspec-qe-actor-author`, `cpt-insightspec-qe-actor-lead`
 
-#### Combine sources, and bring your own reference data
+#### Cross-dataset queries and enrichment
 
 - [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-cross-dataset`
 
-The system **MUST** answer one question spanning several data sets that share a breakdown,
-without inflating any number, and **MUST** let a customer's own reference list — repository
-to product line, person to cost centre — be used as a breakdown everywhere it fits.
+The system **MUST** combine datasets sharing dimensions without aggregate inflation and
+support tenant reference data as additional dimensions wherever the keys are compatible.
 
-**Rationale**: real questions cross sources, and product lines and cost centres are facts
-only the customer has.
+**Rationale**: Shared dimensions enable analysis across sources and tenant classifications.
 
 **Actors**: `cpt-insightspec-qe-actor-author`
 
-#### Funnels and return rates
+#### Funnels and retention
 
 - [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-funnels`
 
-The system **MUST** count how many people, deals or tickets reached each step of a sequence
-within a period, and how many came back after a first action.
+The system **MUST** count entities reaching ordered steps within a period and entities
+returning after an initial event.
 
-**Rationale**: deal stages, ticket transitions and the life of a pull request are all
-funnels.
+**Rationale**: Sequence and return-rate analysis require operations beyond independent counts.
 
 **Actors**: `cpt-insightspec-qe-actor-author`
 
-### 5.4 Who is allowed to ask
+### 5.4 Authorization
 
-#### Administrators only, for now
+#### Initial administrator restriction
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-fr-admin-gate`
 
-The system **MUST** refuse both questions and the list of what can be asked to anyone who is
-not an administrator of the installation, until access rules exist for the data sets that
-describe people.
+The system **MUST** reject query execution and discovery for non-administrators until
+access policies protect datasets containing personal data.
 
-**Rationale**: these data sets show what named people did.
+**Rationale**: The initial engine has no row- or column-level access-policy enforcement.
 
 **Actors**: `cpt-insightspec-qe-actor-admin`, `cpt-insightspec-qe-actor-lead`
 
-#### Access rules
+#### Dataset access policies
 
 - [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-access-policies`
 
-For each data set the system **MUST** enforce who may ask about it at all, which rows may
-count towards their answers — based on facts about the asker, such as the people they manage
-or the repositories their teams own — and which columns they may see. This **MUST** apply to
-every question, no matter how it is broken down.
+The system **MUST** enforce dataset access, row visibility based on caller attributes, and
+column visibility for every query, regardless of its grouping.
 
-**Rationale**: a count per repository is still a count of people's work; what a chart is
-grouped by must not change who is visible in it.
+**Rationale**: Grouping by a resource must not bypass restrictions on the underlying people.
 
 **Actors**: `cpt-insightspec-qe-actor-lead`, `cpt-insightspec-qe-actor-identity`
 
@@ -401,226 +366,209 @@ grouped by must not change who is visible in it.
 
 ### 6.1 NFR Inclusions
 
-#### Right answers without expert knowledge
+#### Consistent result semantics
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-correctness`
 
-Every answer **MUST** cover only the asker's own organisation, count nothing twice, leave a
-cell blank when nothing matched, and treat a day as the same stretch of time for everyone.
-There **MUST** be no way for a question to switch any of this off.
+Queries **MUST** enforce tenant isolation, dataset read rules, null-preserving aggregates
+with the count exception, and consistent UTC day boundaries. Callers **MUST NOT** override
+these rules.
 
-**Threshold**: no exceptions; checked by tests that compare answers which must agree.
+**Threshold**: equivalence checks for regrouping and filtering must agree within their
+applicable aggregate semantics.
 
-**Rationale**: this is why the product answers questions itself instead of handing out SQL.
+**Rationale**: query configuration must not bypass shared data rules.
 
-#### Predictable cost
+#### Bounded execution
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-bounded`
 
-A question **MUST** stay within stated limits, and be rejected rather than run when it would
-exceed them.
+The system **MUST** reject requests exceeding declared input limits and stop execution when
+runtime limits are reached.
 
-**Threshold**: time window at most 731 days; at most 10 000 rows; at most 16 MiB per answer;
-8 questions at once per server, with the rest asked to retry shortly.
+**Threshold**: at most 731 days, 10,000 result rows, 16 MiB per answer, and eight concurrent
+scans per process; excess demand receives a retryable rejection.
 
-**Rationale**: the warehouse is shared with everything else the product does.
+**Rationale**: time and row limits alone do not bound query cost or result size.
 
-#### Fast enough to explore
+#### Interactive latency
 
 - [ ] `p2` - **ID**: `cpt-insightspec-qe-nfr-latency`
 
-An ordinary question **SHOULD** come back within two seconds for 95 out of 100 asks on a
-reference installation.
+Queries with up to four grouping axes over one year **SHOULD** complete within two seconds
+at the 95th percentile on a reference environment.
 
-**Threshold**: 2 seconds at the 95th percentile, up to four breakdowns, one year of data.
+**Threshold**: p95 ≤ 2 seconds. Reference data volume and workload remain to be defined;
+this is a target, not a measured guarantee.
 
-**Rationale**: building a chart is a back-and-forth; waiting breaks it.
+**Rationale**: query composition requires responsive feedback.
 
-#### A promise that does not shift
+#### Published contract
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-contract`
 
-What can be asked and what comes back **MUST** be published in a form other software can
-check against, and anything unrecognised in a question **MUST** be rejected rather than
-ignored.
+Request and response formats **MUST** have a machine-readable contract. Unknown request
+members **MUST** be rejected rather than ignored.
 
-**Threshold**: the published description accepts exactly what the product accepts; any
-divergence stops the build.
+**Threshold**: contract drift checks fail on divergence between published and generated schemas.
 
-**Rationale**: a page built against the description must not disagree with the product.
+**Rationale**: clients need a consistent request and response structure. Semantic constraints
+remain subject to runtime validation.
 
-#### People's data stays handled as people's data
+#### Personal-data handling
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-person-data`
 
-Columns that identify a person **MUST** be shown only to those the access rules allow, and
-**MUST NOT** be copied or stored anywhere by this part of the product. Keeping and deleting
-that data stays where it already happens.
+Personal fields **MUST** be restricted to authorized callers. The engine **MUST NOT** persist
+query result data; retention and deletion remain with the source systems.
 
-**Threshold**: nothing stored here; person columns marked as such where data sets are
-described.
+**Threshold**: no engine-owned result store. Dataset personal-field classification and
+fine-grained policies are planned; the initial implementation uses the administrator gate.
 
-**Rationale**: no second copy of people's activity with a life of its own.
+**Rationale**: query execution must not create an independently retained copy of activity data.
 
 ### 6.2 NFR Exclusions
 
-- **Working offline**: it reads live data; there is nothing to work from offline.
-- **Storing anything reliably**: it stores nothing until saved questions arrive.
-- **Signing in**: handled before a question reaches it.
-- **Uptime and recovery targets**: inherited from the service it lives in; it holds no data
-  of its own to recover.
-- **Accessibility, translation, phones**: the page is administrator-only today and follows
-  the product's usual standards; revisited when leads get access.
-- **Certifications**: none beyond the product's own.
-- **Monitoring**: speed and failures are recorded with the rest of the service; nothing
-  special is needed here.
+- **Offline operation**: queries require warehouse access.
+- **Durable engine storage**: absent until saved queries are implemented.
+- **Authentication, availability, and recovery**: inherited from the hosting service.
+- **Accessibility, localization, and device support**: owned by consuming clients under product standards.
+- **Additional certifications**: no module-specific requirements.
+- **Monitoring**: uses service query-latency and error metrics.
 
 ## 7. Public Library Interfaces
 
 ### 7.1 Public API Surface
 
-#### The question and answer format
+#### Query contract
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-interface-query`
 
-**Type**: the published request and answer format of the analytics API
+**Type**: published analytics request and response format.
 
-**Stability**: still changing while administrator-only; settles when access rules arrive
+**Stability**: experimental while administrator-only.
 
-**Description**: the one way to ask a data set a question, and to find out what can be asked.
+**Description**: structured queries and typed tabular results; discovery reports query limits.
 
-**Breaking Change Policy**: anything already accepted keeps its meaning; new options are
-added, never substituted.
+**Breaking Change Policy**: accepted operations retain their meaning; extensions are additive.
 
 ### 7.2 External Integration Contracts
 
-#### Who is asking
+#### Caller context (planned)
 
 - [ ] `p2` - **ID**: `cpt-insightspec-qe-contract-caller-context`
 
-**Direction**: required from the identity service
+**Direction**: required from identity.
 
-**Protocol/Format**: the asker's permissions, the people they may see, the teams they belong
-to, resolved for each question
+**Protocol/Format**: caller permissions, visible people, and team membership resolved per query.
 
-**Compatibility**: if a fact an access rule needs is missing, the question is refused — never
-answered more widely.
+**Compatibility**: missing attributes required by a policy cause rejection, not broader access.
 
 ## 8. Use Cases
 
-#### Build a chart nobody planned for
+#### Build a query-backed chart
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-usecase-build-chart`
 
 **Actor**: `cpt-insightspec-qe-actor-admin`
 
-**Preconditions**:
-- The person is an administrator; data sets are available.
+**Preconditions**: administrator access and an available dataset.
 
 **Main Flow**:
-1. The page lists the data sets and, for the chosen one, what can be broken down, filtered
-   and counted.
-2. The administrator picks dates, breakdowns, what to count, any filters, and asks.
-3. The product either points at what is wrong, or returns a table with readable names and a
-   note if it was cut short.
-4. The page draws the table and a chart from that answer alone.
 
-**Postconditions**:
-- A chart exists that nobody built into the product.
+1. The client presents dataset fields and query limits.
+2. The administrator selects a time window, grouping, aggregates, and filters.
+3. The engine returns a typed result or validation errors.
+4. The client renders the result and its truncation status.
 
-**Alternative Flows**:
-- **Something is wrong**: each problem is shown next to the box it belongs to; nothing is
-  answered.
-- **Too many rows**: the answer is cut and says so.
+**Postconditions**: a chart uses a query without a pre-built metric.
 
-#### Decide for yourself what counts as test code
+**Alternative Flows**: invalid inputs are identified; truncated results are labelled.
+
+#### Conditional aggregation
 
 - [x] `p1` - **ID**: `cpt-insightspec-qe-usecase-own-category`
 
 **Actor**: `cpt-insightspec-qe-actor-author`
 
-**Preconditions**:
-- File changes can be filtered by path.
+**Preconditions**: administrator access and a dataset with a path dimension and line measurable.
 
 **Main Flow**:
-1. The author adds a second column counting only the changes whose path matches their own
-   pattern.
-2. The product checks the pattern makes sense and counts only those rows.
 
-**Postconditions**:
-- One table shows the matching lines beside the total, per file type, using the author's own
-  definition.
+1. The author requests total lines and lines matching a path pattern, grouped by file type.
+2. The engine validates the pattern and computes both aggregates.
 
-**Alternative Flows**:
-- **The pattern is not valid**: the answer is refused, pointing at the pattern.
+**Postconditions**: results compare a caller-defined category with the total.
 
-#### A lead sees only their own team
+**Alternative Flows**: invalid patterns produce a field violation.
+
+#### Team-scoped query (planned)
 
 - [ ] `p2` - **ID**: `cpt-insightspec-qe-usecase-lead-visibility`
 
 **Actor**: `cpt-insightspec-qe-actor-lead`
 
-**Preconditions**:
-- The data set has an access rule tying it to the people the asker may see.
+**Preconditions**: an enforced dataset policy identifies the caller's visible people.
 
 **Main Flow**:
-1. The lead opens a saved chart broken down by repository.
-2. The product applies the rule before counting anything, so only their people are included.
 
-**Postconditions**:
-- The same saved chart is correct for two different leads, and different for each.
+1. The lead opens a saved query grouped by repository.
+2. The engine restricts rows to authorized people before aggregation.
 
-**Alternative Flows**:
-- **The product cannot tell who the lead may see**: the question is refused, not widened.
+**Postconditions**: results respect the caller's visibility regardless of grouping.
+
+**Alternative Flows**: missing visibility context causes rejection.
 
 ## 9. Acceptance Criteria
 
-- [x] An administrator answers a question about each available data set from the page, with
-  nothing built in advance.
-- [x] Answers that must agree do agree on a test installation: the weeks add up to the whole
-  period; filtering to one value matches what the breakdown showed for it; a pattern matches
-  what the exact values match.
-- [x] Someone who is not an administrator is refused, both the questions and the list.
-- [x] Every refusal names the part of the question that is wrong.
-- [ ] A saved question is refused after the data behind it changes shape, instead of
-  answering something different.
-- [ ] A lead's answer includes only people they may see, however the chart is broken down.
+- [x] Administrators can query declared datasets without pre-built metrics.
+- [x] Automated reconciliation cases cover equivalent grouping and filtering operations.
+- [x] Non-administrators are denied query execution and discovery.
+- [x] Semantic validation errors identify invalid request fields.
+- [ ] Saved queries reject incompatible dataset changes.
+- [ ] Team-lead queries enforce row visibility independently of grouping.
+
+The initial delivery provides the API. The chart-builder workflow also requires the planned
+constructor client; completed API requirements do not establish end-to-end UI delivery.
 
 ## 10. Dependencies
 
-| Dependency | Description | Criticality |
-|------------|-------------|-------------|
-| Prepared data sets | the ready-to-query tables, built with the counting rules already applied | p1 |
-| Record of what the warehouse holds | checked when the product is built, so a data set cannot promise a column that is not there | p1 |
-| Identity service | says who is an administrator today; who may see whom, later | p1 |
-| Published API description | what the page and the automated tests are built from | p1 |
+| Dependency | Purpose | Criticality |
+|---|---|---|
+| Dataset registry | Validated declarations and prepared-data semantics | p1 |
+| Schema catalog | Snapshot metadata used by dataset validation | p1 |
+| Identity service | Administrator checks; planned visibility context | p1 |
+| Published API contract | Client integration and schema drift checks | p1 |
 
 ## 11. Assumptions
 
-- The product ships the first data sets; people add their own later, and both kinds are
-  checked and treated the same way.
-- Administrators may see everything in their own organisation; the restriction is for
-  everyone else.
-- The test installation contains data for every data set, so the checks mean something.
-- Cost depends on the dates and row limit rather than on how large the customer is; those
-  limits are the lever if an installation outgrows them.
+- Shipped datasets provide prepared data; tenant-defined datasets are a later extension.
+- Administrators may query their session's tenant under the initial access model.
+- Reconciliation fixtures cover each supported dataset and the semantics being compared.
+- Query cost depends on data volume, selectivity, and grouping cardinality as well as dates
+  and result limits. Limits alone do not establish latency guarantees.
 
 **Open questions**
 
 | Question | Owner | Resolve by |
 |---|---|---|
-| Where do we record which teams own which repositories? | product + backend | before the first access rule |
-| What protects small groups from being singled out once leads can ask? | product | before the page opens to leads |
-| Which data sets come after commits and file changes, in what order? | product | after the constructor page |
-| Who may add a data set, and what does approval look like when an assistant wrote it? | product | when own data sets start |
-| Is "show me the records behind this number" part of the same request or its own? | backend | when that work starts |
+| Where are team-to-resource mappings defined? | product + backend | before access policies |
+| What replaces minimum-peer suppression for broader access? | product | before team-lead access |
+| What reference volume and workload define the latency target? | backend | before latency acceptance |
+| What nesting limit applies to Boolean groups? | backend | before Boolean filters |
+| Which datasets follow commits and file changes? | product | after constructor workflows |
+| Who may create datasets, and what must approvers review? | product | before tenant-defined datasets |
+| Is drilldown a query mode or a separate operation? | backend | before drilldown |
 
 ## 12. Risks
 
 | Risk | Impact | Mitigation |
-|------|--------|------------|
-| What people want to ask outpaces what we support | they go back to asking engineers, or to SQL | the list in DESIGN is the backlog, in priority order; the SQL console stays for administrators |
-| Access rules take longer than expected | charts stay administrator-only | access rules are the first thing after the basics; the restriction is deliberate, not a default |
-| A very broad question is slow on a large customer | exploring becomes painful | limits on dates, rows, size and how many run at once; the "cut short" note tells the asker to narrow it |
-| The data behind a saved question changes shape | wrong answers or errors | data sets are checked when the product is built; saved questions are re-checked each time they are opened |
-| Someone's own data set is wrong, slow or too revealing | bad numbers spread, or data leaks past its audience | the same checks and limits as a shipped data set; usable by its author alone until an administrator approves it and its access rules are set |
+|---|---|---|
+| Unsupported query operations | Continued dependence on pre-built metrics or SQL | Explicit capability roadmap; retain existing APIs |
+| Delayed access policies | Team leads cannot use the engine | Keep administrator restriction until enforcement is available |
+| Broad or high-cardinality queries | Slow execution or resource exhaustion | Input, byte, timeout, and concurrency limits |
+| Dataset schema changes | Invalid saved queries | Planned revalidation; document snapshot limits |
+| Invalid tenant-defined datasets | Incorrect results or unintended access | Shared validation and limits; planned approval and policies |
+
+**Revision 1.3**: clarified query terminology, initial delivery, planned capabilities,
+validation boundaries, and unresolved requirements.

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "opentelemetry",
  "p256 0.14.0",
  "redis",
+ "regex-lite",
  "reqwest 0.12.28",
  "rmcp",
  "rust_xlsxwriter",

--- a/src/backend/services/analytics/Cargo.toml
+++ b/src/backend/services/analytics/Cargo.toml
@@ -56,6 +56,7 @@ redis = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
+regex-lite = { workspace = true }
 serde_yaml = { workspace = true }
 schemars = { workspace = true }
 url = { workspace = true }

--- a/src/backend/services/analytics/src/api/error.rs
+++ b/src/backend/services/analytics/src/api/error.rs
@@ -14,6 +14,11 @@ use toolkit_canonical_errors::resource_error;
 #[resource_error("gts.cf.insight.analytics_api.metric.v1~")]
 pub struct MetricError;
 
+/// Resource namespace for `/v1/query` (the query contract over declared
+/// datasets). Every refusal is an `invalid_argument` naming the request field.
+#[resource_error("gts.cf.insight.analytics_api.query.v1~")]
+pub struct QueryError;
+
 /// Resource namespace for `/v1/datasets*` (what a query may be built over). A
 /// key this build declares no dataset for is a `not_found`, not a refused
 /// request.

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -11,6 +11,7 @@ mod metric_drilldown;
 mod metric_results;
 mod metrics;
 mod person_names;
+mod query;
 mod reports;
 mod saved_queries;
 pub(crate) mod usage;
@@ -488,6 +489,33 @@ pub(crate) fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) ->
         )
         .standard_errors(openapi)
         .handler(ai::explain::explain_metric)
+        .register(router, openapi);
+
+    // The query surface: one query contract over the declared datasets. Tenancy
+    // binds from the session, so the body names no tenant and every refusal is
+    // a field-named `invalid_argument`. Admin-only until the datasets declare
+    // an entity policy: they carry person columns.
+    router = OperationBuilder::post("/v1/query")
+        .operation_id("analytics_api.query.create")
+        .summary("Answer a query over a declared dataset")
+        .authenticated()
+        .no_license_required()
+        .json_request::<crate::domain::query::contract::dto::QueryRequest>(
+            openapi,
+            "The question to answer",
+        )
+        .json_response_with_schema::<crate::domain::query::contract::dto::QueryAnswer>(
+            openapi,
+            StatusCode::OK,
+            "A typed table",
+        )
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_415(openapi)
+        .error_429(openapi)
+        .error_500(openapi)
+        .handler(query::query)
         .register(router, openapi);
 
     // What a query may be built over. Read-only over the declarations loaded at

--- a/src/backend/services/analytics/src/api/openapi_tests.rs
+++ b/src/backend/services/analytics/src/api/openapi_tests.rs
@@ -52,6 +52,7 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
         "/v1/queries",
         "/v1/queries/{id}",
         "/v1/queries/{id}/run",
+        "/v1/query",
         "/v1/usage/config",
         "/v1/usage/events",
         "/v1/usage/summary",
@@ -60,7 +61,7 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
     }
     assert_eq!(
         paths.len(),
-        28,
+        29,
         "the contract must carry exactly the surviving paths, got {:?}",
         paths.keys().collect::<Vec<_>>()
     );

--- a/src/backend/services/analytics/src/api/query.rs
+++ b/src/backend/services/analytics/src/api/query.rs
@@ -1,0 +1,176 @@
+//! `POST /v1/query` — one query contract over the declared datasets.
+
+use std::sync::{Arc, LazyLock};
+use std::time::Duration;
+
+use axum::Json;
+use axum::extract::Extension;
+use axum::http::HeaderMap;
+use tokio::sync::{Semaphore, SemaphorePermit};
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::SecurityContext;
+
+use super::error::QueryError;
+use super::{ADMIN_ONLY, AppState, require_admin};
+use crate::domain::query::compile::params::QueryParam;
+use crate::domain::query::compile::{self, CompiledQuery};
+use crate::domain::query::contract::dto::{QueryAnswer, QueryRequest};
+use crate::domain::query::validation::PlanError;
+use crate::domain::query::violation::Violation;
+use crate::domain::query::{answer, validation};
+use crate::infra::metrics::QueryKind;
+use crate::infra::query::{BoundedFetchError, MAX_ANSWER_BYTES, fetch_bound_rows};
+
+const MAX_CONCURRENT_QUERIES: usize = 8;
+const ACQUIRE_TIMEOUT: Duration = Duration::from_secs(2);
+static QUERY_SEMAPHORE: LazyLock<Semaphore> =
+    LazyLock::new(|| Semaphore::new(MAX_CONCURRENT_QUERIES));
+
+// SAFETY: the datasets carry person columns and declare no entity policy yet,
+// so the whole surface is administrative until one does.
+pub async fn query(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    headers: HeaderMap,
+    Json(request): Json<QueryRequest>,
+) -> Result<Json<QueryAnswer>, CanonicalError> {
+    require_admin(&state, &headers, admin_only).await?;
+
+    let plan = validation::plan(&request).map_err(no_plan)?;
+
+    // INVARIANT: the scan's tenancy binds from the session, never from the query.
+    let tenant_id = ctx.subject_tenant_id().to_string();
+    let CompiledQuery { sql, params } = compile::compile(&plan, &tenant_id);
+    let bindings: Vec<serde_json::Value> = params.iter().map(QueryParam::binding).collect();
+    let comment = format!("query:{}", plan.dataset.key);
+
+    // INVARIANT: the permit is held across the fetch on purpose — it is the
+    // per-process cap on scans in flight — and released before assembly,
+    // which touches no connection.
+    let permit = acquire_permit().await?;
+    let returned = fetch_bound_rows(&state.ch, &sql, &bindings, QueryKind::Query, &comment)
+        .await
+        .map_err(|error| unanswered(&error, &comment))?;
+    drop(permit);
+
+    let answer = answer::assemble(&plan, returned).map_err(|error| {
+        tracing::error!(error = %error, comment, "query answer assembly failed");
+        CanonicalError::internal("failed to answer the query").create()
+    })?;
+
+    Ok(Json(answer))
+}
+
+fn unanswered(error: &BoundedFetchError, comment: &str) -> CanonicalError {
+    match error {
+        BoundedFetchError::TooLarge => QueryError::invalid_argument()
+            .with_field_violation(
+                "limit",
+                format!(
+                    "the answer exceeded {MAX_ANSWER_BYTES} bytes; lower the limit or narrow the query"
+                ),
+                "OUT_OF_RANGE",
+            )
+            .create(),
+        BoundedFetchError::Fetch(error) => {
+            tracing::error!(error = %error, comment, "query failed");
+            CanonicalError::internal("failed to answer the query").create()
+        }
+    }
+}
+
+async fn acquire_permit() -> Result<SemaphorePermit<'static>, CanonicalError> {
+    tokio::time::timeout(ACQUIRE_TIMEOUT, QUERY_SEMAPHORE.acquire())
+        .await
+        .map_err(|_| {
+            tracing::warn!(
+                capacity = MAX_CONCURRENT_QUERIES,
+                available = QUERY_SEMAPHORE.available_permits(),
+                "query capacity exhausted"
+            );
+            busy()
+        })?
+        .map_err(|_| busy())
+}
+
+fn busy() -> CanonicalError {
+    QueryError::resource_exhausted("query capacity is busy")
+        .with_quota_violation("queries", "concurrency limit reached")
+        .with_quota_violation_retry_after_seconds(ACQUIRE_TIMEOUT.as_secs())
+        .create()
+}
+
+fn admin_only() -> CanonicalError {
+    QueryError::permission_denied()
+        .with_reason(ADMIN_ONLY)
+        .create()
+}
+
+fn no_plan(error: PlanError) -> CanonicalError {
+    match error {
+        PlanError::Refused(violations) => refused(&violations),
+        PlanError::DeclarationsUnusable(error) => {
+            tracing::error!(error = %error, "the shipped dataset declarations are unusable");
+            CanonicalError::internal("failed to answer the query").create()
+        }
+    }
+}
+
+// INVARIANT: the refusal path is reached only with at least one violation, which
+// the builder needs to open a field-violation envelope.
+fn refused(violations: &[Violation]) -> CanonicalError {
+    let Some((first, rest)) = violations.split_first() else {
+        return CanonicalError::internal("a query was refused without a reason").create();
+    };
+
+    let mut refusal = QueryError::invalid_argument().with_field_violation(
+        &first.field,
+        &first.detail,
+        first.reason.as_code(),
+    );
+    for violation in rest {
+        refusal = refusal.with_field_violation(
+            &violation.field,
+            &violation.detail,
+            violation.reason.as_code(),
+        );
+    }
+
+    refusal.create()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use toolkit_canonical_errors::Problem;
+
+    use super::*;
+    use crate::domain::query::violation::Reason;
+
+    #[test]
+    fn a_refusal_reports_every_violation_with_its_field_and_machine_code() {
+        let problem = Problem::from(refused(&[
+            Violation::new(
+                "limit",
+                Reason::OutOfRange,
+                "an answer carries at most 10000 rows",
+            ),
+            Violation::unknown("group_by[0].field", "branch", &["repository"]),
+        ]));
+        let problem = serde_json::to_value(problem).expect("the envelope serializes");
+
+        assert_eq!(problem["status"], 400);
+        assert_eq!(
+            problem["context"]["resource_type"],
+            "gts.cf.insight.analytics_api.query.v1~"
+        );
+        let violations = problem["context"]["field_violations"]
+            .as_array()
+            .expect("field_violations is an array");
+        assert_eq!(violations.len(), 2);
+        assert_eq!(violations[0]["field"], "limit");
+        assert_eq!(violations[0]["reason"], "OUT_OF_RANGE");
+        assert_eq!(violations[1]["field"], "group_by[0].field");
+        assert_eq!(violations[1]["reason"], "UNKNOWN");
+    }
+}

--- a/src/backend/services/analytics/src/domain/datasets/declaration.rs
+++ b/src/backend/services/analytics/src/domain/datasets/declaration.rs
@@ -108,10 +108,6 @@ pub struct Measurable {
     pub field: String,
 }
 
-#[expect(
-    dead_code,
-    reason = "the query engine reads the registry through these; this crate only declares them until it lands"
-)]
 impl Dataset {
     pub fn dimension(&self, field: &str) -> Option<&Dimension> {
         self.dimensions

--- a/src/backend/services/analytics/src/domain/datasets/describe.rs
+++ b/src/backend/services/analytics/src/domain/datasets/describe.rs
@@ -6,6 +6,11 @@
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use crate::domain::query::contract::dto::{
+    DEFAULT_ROW_LIMIT, MAX_AGGREGATES, MAX_FILTER_VALUES, MAX_FILTERS, MAX_GROUP_AXES,
+    MAX_NAME_CHARS, MAX_ORDER_TERMS, MAX_ROW_LIMIT,
+};
+
 use super::declaration::{Dataset, Dimension, Measurable, TimeField};
 use crate::domain::datasets::label_column_name;
 
@@ -25,6 +30,8 @@ pub struct DatasetDescription {
     pub dimensions: Vec<DimensionDescription>,
     /// The columns an aggregate may fold.
     pub measurables: Vec<MeasurableDescription>,
+    /// The bounds a request against this dataset must stay inside.
+    pub limits: QueryLimits,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
@@ -54,12 +61,45 @@ pub struct MeasurableDescription {
     pub field: String,
 }
 
+/// The contract's request bounds, identical for every dataset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[schema(as = QueryLimits)]
+pub struct QueryLimits {
+    pub max_filters: usize,
+    pub max_filter_values: usize,
+    pub max_aggregates: usize,
+    pub max_group_axes: usize,
+    pub max_order_terms: usize,
+    /// Longest an aggregate's name may be, in characters.
+    pub max_name_chars: usize,
+    /// Rows a query gets when it sets no ceiling of its own.
+    pub default_limit: u32,
+    /// Rows a query may ask for at most; over it the query is refused, not clipped.
+    pub max_limit: u32,
+}
+
+impl QueryLimits {
+    const fn contract() -> Self {
+        Self {
+            max_filters: MAX_FILTERS,
+            max_filter_values: MAX_FILTER_VALUES,
+            max_aggregates: MAX_AGGREGATES,
+            max_group_axes: MAX_GROUP_AXES,
+            max_order_terms: MAX_ORDER_TERMS,
+            max_name_chars: MAX_NAME_CHARS,
+            default_limit: DEFAULT_ROW_LIMIT,
+            max_limit: MAX_ROW_LIMIT,
+        }
+    }
+}
+
 pub fn describe(dataset: &Dataset) -> DatasetDescription {
     DatasetDescription {
         key: dataset.key.to_string(),
         time_fields: dataset.time_fields.iter().map(time_field).collect(),
         dimensions: dataset.dimensions.iter().map(dimension).collect(),
         measurables: dataset.measurables.iter().map(measurable).collect(),
+        limits: QueryLimits::contract(),
     }
 }
 
@@ -203,6 +243,20 @@ mod tests {
                 "the description leaks `{internal}`: {json}"
             );
         }
+    }
+
+    #[test]
+    fn the_limits_a_dataset_reports_are_the_ones_validation_enforces() {
+        let limits = description("git_commits").limits;
+
+        assert_eq!(limits.max_filters, MAX_FILTERS);
+        assert_eq!(limits.max_filter_values, MAX_FILTER_VALUES);
+        assert_eq!(limits.max_aggregates, MAX_AGGREGATES);
+        assert_eq!(limits.max_group_axes, MAX_GROUP_AXES);
+        assert_eq!(limits.max_order_terms, MAX_ORDER_TERMS);
+        assert_eq!(limits.max_name_chars, MAX_NAME_CHARS);
+        assert_eq!(limits.default_limit, DEFAULT_ROW_LIMIT);
+        assert_eq!(limits.max_limit, MAX_ROW_LIMIT);
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/datasets/mod.rs
+++ b/src/backend/services/analytics/src/domain/datasets/mod.rs
@@ -43,6 +43,18 @@ pub fn dataset(key: &str) -> Option<&'static Dataset> {
 }
 
 /// Every key a query may name, in declaration order.
+/// Every key a query may name, in declaration order.
+pub fn declared_keys() -> Vec<&'static str> {
+    product_datasets()
+        .map(|datasets| {
+            datasets
+                .iter()
+                .map(|dataset| dataset.key.as_str())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn load(documents: &[&str]) -> Result<Vec<Dataset>, DeclarationError> {
     let catalog =
         product_catalog().map_err(|error| DeclarationError::Document(error.to_string()))?;

--- a/src/backend/services/analytics/src/domain/mod.rs
+++ b/src/backend/services/analytics/src/domain/mod.rs
@@ -12,6 +12,7 @@ pub mod metric_drilldown;
 pub mod metric_key;
 pub mod metric_results;
 pub(crate) mod person_visibility;
+pub mod query;
 pub mod query_gate;
 pub mod reports;
 pub mod saved_query;

--- a/src/backend/services/analytics/src/domain/query/answer.rs
+++ b/src/backend/services/analytics/src/domain/query/answer.rs
@@ -1,0 +1,210 @@
+//! Turns what the warehouse returned into the answer's typed table.
+//!
+//! INVARIANT: the statement aliases every column by position, so the decode is
+//! a lookup by alias and never a guess.
+
+use serde_json::{Map, Value};
+
+use super::contract::dto::{AnswerFlags, QueryAnswer};
+use super::plan::{QueryPlan, column_alias};
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AnswerError {
+    #[error("a returned row is not an object")]
+    RowShape,
+    #[error("a returned row reports no `{alias}` for column `{column}`")]
+    ColumnMissing { alias: String, column: String },
+}
+
+// INVARIANT: the statement asked for one row over the limit; a returned set
+// larger than the limit is the truncation signal, and the extra row is dropped.
+pub fn assemble(plan: &QueryPlan<'_>, returned: Vec<Value>) -> Result<QueryAnswer, AnswerError> {
+    let aliases: Vec<String> = (0..plan.columns.len()).map(column_alias).collect();
+    let limit = plan.limit as usize;
+    let truncated = returned.len() > limit;
+
+    let mut rows = Vec::with_capacity(returned.len().min(limit));
+    for row in returned.into_iter().take(limit) {
+        let Value::Object(row) = row else {
+            return Err(AnswerError::RowShape);
+        };
+        rows.push(decode_row(plan, &aliases, &row)?);
+    }
+
+    Ok(QueryAnswer {
+        columns: plan
+            .columns
+            .iter()
+            .map(|column| column.answer.clone())
+            .collect(),
+        rows,
+        flags: AnswerFlags { truncated },
+    })
+}
+
+fn decode_row(
+    plan: &QueryPlan<'_>,
+    aliases: &[String],
+    row: &Map<String, Value>,
+) -> Result<Vec<Value>, AnswerError> {
+    let mut values = Vec::with_capacity(aliases.len());
+    for (alias, column) in aliases.iter().zip(&plan.columns) {
+        let value = row
+            .get(alias)
+            .ok_or_else(|| AnswerError::ColumnMissing {
+                alias: alias.clone(),
+                column: column.answer.name.clone(),
+            })?
+            .clone();
+
+        // INVARIANT: a grouped column is never NULL; an aggregate may be, and
+        // NULL is the answer rather than a zero to fill in.
+        values.push(value);
+    }
+
+    Ok(values)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::query::contract::dto::{ColumnKind, ColumnType};
+    use crate::domain::query::fixtures;
+    use crate::domain::query::validation::plan_against;
+
+    const GROUPED: &str = r#"{
+      "dataset": "git_commits",
+      "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+      "aggregates": [{"name": "commits", "fn": "count"},
+                     {"name": "added", "fn": "sum", "field": "lines_added"}],
+      "time": {"from": "2026-01-01", "to": "2026-01-31", "grain": "week"},
+      "limit": 2
+    }"#;
+
+    fn returned(rows: &str) -> Vec<Value> {
+        serde_json::from_str(rows).expect("the fixture rows parse")
+    }
+
+    #[test]
+    fn an_answer_reports_its_columns_in_the_order_a_row_carries_them() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        let answer = assemble(
+            &plan,
+            returned(
+                r#"[{"c0": "example/app", "c1": "App", "c2": "2026-01-05", "c3": 12, "c4": 340},
+                    {"c0": "example/lib", "c1": "Lib", "c2": "2026-01-05", "c3": 3, "c4": null}]"#,
+            ),
+        )
+        .expect("the rows decode");
+
+        assert_eq!(
+            answer
+                .columns
+                .iter()
+                .map(|column| (column.name.as_str(), column.kind, column.value_type))
+                .collect::<Vec<_>>(),
+            vec![
+                ("repository", ColumnKind::Dimension, ColumnType::Text),
+                ("repository_label", ColumnKind::Label, ColumnType::Text),
+                ("time", ColumnKind::Bucket, ColumnType::Date),
+                ("commits", ColumnKind::Aggregate, ColumnType::Number),
+                ("added", ColumnKind::Aggregate, ColumnType::Number),
+            ]
+        );
+        assert_eq!(
+            answer.rows,
+            vec![
+                returned(r#"["example/app", "App", "2026-01-05", 12, 340]"#),
+                returned(r#"["example/lib", "Lib", "2026-01-05", 3, null]"#),
+            ]
+        );
+        assert!(!answer.flags.truncated);
+    }
+
+    #[test]
+    fn a_result_one_row_over_the_limit_is_reported_truncated_and_clipped_to_the_limit() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        let answer = assemble(
+            &plan,
+            returned(
+                r#"[{"c0": "a", "c1": "A", "c2": "2026-01-05", "c3": 1, "c4": 1},
+                    {"c0": "b", "c1": "B", "c2": "2026-01-05", "c3": 1, "c4": 1},
+                    {"c0": "c", "c1": "C", "c2": "2026-01-05", "c3": 1, "c4": 1}]"#,
+            ),
+        )
+        .expect("the rows decode");
+
+        assert!(answer.flags.truncated);
+        assert_eq!(answer.rows.len(), 2);
+    }
+
+    #[test]
+    fn a_fold_over_nothing_observed_stays_null_rather_than_becoming_zero() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        let answer = assemble(
+            &plan,
+            returned(
+                r#"[{"c0": "example/app", "c1": "App", "c2": "2026-01-05", "c3": 0, "c4": null}]"#,
+            ),
+        )
+        .expect("the rows decode");
+
+        assert_eq!(answer.rows[0][4], Value::Null);
+    }
+
+    #[test]
+    fn an_answer_over_no_rows_still_reports_its_columns() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        let answer = assemble(&plan, Vec::new()).expect("an empty result decodes");
+
+        assert_eq!(answer.columns.len(), 5);
+        assert!(answer.rows.is_empty());
+        assert!(!answer.flags.truncated);
+    }
+
+    #[test]
+    fn a_row_missing_a_column_the_statement_asked_for_is_an_error_not_a_hole() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        let error = assemble(
+            &plan,
+            returned(r#"[{"c0": "example/app", "c1": "App", "c2": "2026-01-05", "c3": 12}]"#),
+        )
+        .expect_err("the row is short");
+
+        assert_eq!(
+            error,
+            AnswerError::ColumnMissing {
+                alias: "c4".to_owned(),
+                column: "added".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_returned_value_that_is_not_a_row_is_an_error() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        assert_eq!(
+            assemble(&plan, returned("[42]")).expect_err("not a row"),
+            AnswerError::RowShape
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/aggregates.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/aggregates.rs
@@ -1,0 +1,143 @@
+//! The folds a query computes over each group.
+//!
+//! INVARIANT: a fold over nothing observed reports NULL, and `count` — the one
+//! fold whose zero is a real observation — reports 0.
+
+use crate::domain::query::plan::{FoldFn, PlannedAggregate, PlannedFold};
+
+use super::filters;
+use super::params::QueryParam;
+
+pub fn fold_expr(aggregate: &PlannedAggregate<'_>, params: &mut Vec<QueryParam>) -> String {
+    let (function, operand) = match &aggregate.fold {
+        PlannedFold::Rows => ("count", None),
+        PlannedFold::Values {
+            function,
+            measurable,
+        } => (function_name(*function), Some(measurable.field.as_str())),
+    };
+    // A count's zero is a real observation; every other fold saw nothing.
+    let empty = if operand.is_none() { "" } else { "OrNull" };
+
+    let Some(filter) = &aggregate.filter else {
+        return match operand {
+            None => format!("{function}{empty}()"),
+            Some(column) => format!("{function}{empty}({column})"),
+        };
+    };
+
+    // SAFETY: the collapse makes a row the filter is unknown of a definite
+    // non-match rather than a row that silently leaves the fold.
+    let condition = format!("coalesce({}, 0)", filters::render(filter, params));
+    match operand {
+        None => format!("{function}If{empty}({condition})"),
+        Some(column) => format!("{function}If{empty}({column}, {condition})"),
+    }
+}
+
+fn function_name(function: FoldFn) -> &'static str {
+    match function {
+        FoldFn::Sum => "sum",
+        FoldFn::Avg => "avg",
+        FoldFn::Min => "min",
+        FoldFn::Max => "max",
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::datasets::declaration::{Dimension, Measurable};
+    use crate::domain::query::contract::dto::ScalarDto;
+    use crate::domain::query::plan::{FilterTarget, PlannedFilter, PlannedTest};
+
+    fn measurable() -> Measurable {
+        Measurable {
+            field: "lines_added".to_owned(),
+        }
+    }
+
+    fn dimension() -> Dimension {
+        Dimension {
+            field: "source".to_owned(),
+            label_field: None,
+            absent_value: None,
+        }
+    }
+
+    fn on_github(dimension: &Dimension) -> PlannedFilter<'_> {
+        PlannedFilter {
+            target: FilterTarget::Dimension(dimension),
+            test: PlannedTest::Eq(ScalarDto::Text("github".to_owned())),
+        }
+    }
+
+    fn rendered(aggregate: &PlannedAggregate<'_>) -> (String, Vec<QueryParam>) {
+        let mut params = Vec::new();
+        let sql = fold_expr(aggregate, &mut params);
+        (sql, params)
+    }
+
+    fn fold<'d>(fold: PlannedFold<'d>, filter: Option<PlannedFilter<'d>>) -> PlannedAggregate<'d> {
+        PlannedAggregate {
+            index: 0,
+            name: "value".to_owned(),
+            fold,
+            filter,
+        }
+    }
+
+    fn values(function: FoldFn, measurable: &Measurable) -> PlannedFold<'_> {
+        PlannedFold::Values {
+            function,
+            measurable,
+        }
+    }
+
+    #[test]
+    fn every_fold_over_no_observation_reports_null_except_a_count() {
+        let measurable = measurable();
+        let cases = [
+            (PlannedFold::Rows, "count()"),
+            (values(FoldFn::Sum, &measurable), "sumOrNull(lines_added)"),
+            (values(FoldFn::Avg, &measurable), "avgOrNull(lines_added)"),
+            (values(FoldFn::Min, &measurable), "minOrNull(lines_added)"),
+            (values(FoldFn::Max, &measurable), "maxOrNull(lines_added)"),
+        ];
+
+        for (planned, expected) in cases {
+            let label = format!("{planned:?}");
+            let (sql, params) = rendered(&fold(planned, None));
+            assert_eq!(sql, expected, "{label}");
+            assert!(params.is_empty(), "{label}");
+        }
+    }
+
+    #[test]
+    fn a_conditional_fold_treats_an_unknown_condition_as_a_non_match() {
+        let dimension = dimension();
+        let measurable = measurable();
+
+        let (sql, params) = rendered(&fold(
+            values(FoldFn::Sum, &measurable),
+            Some(on_github(&dimension)),
+        ));
+
+        assert_eq!(
+            sql,
+            "sumIfOrNull(lines_added, coalesce(toString(source) = ?, 0))"
+        );
+        assert_eq!(params, vec![QueryParam::Text("github".to_owned())]);
+        assert_eq!(sql.matches('?').count(), params.len());
+    }
+
+    #[test]
+    fn a_conditional_count_folds_rows_and_reads_no_column() {
+        let dimension = dimension();
+
+        let (sql, _) = rendered(&fold(PlannedFold::Rows, Some(on_github(&dimension))));
+
+        assert_eq!(sql, "countIf(coalesce(toString(source) = ?, 0))");
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/filters.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/filters.rs
@@ -1,0 +1,224 @@
+//! Renders one filter into a predicate and the values it binds.
+
+use crate::domain::query::contract::dto::ScalarDto;
+use crate::domain::query::plan::{CompareOp, FilterTarget, PlannedFilter, PlannedTest};
+
+use super::group::dimension_expr;
+use super::params::{QueryParam, placeholders};
+
+pub fn render(filter: &PlannedFilter<'_>, params: &mut Vec<QueryParam>) -> String {
+    let mut bind = |scalar: &ScalarDto| params.push(bound(filter, scalar));
+
+    match &filter.test {
+        // SAFETY: reads the raw column — a dimension's sentinel would answer
+        // that the row always has a value.
+        PlannedTest::NotNull => format!("{} IS NOT NULL", raw_column(filter)),
+        PlannedTest::Eq(value) => {
+            bind(value);
+            format!("{} = ?", comparison_expr(filter))
+        }
+        PlannedTest::Compare(op, value) => {
+            bind(value);
+            format!("{} {} ?", comparison_expr(filter), operator(*op))
+        }
+        PlannedTest::In(values) => {
+            for value in values {
+                bind(value);
+            }
+            format!(
+                "{} IN ({})",
+                comparison_expr(filter),
+                placeholders(values.len())
+            )
+        }
+        PlannedTest::Between { low, high } => {
+            bind(low);
+            bind(high);
+            let expr = comparison_expr(filter);
+            format!("({expr} >= ? AND {expr} <= ?)")
+        }
+        PlannedTest::Like(pattern) => {
+            params.push(QueryParam::Text(pattern.clone()));
+            format!("{} LIKE ?", comparison_expr(filter))
+        }
+        PlannedTest::Matches(pattern) => {
+            params.push(QueryParam::Text(pattern.clone()));
+            format!("match({}, ?)", comparison_expr(filter))
+        }
+    }
+}
+
+fn comparison_expr(filter: &PlannedFilter<'_>) -> String {
+    match filter.target {
+        FilterTarget::Dimension(dimension) => dimension_expr(dimension),
+        FilterTarget::Measurable(measurable) => measurable.field.clone(),
+    }
+}
+
+fn raw_column<'f>(filter: &'f PlannedFilter<'_>) -> &'f str {
+    match filter.target {
+        FilterTarget::Dimension(dimension) => &dimension.field,
+        FilterTarget::Measurable(measurable) => &measurable.field,
+    }
+}
+
+fn bound(filter: &PlannedFilter<'_>, scalar: &ScalarDto) -> QueryParam {
+    match filter.target {
+        FilterTarget::Dimension(_) => QueryParam::text_of(scalar),
+        FilterTarget::Measurable(_) => QueryParam::number_of(scalar),
+    }
+}
+
+fn operator(op: CompareOp) -> &'static str {
+    match op {
+        CompareOp::Gt => ">",
+        CompareOp::Gte => ">=",
+        CompareOp::Lt => "<",
+        CompareOp::Lte => "<=",
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::datasets::declaration::{Dimension, Measurable};
+
+    fn dimension() -> Dimension {
+        Dimension {
+            field: "source_id".to_owned(),
+            label_field: None,
+            absent_value: Some("__unknown__".to_owned()),
+        }
+    }
+
+    fn measurable() -> Measurable {
+        Measurable {
+            field: "lines_added".to_owned(),
+        }
+    }
+
+    fn text(value: &str) -> ScalarDto {
+        ScalarDto::Text(value.to_owned())
+    }
+
+    fn number(raw: &str) -> ScalarDto {
+        ScalarDto::Number(raw.parse().expect("a JSON number"))
+    }
+
+    fn render_with(target: FilterTarget<'_>, test: PlannedTest) -> (String, Vec<QueryParam>) {
+        let filter = PlannedFilter { target, test };
+        let mut params = Vec::new();
+        let sql = render(&filter, &mut params);
+        (sql, params)
+    }
+
+    #[test]
+    fn every_test_over_a_measurable_reads_the_numeric_column() {
+        let measurable = measurable();
+        let cases = [
+            (PlannedTest::Eq(number("500")), "lines_added = ?", 1),
+            (
+                PlannedTest::Compare(CompareOp::Gt, number("500")),
+                "lines_added > ?",
+                1,
+            ),
+            (
+                PlannedTest::Compare(CompareOp::Gte, number("500")),
+                "lines_added >= ?",
+                1,
+            ),
+            (
+                PlannedTest::Compare(CompareOp::Lt, number("500")),
+                "lines_added < ?",
+                1,
+            ),
+            (
+                PlannedTest::Compare(CompareOp::Lte, number("500")),
+                "lines_added <= ?",
+                1,
+            ),
+            (
+                PlannedTest::In(vec![number("1"), number("2")]),
+                "lines_added IN (?, ?)",
+                2,
+            ),
+            (
+                PlannedTest::Between {
+                    low: number("1"),
+                    high: number("9"),
+                },
+                "(lines_added >= ? AND lines_added <= ?)",
+                2,
+            ),
+            (PlannedTest::NotNull, "lines_added IS NOT NULL", 0),
+        ];
+
+        for (test, expected, bound) in cases {
+            let label = format!("{test:?}");
+            let (sql, params) = render_with(FilterTarget::Measurable(&measurable), test);
+            assert_eq!(sql, expected, "{label}");
+            assert_eq!(params.len(), bound, "{label}");
+            assert_eq!(sql.matches('?').count(), params.len(), "{label}");
+        }
+    }
+
+    #[test]
+    fn a_dimension_filter_compares_against_the_value_the_answer_reports() {
+        let dimension = dimension();
+        let (sql, params) = render_with(
+            FilterTarget::Dimension(&dimension),
+            PlannedTest::Eq(text("__unknown__")),
+        );
+
+        assert_eq!(sql, "coalesce(toString(source_id), '__unknown__') = ?");
+        assert_eq!(params, vec![QueryParam::Text("__unknown__".to_owned())]);
+    }
+
+    #[test]
+    fn a_pattern_binds_as_text_against_the_value_the_answer_reports() {
+        let dimension = dimension();
+        let (like, like_params) = render_with(
+            FilterTarget::Dimension(&dimension),
+            PlannedTest::Like("src/%".to_owned()),
+        );
+        assert_eq!(like, "coalesce(toString(source_id), '__unknown__') LIKE ?");
+        assert_eq!(like_params, vec![QueryParam::Text("src/%".to_owned())]);
+
+        let (matches, match_params) = render_with(
+            FilterTarget::Dimension(&dimension),
+            PlannedTest::Matches("^a|b$".to_owned()),
+        );
+        assert_eq!(
+            matches,
+            "match(coalesce(toString(source_id), '__unknown__'), ?)"
+        );
+        assert_eq!(match_params, vec![QueryParam::Text("^a|b$".to_owned())]);
+    }
+
+    #[test]
+    fn not_null_over_a_dimension_asks_the_raw_column_the_sentinel_would_hide() {
+        let dimension = dimension();
+        let (sql, params) = render_with(FilterTarget::Dimension(&dimension), PlannedTest::NotNull);
+
+        assert_eq!(sql, "source_id IS NOT NULL");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn a_measurable_value_binds_as_a_number_and_a_dimension_value_as_text() {
+        let measurable = measurable();
+        let (_, numeric) = render_with(
+            FilterTarget::Measurable(&measurable),
+            PlannedTest::Compare(CompareOp::Gte, number("500")),
+        );
+        assert_eq!(numeric, vec![QueryParam::Int(500)]);
+
+        let dimension = dimension();
+        let (_, textual) = render_with(
+            FilterTarget::Dimension(&dimension),
+            PlannedTest::Eq(number("500")),
+        );
+        assert_eq!(textual, vec![QueryParam::Text("500".to_owned())]);
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/group.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/group.rs
@@ -1,0 +1,81 @@
+//! How a group axis becomes a column of the answer.
+//!
+//! INVARIANT: the answer and a filter both read a dimension's rendered value,
+//! never the raw column.
+
+use crate::domain::datasets::declaration::Dimension;
+use crate::domain::query::plan::{QueryPlan, column_alias};
+
+/// What the answer reports for one dimension; a group is never NULL.
+pub fn dimension_expr(dimension: &Dimension) -> String {
+    let value = format!("toString({})", dimension.field);
+    match &dimension.absent_value {
+        // SAFETY: the sentinel comes from the declaration, not from a caller.
+        Some(absent) => format!("coalesce({value}, '{}')", escape_literal(absent)),
+        None => value,
+    }
+}
+
+/// The declared label beside a dimension's value; one per group, so any row's.
+pub fn label_expr(dimension: &Dimension) -> String {
+    let label = dimension.label_field.as_deref().unwrap_or(&dimension.field);
+    format!("any({label})")
+}
+
+pub fn group_aliases(plan: &QueryPlan<'_>) -> Vec<String> {
+    plan.columns
+        .iter()
+        .enumerate()
+        .filter(|(_, column)| column.groups())
+        .map(|(index, _)| column_alias(index))
+        .collect()
+}
+
+fn escape_literal(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn dimension(absent_value: Option<&str>) -> Dimension {
+        Dimension {
+            field: "repository".to_owned(),
+            label_field: None,
+            absent_value: absent_value.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn a_dimension_over_a_non_nullable_column_reports_the_column_as_text() {
+        assert_eq!(dimension_expr(&dimension(None)), "toString(repository)");
+    }
+
+    #[test]
+    fn a_nullable_dimension_reports_its_absent_rows_under_the_declared_value() {
+        assert_eq!(
+            dimension_expr(&dimension(Some("__unknown__"))),
+            "coalesce(toString(repository), '__unknown__')"
+        );
+    }
+
+    #[test]
+    fn a_label_column_reads_the_declared_label_field() {
+        let dimension = Dimension {
+            field: "repository".to_owned(),
+            label_field: Some("repository_label".to_owned()),
+            absent_value: None,
+        };
+        assert_eq!(label_expr(&dimension), "any(repository_label)");
+    }
+
+    #[test]
+    fn a_quote_in_a_declared_value_cannot_end_the_literal() {
+        assert_eq!(
+            dimension_expr(&dimension(Some("it's"))),
+            r"coalesce(toString(repository), 'it\'s')"
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/mod.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/mod.rs
@@ -1,0 +1,493 @@
+//! Turns a plan into one bounded ClickHouse statement and the values to bind
+//! against it. Nothing here touches a connection.
+//!
+//! SAFETY: only engine-owned strings reach the statement text; every
+//! caller-supplied value binds.
+
+pub mod aggregates;
+pub mod filters;
+pub mod group;
+pub mod order;
+pub mod params;
+pub mod scan;
+pub mod time;
+
+use std::fmt::Write;
+
+use super::plan::{ColumnSource, QueryPlan, column_alias};
+
+use params::QueryParam;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompiledQuery {
+    pub sql: String,
+    pub params: Vec<QueryParam>,
+}
+
+// INVARIANT: placeholders bind by position — folds, then scope predicates,
+// then the row ceiling. The ceiling is one over the limit: the extra row is
+// how the answer knows it was truncated, and assembly drops it.
+pub fn compile(plan: &QueryPlan<'_>, tenant_id: &str) -> CompiledQuery {
+    let mut params = Vec::new();
+
+    let selects = select_terms(plan, &mut params);
+    let predicates = scan::predicates(plan, tenant_id, &mut params);
+    params.push(QueryParam::UInt(u64::from(plan.limit) + 1));
+
+    let mut sql = String::from("SELECT\n");
+    let _ = writeln!(sql, "    {}", selects.join(",\n    "));
+    let _ = writeln!(sql, "FROM {}", scan::from_clause(plan));
+    let _ = writeln!(sql, "WHERE {}", predicates.join("\n  AND "));
+
+    let group_aliases = group::group_aliases(plan);
+    if !group_aliases.is_empty() {
+        let _ = writeln!(sql, "GROUP BY {}", group_aliases.join(", "));
+    }
+
+    let order_terms = order::terms(plan);
+    if !order_terms.is_empty() {
+        let _ = writeln!(sql, "ORDER BY {}", order_terms.join(", "));
+    }
+    let _ = write!(sql, "LIMIT ?");
+
+    CompiledQuery { sql, params }
+}
+
+fn select_terms(plan: &QueryPlan<'_>, params: &mut Vec<QueryParam>) -> Vec<String> {
+    plan.columns
+        .iter()
+        .enumerate()
+        .map(|(index, column)| {
+            let expr = match column.source {
+                ColumnSource::Dimension(dimension) => group::dimension_expr(dimension),
+                ColumnSource::Label(dimension) => group::label_expr(dimension),
+                // INVARIANT: validation admits a time axis only beside a grain.
+                ColumnSource::Bucket => plan
+                    .time
+                    .grain
+                    .map(|grain| time::bucket_expr(plan.time.field, grain))
+                    .unwrap_or_default(),
+                ColumnSource::Aggregate(position) => {
+                    aggregates::fold_expr(&plan.aggregates[position], params)
+                }
+            };
+            format!("{expr} AS {}", column_alias(index))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::datasets::declaration::Dataset;
+    use crate::domain::query::contract::dto::MAX_ROW_LIMIT;
+    use crate::domain::query::fixtures;
+    use crate::domain::query::validation::plan_against;
+
+    const TENANT: &str = "acme-tenant";
+
+    fn compiled(dataset: &Dataset, json: &str) -> CompiledQuery {
+        let request = fixtures::query(json);
+        let plan = plan_against(&request, dataset).expect("the query is admissible");
+        compile(&plan, TENANT)
+    }
+
+    fn text(value: &str) -> QueryParam {
+        QueryParam::Text(value.to_owned())
+    }
+
+    fn lines(expected: &[&str]) -> String {
+        expected.join("\n")
+    }
+
+    #[test]
+    fn a_grouped_bucketed_filtered_query_renders_one_bounded_scan() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            r#"{
+              "dataset": "git_commits",
+              "filters": [
+                {"field": "source", "op": "in", "values": ["github", "gitlab"]},
+                {"field": "lines_added", "op": "gte", "value": 500}
+              ],
+              "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+              "aggregates": [
+                {"name": "commits", "fn": "count"},
+                {"name": "added_on_default", "fn": "sum", "field": "lines_added",
+                 "filter": {"field": "branch_scope", "op": "eq", "value": "default"}}
+              ],
+              "time": {"from": "2026-01-01", "to": "2026-03-31", "grain": "week"},
+              "order": [{"by": "commits", "dir": "desc"}],
+              "limit": 100
+            }"#,
+        );
+
+        assert_eq!(
+            compiled.sql,
+            lines(&[
+                "SELECT",
+                "    toString(repository) AS c0,",
+                "    any(repository_label) AS c1,",
+                "    toStartOfWeek(toDate(authored_at, 'UTC'), 1) AS c2,",
+                "    count() AS c3,",
+                "    sumIfOrNull(lines_added, coalesce(toString(branch_scope) = ?, 0)) AS c4",
+                "FROM insight.git_commits",
+                "WHERE tenant_id = ?",
+                "  AND toDate(authored_at, 'UTC') >= toDate(?, 'UTC')",
+                "  AND toDate(authored_at, 'UTC') <= toDate(?, 'UTC')",
+                "  AND toString(source) IN (?, ?)",
+                "  AND lines_added >= ?",
+                "GROUP BY c0, c2",
+                "ORDER BY c3 DESC, c0 ASC, c2 ASC",
+                "LIMIT ?",
+            ])
+        );
+        assert_eq!(
+            compiled.params,
+            vec![
+                text("default"),
+                text(TENANT),
+                text("2026-01-01"),
+                text("2026-03-31"),
+                text("github"),
+                text("gitlab"),
+                QueryParam::Int(500),
+                QueryParam::UInt(101),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_query_grouping_by_nothing_folds_the_window_into_one_row() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert_eq!(
+            compiled.sql,
+            lines(&[
+                "SELECT",
+                "    count() AS c0",
+                "FROM insight.git_commits",
+                "WHERE tenant_id = ?",
+                "  AND toDate(authored_at, 'UTC') >= toDate(?, 'UTC')",
+                "  AND toDate(authored_at, 'UTC') <= toDate(?, 'UTC')",
+                "LIMIT ?",
+            ])
+        );
+    }
+
+    #[test]
+    fn every_grain_renders_its_own_bucket() {
+        let dataset = fixtures::commits();
+        let cases = [
+            ("day", "toDate(authored_at, 'UTC') AS c0"),
+            ("week", "toStartOfWeek(toDate(authored_at, 'UTC'), 1) AS c0"),
+            ("month", "toStartOfMonth(toDate(authored_at, 'UTC')) AS c0"),
+        ];
+
+        for (grain, expected) in cases {
+            let compiled = compiled(
+                &dataset,
+                &format!(
+                    r#"{{"dataset": "git_commits",
+                         "group_by": [{{"axis": "time"}}],
+                         "aggregates": [{{"name": "commits", "fn": "count"}}],
+                         "time": {{"from": "2026-01-01", "to": "2026-01-31", "grain": "{grain}"}}}}"#
+                ),
+            );
+            assert!(compiled.sql.contains(expected), "{grain}: {}", compiled.sql);
+        }
+    }
+
+    #[test]
+    fn every_fold_renders_the_function_its_empty_case_needs() {
+        let dataset = fixtures::commits();
+        let cases = [
+            ("count", None, "count() AS c0"),
+            ("sum", Some("lines_added"), "sumOrNull(lines_added) AS c0"),
+            ("avg", Some("lines_added"), "avgOrNull(lines_added) AS c0"),
+            (
+                "min",
+                Some("lines_removed"),
+                "minOrNull(lines_removed) AS c0",
+            ),
+            (
+                "max",
+                Some("lines_removed"),
+                "maxOrNull(lines_removed) AS c0",
+            ),
+        ];
+
+        for (function, field, expected) in cases {
+            let field = field.map_or(String::new(), |name| format!(r#", "field": "{name}""#));
+            let compiled = compiled(
+                &dataset,
+                &format!(
+                    r#"{{"dataset": "git_commits",
+                         "aggregates": [{{"name": "value", "fn": "{function}"{field}}}],
+                         "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+                ),
+            );
+            assert!(
+                compiled.sql.contains(expected),
+                "{function}: {}",
+                compiled.sql
+            );
+        }
+    }
+
+    #[test]
+    fn every_filter_operator_renders_its_own_predicate() {
+        let dataset = fixtures::commits();
+        let cases = [
+            (
+                r#"{"field": "source", "op": "eq", "value": "github"}"#,
+                "toString(source) = ?",
+            ),
+            (
+                r#"{"field": "source", "op": "in", "values": ["github"]}"#,
+                "toString(source) IN (?)",
+            ),
+            (
+                r#"{"field": "lines_added", "op": "gt", "value": 1}"#,
+                "lines_added > ?",
+            ),
+            (
+                r#"{"field": "lines_added", "op": "gte", "value": 1}"#,
+                "lines_added >= ?",
+            ),
+            (
+                r#"{"field": "lines_added", "op": "lt", "value": 1}"#,
+                "lines_added < ?",
+            ),
+            (
+                r#"{"field": "lines_added", "op": "lte", "value": 1}"#,
+                "lines_added <= ?",
+            ),
+            (
+                r#"{"field": "lines_added", "op": "between", "low": 1, "high": 9}"#,
+                "(lines_added >= ? AND lines_added <= ?)",
+            ),
+            (
+                r#"{"field": "source_id", "op": "not_null"}"#,
+                "source_id IS NOT NULL",
+            ),
+            (
+                r#"{"field": "repository", "op": "like", "value": "example/%"}"#,
+                "toString(repository) LIKE ?",
+            ),
+            (
+                r#"{"field": "repository", "op": "match", "value": "^example/"}"#,
+                "match(toString(repository), ?)",
+            ),
+        ];
+
+        for (filter, expected) in cases {
+            let compiled = compiled(
+                &dataset,
+                &format!(
+                    r#"{{"dataset": "git_commits", "filters": [{filter}],
+                         "aggregates": [{{"name": "commits", "fn": "count"}}],
+                         "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+                ),
+            );
+            assert!(
+                compiled.sql.contains(expected),
+                "{filter}: {}",
+                compiled.sql
+            );
+        }
+    }
+
+    #[test]
+    fn a_nullable_dimension_groups_its_absent_rows_under_the_declared_value() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "source_id"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert!(
+            compiled
+                .sql
+                .contains("coalesce(toString(source_id), '__unknown__') AS c0"),
+            "{}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn tenancy_leads_every_scan_and_binds_from_the_session() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            r#"{"dataset": "git_commits",
+                 "filters": [{"field": "source", "op": "eq", "value": "github"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert!(compiled.sql.contains("WHERE tenant_id = ?\n  AND"));
+        assert_eq!(compiled.params[0], text(TENANT));
+    }
+
+    #[test]
+    fn a_query_over_a_relation_that_must_be_read_collapsed_scans_it_final() {
+        let mut dataset = fixtures::commits();
+        dataset.read_discipline = crate::domain::field_catalog::model::ReadDiscipline::Final;
+        let compiled = compiled(
+            &dataset,
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert!(compiled.sql.contains("FROM insight.git_commits FINAL"));
+    }
+
+    #[test]
+    fn the_row_ceiling_binds_last_and_one_over_the_limit() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            &format!(
+                r#"{{"dataset": "git_commits",
+                     "aggregates": [{{"name": "commits", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}},
+                     "limit": {MAX_ROW_LIMIT}}}"#
+            ),
+        );
+
+        assert!(compiled.sql.ends_with("LIMIT ?"));
+        assert_eq!(
+            compiled.params.last(),
+            Some(&QueryParam::UInt(u64::from(MAX_ROW_LIMIT) + 1))
+        );
+    }
+
+    #[test]
+    fn a_grouped_answer_orders_by_every_group_column_the_query_did_not_name() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "dimension", "field": "source"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"},
+                 "order": [{"by": "source", "dir": "desc"}]}"#,
+        );
+
+        assert!(
+            compiled.sql.contains("ORDER BY c2 DESC, c0 ASC"),
+            "{}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn every_rendered_statement_binds_one_parameter_per_placeholder() {
+        let dataset = fixtures::commits();
+        let queries = [
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "author_email"}, {"axis": "time"}],
+                 "filters": [{"field": "source_id", "op": "in", "values": ["a", "b", "c"]},
+                             {"field": "lines_removed", "op": "between", "low": 0, "high": 100},
+                             {"field": "repository", "op": "not_null"}],
+                 "aggregates": [{"name": "commits", "fn": "count",
+                                 "filter": {"field": "source", "op": "eq", "value": "github"}},
+                                {"name": "added", "fn": "sum", "field": "lines_added"},
+                                {"name": "biggest", "fn": "max", "field": "lines_added",
+                                 "filter": {"field": "lines_added", "op": "gt", "value": 10}}],
+                 "time": {"field": "authored_date", "from": "2026-01-01", "to": "2026-12-31",
+                          "grain": "month"},
+                 "order": [{"by": "added", "dir": "desc"}],
+                 "limit": 250}"#,
+        ];
+
+        for query in queries {
+            let compiled = compiled(&dataset, query);
+            assert_eq!(
+                compiled.sql.matches('?').count(),
+                compiled.params.len(),
+                "{}",
+                compiled.sql
+            );
+        }
+    }
+
+    #[test]
+    fn a_query_over_the_file_change_dataset_scans_its_own_relation() {
+        let request = fixtures::query(
+            r#"{"dataset": "git_file_changes",
+                 "group_by": [{"axis": "dimension", "field": "file_extension"}, {"axis": "time"}],
+                 "aggregates": [
+                   {"name": "changes", "fn": "count"},
+                   {"name": "added_to_tests", "fn": "sum", "field": "lines_added",
+                    "filter": {"field": "category", "op": "eq", "value": "test"}}
+                 ],
+                 "time": {"from": "2026-01-01", "to": "2026-03-31", "grain": "month"},
+                 "order": [{"by": "changes", "dir": "desc"}],
+                 "limit": 500}"#,
+        );
+        let plan = crate::domain::query::validation::plan(&request).expect("admissible");
+        let compiled = compile(&plan, TENANT);
+
+        assert_eq!(
+            compiled.sql,
+            lines(&[
+                "SELECT",
+                "    toString(file_extension) AS c0,",
+                "    any(file_extension_label) AS c1,",
+                "    toStartOfMonth(toDate(authored_at, 'UTC')) AS c2,",
+                "    count() AS c3,",
+                "    sumIfOrNull(lines_added, coalesce(toString(category) = ?, 0)) AS c4",
+                "FROM insight.git_file_changes",
+                "WHERE tenant_id = ?",
+                "  AND toDate(authored_at, 'UTC') >= toDate(?, 'UTC')",
+                "  AND toDate(authored_at, 'UTC') <= toDate(?, 'UTC')",
+                "GROUP BY c0, c2",
+                "ORDER BY c3 DESC, c0 ASC, c2 ASC",
+                "LIMIT ?",
+            ])
+        );
+        assert_eq!(
+            compiled.params,
+            vec![
+                text("test"),
+                text(TENANT),
+                text("2026-01-01"),
+                text("2026-03-31"),
+                QueryParam::UInt(501),
+            ]
+        );
+        assert_eq!(compiled.sql.matches('?').count(), compiled.params.len());
+    }
+
+    #[test]
+    fn the_shipped_dataset_compiles_the_same_query_the_fixture_does() {
+        let request = fixtures::query(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-03-31", "grain": "week"}}"#,
+        );
+        let plan = crate::domain::query::validation::plan(&request).expect("admissible");
+        let compiled = compile(&plan, TENANT);
+
+        assert!(compiled.sql.contains("FROM insight.git_commits"));
+        assert_eq!(compiled.sql.matches('?').count(), compiled.params.len());
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/order.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/order.rs
@@ -1,0 +1,36 @@
+//! How the answer's rows are ordered and how many of them there are.
+//!
+//! INVARIANT: a grouped query orders by every group column the query did not
+//! name, so a row ceiling truncates the same rows on every run.
+
+use crate::domain::query::contract::dto::Direction;
+use crate::domain::query::plan::{QueryPlan, column_alias};
+
+pub fn terms(plan: &QueryPlan<'_>) -> Vec<String> {
+    let mut ordered: Vec<usize> = Vec::with_capacity(plan.order.len() + plan.group_by.len());
+    let mut terms = Vec::with_capacity(ordered.capacity());
+
+    for term in &plan.order {
+        ordered.push(term.column);
+        terms.push(format!(
+            "{} {}",
+            column_alias(term.column),
+            direction(term.direction)
+        ));
+    }
+
+    for (index, column) in plan.columns.iter().enumerate() {
+        if column.groups() && !ordered.contains(&index) {
+            terms.push(format!("{} ASC", column_alias(index)));
+        }
+    }
+
+    terms
+}
+
+fn direction(direction: Direction) -> &'static str {
+    match direction {
+        Direction::Asc => "ASC",
+        Direction::Desc => "DESC",
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/params.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/params.rs
@@ -1,0 +1,107 @@
+//! Bound values, in the spelling ClickHouse receives them in.
+//!
+//! SAFETY: every caller-supplied value in a compiled statement is one of these.
+//! Nothing here is ever written into the SQL text.
+
+use crate::domain::query::contract::dto::ScalarDto;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryParam {
+    Text(String),
+    Int(i64),
+    UInt(u64),
+    Float(f64),
+}
+
+impl QueryParam {
+    /// A dimension compares as text, whatever the column's own type is.
+    pub fn text_of(scalar: &ScalarDto) -> Self {
+        Self::Text(match scalar {
+            ScalarDto::Bool(value) => value.to_string(),
+            ScalarDto::Number(value) => value.to_string(),
+            ScalarDto::Text(value) => value.clone(),
+        })
+    }
+
+    /// A measurable compares against the numeric column itself.
+    pub fn number_of(scalar: &ScalarDto) -> Self {
+        let ScalarDto::Number(number) = scalar else {
+            return Self::text_of(scalar);
+        };
+        if let Some(value) = number.as_i64() {
+            Self::Int(value)
+        } else if let Some(value) = number.as_u64() {
+            Self::UInt(value)
+        } else if let Some(value) = number.as_f64() {
+            Self::Float(value)
+        } else {
+            Self::Text(number.to_string())
+        }
+    }
+
+    pub fn binding(&self) -> serde_json::Value {
+        match self {
+            Self::Text(value) => serde_json::Value::String(value.clone()),
+            Self::Int(value) => serde_json::Value::from(*value),
+            Self::UInt(value) => serde_json::Value::from(*value),
+            Self::Float(value) => serde_json::Number::from_f64(*value)
+                .map_or_else(serde_json::Value::default, serde_json::Value::Number),
+        }
+    }
+}
+
+pub fn placeholders(count: usize) -> String {
+    vec!["?"; count].join(", ")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn number(raw: &str) -> ScalarDto {
+        ScalarDto::Number(raw.parse().expect("a JSON number"))
+    }
+
+    #[test]
+    fn a_dimension_value_binds_as_the_text_the_answer_reports() {
+        assert_eq!(
+            QueryParam::text_of(&ScalarDto::Text("github".to_owned())),
+            QueryParam::Text("github".to_owned())
+        );
+        assert_eq!(
+            QueryParam::text_of(&number("42")),
+            QueryParam::Text("42".to_owned())
+        );
+        assert_eq!(
+            QueryParam::text_of(&ScalarDto::Bool(true)),
+            QueryParam::Text("true".to_owned())
+        );
+    }
+
+    #[test]
+    fn a_measurable_value_keeps_the_numeric_width_it_was_written_in() {
+        assert_eq!(QueryParam::number_of(&number("500")), QueryParam::Int(500));
+        assert_eq!(QueryParam::number_of(&number("-1")), QueryParam::Int(-1));
+        assert_eq!(
+            QueryParam::number_of(&number("18446744073709551615")),
+            QueryParam::UInt(u64::MAX)
+        );
+        assert_eq!(
+            QueryParam::number_of(&number("1.5")),
+            QueryParam::Float(1.5)
+        );
+    }
+
+    #[test]
+    fn a_bound_value_reaches_the_driver_with_its_own_json_type() {
+        assert!(QueryParam::Int(5).binding().is_number());
+        assert!(QueryParam::Text("5".to_owned()).binding().is_string());
+    }
+
+    #[test]
+    fn placeholders_are_one_per_value() {
+        assert_eq!(placeholders(1), "?");
+        assert_eq!(placeholders(3), "?, ?, ?");
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/scan.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/scan.rs
@@ -1,0 +1,41 @@
+//! What a scan reads and what it is scoped to.
+//!
+//! INVARIANT: tenancy leads every read, bound from the session and never from
+//! the request.
+
+use crate::domain::field_catalog::model::ReadDiscipline;
+use crate::domain::query::plan::QueryPlan;
+
+use super::filters;
+use super::params::QueryParam;
+use super::time::event_day;
+
+pub fn from_clause(plan: &QueryPlan<'_>) -> String {
+    let relation = format!("{}.{}", plan.dataset.database, plan.dataset.relation);
+    match plan.dataset.read_discipline {
+        ReadDiscipline::Plain => relation,
+        ReadDiscipline::Final => format!("{relation} FINAL"),
+    }
+}
+
+/// The `WHERE` predicates, in binding order: tenancy, window, then row filters.
+pub fn predicates(
+    plan: &QueryPlan<'_>,
+    tenant_id: &str,
+    params: &mut Vec<QueryParam>,
+) -> Vec<String> {
+    let mut predicates = vec![format!("{} = ?", plan.dataset.tenant_field)];
+    params.push(QueryParam::Text(tenant_id.to_owned()));
+
+    let day = event_day(plan.time.field);
+    predicates.push(format!("{day} >= toDate(?, 'UTC')"));
+    params.push(QueryParam::Text(plan.time.from.to_string()));
+    predicates.push(format!("{day} <= toDate(?, 'UTC')"));
+    params.push(QueryParam::Text(plan.time.to.to_string()));
+
+    for filter in &plan.filters {
+        predicates.push(filters::render(filter, params));
+    }
+
+    predicates
+}

--- a/src/backend/services/analytics/src/domain/query/compile/time.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/time.rs
@@ -1,0 +1,73 @@
+//! The time bucket and the window every scan is bounded by. UTC only.
+//!
+//! INVARIANT: every day boundary names its zone. A bare `toDate` over a
+//! `DateTime` reads the server's zone, so the same query would bucket rows
+//! differently on two installations.
+
+use crate::domain::datasets::declaration::TimeField;
+use crate::domain::query::contract::dto::Grain;
+
+/// ClickHouse's Monday-first week mode.
+const MONDAY_FIRST: u8 = 1;
+const ZONE: &str = "'UTC'";
+
+// SAFETY: an absent event time compares NULL against both bounds, so the row
+// falls outside every window and the scan never reads it.
+pub fn event_day(field: &TimeField) -> String {
+    format!("toDate({}, {ZONE})", field.field)
+}
+
+// SAFETY: `assumeNotNull` is sound because the window bounds already excluded
+// every row whose event time is absent.
+pub fn bucket_expr(field: &TimeField, grain: Grain) -> String {
+    let day = if field.nullable {
+        format!("toDate(assumeNotNull({}), {ZONE})", field.field)
+    } else {
+        format!("toDate({}, {ZONE})", field.field)
+    };
+
+    match grain {
+        Grain::Day => day,
+        Grain::Week => format!("toStartOfWeek({day}, {MONDAY_FIRST})"),
+        Grain::Month => format!("toStartOfMonth({day})"),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn field(nullable: bool) -> TimeField {
+        TimeField {
+            field: "authored_at".to_owned(),
+            nullable,
+            default: true,
+        }
+    }
+
+    #[test]
+    fn each_grain_renders_its_own_bucket_boundary() {
+        let cases = [
+            (Grain::Day, "toDate(authored_at, 'UTC')"),
+            (Grain::Week, "toStartOfWeek(toDate(authored_at, 'UTC'), 1)"),
+            (Grain::Month, "toStartOfMonth(toDate(authored_at, 'UTC'))"),
+        ];
+        for (grain, expected) in cases {
+            assert_eq!(bucket_expr(&field(false), grain), expected, "{grain:?}");
+        }
+    }
+
+    #[test]
+    fn a_nullable_event_time_buckets_the_value_the_window_already_admitted() {
+        assert_eq!(
+            bucket_expr(&field(true), Grain::Day),
+            "toDate(assumeNotNull(authored_at), 'UTC')"
+        );
+    }
+
+    #[test]
+    fn the_window_bounds_compare_against_the_event_day() {
+        assert_eq!(event_day(&field(true)), "toDate(authored_at, 'UTC')");
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/contract/dto.rs
+++ b/src/backend/services/analytics/src/domain/query/contract/dto.rs
@@ -1,0 +1,631 @@
+//! The wire shape of a query and of the answer it gets.
+
+use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+pub const MAX_FILTERS: usize = 32;
+pub const MAX_FILTER_VALUES: usize = 256;
+pub const MAX_AGGREGATES: usize = 16;
+pub const MAX_GROUP_AXES: usize = 4;
+pub const MAX_ORDER_TERMS: usize = 4;
+pub const MAX_NAME_CHARS: usize = 64;
+pub const MAX_PATTERN_CHARS: usize = 256;
+pub const DEFAULT_ROW_LIMIT: u32 = 1_000;
+pub const MAX_ROW_LIMIT: u32 = 10_000;
+/// Two years inclusive of a leap day, so a year-over-year window fits.
+pub const MAX_WINDOW_DAYS: i64 = 731;
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(as = Query)]
+pub struct QueryRequest {
+    pub dataset: String,
+    /// Row filters, narrowing the scan before aggregation.
+    #[serde(default)]
+    pub filters: Vec<FilterDto>,
+    #[serde(default)]
+    pub group_by: Vec<GroupAxisDto>,
+    pub aggregates: Vec<AggregateDto>,
+    /// The window every scan is bounded by, and the width of its buckets.
+    pub time: TimeDto,
+    #[serde(default)]
+    pub order: Vec<OrderDto>,
+    /// Row ceiling; a query over the cap is refused rather than clipped.
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+// INVARIANT: every tagged request shape is an enum of struct variants with
+// `deny_unknown_fields` on the enum, so an operand of another variant is refused
+// at deserialization and the published schema carries the tag beside the
+// operands of each variant.
+#[derive(Debug, Clone, PartialEq, Deserialize, ToSchema)]
+#[serde(tag = "op", rename_all = "snake_case", deny_unknown_fields)]
+#[schema(as = QueryFilter)]
+pub enum FilterDto {
+    Eq {
+        /// A declared dimension or measurable of the dataset.
+        field: String,
+        value: ScalarDto,
+    },
+    In {
+        /// A declared dimension or measurable of the dataset.
+        field: String,
+        /// At least one value, and at most the contract's cap.
+        // INVARIANT: equals MAX_FILTER_VALUES; the derive takes a literal only,
+        // and a test pins the two together.
+        #[schema(min_items = 1, max_items = 256)]
+        values: Vec<ScalarDto>,
+    },
+    Gt {
+        /// A declared measurable of the dataset.
+        field: String,
+        value: ScalarDto,
+    },
+    Gte {
+        /// A declared measurable of the dataset.
+        field: String,
+        value: ScalarDto,
+    },
+    Lt {
+        /// A declared measurable of the dataset.
+        field: String,
+        value: ScalarDto,
+    },
+    Lte {
+        /// A declared measurable of the dataset.
+        field: String,
+        value: ScalarDto,
+    },
+    Between {
+        /// A declared measurable of the dataset.
+        field: String,
+        /// Inclusive lower bound.
+        low: ScalarDto,
+        /// Inclusive upper bound.
+        high: ScalarDto,
+    },
+    NotNull {
+        /// A declared dimension or measurable of the dataset.
+        field: String,
+    },
+    /// SQL `LIKE`: `%` matches any run, `_` one character.
+    Like {
+        /// A declared dimension of the dataset.
+        field: String,
+        // INVARIANT: equals MAX_PATTERN_CHARS; the derive takes a literal only,
+        // and a test pins the two together.
+        #[schema(max_length = 256)]
+        value: String,
+    },
+    /// An RE2 regular expression, unanchored.
+    #[serde(rename = "match")]
+    Matches {
+        /// A declared dimension of the dataset.
+        field: String,
+        #[schema(max_length = 256)]
+        value: String,
+    },
+}
+
+impl FilterDto {
+    pub fn field(&self) -> &str {
+        match self {
+            Self::Eq { field, .. }
+            | Self::In { field, .. }
+            | Self::Gt { field, .. }
+            | Self::Gte { field, .. }
+            | Self::Lt { field, .. }
+            | Self::Lte { field, .. }
+            | Self::Between { field, .. }
+            | Self::NotNull { field }
+            | Self::Like { field, .. }
+            | Self::Matches { field, .. } => field,
+        }
+    }
+}
+
+/// A filter value, in the JSON type it was written as.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum ScalarDto {
+    Bool(bool),
+    Number(serde_json::Number),
+    Text(String),
+}
+
+// WORKAROUND: the derive cannot annotate a newtype variant's field, and
+// `serde_json::Number` carries no schema of its own.
+impl utoipa::PartialSchema for ScalarDto {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::OneOfBuilder::new()
+            .item(<String as utoipa::PartialSchema>::schema())
+            .item(<f64 as utoipa::PartialSchema>::schema())
+            .item(<bool as utoipa::PartialSchema>::schema())
+            .description(Some("A filter value: text, a number, or a boolean"))
+            .into()
+    }
+}
+
+impl utoipa::ToSchema for ScalarDto {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("QueryFilterValue")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, ToSchema)]
+#[serde(tag = "axis", rename_all = "snake_case", deny_unknown_fields)]
+#[schema(as = QueryGroupAxis)]
+pub enum GroupAxisDto {
+    Dimension {
+        /// A declared dimension of the dataset.
+        field: String,
+    },
+    /// The time bucket as a group axis; its width is `time.grain`.
+    Time {},
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, ToSchema)]
+#[serde(tag = "fn", rename_all = "snake_case", deny_unknown_fields)]
+#[schema(as = QueryAggregate)]
+pub enum AggregateDto {
+    Count {
+        /// What the answer column is called.
+        name: String,
+        /// Restricts this fold to the rows one filter selects.
+        #[serde(default)]
+        filter: Option<FilterDto>,
+    },
+    Sum {
+        /// What the answer column is called.
+        name: String,
+        /// A declared measurable of the dataset.
+        field: String,
+        /// Restricts this fold to the rows one filter selects.
+        #[serde(default)]
+        filter: Option<FilterDto>,
+    },
+    Avg {
+        /// What the answer column is called.
+        name: String,
+        /// A declared measurable of the dataset.
+        field: String,
+        /// Restricts this fold to the rows one filter selects.
+        #[serde(default)]
+        filter: Option<FilterDto>,
+    },
+    Min {
+        /// What the answer column is called.
+        name: String,
+        /// A declared measurable of the dataset.
+        field: String,
+        /// Restricts this fold to the rows one filter selects.
+        #[serde(default)]
+        filter: Option<FilterDto>,
+    },
+    Max {
+        /// What the answer column is called.
+        name: String,
+        /// A declared measurable of the dataset.
+        field: String,
+        /// Restricts this fold to the rows one filter selects.
+        #[serde(default)]
+        filter: Option<FilterDto>,
+    },
+}
+
+impl AggregateDto {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Count { name, .. }
+            | Self::Sum { name, .. }
+            | Self::Avg { name, .. }
+            | Self::Min { name, .. }
+            | Self::Max { name, .. } => name,
+        }
+    }
+
+    pub fn filter(&self) -> Option<&FilterDto> {
+        match self {
+            Self::Count { filter, .. }
+            | Self::Sum { filter, .. }
+            | Self::Avg { filter, .. }
+            | Self::Min { filter, .. }
+            | Self::Max { filter, .. } => filter.as_ref(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(as = QueryTime)]
+pub struct TimeDto {
+    /// A declared time field; the dataset's default when omitted.
+    #[serde(default)]
+    pub field: Option<String>,
+    /// Inclusive first day, UTC.
+    pub from: NaiveDate,
+    /// Inclusive last day, UTC.
+    pub to: NaiveDate,
+    /// Bucket width. Required with an `{"axis": "time"}` axis, refused without one.
+    #[serde(default)]
+    pub grain: Option<Grain>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[schema(as = QueryGrain)]
+pub enum Grain {
+    Day,
+    Week,
+    Month,
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(as = QueryOrder)]
+pub struct OrderDto {
+    /// A column the answer reports: a grouped dimension, `time`, or an aggregate name.
+    pub by: String,
+    #[serde(default)]
+    pub dir: Direction,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[schema(as = QueryDirection)]
+pub enum Direction {
+    #[default]
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct QueryAnswer {
+    pub columns: Vec<AnswerColumn>,
+    /// One cell per column, in column order; a fold that observed nothing is null.
+    #[schema(schema_with = answer_rows_schema)]
+    pub rows: Vec<Vec<serde_json::Value>>,
+    pub flags: AnswerFlags,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[schema(as = QueryAnswerFlags)]
+pub struct AnswerFlags {
+    /// More groups matched than the limit admits; the rows are the first
+    /// `limit` of them in the answer's order.
+    pub truncated: bool,
+}
+
+fn answer_rows_schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+    use utoipa::openapi::schema::{ArrayBuilder, Object, SchemaType};
+
+    let cell = Object::with_type(SchemaType::AnyValue);
+    ArrayBuilder::new()
+        .items(ArrayBuilder::new().items(cell))
+        .into()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[schema(as = QueryAnswerColumn)]
+pub struct AnswerColumn {
+    pub name: String,
+    pub kind: ColumnKind,
+    #[serde(rename = "type")]
+    pub value_type: ColumnType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[schema(as = QueryColumnKind)]
+pub enum ColumnKind {
+    Dimension,
+    /// The declared display label of the dimension column before it, named
+    /// `<field>_label`; null when the dataset carries none for a group.
+    Label,
+    Bucket,
+    Aggregate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[schema(as = QueryColumnType)]
+pub enum ColumnType {
+    Text,
+    Number,
+    Date,
+}
+
+impl toolkit::api::api_dto::RequestApiDto for QueryRequest {}
+impl toolkit::api::api_dto::ResponseApiDto for QueryAnswer {}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> Result<QueryRequest, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    const MINIMAL: &str = r#"{
+      "dataset": "git_commits",
+      "aggregates": [{"name": "commits", "fn": "count"}],
+      "time": {"from": "2026-01-01", "to": "2026-01-31"}
+    }"#;
+
+    #[test]
+    fn a_query_naming_only_what_it_needs_deserializes() {
+        let query = parse(MINIMAL).expect("the minimal query is in the contract");
+
+        assert_eq!(query.dataset, "git_commits");
+        assert!(query.filters.is_empty());
+        assert!(query.group_by.is_empty());
+        assert!(query.order.is_empty());
+        assert_eq!(query.limit, None);
+        assert_eq!(query.time.grain, None);
+        assert!(matches!(query.aggregates[0], AggregateDto::Count { .. }));
+    }
+
+    #[test]
+    fn a_key_the_contract_does_not_declare_is_refused_at_deserialization() {
+        let cases = [
+            r#"{"dataset": "d", "aggregates": [], "time": {"from": "2026-01-01", "to": "2026-01-02"}, "having": []}"#,
+            r#"{"dataset": "d", "aggregates": [{"name": "n", "fn": "count", "quantile": 0.9}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "time": {"from": "2026-01-01", "to": "2026-01-02", "timezone": "UTC"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "filters": [{"field": "f", "op": "eq", "values": [1], "extra": 2}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "order": [{"by": "n", "dir": "asc", "nulls": "last"}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+        ];
+        for json in cases {
+            assert!(parse(json).is_err(), "{json}");
+        }
+    }
+
+    #[test]
+    fn an_enumerated_field_refuses_a_value_outside_its_enumeration() {
+        let cases = [
+            r#"{"dataset": "d", "aggregates": [{"name": "n", "fn": "median"}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "filters": [{"field": "f", "op": "regex", "value": "x"}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "time": {"from": "2026-01-01", "to": "2026-01-02", "grain": "quarter"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "order": [{"by": "n", "dir": "sideways"}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+        ];
+        for json in cases {
+            assert!(parse(json).is_err(), "{json}");
+        }
+    }
+
+    #[test]
+    fn a_group_axis_is_either_a_dimension_or_the_time_bucket() {
+        let query = parse(
+            r#"{
+              "dataset": "git_commits",
+              "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+              "aggregates": [{"name": "commits", "fn": "count"}],
+              "time": {"from": "2026-01-01", "to": "2026-01-31", "grain": "week"}
+            }"#,
+        )
+        .expect("both axis shapes are in the contract");
+
+        assert!(matches!(query.group_by[0], GroupAxisDto::Dimension { .. }));
+        assert!(matches!(query.group_by[1], GroupAxisDto::Time {}));
+
+        assert!(
+            parse(
+                r#"{"dataset": "d", "group_by": [{"bin": {"field": "f", "width": 10}}],
+                    "aggregates": [], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#
+            )
+            .is_err(),
+            "a bin axis is not a shape this contract carries yet"
+        );
+    }
+
+    #[test]
+    fn a_filter_value_keeps_the_json_type_it_was_written_as() {
+        let query = parse(
+            r#"{
+              "dataset": "git_commits",
+              "filters": [
+                {"field": "source", "op": "eq", "value": "github"},
+                {"field": "lines_added", "op": "gte", "value": 500},
+                {"field": "lines_added", "op": "not_null"}
+              ],
+              "aggregates": [{"name": "commits", "fn": "count"}],
+              "time": {"from": "2026-01-01", "to": "2026-01-31"}
+            }"#,
+        )
+        .expect("the filter shapes are in the contract");
+
+        assert_eq!(
+            query.filters[0],
+            FilterDto::Eq {
+                field: "source".to_owned(),
+                value: ScalarDto::Text("github".to_owned()),
+            }
+        );
+        assert!(matches!(
+            &query.filters[1],
+            FilterDto::Gte {
+                value: ScalarDto::Number(_),
+                ..
+            }
+        ));
+        assert!(matches!(query.filters[2], FilterDto::NotNull { .. }));
+    }
+
+    fn filter(json: &str) -> Result<FilterDto, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    #[test]
+    fn the_published_in_list_bounds_are_the_ones_validation_enforces() {
+        let schema = serde_json::to_value(<FilterDto as utoipa::PartialSchema>::schema())
+            .expect("the filter schema serializes");
+        let values = schema["oneOf"]
+            .as_array()
+            .expect("a tagged union")
+            .iter()
+            .find_map(|variant| variant["properties"].get("values"))
+            .expect("the `in` variant publishes `values`");
+
+        assert_eq!(values["minItems"], 1);
+        assert_eq!(values["maxItems"], MAX_FILTER_VALUES);
+
+        for op in ["like", "match"] {
+            let pattern = schema["oneOf"]
+                .as_array()
+                .expect("a tagged union")
+                .iter()
+                .find(|variant| variant["properties"]["op"]["enum"][0] == op)
+                .map_or_else(
+                    || panic!("the `{op}` variant publishes `value`"),
+                    |variant| &variant["properties"]["value"],
+                );
+            assert_eq!(pattern["maxLength"], MAX_PATTERN_CHARS, "{op}");
+        }
+    }
+
+    #[test]
+    fn every_filter_operator_carries_exactly_the_operands_it_takes() {
+        let cases = [
+            (
+                r#"{"op": "eq", "field": "source", "value": "github"}"#,
+                FilterDto::Eq {
+                    field: "source".to_owned(),
+                    value: ScalarDto::Text("github".to_owned()),
+                },
+            ),
+            (
+                r#"{"op": "in", "field": "source", "values": ["github", "gitlab"]}"#,
+                FilterDto::In {
+                    field: "source".to_owned(),
+                    values: vec![
+                        ScalarDto::Text("github".to_owned()),
+                        ScalarDto::Text("gitlab".to_owned()),
+                    ],
+                },
+            ),
+            (
+                r#"{"op": "lt", "field": "lines_added", "value": 10}"#,
+                FilterDto::Lt {
+                    field: "lines_added".to_owned(),
+                    value: ScalarDto::Number(10.into()),
+                },
+            ),
+            (
+                r#"{"op": "between", "field": "lines_added", "low": 1, "high": 9}"#,
+                FilterDto::Between {
+                    field: "lines_added".to_owned(),
+                    low: ScalarDto::Number(1.into()),
+                    high: ScalarDto::Number(9.into()),
+                },
+            ),
+            (
+                r#"{"op": "not_null", "field": "source_id"}"#,
+                FilterDto::NotNull {
+                    field: "source_id".to_owned(),
+                },
+            ),
+            (
+                r#"{"op": "like", "field": "file_path", "value": "%/tests/%"}"#,
+                FilterDto::Like {
+                    field: "file_path".to_owned(),
+                    value: "%/tests/%".to_owned(),
+                },
+            ),
+            (
+                r#"{"op": "match", "field": "file_path", "value": "\\.(test|spec)\\.ts$"}"#,
+                FilterDto::Matches {
+                    field: "file_path".to_owned(),
+                    value: "\\.(test|spec)\\.ts$".to_owned(),
+                },
+            ),
+        ];
+
+        for (json, expected) in cases {
+            assert_eq!(filter(json).expect(json), expected, "{json}");
+        }
+    }
+
+    #[test]
+    fn an_operand_belonging_to_another_operator_is_refused_at_deserialization() {
+        let cases = [
+            r#"{"op": "eq", "field": "source", "values": ["github"]}"#,
+            r#"{"op": "eq", "field": "source", "value": "a", "high": "b"}"#,
+            r#"{"op": "in", "field": "source", "value": "github"}"#,
+            r#"{"op": "gte", "field": "lines_added", "low": 1, "high": 9}"#,
+            r#"{"op": "between", "field": "lines_added", "value": 1}"#,
+            r#"{"op": "between", "field": "lines_added", "low": 1}"#,
+            r#"{"op": "not_null", "field": "source_id", "value": 1}"#,
+            r#"{"op": "like", "field": "file_path", "value": 1}"#,
+            r#"{"op": "match", "field": "file_path", "values": ["a"]}"#,
+            r#"{"field": "source", "value": "github"}"#,
+        ];
+
+        for json in cases {
+            assert!(filter(json).is_err(), "{json}");
+        }
+    }
+
+    fn aggregate(json: &str) -> Result<AggregateDto, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    #[test]
+    fn every_fold_carries_a_column_exactly_when_it_reads_one() {
+        let count = aggregate(r#"{"fn": "count", "name": "commits"}"#).expect("a count");
+        assert_eq!(
+            count,
+            AggregateDto::Count {
+                name: "commits".to_owned(),
+                filter: None,
+            }
+        );
+
+        for function in ["sum", "avg", "min", "max"] {
+            let json = format!(r#"{{"fn": "{function}", "name": "v", "field": "lines_added"}}"#);
+            let parsed = aggregate(&json).unwrap_or_else(|error| panic!("{json}: {error}"));
+            assert_eq!(parsed.name(), "v", "{json}");
+        }
+    }
+
+    #[test]
+    fn a_fold_that_names_the_wrong_operands_is_refused_at_deserialization() {
+        let cases = [
+            r#"{"fn": "count", "name": "commits", "field": "lines_added"}"#,
+            r#"{"fn": "sum", "name": "added"}"#,
+            r#"{"fn": "median", "name": "v", "field": "lines_added"}"#,
+            r#"{"name": "v", "field": "lines_added"}"#,
+        ];
+
+        for json in cases {
+            assert!(aggregate(json).is_err(), "{json}");
+        }
+    }
+
+    #[test]
+    fn a_group_axis_names_the_axis_it_is() {
+        let cases = [
+            r#"{"axis": "dimension", "field": "repository"}"#,
+            r#"{"axis": "time"}"#,
+        ];
+        for json in cases {
+            serde_json::from_str::<GroupAxisDto>(json).unwrap_or_else(|error| {
+                panic!("{json}: {error}");
+            });
+        }
+
+        let refused = [
+            r#"{"axis": "time", "dimension": "repository"}"#,
+            r#"{"axis": "dimension"}"#,
+            r#"{"dimension": "repository"}"#,
+            r#"{"axis": "bin", "field": "lines_added", "width": 10}"#,
+        ];
+        for json in refused {
+            assert!(
+                serde_json::from_str::<GroupAxisDto>(json).is_err(),
+                "{json}"
+            );
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/contract/mod.rs
+++ b/src/backend/services/analytics/src/domain/query/contract/mod.rs
@@ -1,0 +1,3 @@
+//! The query contract: the request a caller writes and the answer it gets back.
+
+pub mod dto;

--- a/src/backend/services/analytics/src/domain/query/fixtures.rs
+++ b/src/backend/services/analytics/src/domain/query/fixtures.rs
@@ -1,0 +1,74 @@
+//! A dataset for the engine's own tests, validated the way a shipped one is.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use crate::domain::field_catalog::loader;
+
+use super::contract::dto::QueryRequest;
+use crate::domain::datasets::declaration::{Dataset, DatasetDocument};
+use crate::domain::datasets::validate;
+
+const SNAPSHOT: &str = r#"[
+  {
+    "database": "insight",
+    "relation": "git_commits",
+    "engine": "MergeTree",
+    "columns": [
+      {"name": "tenant_id", "type": "Nullable(String)"},
+      {"name": "source_id", "type": "Nullable(String)"},
+      {"name": "commit_hash", "type": "String"},
+      {"name": "author_email", "type": "String"},
+      {"name": "message", "type": "String"},
+      {"name": "authored_at", "type": "DateTime"},
+      {"name": "authored_date", "type": "Date"},
+      {"name": "branch_scope", "type": "String"},
+      {"name": "branch_scope_label", "type": "String"},
+      {"name": "repository", "type": "String"},
+      {"name": "repository_label", "type": "String"},
+      {"name": "source", "type": "String"},
+      {"name": "source_label", "type": "String"},
+      {"name": "lines_added", "type": "Nullable(Int64)"},
+      {"name": "lines_removed", "type": "Nullable(Int64)"}
+    ]
+  }
+]"#;
+
+const DECLARATION: &str = "
+key: git_commits
+database: insight
+relation: git_commits
+read_discipline: plain
+tenant_field: tenant_id
+time_fields:
+  - field: authored_at
+    default: true
+  - field: authored_date
+dimensions:
+  - field: author_email
+  - field: branch_scope
+    label_field: branch_scope_label
+  - field: repository
+    label_field: repository_label
+  - field: source
+    label_field: source_label
+  - field: source_id
+    absent_value: __unknown__
+measurables:
+  - field: lines_added
+  - field: lines_removed
+row_identity:
+  - tenant_id
+  - source
+  - commit_hash
+";
+
+pub fn commits() -> Dataset {
+    let catalog = loader::load(SNAPSHOT).expect("the fixture snapshot parses");
+    let document: DatasetDocument =
+        serde_yaml::from_str(DECLARATION).expect("the fixture declaration parses");
+    validate::validate(document, &catalog).expect("the fixture declaration is admissible")
+}
+
+pub fn query(json: &str) -> QueryRequest {
+    serde_json::from_str(json).expect("the fixture query is in the contract")
+}

--- a/src/backend/services/analytics/src/domain/query/mod.rs
+++ b/src/backend/services/analytics/src/domain/query/mod.rs
@@ -1,0 +1,13 @@
+//! The query engine: one query contract over declared datasets.
+//!
+//! INVARIANT: identity is a dataset's declared policy, and no dataset in this
+//! build declares one.
+
+pub mod answer;
+pub mod compile;
+pub mod contract;
+#[cfg(test)]
+pub mod fixtures;
+pub mod plan;
+pub mod validation;
+pub mod violation;

--- a/src/backend/services/analytics/src/domain/query/plan.rs
+++ b/src/backend/services/analytics/src/domain/query/plan.rs
@@ -1,0 +1,162 @@
+//! A query bound to its dataset, with every field reference already resolved.
+//!
+//! INVARIANT: a plan exists only for a query [`super::validation`] accepted, so
+//! the compiler never re-asks whether anything is declared.
+
+use chrono::NaiveDate;
+
+use super::contract::dto::{AnswerColumn, Direction, Grain, ScalarDto};
+use crate::domain::datasets::declaration::{Dataset, Dimension, Measurable, TimeField};
+pub use crate::domain::datasets::label_column_name;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryPlan<'d> {
+    pub dataset: &'d Dataset,
+    pub filters: Vec<PlannedFilter<'d>>,
+    pub group_by: Vec<PlannedAxis<'d>>,
+    pub aggregates: Vec<PlannedAggregate<'d>>,
+    pub time: PlannedTime<'d>,
+    pub order: Vec<PlannedOrder>,
+    pub limit: u32,
+    pub columns: Vec<PlannedColumn<'d>>,
+}
+
+/// One column of the answer and what the statement selects for it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannedColumn<'d> {
+    pub answer: AnswerColumn,
+    pub source: ColumnSource<'d>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ColumnSource<'d> {
+    Dimension(&'d Dimension),
+    /// The declared label of a dimension the answer also carries the value of.
+    Label(&'d Dimension),
+    Bucket,
+    /// Index into [`QueryPlan::aggregates`].
+    Aggregate(usize),
+}
+
+impl PlannedColumn<'_> {
+    /// Whether the statement groups by this column.
+    pub fn groups(&self) -> bool {
+        match self.source {
+            ColumnSource::Dimension(_) | ColumnSource::Bucket => true,
+            ColumnSource::Label(_) | ColumnSource::Aggregate(_) => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlannedAxis<'d> {
+    Dimension(&'d Dimension),
+    Time,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannedFilter<'d> {
+    pub target: FilterTarget<'d>,
+    pub test: PlannedTest,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PlannedTest {
+    Eq(ScalarDto),
+    /// INVARIANT: validation admits between one value and the contract's cap.
+    In(Vec<ScalarDto>),
+    Compare(CompareOp, ScalarDto),
+    Between {
+        low: ScalarDto,
+        high: ScalarDto,
+    },
+    NotNull,
+    /// INVARIANT: validation admits a pattern only over a dimension and within the length cap.
+    Like(String),
+    /// INVARIANT: validation compiled the expression, so the warehouse will too.
+    Matches(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompareOp {
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+}
+
+impl PlannedTest {
+    pub fn operands(&self) -> Vec<(String, &ScalarDto)> {
+        match self {
+            Self::Eq(value) | Self::Compare(_, value) => vec![("value".to_owned(), value)],
+            Self::In(values) => values
+                .iter()
+                .enumerate()
+                .map(|(index, value)| (format!("values[{index}]"), value))
+                .collect(),
+            Self::Between { low, high } => {
+                vec![("low".to_owned(), low), ("high".to_owned(), high)]
+            }
+            Self::NotNull | Self::Like(_) | Self::Matches(_) => Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilterTarget<'d> {
+    /// Compared against the value the answer reports, never the raw column.
+    Dimension(&'d Dimension),
+    /// Compared against the numeric column itself.
+    Measurable(&'d Measurable),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannedAggregate<'d> {
+    /// Position in the request's `aggregates`, which a refusal names.
+    pub index: usize,
+    pub name: String,
+    pub fold: PlannedFold<'d>,
+    pub filter: Option<PlannedFilter<'d>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlannedFold<'d> {
+    Rows,
+    Values {
+        function: FoldFn,
+        measurable: &'d Measurable,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FoldFn {
+    Sum,
+    Avg,
+    Min,
+    Max,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedTime<'d> {
+    pub field: &'d TimeField,
+    pub from: NaiveDate,
+    pub to: NaiveDate,
+    /// Present exactly when the query carries a time axis.
+    pub grain: Option<Grain>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlannedOrder {
+    /// Index into [`QueryPlan::columns`].
+    pub column: usize,
+    pub direction: Direction,
+}
+
+/// The name the bucket column answers under, and an order term reaches it by.
+pub const BUCKET_COLUMN: &str = "time";
+
+// SAFETY: aliases are positional and engine-owned, so no caller-supplied string
+// reaches the SQL text, and no alias can shadow the column it reads.
+pub fn column_alias(index: usize) -> String {
+    format!("c{index}")
+}

--- a/src/backend/services/analytics/src/domain/query/validation.rs
+++ b/src/backend/services/analytics/src/domain/query/validation.rs
@@ -1,0 +1,1217 @@
+//! Binds a query to its dataset, or refuses it.
+//!
+//! INVARIANT: the whole query is checked before anything is refused, so a caller
+//! sees every problem at once.
+
+use std::collections::HashSet;
+
+use chrono::NaiveDate;
+
+use super::contract::dto::{
+    AggregateDto, AnswerColumn, ColumnKind, ColumnType, DEFAULT_ROW_LIMIT, FilterDto, GroupAxisDto,
+    MAX_AGGREGATES, MAX_FILTER_VALUES, MAX_FILTERS, MAX_GROUP_AXES, MAX_NAME_CHARS,
+    MAX_ORDER_TERMS, MAX_PATTERN_CHARS, MAX_ROW_LIMIT, MAX_WINDOW_DAYS, OrderDto, QueryRequest,
+    ScalarDto,
+};
+use super::plan::{
+    BUCKET_COLUMN, ColumnSource, CompareOp, FilterTarget, FoldFn, PlannedAggregate, PlannedAxis,
+    PlannedColumn, PlannedFilter, PlannedFold, PlannedOrder, PlannedTest, PlannedTime, QueryPlan,
+    label_column_name,
+};
+use super::violation::{Reason, Violation};
+use crate::domain::datasets;
+use crate::domain::datasets::declaration::Dataset;
+use crate::domain::datasets::validate::DeclarationError;
+
+/// Why a request got no plan: the request's fault, or this build's.
+#[derive(Debug)]
+pub enum PlanError {
+    Refused(Vec<Violation>),
+    /// The shipped declarations failed to load, so no query can be answered.
+    DeclarationsUnusable(&'static DeclarationError),
+}
+
+pub fn plan(request: &QueryRequest) -> Result<QueryPlan<'static>, PlanError> {
+    let declared = datasets::product_datasets().map_err(PlanError::DeclarationsUnusable)?;
+
+    let dataset = declared
+        .iter()
+        .find(|dataset| dataset.key.as_str() == request.dataset)
+        .ok_or_else(|| {
+            PlanError::Refused(vec![Violation::unknown(
+                "dataset",
+                &request.dataset,
+                &datasets::declared_keys(),
+            )])
+        })?;
+
+    plan_against(request, dataset).map_err(PlanError::Refused)
+}
+
+pub fn plan_against<'d>(
+    request: &QueryRequest,
+    dataset: &'d Dataset,
+) -> Result<QueryPlan<'d>, Vec<Violation>> {
+    let mut violations = Vec::new();
+
+    let filters = plan_filters(&request.filters, dataset, &mut violations);
+    let group_by = plan_axes(&request.group_by, dataset, &mut violations);
+    let aggregates = plan_aggregates(&request.aggregates, dataset, &mut violations);
+    let time = plan_time(request, &group_by, dataset, &mut violations);
+    let limit = plan_limit(request.limit, &mut violations);
+
+    let columns = answer_columns(&group_by, &aggregates, &mut violations);
+    let order = plan_order(&request.order, &columns, &mut violations);
+
+    let Some(time) = time else {
+        return Err(violations);
+    };
+    if !violations.is_empty() {
+        return Err(violations);
+    }
+
+    Ok(QueryPlan {
+        dataset,
+        filters,
+        group_by,
+        aggregates,
+        time,
+        order,
+        limit,
+        columns,
+    })
+}
+
+fn plan_filters<'d>(
+    filters: &[FilterDto],
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Vec<PlannedFilter<'d>> {
+    if filters.len() > MAX_FILTERS {
+        violations.push(Violation::new(
+            "filters",
+            Reason::OutOfRange,
+            format!("a query carries at most {MAX_FILTERS} filters"),
+        ));
+    }
+
+    filters
+        .iter()
+        .enumerate()
+        .filter_map(|(index, filter)| {
+            plan_filter(filter, &format!("filters[{index}]"), dataset, violations)
+        })
+        .collect()
+}
+
+fn plan_filter<'d>(
+    filter: &FilterDto,
+    path: &str,
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Option<PlannedFilter<'d>> {
+    let target = resolve_filter_target(filter, path, dataset, violations)?;
+    let test = planned_test(filter, path, violations)?;
+    check_operands(&test, &target, path, violations);
+
+    Some(PlannedFilter { target, test })
+}
+
+// INVARIANT: every operator but `in` has its arity fixed by its shape.
+fn planned_test(
+    filter: &FilterDto,
+    path: &str,
+    violations: &mut Vec<Violation>,
+) -> Option<PlannedTest> {
+    let test = match filter {
+        FilterDto::Eq { value, .. } => PlannedTest::Eq(value.clone()),
+        FilterDto::In { values, .. } => {
+            let complaint = match values.len() {
+                0 => Some("takes at least one value".to_owned()),
+                n if n > MAX_FILTER_VALUES => {
+                    Some(format!("takes at most {MAX_FILTER_VALUES} values"))
+                }
+                _ => None,
+            };
+            if let Some(complaint) = complaint {
+                violations.push(Violation::new(
+                    format!("{path}.values"),
+                    Reason::OutOfRange,
+                    format!("`in` {complaint}, and {} were given", values.len()),
+                ));
+                return None;
+            }
+            PlannedTest::In(values.clone())
+        }
+        FilterDto::Gt { value, .. } => PlannedTest::Compare(CompareOp::Gt, value.clone()),
+        FilterDto::Gte { value, .. } => PlannedTest::Compare(CompareOp::Gte, value.clone()),
+        FilterDto::Lt { value, .. } => PlannedTest::Compare(CompareOp::Lt, value.clone()),
+        FilterDto::Lte { value, .. } => PlannedTest::Compare(CompareOp::Lte, value.clone()),
+        FilterDto::Between { low, high, .. } => PlannedTest::Between {
+            low: low.clone(),
+            high: high.clone(),
+        },
+        FilterDto::NotNull { .. } => PlannedTest::NotNull,
+        FilterDto::Like { value, .. } => {
+            check_pattern_length(value, path, violations)?;
+            PlannedTest::Like(value.clone())
+        }
+        FilterDto::Matches { value, .. } => {
+            check_pattern_length(value, path, violations)?;
+            if let Err(error) = regex_lite::Regex::new(value) {
+                violations.push(Violation::new(
+                    format!("{path}.value"),
+                    Reason::Malformed,
+                    format!("the pattern is not a regular expression: {error}"),
+                ));
+                return None;
+            }
+            PlannedTest::Matches(value.clone())
+        }
+    };
+
+    Some(test)
+}
+
+fn check_pattern_length(pattern: &str, path: &str, violations: &mut Vec<Violation>) -> Option<()> {
+    if pattern.chars().count() <= MAX_PATTERN_CHARS {
+        return Some(());
+    }
+    violations.push(Violation::new(
+        format!("{path}.value"),
+        Reason::OutOfRange,
+        format!("a pattern is at most {MAX_PATTERN_CHARS} characters"),
+    ));
+    None
+}
+
+fn resolve_filter_target<'d>(
+    filter: &FilterDto,
+    path: &str,
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Option<FilterTarget<'d>> {
+    if let Some(dimension) = dataset.dimension(filter.field()) {
+        return Some(FilterTarget::Dimension(dimension));
+    }
+    if let Some(measurable) = dataset.measurable(filter.field()) {
+        return Some(FilterTarget::Measurable(measurable));
+    }
+
+    let mut admissible = dataset.dimension_names();
+    admissible.extend(dataset.measurable_names());
+    violations.push(Violation::unknown(
+        format!("{path}.field"),
+        filter.field(),
+        &admissible,
+    ));
+    None
+}
+
+// INVARIANT: a dimension compares as text, so an ordered test over it would
+// order lexicographically; a measurable compares against the numeric column, so
+// a pattern cannot apply and only a number can be on the other side.
+fn check_operands(
+    test: &PlannedTest,
+    target: &FilterTarget<'_>,
+    path: &str,
+    violations: &mut Vec<Violation>,
+) {
+    let measurable = match target {
+        FilterTarget::Dimension(dimension) => {
+            if matches!(test, PlannedTest::Compare(..) | PlannedTest::Between { .. }) {
+                violations.push(Violation::new(
+                    format!("{path}.op"),
+                    Reason::Unexpected,
+                    format!(
+                        "`{}` is a dimension and takes eq, in, not_null, like or match",
+                        dimension.field
+                    ),
+                ));
+            }
+            return;
+        }
+        FilterTarget::Measurable(measurable) => measurable,
+    };
+
+    if matches!(test, PlannedTest::Like(_) | PlannedTest::Matches(_)) {
+        violations.push(Violation::new(
+            format!("{path}.op"),
+            Reason::Unexpected,
+            format!(
+                "`{}` is numeric and takes eq, in, not_null, the comparisons or between",
+                measurable.field
+            ),
+        ));
+        return;
+    }
+
+    for (operand, value) in test.operands() {
+        if matches!(value, ScalarDto::Number(_)) {
+            continue;
+        }
+        violations.push(Violation::new(
+            format!("{path}.{operand}"),
+            Reason::TypeMismatch,
+            format!(
+                "`{}` is numeric and compares against numbers",
+                measurable.field
+            ),
+        ));
+    }
+}
+
+fn plan_axes<'d>(
+    axes: &[GroupAxisDto],
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Vec<PlannedAxis<'d>> {
+    if axes.len() > MAX_GROUP_AXES {
+        violations.push(Violation::new(
+            "group_by",
+            Reason::OutOfRange,
+            format!("a query groups by at most {MAX_GROUP_AXES} axes"),
+        ));
+    }
+
+    let mut seen_dimensions = HashSet::new();
+    let mut seen_time = false;
+    let mut planned = Vec::with_capacity(axes.len());
+
+    for (index, axis) in axes.iter().enumerate() {
+        match axis {
+            GroupAxisDto::Dimension { field: named } => {
+                let Some(dimension) = dataset.dimension(named) else {
+                    violations.push(Violation::unknown(
+                        format!("group_by[{index}].field"),
+                        named,
+                        &dataset.dimension_names(),
+                    ));
+                    continue;
+                };
+                if !seen_dimensions.insert(dimension.field.as_str()) {
+                    violations.push(Violation::new(
+                        format!("group_by[{index}].field"),
+                        Reason::Duplicate,
+                        format!("`{}` is already a group axis", dimension.field),
+                    ));
+                    continue;
+                }
+                planned.push(PlannedAxis::Dimension(dimension));
+            }
+            GroupAxisDto::Time {} => {
+                if seen_time {
+                    violations.push(Violation::new(
+                        format!("group_by[{index}].axis"),
+                        Reason::Duplicate,
+                        "a query carries one time axis",
+                    ));
+                    continue;
+                }
+                seen_time = true;
+                planned.push(PlannedAxis::Time);
+            }
+        }
+    }
+
+    planned
+}
+
+fn plan_aggregates<'d>(
+    aggregates: &[AggregateDto],
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Vec<PlannedAggregate<'d>> {
+    if aggregates.is_empty() {
+        violations.push(Violation::new(
+            "aggregates",
+            Reason::Missing,
+            "a query computes at least one aggregate",
+        ));
+    }
+    if aggregates.len() > MAX_AGGREGATES {
+        violations.push(Violation::new(
+            "aggregates",
+            Reason::OutOfRange,
+            format!("a query carries at most {MAX_AGGREGATES} aggregates"),
+        ));
+    }
+
+    let mut seen = HashSet::new();
+    let mut planned = Vec::with_capacity(aggregates.len());
+
+    for (index, aggregate) in aggregates.iter().enumerate() {
+        let path = format!("aggregates[{index}]");
+        let name = aggregate.name();
+        if !is_answer_name(name) {
+            violations.push(Violation::new(
+                format!("{path}.name"),
+                Reason::Malformed,
+                format!(
+                    "an aggregate name is lowercase snake_case of at most {MAX_NAME_CHARS} characters"
+                ),
+            ));
+            continue;
+        }
+        if !seen.insert(name) {
+            violations.push(Violation::new(
+                format!("{path}.name"),
+                Reason::Duplicate,
+                format!("`{name}` names two aggregates"),
+            ));
+            continue;
+        }
+
+        let Some(fold) = plan_fold(aggregate, &path, dataset, violations) else {
+            continue;
+        };
+        let declared_filter = aggregate.filter();
+        let filter = declared_filter
+            .and_then(|filter| plan_filter(filter, &format!("{path}.filter"), dataset, violations));
+        if declared_filter.is_some() && filter.is_none() {
+            continue;
+        }
+
+        planned.push(PlannedAggregate {
+            index,
+            name: name.to_owned(),
+            fold,
+            filter,
+        });
+    }
+
+    planned
+}
+
+fn plan_fold<'d>(
+    aggregate: &AggregateDto,
+    path: &str,
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Option<PlannedFold<'d>> {
+    let (function, field) = match aggregate {
+        AggregateDto::Count { .. } => return Some(PlannedFold::Rows),
+        AggregateDto::Sum { field, .. } => (FoldFn::Sum, field),
+        AggregateDto::Avg { field, .. } => (FoldFn::Avg, field),
+        AggregateDto::Min { field, .. } => (FoldFn::Min, field),
+        AggregateDto::Max { field, .. } => (FoldFn::Max, field),
+    };
+
+    let Some(measurable) = dataset.measurable(field) else {
+        violations.push(Violation::unknown(
+            format!("{path}.field"),
+            field,
+            &dataset.measurable_names(),
+        ));
+        return None;
+    };
+
+    Some(PlannedFold::Values {
+        function,
+        measurable,
+    })
+}
+
+fn plan_time<'d>(
+    request: &QueryRequest,
+    group_by: &[PlannedAxis<'d>],
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Option<PlannedTime<'d>> {
+    let time = &request.time;
+    if time.from > time.to {
+        violations.push(Violation::new(
+            "time.from",
+            Reason::OutOfRange,
+            "the window starts after it ends",
+        ));
+    } else if (time.to - time.from).num_days() >= MAX_WINDOW_DAYS {
+        violations.push(Violation::new(
+            "time.to",
+            Reason::OutOfRange,
+            format!("a window spans at most {MAX_WINDOW_DAYS} days"),
+        ));
+    }
+    check_window_days_representable(time.from, time.to, violations);
+
+    let buckets = group_by
+        .iter()
+        .any(|axis| matches!(axis, PlannedAxis::Time));
+    match (buckets, time.grain) {
+        (true, None) => violations.push(Violation::new(
+            "time.grain",
+            Reason::Missing,
+            "a time axis needs a bucket width",
+        )),
+        (false, Some(_)) => violations.push(Violation::new(
+            "time.grain",
+            Reason::Unexpected,
+            "a bucket width buckets nothing without an `{\"axis\": \"time\"}` axis",
+        )),
+        (true, Some(_)) | (false, None) => {}
+    }
+
+    let field = match time.field.as_deref() {
+        None => dataset.default_time_field(),
+        Some(named) => {
+            let found = dataset.time_field(named);
+            if found.is_none() {
+                violations.push(Violation::unknown(
+                    "time.field",
+                    named,
+                    &dataset.time_field_names(),
+                ));
+            }
+            found
+        }
+    }?;
+
+    Some(PlannedTime {
+        field,
+        from: time.from,
+        to: time.to,
+        grain: time.grain,
+    })
+}
+
+// SAFETY: the compiler renders every bound day through `toDate`, which clamps a
+// day outside the warehouse's `Date` range instead of refusing it — so a window
+// the caller never asked for would match rows.
+fn check_window_days_representable(
+    from: NaiveDate,
+    to: NaiveDate,
+    violations: &mut Vec<Violation>,
+) {
+    let (earliest, latest) = representable_window_days();
+    for (field, day) in [("time.from", from), ("time.to", to)] {
+        if day < earliest || day > latest {
+            violations.push(Violation::new(
+                field,
+                Reason::OutOfRange,
+                format!("a window day lies between {earliest} and {latest}"),
+            ));
+        }
+    }
+}
+
+/// The range of ClickHouse's `Date`.
+fn representable_window_days() -> (NaiveDate, NaiveDate) {
+    let earliest = NaiveDate::from_ymd_opt(1970, 1, 1);
+    let latest = NaiveDate::from_ymd_opt(2149, 6, 6);
+    match (earliest, latest) {
+        (Some(earliest), Some(latest)) => (earliest, latest),
+        (None, _) | (_, None) => unreachable!("the Date range is a valid calendar range"),
+    }
+}
+
+fn plan_limit(limit: Option<u32>, violations: &mut Vec<Violation>) -> u32 {
+    match limit {
+        None => DEFAULT_ROW_LIMIT,
+        Some(0) => {
+            violations.push(Violation::new(
+                "limit",
+                Reason::OutOfRange,
+                "a limit of zero asks for no rows",
+            ));
+            DEFAULT_ROW_LIMIT
+        }
+        Some(requested) if requested > MAX_ROW_LIMIT => {
+            violations.push(Violation::new(
+                "limit",
+                Reason::OutOfRange,
+                format!("an answer carries at most {MAX_ROW_LIMIT} rows"),
+            ));
+            DEFAULT_ROW_LIMIT
+        }
+        Some(requested) => requested,
+    }
+}
+
+// INVARIANT: no two answer columns share a name, or an order term could not say
+// which one it means.
+fn answer_columns<'d>(
+    group_by: &[PlannedAxis<'d>],
+    aggregates: &[PlannedAggregate<'d>],
+    violations: &mut Vec<Violation>,
+) -> Vec<PlannedColumn<'d>> {
+    let mut columns: Vec<PlannedColumn<'d>> =
+        Vec::with_capacity(2 * group_by.len() + aggregates.len());
+
+    for axis in group_by {
+        match axis {
+            PlannedAxis::Dimension(dimension) => {
+                columns.push(PlannedColumn {
+                    answer: AnswerColumn {
+                        name: dimension.field.clone(),
+                        kind: ColumnKind::Dimension,
+                        value_type: ColumnType::Text,
+                    },
+                    source: ColumnSource::Dimension(dimension),
+                });
+                if dimension.label_field.is_some() {
+                    columns.push(PlannedColumn {
+                        answer: AnswerColumn {
+                            name: label_column_name(dimension),
+                            kind: ColumnKind::Label,
+                            value_type: ColumnType::Text,
+                        },
+                        source: ColumnSource::Label(dimension),
+                    });
+                }
+            }
+            PlannedAxis::Time => columns.push(PlannedColumn {
+                answer: AnswerColumn {
+                    name: BUCKET_COLUMN.to_owned(),
+                    kind: ColumnKind::Bucket,
+                    value_type: ColumnType::Date,
+                },
+                source: ColumnSource::Bucket,
+            }),
+        }
+    }
+
+    for (position, aggregate) in aggregates.iter().enumerate() {
+        if columns
+            .iter()
+            .any(|column| column.answer.name == aggregate.name)
+        {
+            violations.push(Violation::new(
+                format!("aggregates[{}].name", aggregate.index),
+                Reason::Duplicate,
+                format!("`{}` is already a column of this answer", aggregate.name),
+            ));
+            continue;
+        }
+        columns.push(PlannedColumn {
+            answer: AnswerColumn {
+                name: aggregate.name.clone(),
+                kind: ColumnKind::Aggregate,
+                value_type: ColumnType::Number,
+            },
+            source: ColumnSource::Aggregate(position),
+        });
+    }
+
+    columns
+}
+
+fn plan_order(
+    order: &[OrderDto],
+    columns: &[PlannedColumn<'_>],
+    violations: &mut Vec<Violation>,
+) -> Vec<PlannedOrder> {
+    if order.len() > MAX_ORDER_TERMS {
+        violations.push(Violation::new(
+            "order",
+            Reason::OutOfRange,
+            format!("a query orders by at most {MAX_ORDER_TERMS} columns"),
+        ));
+    }
+
+    let names: Vec<&str> = columns
+        .iter()
+        .map(|column| column.answer.name.as_str())
+        .collect();
+    let mut seen = HashSet::new();
+    let mut planned = Vec::with_capacity(order.len());
+
+    for (index, term) in order.iter().enumerate() {
+        let Some(column) = columns
+            .iter()
+            .position(|column| column.answer.name == term.by)
+        else {
+            violations.push(Violation::unknown(
+                format!("order[{index}].by"),
+                &term.by,
+                &names,
+            ));
+            continue;
+        };
+        if !seen.insert(column) {
+            violations.push(Violation::new(
+                format!("order[{index}].by"),
+                Reason::Duplicate,
+                format!("`{}` is already an ordering term", term.by),
+            ));
+            continue;
+        }
+        planned.push(PlannedOrder {
+            column,
+            direction: term.dir,
+        });
+    }
+
+    planned
+}
+
+fn is_answer_name(name: &str) -> bool {
+    if name.chars().count() > MAX_NAME_CHARS {
+        return false;
+    }
+    let mut characters = name.chars();
+    match characters.next() {
+        Some(first) if first.is_ascii_lowercase() => {}
+        Some(_) | None => return false,
+    }
+    characters.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::query::contract::dto::{Direction, Grain};
+    use crate::domain::query::fixtures;
+
+    fn refuse(json: &str) -> Vec<Violation> {
+        let dataset = fixtures::commits();
+        plan_against(&fixtures::query(json), &dataset).expect_err("the query must be refused")
+    }
+
+    fn only(json: &str) -> Violation {
+        let mut violations = refuse(json);
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        violations.remove(0)
+    }
+
+    fn accept(json: &str) -> (Dataset, QueryRequest) {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(json);
+        plan_against(&request, &dataset).expect("the query must be admissible");
+        (dataset, request)
+    }
+
+    const COUNT_BY_WEEK: &str = r#"{
+      "dataset": "git_commits",
+      "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+      "aggregates": [{"name": "commits", "fn": "count"}],
+      "time": {"from": "2026-01-01", "to": "2026-03-31", "grain": "week"},
+      "order": [{"by": "commits", "dir": "desc"}],
+      "limit": 50
+    }"#;
+
+    #[test]
+    fn a_grouped_bucketed_query_binds_every_reference_it_names() {
+        let dataset = fixtures::commits();
+        let plan = plan_against(&fixtures::query(COUNT_BY_WEEK), &dataset).expect("admissible");
+
+        assert_eq!(plan.limit, 50);
+        assert!(plan.group_by.contains(&PlannedAxis::Time));
+        assert_eq!(plan.time.grain, Some(Grain::Week));
+        assert_eq!(plan.time.field.field, "authored_at");
+        assert_eq!(
+            plan.columns
+                .iter()
+                .map(|column| {
+                    (
+                        column.answer.name.as_str(),
+                        column.answer.kind,
+                        column.answer.value_type,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                ("repository", ColumnKind::Dimension, ColumnType::Text),
+                ("repository_label", ColumnKind::Label, ColumnType::Text),
+                ("time", ColumnKind::Bucket, ColumnType::Date),
+                ("commits", ColumnKind::Aggregate, ColumnType::Number),
+            ]
+        );
+        assert_eq!(
+            plan.order,
+            vec![PlannedOrder {
+                column: 3,
+                direction: Direction::Desc,
+            }]
+        );
+    }
+
+    #[test]
+    fn a_dimension_without_a_declared_label_answers_its_value_alone() {
+        let dataset = fixtures::commits();
+        let plan = plan_against(
+            &fixtures::query(
+                r#"{"dataset": "git_commits",
+                     "group_by": [{"axis": "dimension", "field": "author_email"}],
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+            ),
+            &dataset,
+        )
+        .expect("admissible");
+
+        let names: Vec<&str> = plan
+            .columns
+            .iter()
+            .map(|column| column.answer.name.as_str())
+            .collect();
+        assert_eq!(names, ["author_email", "commits"]);
+    }
+
+    #[test]
+    fn an_aggregate_colliding_with_a_group_column_is_refused_at_its_own_request_index() {
+        let violations = refuse(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "source"}],
+                 "aggregates": [{"name": "Bad", "fn": "count"}, {"name": "source", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        let fields: Vec<&str> = violations
+            .iter()
+            .map(|violation| violation.field.as_str())
+            .collect();
+        assert_eq!(fields, ["aggregates[0].name", "aggregates[1].name"]);
+        assert_eq!(violations[1].reason, Reason::Duplicate);
+    }
+
+    #[test]
+    fn a_window_day_the_warehouse_cannot_represent_is_refused_rather_than_clamped() {
+        for (json, field) in [
+            (
+                r#"{"dataset": "git_commits",
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "1960-01-01", "to": "1960-01-31"}}"#,
+                vec!["time.from", "time.to"],
+            ),
+            (
+                r#"{"dataset": "git_commits",
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "2149-06-01", "to": "2149-06-07"}}"#,
+                vec!["time.to"],
+            ),
+        ] {
+            let violations = refuse(json);
+            let fields: Vec<&str> = violations
+                .iter()
+                .map(|violation| violation.field.as_str())
+                .collect();
+            assert_eq!(fields, field, "{json}");
+            assert!(violations.iter().all(|v| v.reason == Reason::OutOfRange));
+        }
+    }
+
+    #[test]
+    fn a_query_naming_no_limit_takes_the_default_ceiling() {
+        let dataset = fixtures::commits();
+        let plan = plan_against(
+            &fixtures::query(
+                r#"{"dataset": "git_commits",
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+            ),
+            &dataset,
+        )
+        .expect("admissible");
+
+        assert_eq!(plan.limit, DEFAULT_ROW_LIMIT);
+        assert_eq!(plan.time.grain, None);
+        assert!(!plan.group_by.contains(&PlannedAxis::Time));
+    }
+
+    #[test]
+    fn a_query_over_the_row_ceiling_is_refused_rather_than_clipped() {
+        let violation = only(&format!(
+            r#"{{"dataset": "git_commits",
+                 "aggregates": [{{"name": "commits", "fn": "count"}}],
+                 "time": {{"from": "2026-01-01", "to": "2026-01-31"}},
+                 "limit": {}}}"#,
+            MAX_ROW_LIMIT + 1
+        ));
+
+        assert_eq!(violation.field, "limit");
+        assert_eq!(violation.reason, Reason::OutOfRange);
+    }
+
+    #[test]
+    fn a_group_axis_the_dataset_does_not_declare_is_refused_with_the_admissible_set() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "branch"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert_eq!(violation.field, "group_by[0].field");
+        assert_eq!(violation.reason, Reason::Unknown);
+        assert!(violation.detail.contains("repository"), "{violation:?}");
+    }
+
+    #[test]
+    fn a_time_axis_and_a_bucket_width_each_require_the_other() {
+        let missing = only(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "time"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(missing.field, "time.grain");
+        assert_eq!(missing.reason, Reason::Missing);
+
+        let unexpected = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31", "grain": "day"}}"#,
+        );
+        assert_eq!(unexpected.field, "time.grain");
+        assert_eq!(unexpected.reason, Reason::Unexpected);
+    }
+
+    #[test]
+    fn a_repeated_axis_is_refused() {
+        for (json, field) in [
+            (
+                r#"{"dataset": "git_commits",
+                     "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "dimension", "field": "repository"}],
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+                "group_by[1].field",
+            ),
+            (
+                r#"{"dataset": "git_commits",
+                     "group_by": [{"axis": "time"}, {"axis": "time"}],
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "2026-01-01", "to": "2026-01-31", "grain": "day"}}"#,
+                "group_by[1].axis",
+            ),
+        ] {
+            let violation = only(json);
+            assert_eq!(violation.field, field);
+            assert_eq!(violation.reason, Reason::Duplicate);
+        }
+    }
+
+    #[test]
+    fn a_window_that_ends_before_it_starts_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-03-31", "to": "2026-01-01"}}"#,
+        );
+        assert_eq!(violation.field, "time.from");
+        assert_eq!(violation.reason, Reason::OutOfRange);
+    }
+
+    #[test]
+    fn a_window_wider_than_the_cap_is_refused_and_one_at_the_cap_is_not() {
+        let at_cap = fixtures::query(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2024-01-01", "to": "2025-12-31"}}"#,
+        );
+        plan_against(&at_cap, &fixtures::commits()).expect("731 days inclusive is the cap");
+
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2024-01-01", "to": "2026-01-01"}}"#,
+        );
+        assert_eq!(violation.field, "time.to");
+        assert_eq!(violation.reason, Reason::OutOfRange);
+    }
+
+    #[test]
+    fn a_time_field_the_dataset_does_not_declare_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"field": "ingested_at", "from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "time.field");
+        assert_eq!(violation.reason, Reason::Unknown);
+        assert!(violation.detail.contains("authored_at"), "{violation:?}");
+    }
+
+    #[test]
+    fn a_query_computing_nothing_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits", "aggregates": [],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "aggregates");
+        assert_eq!(violation.reason, Reason::Missing);
+    }
+
+    #[test]
+    fn an_aggregate_over_a_column_that_is_not_a_measurable_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "added", "fn": "sum", "field": "repository"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "aggregates[0].field");
+        assert_eq!(violation.reason, Reason::Unknown);
+        assert!(violation.detail.contains("lines_added"), "{violation:?}");
+    }
+
+    #[test]
+    fn two_answer_columns_may_not_share_a_name() {
+        let repeated = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"},
+                                {"name": "commits", "fn": "sum", "field": "lines_added"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(repeated.field, "aggregates[1].name");
+        assert_eq!(repeated.reason, Reason::Duplicate);
+
+        let shadowing = only(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "repository"}],
+                 "aggregates": [{"name": "repository", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(shadowing.field, "aggregates[0].name");
+        assert_eq!(shadowing.reason, Reason::Duplicate);
+    }
+
+    #[test]
+    fn an_aggregate_name_outside_the_answer_name_shape_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "Commits Merged", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "aggregates[0].name");
+        assert_eq!(violation.reason, Reason::Malformed);
+    }
+
+    #[test]
+    fn an_in_filter_takes_between_one_value_and_the_cap() {
+        let over = format!(
+            "[{}]",
+            (0..=MAX_FILTER_VALUES)
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+
+        for values in ["[]", over.as_str()] {
+            let violation = only(&format!(
+                r#"{{"dataset": "git_commits",
+                     "filters": [{{"field": "lines_added", "op": "in", "values": {values}}}],
+                     "aggregates": [{{"name": "commits", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+            ));
+            assert_eq!(violation.field, "filters[0].values");
+            assert_eq!(violation.reason, Reason::OutOfRange);
+        }
+    }
+    #[test]
+    fn a_measurable_filter_compares_against_numbers_only() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "filters": [{"field": "lines_added", "op": "gte", "value": "500"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "filters[0].value");
+        assert_eq!(violation.reason, Reason::TypeMismatch);
+    }
+
+    #[test]
+    fn an_ordered_test_over_a_dimension_is_refused_rather_than_compared_as_text() {
+        let filters = [
+            r#"{"field": "repository", "op": "gt", "value": "b"}"#,
+            r#"{"field": "repository", "op": "lte", "value": "b"}"#,
+            r#"{"field": "repository", "op": "between", "low": "a", "high": "b"}"#,
+        ];
+        for filter in filters {
+            let violation = only(&format!(
+                r#"{{"dataset": "git_commits",
+                     "filters": [{filter}],
+                     "aggregates": [{{"name": "commits", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+            ));
+            assert_eq!(violation.field, "filters[0].op", "{filter}");
+            assert_eq!(violation.reason, Reason::Unexpected, "{filter}");
+        }
+    }
+
+    #[test]
+    fn a_pattern_test_is_admitted_over_a_dimension_and_refused_over_a_measurable() {
+        let dataset = fixtures::commits();
+        for op in ["like", "match"] {
+            let request = fixtures::query(&format!(
+                r#"{{"dataset": "git_commits",
+                     "filters": [{{"field": "repository", "op": "{op}", "value": "example/%"}}],
+                     "aggregates": [{{"name": "commits", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+            ));
+            plan_against(&request, &dataset).unwrap_or_else(|v| panic!("{op}: {v:?}"));
+
+            let violation = only(&format!(
+                r#"{{"dataset": "git_commits",
+                     "filters": [{{"field": "lines_added", "op": "{op}", "value": "1%"}}],
+                     "aggregates": [{{"name": "commits", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+            ));
+            assert_eq!(violation.field, "filters[0].op", "{op}");
+            assert_eq!(violation.reason, Reason::Unexpected, "{op}");
+        }
+    }
+
+    #[test]
+    fn a_pattern_that_is_not_a_regular_expression_or_is_too_long_is_refused() {
+        let malformed = only(
+            r#"{"dataset": "git_commits",
+                 "filters": [{"field": "repository", "op": "match", "value": "("}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(malformed.field, "filters[0].value");
+        assert_eq!(malformed.reason, Reason::Malformed);
+
+        let long = "%".repeat(MAX_PATTERN_CHARS + 1);
+        let too_long = only(&format!(
+            r#"{{"dataset": "git_commits",
+                 "filters": [{{"field": "repository", "op": "like", "value": "{long}"}}],
+                 "aggregates": [{{"name": "commits", "fn": "count"}}],
+                 "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+        ));
+        assert_eq!(too_long.field, "filters[0].value");
+        assert_eq!(too_long.reason, Reason::OutOfRange);
+    }
+
+    #[test]
+    fn a_filter_over_a_column_that_is_neither_a_dimension_nor_a_measurable_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "filters": [{"field": "message", "op": "eq", "value": "x"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "filters[0].field");
+        assert_eq!(violation.reason, Reason::Unknown);
+        assert!(violation.detail.contains("lines_added"), "{violation:?}");
+    }
+
+    #[test]
+    fn a_conditional_aggregate_filter_is_refused_on_its_own_path() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count",
+                                 "filter": {"field": "branch", "op": "eq", "value": "main"}}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "aggregates[0].filter.field");
+        assert_eq!(violation.reason, Reason::Unknown);
+    }
+
+    #[test]
+    fn an_order_term_names_a_column_the_answer_reports() {
+        let unknown = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"},
+                 "order": [{"by": "repository"}]}"#,
+        );
+        assert_eq!(unknown.field, "order[0].by");
+        assert_eq!(unknown.reason, Reason::Unknown);
+        assert!(unknown.detail.contains("commits"), "{unknown:?}");
+
+        let repeated = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"},
+                 "order": [{"by": "commits"}, {"by": "commits", "dir": "desc"}]}"#,
+        );
+        assert_eq!(repeated.field, "order[1].by");
+        assert_eq!(repeated.reason, Reason::Duplicate);
+    }
+
+    #[test]
+    fn every_problem_in_one_query_is_reported_at_once() {
+        let violations = refuse(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "branch"}],
+                 "aggregates": [{"name": "added", "fn": "sum", "field": "branch_scope"}],
+                 "time": {"from": "2026-03-31", "to": "2026-01-01"},
+                 "limit": 0}"#,
+        );
+
+        let fields: Vec<&str> = violations
+            .iter()
+            .map(|violation| violation.field.as_str())
+            .collect();
+        assert_eq!(
+            fields,
+            vec![
+                "group_by[0].field",
+                "aggregates[0].field",
+                "time.from",
+                "limit"
+            ]
+        );
+    }
+
+    fn refused_by_the_build(json: &str) -> Vec<Violation> {
+        match plan(&fixtures::query(json)) {
+            Err(PlanError::Refused(violations)) => violations,
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_dataset_this_build_does_not_declare_is_refused_with_the_declared_keys() {
+        let violations = refused_by_the_build(
+            r#"{"dataset": "git_tags",
+                 "aggregates": [{"name": "tags", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].field, "dataset");
+        assert!(violations[0].detail.contains("git_commits"));
+    }
+
+    #[test]
+    fn a_dimension_another_dataset_declares_is_still_refused_here() {
+        let axis = r#""group_by": [{"axis": "dimension", "field": "file_extension"}]"#;
+        let query = |dataset: &str| {
+            format!(
+                r#"{{"dataset": "{dataset}", {axis},
+                     "aggregates": [{{"name": "changes", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+            )
+        };
+
+        plan(&fixtures::query(&query("git_file_changes")))
+            .expect("the file-change dataset groups by it");
+
+        let violations = refused_by_the_build(&query("git_commits"));
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert_eq!(violations[0].field, "group_by[0].field");
+        assert_eq!(violations[0].reason, Reason::Unknown);
+        let (_, admissible) = violations[0]
+            .detail
+            .split_once("declared: ")
+            .expect("the refusal reports what would have been admissible");
+        assert!(
+            !admissible.contains("file_extension"),
+            "the admissible set must be the commit dataset's own: {admissible:?}"
+        );
+        assert!(admissible.contains("repository"), "{admissible:?}");
+    }
+
+    #[test]
+    fn the_shipped_dataset_answers_the_same_query_the_fixture_does() {
+        plan(&fixtures::query(COUNT_BY_WEEK)).expect("the shipped declaration admits it");
+    }
+
+    #[test]
+    fn a_filter_over_a_nullable_dimension_binds_to_the_dimension_not_the_column() {
+        let (dataset, request) = accept(
+            r#"{"dataset": "git_commits",
+                 "filters": [{"field": "source_id", "op": "eq", "value": "__unknown__"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        assert!(matches!(
+            plan.filters[0].target,
+            FilterTarget::Dimension(dimension) if dimension.absent_value.is_some()
+        ));
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/violation.rs
+++ b/src/backend/services/analytics/src/domain/query/violation.rs
@@ -1,0 +1,105 @@
+//! Why a query is refused: the request field, a machine code, and a sentence.
+
+use std::fmt::Write;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    /// A path into the request document, such as `filters[1].value`.
+    pub field: String,
+    pub reason: Reason,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reason {
+    Unknown,
+    Missing,
+    Unexpected,
+    OutOfRange,
+    Duplicate,
+    /// The field cannot hold a value of that type.
+    TypeMismatch,
+    /// The type fits; the field's own shape rule rejects the value.
+    Malformed,
+}
+
+impl Reason {
+    pub fn as_code(self) -> &'static str {
+        match self {
+            Self::Unknown => "UNKNOWN",
+            Self::Missing => "MISSING",
+            Self::Unexpected => "UNEXPECTED",
+            Self::OutOfRange => "OUT_OF_RANGE",
+            Self::Duplicate => "DUPLICATE",
+            Self::TypeMismatch => "TYPE_MISMATCH",
+            Self::Malformed => "MALFORMED",
+        }
+    }
+}
+
+impl Violation {
+    pub fn new(field: impl Into<String>, reason: Reason, detail: impl Into<String>) -> Self {
+        Self {
+            field: field.into(),
+            reason,
+            detail: detail.into(),
+        }
+    }
+
+    /// A refusal that also reports what would have been admissible.
+    pub fn unknown(field: impl Into<String>, named: &str, admissible: &[&str]) -> Self {
+        let mut detail = format!("`{named}` is not declared here");
+        if admissible.is_empty() {
+            detail.push_str("; this dataset declares none");
+        } else {
+            let _ = write!(detail, "; declared: {}", admissible.join(", "));
+        }
+
+        Self::new(field, Reason::Unknown, detail)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_unknown_field_refusal_reports_the_admissible_set() {
+        let violation =
+            Violation::unknown("group_by[0].field", "branch", &["repository", "source"]);
+
+        assert_eq!(violation.field, "group_by[0].field");
+        assert_eq!(violation.reason, Reason::Unknown);
+        assert_eq!(
+            violation.detail,
+            "`branch` is not declared here; declared: repository, source"
+        );
+    }
+
+    #[test]
+    fn an_unknown_field_refusal_over_an_empty_set_says_so() {
+        let violation = Violation::unknown("aggregates[0].field", "lines", &[]);
+        assert_eq!(
+            violation.detail,
+            "`lines` is not declared here; this dataset declares none"
+        );
+    }
+
+    #[test]
+    fn every_reason_carries_a_distinct_machine_code() {
+        let reasons = [
+            Reason::Unknown,
+            Reason::Missing,
+            Reason::Unexpected,
+            Reason::OutOfRange,
+            Reason::Duplicate,
+            Reason::TypeMismatch,
+            Reason::Malformed,
+        ];
+        let mut codes: Vec<&str> = reasons.iter().map(|reason| reason.as_code()).collect();
+        codes.sort_unstable();
+        codes.dedup();
+        assert_eq!(codes.len(), reasons.len());
+    }
+}

--- a/src/backend/services/analytics/src/infra/metrics.rs
+++ b/src/backend/services/analytics/src/infra/metrics.rs
@@ -14,6 +14,7 @@ use opentelemetry::metrics::{Counter, Histogram, Meter};
 // so the `kind` label on `analytics.metric_query.duration` stays bounded.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum QueryKind {
+    Query,
     Ranking,
     PeriodBatch,
     PeerBatch,
@@ -30,6 +31,7 @@ pub(crate) enum QueryKind {
 impl QueryKind {
     const fn as_str(self) -> &'static str {
         match self {
+            Self::Query => "query",
             Self::Ranking => "ranking",
             Self::PeriodBatch => "period_batch",
             Self::PeerBatch => "peer_batch",

--- a/src/backend/services/analytics/src/infra/query.rs
+++ b/src/backend/services/analytics/src/infra/query.rs
@@ -6,6 +6,9 @@ use sha2::{Digest as _, Sha256};
 use super::metrics::{self, ErrorClass, QueryKind, QueryOutcome};
 
 const QUERY_FETCH_TIMEOUT: Duration = Duration::from_mins(1);
+/// The most an answer may weigh before decoding: a row limit bounds rows, not
+/// the strings in them.
+pub(crate) const MAX_ANSWER_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum QueryFetchError {
@@ -27,6 +30,150 @@ impl QueryFetchError {
             Self::Parse(_) => ErrorClass::ParseFailed,
         }
     }
+}
+
+/// What a bounded fetch can fail with: anything a fetch can, or the ceiling.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum BoundedFetchError {
+    #[error(transparent)]
+    Fetch(#[from] QueryFetchError),
+    #[error("query result exceeded {MAX_ANSWER_BYTES} bytes")]
+    TooLarge,
+}
+
+impl BoundedFetchError {
+    fn class(&self) -> ErrorClass {
+        match self {
+            Self::Fetch(error) => error.class(),
+            Self::TooLarge => ErrorClass::ResourceExhausted,
+        }
+    }
+}
+
+// WORKAROUND: ClickHouse quotes every 64-bit integer by default, which would
+// make an answer's number column arrive as a string.
+pub(crate) async fn fetch_bound_rows(
+    client: &insight_clickhouse::Client,
+    sql: &str,
+    params: &[serde_json::Value],
+    kind: QueryKind,
+    log_comment: &str,
+) -> Result<Vec<serde_json::Value>, BoundedFetchError> {
+    let started = Instant::now();
+    let result = fetch_bound_rows_inner(client, sql, params, log_comment).await;
+
+    match &result {
+        Ok(_) => metrics::record_query(kind, QueryOutcome::Success, started.elapsed()),
+        Err(error) => {
+            metrics::record_query(kind, QueryOutcome::Error, started.elapsed());
+            metrics::record_clickhouse_error(kind, error.class());
+        }
+    }
+    result
+}
+
+async fn fetch_bound_rows_inner(
+    client: &insight_clickhouse::Client,
+    sql: &str,
+    params: &[serde_json::Value],
+    log_comment: &str,
+) -> Result<Vec<serde_json::Value>, BoundedFetchError> {
+    let mut query = client
+        .query(sql)
+        .with_setting("log_comment", log_comment)
+        .with_setting("output_format_json_quote_64bit_integers", "0");
+    for param in params {
+        query = query.bind(param);
+    }
+
+    let mut cursor = query.fetch_bytes("JSONEachRow").map_err(|error| {
+        log_query_failure(
+            &error.to_string(),
+            log_comment,
+            sql,
+            "ClickHouse query failed",
+        );
+        QueryFetchError::Submit(error.to_string())
+    })?;
+
+    let raw_bytes = tokio::time::timeout(QUERY_FETCH_TIMEOUT, collect_bounded(&mut cursor))
+        .await
+        .map_err(|_| {
+            log_query_failure(
+                "timeout",
+                log_comment,
+                sql,
+                "ClickHouse query fetch timed out",
+            );
+            QueryFetchError::Timeout
+        })?
+        .map_err(|error| match error {
+            ChunkError::TooLarge => {
+                tracing::warn!(
+                    comment = log_comment,
+                    "ClickHouse query result exceeded the byte ceiling"
+                );
+                BoundedFetchError::TooLarge
+            }
+            ChunkError::Fetch(message) => {
+                log_query_failure(&message, log_comment, sql, "ClickHouse query fetch failed");
+                BoundedFetchError::Fetch(QueryFetchError::Fetch(message))
+            }
+        })?;
+
+    let parsed = tokio::task::spawn_blocking(move || parse_json_rows(&raw_bytes))
+        .await
+        .map_err(|error| {
+            log_query_failure(
+                &error.to_string(),
+                log_comment,
+                sql,
+                "ClickHouse row parsing task failed",
+            );
+            QueryFetchError::Parse(error.to_string())
+        })?;
+
+    parsed.map_err(|error| {
+        log_query_failure(
+            &error.to_string(),
+            log_comment,
+            sql,
+            "failed to parse ClickHouse query rows",
+        );
+        BoundedFetchError::Fetch(QueryFetchError::Parse(error.to_string()))
+    })
+}
+
+fn parse_json_rows(raw_bytes: &[u8]) -> Result<Vec<serde_json::Value>, serde_json::Error> {
+    raw_bytes
+        .split(|&byte| byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(serde_json::from_slice)
+        .collect()
+}
+
+enum ChunkError {
+    TooLarge,
+    Fetch(String),
+}
+
+// SAFETY: the ceiling is enforced chunk by chunk while receiving, so an
+// oversized result is abandoned rather than buffered and then measured.
+async fn collect_bounded(
+    cursor: &mut clickhouse::query::BytesCursor,
+) -> Result<Vec<u8>, ChunkError> {
+    let mut buffer: Vec<u8> = Vec::new();
+    while let Some(chunk) = cursor
+        .next()
+        .await
+        .map_err(|error| ChunkError::Fetch(error.to_string()))?
+    {
+        if buffer.len() + chunk.len() > MAX_ANSWER_BYTES {
+            return Err(ChunkError::TooLarge);
+        }
+        buffer.extend_from_slice(&chunk);
+    }
+    Ok(buffer)
 }
 
 pub(crate) async fn fetch_json_rows<T>(

--- a/tests/stand/api/analytics/test_datasets.py
+++ b/tests/stand/api/analytics/test_datasets.py
@@ -66,6 +66,9 @@ def test_the_listing_describes_every_dataset_a_query_may_name(api: ApiClient) ->
             f"{dataset.key}: a window binds to exactly one default time field: "
             f"{dataset.time_fields}"
         )
+        assert dataset.limits.max_limit >= dataset.limits.default_limit, (
+            f"{dataset.key}: the default row ceiling is above the maximum: {dataset.limits}"
+        )
         for dimension in dataset.dimensions:
             if dimension.label is not None:
                 assert dimension.label == f"{dimension.field}_label", (

--- a/tests/stand/api/analytics/test_query.py
+++ b/tests/stand/api/analytics/test_query.py
@@ -1,0 +1,434 @@
+"""`POST /v1/query` — the query contract over the declared datasets.
+
+    POST /v1/query   200 admin · 403 everybody else
+                     400 (unknown dataset, undeclared dimension, a limit over
+                          the cap, a window over the cap, an ordered test over a
+                          dimension, a body naming a tenant)
+
+Deployed-path because no unit test reaches these: the session's tenant becoming
+the scan's leading predicate, the compiled statement being SQL a real ClickHouse
+accepts, the gold relation the declaration binds having been built, and the
+admin gate — which lives inside the handler, so the edge admits the request and
+the refusal comes from the role check.
+
+No expected number is written into this file; the 200 cases reconcile two
+independent queries against each other.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_stand import ApiClient, ApiResponse, Manifest, PersonaSession, analytics_path
+from insight_stand.api import JsonValue
+
+from ..schemas import ProblemDocument
+from ..schemas.analytics import QueryAnswer
+from . import query_window
+
+QUERY = analytics_path("/v1/query")
+
+#: The datasets this build declares. A key the service does not carry is the
+#: other half of the pair, and it is well-formed so a refusal is the
+#: declaration's rather than a spelling rejection dressed as one.
+GIT_COMMITS = "git_commits"
+GIT_FILE_CHANGES = "git_file_changes"
+UNKNOWN_DATASET = "stand_does_not_exist"
+
+
+def _query(
+    manifest: Manifest, *, grain: str | None = None, **overrides: JsonValue
+) -> dict[str, JsonValue]:
+    start, end = query_window(manifest)
+    time: dict[str, JsonValue] = {"from": start, "to": end}
+    if grain is not None:
+        time["grain"] = grain
+
+    body: dict[str, JsonValue] = {
+        "dataset": GIT_COMMITS,
+        "aggregates": [{"name": "commits", "fn": "count"}],
+        "time": time,
+    }
+    body.update(overrides)
+    return body
+
+
+def _post(api: ApiClient, body: dict[str, JsonValue]) -> ApiResponse:
+    return api.post(QUERY, json_body=body)
+
+
+def _violated_fields(response: ApiResponse) -> list[str]:
+    """Every request field the refusal names, so a caller could repair the query."""
+    violations = response.parse(ProblemDocument).context.get("field_violations")
+    assert isinstance(violations, list), (
+        f"a refusal must carry field_violations: {response.text[:300]}"
+    )
+
+    fields: list[str] = []
+    for violation in violations:
+        assert isinstance(violation, dict), f"a violation must be an object: {violation}"
+        field = violation.get("field")
+        assert isinstance(field, str), f"a violation must name a field: {violation}"
+        fields.append(field)
+    return fields
+
+
+def _column_names(answer: QueryAnswer) -> list[str]:
+    return [column.name for column in answer.columns]
+
+
+def _answered(response: ApiResponse) -> QueryAnswer:
+    """A 200 with at least one row: the seed guarantees commits in the window, so
+    an empty table would be a scan that reached the wrong rows, not a quiet stand."""
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+    answer = response.parse(QueryAnswer)
+    assert answer.rows, f"the seeded window answered no rows: {response.text[:300]}"
+    for row in answer.rows:
+        assert len(row) == len(answer.columns), (
+            f"a row carries {len(row)} values for {len(answer.columns)} columns: {row}"
+        )
+    return answer
+
+
+@pytest.fixture(scope="module")
+def api(admin_operator_session: PersonaSession) -> ApiClient:
+    """The surface is admin-only, so every case below queries as the operator."""
+    return admin_operator_session.client
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_a_bucketed_query_answers_a_typed_table_whose_rows_match_its_columns(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    body = _query(
+        stand_manifest,
+        grain="month",
+        group_by=[{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+        order=[{"by": "commits", "dir": "desc"}],
+        limit=200,
+    )
+
+    answer = _answered(_post(api, body))
+    assert _column_names(answer) == ["repository", "repository_label", "time", "commits"], (
+        f"the answer's columns are not the ones the query asked for: {answer.columns}"
+    )
+    assert [column.kind for column in answer.columns] == [
+        "dimension",
+        "label",
+        "bucket",
+        "aggregate",
+    ]
+    assert not answer.flags.truncated, "a 200-row ceiling over the seed's repositories truncated"
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_the_buckets_of_a_grouped_count_sum_to_the_same_window_folded_whole(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A bucketed and an ungrouped count read the same rows, so they must agree
+    whatever the stand was seeded with."""
+    total_rows = _answered(_post(api, _query(stand_manifest))).rows
+    assert len(total_rows) == 1, f"an ungrouped query answers one row, got {total_rows}"
+    total = total_rows[0][0]
+    assert isinstance(total, int) and total > 0, f"the seeded window counts no commit: {total}"
+
+    bucketed_body = _query(stand_manifest, grain="month", group_by=[{"axis": "time"}], limit=10_000)
+    bucketed = _answered(_post(api, bucketed_body))
+
+    summed = sum(row[1] for row in bucketed.rows)
+    assert summed == total, (
+        f"the monthly buckets sum to {summed} and the same window folded whole "
+        f"is {total} — grouping changed which rows were counted"
+    )
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_a_filter_on_a_dimension_value_reads_the_rows_its_group_counted(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A group-by answers one count per `source`; an `eq` filter on each value
+    must answer the same count, or a filter and a group read a dimension
+    differently. The two queries are independent scans."""
+    grouped = _answered(
+        _post(api, _query(stand_manifest, group_by=[{"axis": "dimension", "field": "source"}]))
+    )
+    assert _column_names(grouped) == ["source", "source_label", "commits"]
+
+    for source, _label, expected in grouped.rows:
+        filtered = _answered(
+            _post(
+                api,
+                _query(
+                    stand_manifest,
+                    filters=[{"field": "source", "op": "eq", "value": source}],
+                ),
+            )
+        )
+        assert filtered.rows[0][0] == expected, (
+            f"source={source!r}: grouped count {expected}, filtered count {filtered.rows[0][0]}"
+        )
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_a_pattern_over_a_dimension_reads_the_rows_its_exact_values_would(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A `match` alternation over `source` must count what an `in` over the same
+    two values counts, and a `like` on one value what `eq` counts: three
+    independent scans that read one set of rows."""
+    grouped = _answered(
+        _post(api, _query(stand_manifest, group_by=[{"axis": "dimension", "field": "source"}]))
+    )
+    sources = [row[0] for row in grouped.rows]
+    first = sources[0]
+
+    liked = _answered(
+        _post(
+            api, _query(stand_manifest, filters=[{"field": "source", "op": "like", "value": first}])
+        )
+    )
+    exact = _answered(
+        _post(
+            api, _query(stand_manifest, filters=[{"field": "source", "op": "eq", "value": first}])
+        )
+    )
+    assert liked.rows[0][0] == exact.rows[0][0], f"like vs eq on {first!r}"
+
+    pattern = "^(" + "|".join(sources) + ")$"
+    matched = _answered(
+        _post(
+            api,
+            _query(stand_manifest, filters=[{"field": "source", "op": "match", "value": pattern}]),
+        )
+    )
+    listed = _answered(
+        _post(
+            api,
+            _query(stand_manifest, filters=[{"field": "source", "op": "in", "values": sources}]),
+        )
+    )
+    assert matched.rows[0][0] == listed.rows[0][0], f"match vs in over {sources}"
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_a_limit_below_the_group_count_is_reported_truncated_and_at_it_is_not(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """The group count comes from the stand itself: an unclipped daily count
+    says how many buckets there are, then one below it must truncate and
+    exactly it must not."""
+    whole = _answered(
+        _post(api, _query(stand_manifest, grain="day", group_by=[{"axis": "time"}], limit=10_000))
+    )
+    assert not whole.flags.truncated, "the seed has more than 10000 days"
+    buckets = len(whole.rows)
+    if buckets < 2:
+        pytest.skip("the seeded window holds one bucket, so nothing can be clipped")
+
+    clipped = _answered(
+        _post(
+            api,
+            _query(stand_manifest, grain="day", group_by=[{"axis": "time"}], limit=buckets - 1),
+        )
+    )
+    assert clipped.flags.truncated, f"{buckets} buckets behind a limit of {buckets - 1}"
+    assert len(clipped.rows) == buckets - 1
+
+    exact = _answered(
+        _post(api, _query(stand_manifest, grain="day", group_by=[{"axis": "time"}], limit=buckets))
+    )
+    assert not exact.flags.truncated, f"{buckets} buckets behind a limit of {buckets}"
+    assert len(exact.rows) == buckets
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.versatility
+@pytest.mark.parametrize("grain", ["day", "week", "month"])
+def test_every_declared_grain_answers_a_bucket_column(
+    api: ApiClient, stand_manifest: Manifest, grain: str
+) -> None:
+    """Shape only: bucket boundaries are the compiler's rendered-SQL goldens' job."""
+    body = _query(stand_manifest, grain=grain, group_by=[{"axis": "time"}], limit=10_000)
+
+    answer = _answered(_post(api, body))
+    assert _column_names(answer) == ["time", "commits"], f"grain={grain}"
+
+
+@pytest.mark.reliability
+@pytest.mark.parametrize(
+    ("label", "overrides", "field"),
+    [
+        ("a dataset this build does not declare", {"dataset": UNKNOWN_DATASET}, "dataset"),
+        (
+            "a dimension the dataset does not declare",
+            {"group_by": [{"axis": "dimension", "field": "branch"}]},
+            "group_by[0].field",
+        ),
+        ("a row ceiling over the cap", {"limit": 1_000_000}, "limit"),
+        (
+            "a window wider than the cap",
+            {"time": {"from": "2020-01-01", "to": "2026-01-01"}},
+            "time.to",
+        ),
+        (
+            "an ordered test over a dimension",
+            {"filters": [{"field": "repository", "op": "gt", "value": "a"}]},
+            "filters[0].op",
+        ),
+        (
+            "a pattern test over a measurable",
+            {"filters": [{"field": "lines_added", "op": "like", "value": "1%"}]},
+            "filters[0].op",
+        ),
+        (
+            "a pattern that is not a regular expression",
+            {"filters": [{"field": "repository", "op": "match", "value": "("}]},
+            "filters[0].value",
+        ),
+        (
+            "an aggregate over a column that is not a measurable",
+            {"aggregates": [{"name": "added", "fn": "sum", "field": "message"}]},
+            "aggregates[0].field",
+        ),
+    ],
+)
+def test_a_query_the_dataset_cannot_answer_is_refused_naming_the_field(
+    api: ApiClient,
+    stand_manifest: Manifest,
+    label: str,
+    overrides: dict[str, JsonValue],
+    field: str,
+) -> None:
+    """400 rather than 404 throughout, the unknown dataset included: this is a
+    statement about the request, not about a missing resource."""
+    body = _query(stand_manifest)
+    body.update(overrides)
+
+    response = _post(api, body)
+
+    assert response.status_code == 400, (
+        f"{label}: status={response.status_code} {response.text[:300]}"
+    )
+    assert field in _violated_fields(response), (
+        f"{label}: the refusal did not name {field!r}: {response.text[:300]}"
+    )
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.versatility
+def test_the_file_change_dataset_answers_over_its_own_declared_dimensions(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """`file_extension` is a dimension of this dataset alone, so a 200 is evidence
+    the query reached THIS relation rather than the commit one."""
+    body = _query(
+        stand_manifest,
+        grain="month",
+        dataset=GIT_FILE_CHANGES,
+        group_by=[{"axis": "dimension", "field": "file_extension"}, {"axis": "time"}],
+        aggregates=[
+            {"name": "changes", "fn": "count"},
+            {
+                "name": "added_to_tests",
+                "fn": "sum",
+                "field": "lines_added",
+                "filter": {"field": "category", "op": "eq", "value": "test"},
+            },
+        ],
+        limit=500,
+    )
+
+    answer = _answered(_post(api, body))
+    assert _column_names(answer) == [
+        "file_extension",
+        "file_extension_label",
+        "time",
+        "changes",
+        "added_to_tests",
+    ]
+
+
+@pytest.mark.reliability
+def test_a_dimension_belongs_to_its_dataset_and_not_to_the_build(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """The other half of the pair above: the same axis refused on the dataset that
+    does not declare it, which is what proves validation is dataset-scoped."""
+    body = _query(stand_manifest, group_by=[{"axis": "dimension", "field": "file_extension"}])
+
+    response = _post(api, body)
+
+    assert response.status_code == 400, f"status={response.status_code} {response.text[:300]}"
+    assert "group_by[0].field" in _violated_fields(response), (
+        f"the refusal did not name the axis: {response.text[:300]}"
+    )
+
+
+@pytest.mark.reliability
+@pytest.mark.parametrize(
+    ("label", "overrides"),
+    [
+        (
+            "an operand belonging to another filter operator",
+            {"filters": [{"field": "source", "op": "eq", "values": ["github"]}]},
+        ),
+        (
+            "a fold naming a column its variant does not read",
+            {"aggregates": [{"name": "commits", "fn": "count", "field": "lines_added"}]},
+        ),
+        (
+            "a fold missing the column its variant reads",
+            {"aggregates": [{"name": "added", "fn": "sum"}]},
+        ),
+        (
+            "a group axis that names no axis",
+            {"group_by": [{"dimension": "repository"}]},
+        ),
+    ],
+)
+def test_an_operand_from_another_variant_is_refused_before_anything_validates(
+    api: ApiClient, stand_manifest: Manifest, label: str, overrides: dict[str, JsonValue]
+) -> None:
+    """Each body pairs a tag with an operand another variant takes, so the refusal
+    is the body extractor's rather than any dataset rule's."""
+    body = _query(stand_manifest)
+    body.update(overrides)
+
+    response = _post(api, body)
+
+    assert response.status_code in {400, 422}, (
+        f"{label}: status={response.status_code} {response.text[:300]}"
+    )
+
+
+@pytest.mark.security
+def test_a_lead_is_refused_the_query_surface(
+    lead_session: PersonaSession, stand_manifest: Manifest
+) -> None:
+    """An ordinary authenticated caller, not an anonymous one: the datasets carry
+    person columns and declare no visibility policy yet, so nobody below the
+    operator gets a row — a well-formed query included."""
+    response = lead_session.client.post(QUERY, json_body=_query(stand_manifest))
+
+    assert response.status_code == 403, (
+        f"answered {response.status_code} for a lead: {response.text[:300]}"
+    )
+    assert response.parse(ProblemDocument).status == 403
+
+
+@pytest.mark.security
+def test_a_query_cannot_name_a_tenant_of_its_own(api: ApiClient, stand_manifest: Manifest) -> None:
+    """The contract refuses every key it does not declare, so a query has no lever
+    to scope itself to another tenant."""
+    body = _query(stand_manifest)
+    body["tenant_id"] = "00000000-0000-0000-0000-000000000000"
+
+    response = _post(api, body)
+
+    assert response.status_code in {400, 422}, (
+        f"an off-contract key was accepted: status={response.status_code} {response.text[:300]}"
+    )

--- a/tests/stand/api/analytics/test_request_contracts.py
+++ b/tests/stand/api/analytics/test_request_contracts.py
@@ -55,6 +55,7 @@ BODY_ROUTES: tuple[tuple[str, str], ...] = (
     ("PUT", f"/v1/queries/{scratch.UNKNOWN_ID}"),
     ("POST", f"/v1/queries/{scratch.UNKNOWN_ID}/run"),
     ("POST", "/v1/metric-results"),
+    ("POST", "/v1/query"),
     ("POST", "/v1/reports/preview"),
     ("POST", "/v1/reports/export"),
     ("POST", "/v1/metric-drilldown"),

--- a/tests/stand/api/operations.py
+++ b/tests/stand/api/operations.py
@@ -105,7 +105,7 @@ def _i(method: str, suffix: str) -> Operation:
     return Operation(method=method, path=identity_path(suffix), service="identity")
 
 
-#: analytics — 28 operations.
+#: analytics — 29 operations.
 ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("GET", "/v1/queries"),
     _a("POST", "/v1/queries"),
@@ -115,6 +115,9 @@ ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("POST", f"/v1/queries/{SOME_ID}/run"),
     _a("GET", "/v1/metric-definitions"),
     _a("POST", "/v1/metric-results"),
+    # The query contract over the declared datasets. One literal url: it takes a
+    # body and no path parameter, and the dataset it reads is named in the body.
+    _a("POST", "/v1/query"),
     # What a query may be built over. Read-only over the declarations the build
     # loaded at boot, so both are installation-wide reads with no tenant scope.
     _a("GET", "/v1/datasets"),

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -28,8 +28,8 @@ from .common import UnzonedDatetime
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 from enum import StrEnum
 from typing import Any
-from uuid import UUID
 from datetime import date as date_aliased
+from uuid import UUID
 
 
 class AiConfigResponse(BaseModel):
@@ -728,6 +728,46 @@ class PutSettingsRequest(BaseModel):
     system_prompt: str
 
 
+class Fn(StrEnum):
+    count = 'count'
+
+
+class Fn1(StrEnum):
+    sum = 'sum'
+
+
+class Fn2(StrEnum):
+    avg = 'avg'
+
+
+class Fn3(StrEnum):
+    min = 'min'
+
+
+class Fn4(StrEnum):
+    max = 'max'
+
+
+class QueryAnswerFlags(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    truncated: bool = Field(..., description="More groups matched than the limit admits; the rows are the first\n`limit` of them in the answer's order.")
+
+
+class QueryColumnKind(StrEnum):
+    dimension = 'dimension'
+    label = 'label'
+    bucket = 'bucket'
+    aggregate = 'aggregate'
+
+
+class QueryColumnType(StrEnum):
+    text = 'text'
+    number = 'number'
+    date = 'date'
+
+
 class QueryDatasetDimension(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
@@ -750,6 +790,158 @@ class QueryDatasetTimeField(BaseModel):
     )
     default: bool = Field(..., description="The field a query's window binds to when it names none.")
     field: str
+
+
+class QueryDirection(StrEnum):
+    asc = 'asc'
+    desc = 'desc'
+
+
+class Op(StrEnum):
+    eq = 'eq'
+
+
+class Op1(StrEnum):
+    in_ = 'in'
+
+
+class Op2(StrEnum):
+    gt = 'gt'
+
+
+class Op3(StrEnum):
+    gte = 'gte'
+
+
+class Op4(StrEnum):
+    lt = 'lt'
+
+
+class Op5(StrEnum):
+    lte = 'lte'
+
+
+class Op6(StrEnum):
+    between = 'between'
+
+
+class Op7(StrEnum):
+    not_null = 'not_null'
+
+
+class QueryFilter8(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared dimension or measurable of the dataset.')
+    op: Op7
+
+
+class Op8(StrEnum):
+    like = 'like'
+
+
+class QueryFilter9(BaseModel):
+    """
+    SQL `LIKE`: `%` matches any run, `_` one character.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared dimension of the dataset.')
+    op: Op8
+    value: str = Field(..., max_length=256)
+
+
+class Op9(StrEnum):
+    match = 'match'
+
+
+class QueryFilter10(BaseModel):
+    """
+    An RE2 regular expression, unanchored.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared dimension of the dataset.')
+    op: Op9
+    value: str = Field(..., max_length=256)
+
+
+class QueryFilterValue(RootModel[str | float | bool]):
+    root: str | float | bool = Field(..., description='A filter value: text, a number, or a boolean')
+
+
+class QueryGrain(StrEnum):
+    day = 'day'
+    week = 'week'
+    month = 'month'
+
+
+class Axis(StrEnum):
+    dimension = 'dimension'
+
+
+class QueryGroupAxis1(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    axis: Axis
+    field: str = Field(..., description='A declared dimension of the dataset.')
+
+
+class Axis1(StrEnum):
+    time = 'time'
+
+
+class QueryGroupAxis2(BaseModel):
+    """
+    The time bucket as a group axis; its width is `time.grain`.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    axis: Axis1
+
+
+class QueryGroupAxis(RootModel[QueryGroupAxis1 | QueryGroupAxis2]):
+    root: QueryGroupAxis1 | QueryGroupAxis2
+
+
+class QueryLimits(BaseModel):
+    """
+    The contract's request bounds, identical for every dataset.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    default_limit: int = Field(..., description='Rows a query gets when it sets no ceiling of its own.', ge=0)
+    max_aggregates: int = Field(..., ge=0)
+    max_filter_values: int = Field(..., ge=0)
+    max_filters: int = Field(..., ge=0)
+    max_group_axes: int = Field(..., ge=0)
+    max_limit: int = Field(..., description='Rows a query may ask for at most; over it the query is refused, not clipped.', ge=0)
+    max_name_chars: int = Field(..., description="Longest an aggregate's name may be, in characters.", ge=0)
+    max_order_terms: int = Field(..., ge=0)
+
+
+class QueryOrder(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    by: str = Field(..., description='A column the answer reports: a grouped dimension, `time`, or an aggregate name.')
+    dir: QueryDirection | None = None
+
+
+class QueryTime(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str | None = Field(None, description="A declared time field; the dataset's default when omitted.")
+    from_: date_aliased = Field(..., alias='from', description='Inclusive first day, UTC.')
+    grain: QueryGrain | None = None
+    to: date_aliased = Field(..., description='Inclusive last day, UTC.')
 
 
 class ReportCell(RootModel[str | float]):
@@ -1352,12 +1544,22 @@ class MetricSnapshot(BaseModel):
     value: str = Field(..., description='The formatted value the tile shows.')
 
 
+class QueryAnswerColumn(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    kind: QueryColumnKind
+    name: str
+    type: QueryColumnType
+
+
 class QueryDataset(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
     dimensions: list[QueryDatasetDimension] = Field(..., description='The axes a query may group by, and filter on beside the measurables.')
     key: str
+    limits: QueryLimits = Field(..., description='The bounds a request against this dataset must stay inside.')
     measurables: list[QueryDatasetMeasurable] = Field(..., description='The columns an aggregate may fold.')
     time_fields: list[QueryDatasetTimeField] = Field(..., description='The columns a query may bound its window by, and bucket on.')
 
@@ -1367,6 +1569,74 @@ class QueryDatasetList(BaseModel):
         extra='forbid',
     )
     datasets: list[QueryDataset]
+
+
+class QueryFilter1(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared dimension or measurable of the dataset.')
+    op: Op
+    value: QueryFilterValue
+
+
+class QueryFilter2(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared dimension or measurable of the dataset.')
+    op: Op1
+    values: list[QueryFilterValue] = Field(..., description="At least one value, and at most the contract's cap.", max_length=256, min_length=1)
+
+
+class QueryFilter3(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    op: Op2
+    value: QueryFilterValue
+
+
+class QueryFilter4(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    op: Op3
+    value: QueryFilterValue
+
+
+class QueryFilter5(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    op: Op4
+    value: QueryFilterValue
+
+
+class QueryFilter6(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    op: Op5
+    value: QueryFilterValue
+
+
+class QueryFilter7(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    high: QueryFilterValue = Field(..., description='Inclusive upper bound.')
+    low: QueryFilterValue = Field(..., description='Inclusive lower bound.')
+    op: Op6
+
+
+class QueryFilter(RootModel[QueryFilter1 | QueryFilter2 | QueryFilter3 | QueryFilter4 | QueryFilter5 | QueryFilter6 | QueryFilter7 | QueryFilter8 | QueryFilter9 | QueryFilter10]):
+    root: QueryFilter1 | QueryFilter2 | QueryFilter3 | QueryFilter4 | QueryFilter5 | QueryFilter6 | QueryFilter7 | QueryFilter8 | QueryFilter9 | QueryFilter10
 
 
 class ReportExportRequest(BaseModel):
@@ -1571,6 +1841,68 @@ class MetricResultViewDto(RootModel[MetricResultViewDto1 | MetricResultViewDto2 
     root: MetricResultViewDto1 | MetricResultViewDto2 | MetricResultViewDto3 | MetricResultViewDto4 | MetricResultViewDto5 | MetricResultViewDto6 | MetricResultViewDto7
 
 
+class QueryAggregate1(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    filter: QueryFilter | None = None
+    fn: Fn
+    name: str = Field(..., description='What the answer column is called.')
+
+
+class QueryAggregate2(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    filter: QueryFilter | None = None
+    fn: Fn1
+    name: str = Field(..., description='What the answer column is called.')
+
+
+class QueryAggregate3(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    filter: QueryFilter | None = None
+    fn: Fn2
+    name: str = Field(..., description='What the answer column is called.')
+
+
+class QueryAggregate4(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    filter: QueryFilter | None = None
+    fn: Fn3
+    name: str = Field(..., description='What the answer column is called.')
+
+
+class QueryAggregate5(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    filter: QueryFilter | None = None
+    fn: Fn4
+    name: str = Field(..., description='What the answer column is called.')
+
+
+class QueryAggregate(RootModel[QueryAggregate1 | QueryAggregate2 | QueryAggregate3 | QueryAggregate4 | QueryAggregate5]):
+    root: QueryAggregate1 | QueryAggregate2 | QueryAggregate3 | QueryAggregate4 | QueryAggregate5
+
+
+class QueryAnswer(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    columns: list[QueryAnswerColumn]
+    flags: QueryAnswerFlags
+    rows: list[list[Any]]
+
+
 class MetricDrilldownResponse(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
@@ -1643,3 +1975,16 @@ class MetricResultsResponse(BaseModel):
         extra='forbid',
     )
     metrics: list[MetricResultDto]
+
+
+class Query(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    aggregates: list[QueryAggregate]
+    dataset: str
+    filters: list[QueryFilter] | None = Field(None, description='Row filters, narrowing the scan before aggregation.')
+    group_by: list[QueryGroupAxis] | None = None
+    limit: int | None = Field(None, description='Row ceiling; a query over the cap is refused rather than clipped.', ge=0)
+    order: list[QueryOrder] | None = None
+    time: QueryTime = Field(..., description='The window every scan is bounded by, and the width of its buckets.')


### PR DESCRIPTION
Depends on [#3321](https://github.com/constructorfabric/insight/pull/3321) for dataset declarations and discovery.

**Why.** Query combinations outside pre-built metrics require server changes, preventing chart authors from selecting their own filters, grouping, and calculations.

**What changed.** Adds `POST /v1/query` for structured queries over one declared dataset. Validation and parameterized compilation apply session tenancy, UTC boundaries, and execution limits; responses contain typed columns, dimension labels, and truncation status.

**Administrator-only access.** Row and column policies are not implemented, so queries remain restricted to administrators. Broader access requires policy enforcement.

**Coverage.** Five aggregate functions—count, sum, average, minimum, and maximum—support optional filters. Dimension and day/week/month grouping are implemented.

**Execution limits.** At most 731 days, 10,000 result rows, eight concurrent scans per process, and 16 MiB of fetched warehouse data; the byte cap excludes final HTTP serialization.

**Out of scope.** Constructor UI, advanced query operations, saved queries, and access policies remain in the [design roadmap](https://github.com/constructorfabric/insight/blob/feat/ask-slice/docs/domain/query-engine/DESIGN.md). Existing metric APIs remain available.

**Verified.** Documentation structure, TOCs, IDs, and links checked. Application checks were not rerun for the documentation update.
