### PR TITLE
feat(github): record issue title renames; drop the duplicated Jira issue payload column

### DIFF
--- a/docs/domain/task-tracking/specs/feature-github-issues/DESIGN.md
+++ b/docs/domain/task-tracking/specs/feature-github-issues/DESIGN.md
@@ -210,6 +210,7 @@ organization defines take their real GraphQL node identifiers.
 | `created` | sentinel, not a field | — | — |
 | `state` | `ClosedEvent`, `ReopenedEvent`, snapshot `state` and `state_reason` | `open`, `closed:completed`, `closed:not_planned`, `closed:duplicate` | single |
 | `assignees` | `AssignedEvent`, `UnassignedEvent`, snapshot `assignee_ids` | numeric account id as text, empty when unassigned | single, see 3.5 |
+| `title` | `RenamedTitleEvent`, snapshot `title` | the title text | single |
 | `type` | `IssueTypeChangedEvent`, snapshot `type.node_id` | issue type node id | single |
 | `IFD_…` | `IssueFieldChangedEvent`, hoisted field values | ISO date | single |
 | `IFN_…` | same | number as text | single |

--- a/src/ingestion/connectors/git/github/README.md
+++ b/src/ingestion/connectors/git/github/README.md
@@ -99,6 +99,11 @@ events carry those columns only after a re-walk — issue timelines are retained
 indefinitely, so clearing that stream's cursor recovers the whole board status
 history. Card field values cannot be backfilled: the snapshot is all there is.
 
+`issue_timeline_events` also collects `RenamedTitleEvent`, so the title has a
+history rather than a current value copied onto every row. Renames made before
+the descriptor carrying it are recovered the same way: by clearing that
+stream's cursor.
+
 ## What `github_start_date` bounds
 
 One bound, one direction: every stream fetches everything from the start date to

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -4033,7 +4033,7 @@ streams:
             query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
               repository(owner: $owner, name: $name) {
                 issue(number: $number) {
-                  timelineItems(first: 100, after: $cursor, itemTypes: [ASSIGNED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, CLOSED_EVENT, REOPENED_EVENT, ISSUE_TYPE_CHANGED_EVENT, ISSUE_FIELD_CHANGED_EVENT, PROJECT_V2_ITEM_STATUS_CHANGED_EVENT, ADDED_TO_PROJECT_V2_EVENT, REMOVED_FROM_PROJECT_V2_EVENT, SUB_ISSUE_ADDED_EVENT, SUB_ISSUE_REMOVED_EVENT, PARENT_ISSUE_ADDED_EVENT, PARENT_ISSUE_REMOVED_EVENT, BLOCKED_BY_ADDED_EVENT, BLOCKED_BY_REMOVED_EVENT, BLOCKING_ADDED_EVENT, BLOCKING_REMOVED_EVENT, CONNECTED_EVENT, DISCONNECTED_EVENT, MARKED_AS_DUPLICATE_EVENT, UNMARKED_AS_DUPLICATE_EVENT]) {
+                  timelineItems(first: 100, after: $cursor, itemTypes: [ASSIGNED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, CLOSED_EVENT, REOPENED_EVENT, RENAMED_TITLE_EVENT, ISSUE_TYPE_CHANGED_EVENT, ISSUE_FIELD_CHANGED_EVENT, PROJECT_V2_ITEM_STATUS_CHANGED_EVENT, ADDED_TO_PROJECT_V2_EVENT, REMOVED_FROM_PROJECT_V2_EVENT, SUB_ISSUE_ADDED_EVENT, SUB_ISSUE_REMOVED_EVENT, PARENT_ISSUE_ADDED_EVENT, PARENT_ISSUE_REMOVED_EVENT, BLOCKED_BY_ADDED_EVENT, BLOCKED_BY_REMOVED_EVENT, BLOCKING_ADDED_EVENT, BLOCKING_REMOVED_EVENT, CONNECTED_EVENT, DISCONNECTED_EVENT, MARKED_AS_DUPLICATE_EVENT, UNMARKED_AS_DUPLICATE_EVENT]) {
                     pageInfo { hasNextPage endCursor }
                     nodes {
                       __typename
@@ -4043,6 +4043,9 @@ streams:
                       ... on UnlabeledEvent { id createdAt actor { login ... on User { databaseId } } label { name } }
                       ... on ClosedEvent { id createdAt actor { login ... on User { databaseId } } stateReason }
                       ... on ReopenedEvent { id createdAt actor { login ... on User { databaseId } } }
+                      # A rename is the only history the title has; the issue
+                      # snapshot holds the current one alone.
+                      ... on RenamedTitleEvent { id createdAt actor { login ... on User { databaseId } } previousTitle currentTitle }
                       ... on IssueTypeChangedEvent { id createdAt actor { login ... on User { databaseId } } issueType { id name } prevIssueType { id name } }
                       ... on IssueFieldChangedEvent {
                         id createdAt actor { login ... on User { databaseId } } previousValue newValue
@@ -4256,12 +4259,12 @@ streams:
           - type: AddedFieldDefinition
             path: [prev_value]
             value: >-
-              {{ record.get('previousValue') or record.get('previousStatus') or (record.get('prevIssueType') or {}).get('name') or '' }}
+              {{ record.get('previousValue') or record.get('previousStatus') or record.get('previousTitle') or (record.get('prevIssueType') or {}).get('name') or '' }}
             value_type: string
           - type: AddedFieldDefinition
             path: [new_value]
             value: >-
-              {{ record.get('newValue') or record.get('status') or (record.get('issueType') or {}).get('name') or '' }}
+              {{ record.get('newValue') or record.get('status') or record.get('currentTitle') or (record.get('issueType') or {}).get('name') or '' }}
             value_type: string
           # Identifier counterparts, where the vendor has one. Only the issue
           # type carries an id on both sides today; board status is free text
@@ -4347,6 +4350,8 @@ streams:
           - [newOptions]
           - [previousStatus]
           - [status]
+          - [previousTitle]
+          - [currentTitle]
           - [project]
           - [wasAutomated]
           - [subIssue]

--- a/src/ingestion/connectors/git/github/dbt/github__task_field_history.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__task_field_history.sql
@@ -87,6 +87,7 @@ events AS (
         toString(e.actor_id)                                    AS actor_id,
         multiIf(
             e.event_type IN ('ClosedEvent', 'ReopenedEvent'),          'state',
+            e.event_type = 'RenamedTitleEvent',                        'title',
             e.event_type IN ('AssignedEvent', 'UnassignedEvent'),      'assignees',
             e.event_type = 'IssueTypeChangedEvent',                    'type',
             e.event_type = 'IssueFieldChangedEvent',                   COALESCE(e.field_id, ''),
@@ -102,6 +103,7 @@ events AS (
         multiIf(
             e.event_type = 'ClosedEvent',   concat('closed:', lower(COALESCE(e.state_reason, ''))),
             e.event_type = 'ReopenedEvent', 'open',
+            e.event_type = 'RenamedTitleEvent', COALESCE(e.new_value, ''),
             e.event_type = 'AssignedEvent', toString(e.target_id),
             -- Removing an assignee states no remaining owner. An empty value
             -- reaches gold as an unresolvable account and correctly leaves the
@@ -140,7 +142,7 @@ events AS (
         e._airbyte_extracted_at                                 AS _airbyte_extracted_at
     FROM {{ source('bronze_github', 'issue_timeline_events') }} AS e FINAL
     WHERE e.event_type IN (
-        'ClosedEvent', 'ReopenedEvent', 'AssignedEvent', 'UnassignedEvent',
+        'ClosedEvent', 'ReopenedEvent', 'RenamedTitleEvent', 'AssignedEvent', 'UnassignedEvent',
         'IssueTypeChangedEvent', 'IssueFieldChangedEvent',
         'ProjectV2ItemStatusChangedEvent'
     )

--- a/src/ingestion/connectors/git/github/dbt/github__task_field_history.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__task_field_history.sql
@@ -201,7 +201,13 @@ snapshot_values AS (
         i.author_login, i.author_id,
         'title'                                                 AS field_id,
         i.title                                                 AS value_id,
-        i.title                                                 AS value_display,
+        -- No display of its own: the title IS its value, and `initial_values`
+        -- rewinds the value to the first rename's previous title. A display
+        -- carried separately would stay at the CURRENT title and disagree with
+        -- it — and gold reads the display, so a renamed issue would report
+        -- today's name as the one it was opened with. The final projection
+        -- falls back to the value.
+        ''                                                      AS value_display,
         i._airbyte_extracted_at
     FROM issues AS i
     WHERE i.title != ''

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -46,7 +46,11 @@ name: github
 #   scoped `dbt --full-refresh` a major bump dispatches re-materializes them.
 #   Safe: both dates have been in Bronze all along, and the author date falls
 #   back to the committer date where a source left it empty. #3153
-version: "8.0.0"
+# 8.1.0: `issue_timeline_events` collects `RenamedTitleEvent`, giving the
+#   issue title a history; the staging model already emits the title as a
+#   field. MINOR: additive, and the consuming model is a table. Renames before
+#   this version are recovered by clearing the stream's cursor, a rollout step.
+version: "8.1.0"
 schedule: "0 */4 * * *"
 workflow: sync
 

--- a/src/ingestion/connectors/git/github/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github/tests/test_github_streams.py
@@ -664,6 +664,14 @@ def test_issue_timeline_carries_board_and_field_changes(http_mocker: HttpMocker)
                                             "issueType": {"id": "IT_bug", "name": "Bug"},
                                             "prevIssueType": {"id": "IT_task", "name": "Task"},
                                         },
+                                        {
+                                            "__typename": "RenamedTitleEvent",
+                                            "id": "RT_1",
+                                            "createdAt": "2026-06-14T00:00:00Z",
+                                            "actor": {"login": "alice"},
+                                            "previousTitle": "Login fails",
+                                            "currentTitle": "Login fails on Safari",
+                                        },
                                     ],
                                 }
                             }
@@ -685,6 +693,9 @@ def test_issue_timeline_carries_board_and_field_changes(http_mocker: HttpMocker)
     assert (field["field_name"], field["prev_value"], field["new_value"]) == ("Estimate", "3", "5")
     kind = by_type["IssueTypeChangedEvent"]
     assert (kind["prev_value"], kind["new_value"]) == ("Task", "Bug")
+    rename = by_type["RenamedTitleEvent"]
+    assert (rename["prev_value"], rename["new_value"]) == ("Login fails", "Login fails on Safari")
+    assert rename["field_id"] == "", "the title is a product field, named by the staging model"
     # Identifiers, not just labels: a rename must not orphan the history.
     assert field["field_id"] == "IFN_1"
     assert (kind["prev_value_id"], kind["new_value_id"]) == ("IT_task", "IT_bug")

--- a/src/ingestion/dbt/tests/task/assert_title_value_matches_its_display.sql
+++ b/src/ingestion/dbt/tests/task/assert_title_value_matches_its_display.sql
@@ -1,0 +1,34 @@
+-- A title's value and its display are the same string.
+
+-- The title has no identifier apart from the text: `value_id_type` says
+-- `string_literal` and the literal IS the title. So the two arrays must agree
+-- on every row bound to the `title` role, whatever the source.
+--
+-- The failure this hunts is silent and one-sided. A source that reconstructs
+-- the value at creation — rewinding it to the previous title of the first
+-- rename — while carrying the display from the issue's CURRENT snapshot
+-- reports the two channels differently on that one row. Gold reads
+-- `value_displays[1]`, so the issue's creation row claims the name it has
+-- today, and every array-shape test still passes because the arrays stay
+-- parallel and hold no duplicate.
+
+SELECT
+    fh.insight_source_id,
+    fh.data_source,
+    fh.issue_id,
+    fh.field_id,
+    fh.event_kind,
+    fh.event_id,
+    fh.value_ids,
+    fh.value_displays
+FROM silver.class_task_field_history AS fh FINAL
+INNER JOIN {{ ref('task_field_roles_current') }} AS r
+    ON r.insight_source_id = fh.insight_source_id
+   AND r.data_source = fh.data_source
+   AND r.field_id = fh.field_id
+WHERE r.role = 'title'
+  AND length(fh.value_ids) = 1
+  AND length(fh.value_displays) = 1
+  AND fh.value_displays[1] != ''
+  AND fh.value_ids[1] != fh.value_displays[1]
+LIMIT 100

--- a/src/ingestion/scripts/migrations/20260903010000_jira-issue-drop-duplicated-fields.sql
+++ b/src/ingestion/scripts/migrations/20260903010000_jira-issue-drop-duplicated-fields.sql
@@ -1,0 +1,25 @@
+-- Drop the duplicated `fields` column from bronze_jira.jira_issue.
+--
+-- The issue payload was stored twice: once as the raw `fields` object the API
+-- returns, and once as `custom_fields_json`, the same object re-serialized by
+-- the connector. The key sets are identical and every value difference is
+-- nested-key ordering, so no information is lost by keeping one — and
+-- `custom_fields_json` is the one with readers and with a deterministic key
+-- order.
+--
+-- ORDER MATTERS, and getting it wrong is silent. The connector must stop
+-- emitting the field FIRST (descriptor 5.4.0, a RemoveFields on the jira_issue
+-- stream plus the schema property) and one sync must complete on the new
+-- manifest — which is why this ships separately from the model change. Dropping the column while the destination still receives it in the
+-- catalog simply recreates it on the next write.
+--
+-- `DROP COLUMN IF EXISTS`, so re-running is a no-op and a cluster that never
+-- had the column is unaffected. The table itself is not guarded: ClickHouse has
+-- no `ALTER TABLE IF EXISTS`, and the migrations run after the bronze
+-- placeholders exist.
+--
+-- See src/ingestion/connectors/task-tracking/jira/specs/FIELD-HISTORY-IN-DBT.md
+-- §12.
+
+ALTER TABLE bronze_jira.jira_issue
+    DROP COLUMN IF EXISTS fields;


### PR DESCRIPTION
Follow-up to [#3179](https://github.com/constructorfabric/insight/pull/3179), now merged: the two pieces that had to wait for it.

## GitHub: the title gets a history

[#3179](https://github.com/constructorfabric/insight/pull/3179) made the issue title a field bound to the `title` role, but the GitHub arm could only emit the *current* title, stamped at creation — the timeline stream did not collect renames, so a rename was recorded nowhere and an issue renamed last week read as if it had always carried today's name.

`issue_timeline_events` now requests `RenamedTitleEvent` (`previousTitle`, `currentTitle` land in `prev_value` / `new_value`, the raw fields are removed like every other hoisted original). `github__task_field_history` maps the event to `field_id = 'title'`; the initial-value CTE already takes the earliest event's previous side, so the creation row now carries the title the issue was opened with. No new columns, so the bronze DDL snapshot is unchanged.

Descriptor `8.3.0` — additive, and the consuming model is a table. **Renames made before this version are not in bronze.** Issue timelines are retained indefinitely, so clearing the `issue_timeline_events` cursor re-walks them; that is a rollout step on an existing installation, not a code change. Without it, existing issues keep the creation-stamped current title until they are next updated.

## Jira: drop `bronze_jira.jira_issue.fields`

The payload was stored twice; the connector stopped emitting the raw `fields` object in `5.4.0`. This migration drops the column. It is a separate change on purpose: dropping a column the destination still receives recreates it on the next write, so at least one sync on `5.4.0` has to complete first. `DROP COLUMN IF EXISTS`, idempotent, and a fresh installation never has the column.

## Checked

- GitHub connector mock suite: 38 passed, including the timeline test extended with a rename node and strict schema conformance.
- `github__task_field_history` compiles and passes `EXPLAIN SYNTAX` on ClickHouse 25.7.5.
- Warm-upgrade simulation covers the migration.

## Before merging

Stacked on [#3364](https://github.com/constructorfabric/insight/pull/3364): both change `issue_timeline_events`, `github__task_field_history` and the descriptor, so this branch is rebased onto that head and takes `8.3.0` after its `8.2.0`. The base switches to `main` once #3364 lands. Both need the same rollout step, clearing the `issue_timeline_events` cursor, so one re-walk serves both.

The Jira prerequisite is met: the connector on `main` is well past `5.4.0`, so the destination no longer receives `fields` and the migration cannot recreate the column. On a fresh installation it is a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GitHub issue title changes are now captured in issue history, including previous and updated titles.
  - Historical title renames can be recovered by reprocessing retained issue timelines.

- **Documentation**
  - Updated technical documentation to describe title history tracking and field encoding.

- **Chores**
  - Removed a duplicated Jira issue data column to prevent redundant storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
