### PR TITLE
feat(observability): gears services emit JSON log lines

### DIFF
--- a/charts/insight/README.md
+++ b/charts/insight/README.md
@@ -107,7 +107,7 @@ See comments in [`values.yaml`](./values.yaml) — every block is documented inl
 Key groups:
 
 - `credentials.deploymentMode` / `credentials.autoGenerate` — who owns the generated Secrets (`helm` with lookup-based reuse, or `gitops` with out-of-band Secrets)
-- `global.*` — cluster-wide defaults (pull secrets, storage class, `tenantDefaultId`, `observability.otlp.endpoint`)
+- `global.*` — cluster-wide defaults (pull secrets, storage class, `tenantDefaultId`, `observability.logs.{level,format}`, `observability.otlp.endpoint`)
 - `<dep>.host` / `<dep>.port` / `<dep>.passwordSecret` (Redpanda: `<dep>.brokers`) — external-infra wiring for ClickHouse, MariaDB, Redis, Redpanda
 - `gateway` / `authenticator` / `analytics` — **mandatory** app services (no deploy flag; the gateway is the single entrance and the product is one unit)
 - `authenticator.oidc.*` — OIDC upstream and login-resolution mode (`resolveBy: external_id | email`)

--- a/charts/insight/templates/platform-config.yaml
+++ b/charts/insight/templates/platform-config.yaml
@@ -69,7 +69,11 @@ data:
   # any OTel SDK (.NET, Python) picks them up with zero custom glue. Each
   # service still sets its OWN OTEL_SERVICE_NAME. No endpoint → no OTEL_*
   # vars → services log to stdout only and whoever runs the cluster collects.
-  INSIGHT_LOG_LEVEL: {{ $obsLogs.level | default "info" | quote }}
+  INSIGHT_LOG_LEVEL:  {{ $obsLogs.level | default "info" | quote }}
+  # INVARIANT: format reads global.observability.logs.format ONLY — the gears
+  # subcharts can't see the legacy top-level observability block, so honouring
+  # it here would let the two surfaces render different formats.
+  INSIGHT_LOG_FORMAT: {{ ((((.Values.global).observability).logs).format) | default "json" | quote }}
   {{- if $otlpEndpoint }}
   {{- $otlpProtocol := $obsOtlp.protocol | default "grpc" }}
   OTEL_EXPORTER_OTLP_ENDPOINT: {{ $otlpEndpoint | quote }}

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -131,7 +131,7 @@ global:
   # it is separate releases, driven by the deploy pipeline (inventory
   # toggles; see deploy/gitops/system/README.md). This block only governs what
   # services EMIT. The values are published into the `{release}-platform`
-  # ConfigMap as INSIGHT_LOG_LEVEL / OTEL_* env vars (plus the gears-rust
+  # ConfigMap as INSIGHT_LOG_LEVEL / INSIGHT_LOG_FORMAT / OTEL_* env vars (plus the gears-rust
   # dialect, APP__opentelemetry__*), so every pod that does `envFrom` picks
   # them up uniformly. Lives under `global` so the service subcharts can hash
   # it into a pod-template annotation and roll on change (a top-level
@@ -139,6 +139,7 @@ global:
   observability:
     logs:
       level: info # debug|info|warn|error — default level for all services
+      format: json # json|text — console line shape for the gears services
     otlp:
       endpoint: "" # empty = stdout only; set = services export OTLP here
       protocol: grpc # grpc | http/protobuf

--- a/deploy/HELM_DEPLOY.md
+++ b/deploy/HELM_DEPLOY.md
@@ -26,6 +26,7 @@ This runbook shows a platform or DevOps engineer how to install the Insight busi
 - [Step 3 — Create the namespace and apply the secrets](#step-3--create-the-namespace-and-apply-the-secrets)
 - [Step 4 — Install with Helm](#step-4--install-with-helm)
 - [Step 5 — Verify the install](#step-5--verify-the-install)
+  - [Where the logs go](#where-the-logs-go)
 - [Step 6 — Configure connectors (optional)](#step-6--configure-connectors-optional)
 - [Step 7 — Seed demo data (test stands only)](#step-7--seed-demo-data-test-stands-only)
 - [Appendix — Reference](#appendix--reference)
@@ -402,6 +403,10 @@ kubectl -n insight get cronworkflow
 ```
 
 Then open `https://<HOST>` — the host from Step 1 — and confirm the login redirect to your OIDC provider.
+
+### Where the logs go
+
+On a default install no log collector is configured (`global.observability.otlp.endpoint` is empty), and the umbrella never installs one. Every pod then writes its log lines to its own standard output/error and nowhere else; read them with `kubectl -n insight logs deploy/<service>`. The five gears services emit JSON (one object per line), governed by two install-wide knobs: `global.observability.logs.level` (`info` by default) and `global.observability.logs.format` (`json` by default; set `text` for human-readable lines, at the cost of any collector's level parsing). The gateway, frontend and ingestion workflow pods keep formats of their own for now (constructorfabric/insight#2488 tracks converging them).
 
 ## Step 6 — Configure connectors (optional)
 

--- a/deploy/gitops/system/alloy/values.yaml
+++ b/deploy/gitops/system/alloy/values.yaml
@@ -90,10 +90,16 @@ alloy:
       // ── Parse OUR structured JSON to promote `level` to a label.
       //    Non-JSON lines (raw Airbyte / dbt output) fall through the
       //    stage untouched — they still arrive in Loki, just without a
-      //    `level` label.
+      //    `level` label. The gears services (tracing-subscriber JSON)
+      //    write "INFO"/"ERROR" uppercase; lowercase before labelling so
+      //    every dashboard and alert matches one spelling.
       loki.process "parse" {
         stage.json {
           expressions = { level = "level" }
+        }
+        stage.template {
+          source   = "level"
+          template = "{{ ToLower .Value }}"
         }
         stage.labels {
           values = { level = "" }

--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -1066,7 +1066,7 @@ dashboards:
                 "type": "loki",
                 "uid": "loki"
               },
-              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.\n\nThe starting point: which services are talking, and which of them are unhappy. `error rate` is errors as a share of that service's own lines, so a quiet service with a few failures still stands out.",
+              "description": "**Counts only lines carrying a `level` label.** Alloy promotes `level` from JSON logs; the Rust services emit JSON (insight#3189), so their lines are labelled and counted — nginx `[error]` and ClickHouse `<Error>` lines still carry no level label. The ClickHouse row below matches on line content and is unaffected.\n\nThe starting point: which services are talking, and which of them are unhappy. `error rate` is errors as a share of that service's own lines, so a quiet service with a few failures still stands out.",
               "fieldConfig": {
                 "defaults": {
                   "custom": {
@@ -1219,7 +1219,7 @@ dashboards:
                   "refId": "C"
                 },
                 {
-                  "expr": "100 * sum by (container) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=~\"error|fatal\"} [$__range])) / sum by (container) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=~\"error|fatal\"} [$__range]))",
+                  "expr": "100 * sum by (container) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\", level=~\"error|fatal\"} [$__range])) / sum by (container) (count_over_time({namespace=~\"$ns\", container=~\"$svc\", container!~\"loki|grafana|alloy\"} [$__range]))",
                   "instant": true,
                   "refId": "D"
                 }
@@ -1301,7 +1301,7 @@ dashboards:
             },
             {
               "collapsed": false,
-              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.",
+              "description": "**Counts only lines carrying a `level` label.** Alloy promotes `level` from JSON logs; the Rust services emit JSON (insight#3189), so their lines are labelled and counted — nginx `[error]` and ClickHouse `<Error>` lines still carry no level label. The ClickHouse row below matches on line content and is unaffected.",
               "gridPos": {
                 "h": 1,
                 "w": 24,
@@ -1317,7 +1317,7 @@ dashboards:
                 "type": "loki",
                 "uid": "loki"
               },
-              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.\n\nMatches all four log formats on this stand: Rust tracing (ERROR), ClickHouse (<Error>), nginx ([error]) and JSON (\"level\":\"error\"). Filtering on the `level` label alone would miss most of them — see the dashboard notes.",
+              "description": "**Counts only lines carrying a `level` label.** Alloy promotes `level` from JSON logs; the Rust services emit JSON (insight#3189), so their lines are labelled and counted — nginx `[error]` and ClickHouse `<Error>` lines still carry no level label. The ClickHouse row below matches on line content and is unaffected.\n\nCounts lines labelled `error` or `fatal`. ClickHouse failures are matched on line content in the row below.",
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -1376,7 +1376,7 @@ dashboards:
                 "type": "loki",
                 "uid": "loki"
               },
-              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.",
+              "description": "**Counts only lines carrying a `level` label.** Alloy promotes `level` from JSON logs; the Rust services emit JSON (insight#3189), so their lines are labelled and counted — nginx `[error]` and ClickHouse `<Error>` lines still carry no level label. The ClickHouse row below matches on line content and is unaffected.",
               "fieldConfig": {
                 "defaults": {
                   "color": {
@@ -1419,7 +1419,7 @@ dashboards:
                 "type": "loki",
                 "uid": "loki"
               },
-              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.",
+              "description": "**Counts only lines carrying a `level` label.** Alloy promotes `level` from JSON logs; the Rust services emit JSON (insight#3189), so their lines are labelled and counted — nginx `[error]` and ClickHouse `<Error>` lines still carry no level label. The ClickHouse row below matches on line content and is unaffected.",
               "fieldConfig": {
                 "defaults": {
                   "custom": {
@@ -1464,7 +1464,7 @@ dashboards:
                 "type": "loki",
                 "uid": "loki"
               },
-              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.\n\nOnly counts lines whose level was successfully parsed. Access-log lines legitimately have no severity, so this is a share of levelled lines, not of all traffic.",
+              "description": "**Counts only lines carrying a `level` label.** Alloy promotes `level` from JSON logs; the Rust services emit JSON (insight#3189), so their lines are labelled and counted — nginx `[error]` and ClickHouse `<Error>` lines still carry no level label. The ClickHouse row below matches on line content and is unaffected.\n\nOnly counts lines whose level was successfully parsed. Access-log lines legitimately have no severity, so this is a share of levelled lines, not of all traffic.",
               "fieldConfig": {
                 "defaults": {
                   "unit": "short"
@@ -1544,7 +1544,7 @@ dashboards:
                 "type": "loki",
                 "uid": "loki"
               },
-              "description": "**Reads near zero on this stand, and that is not a claim that there are no errors.** Since the gitops observability rollout (2026-08-31) Alloy promotes `level` only from JSON logs, so nginx `[error]`, Rust ` ERROR ` and ClickHouse `<Error>` lines carry no level label. The ClickHouse row below matches on line content and is unaffected.",
+              "description": "**Counts only lines carrying a `level` label.** Alloy promotes `level` from JSON logs; the Rust services emit JSON (insight#3189), so their lines are labelled and counted — nginx `[error]` and ClickHouse `<Error>` lines still carry no level label. The ClickHouse row below matches on line content and is unaffected.",
               "gridPos": {
                 "h": 12,
                 "w": 24,
@@ -3449,7 +3449,7 @@ dashboards:
                     "type": "loki",
                     "uid": "loki"
                   },
-                  "expr": "100 * (1 - ((sum (count_over_time({namespace=\"insight\", container=\"analytics\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | status >= 400 [$__range])) or (sum (count_over_time({namespace=\"insight\", container=\"analytics\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range])) * 0)) / sum (count_over_time({namespace=\"insight\", container=\"analytics\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range]))))",
+                  "expr": "100 * (1 - ((sum (count_over_time({namespace=\"insight\", container=\"analytics\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` | fields_status >= 400 [$__range])) or (sum (count_over_time({namespace=\"insight\", container=\"analytics\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` [$__range])) * 0)) / sum (count_over_time({namespace=\"insight\", container=\"analytics\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` [$__range]))))",
                   "legendFormat": "analytics",
                   "queryType": "instant",
                   "refId": "A"
@@ -3459,7 +3459,7 @@ dashboards:
                     "type": "loki",
                     "uid": "loki"
                   },
-                  "expr": "100 * (1 - ((sum (count_over_time({namespace=\"insight\", container=\"authenticator\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | status >= 400 [$__range])) or (sum (count_over_time({namespace=\"insight\", container=\"authenticator\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range])) * 0)) / sum (count_over_time({namespace=\"insight\", container=\"authenticator\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range]))))",
+                  "expr": "100 * (1 - ((sum (count_over_time({namespace=\"insight\", container=\"authenticator\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` | fields_status >= 400 [$__range])) or (sum (count_over_time({namespace=\"insight\", container=\"authenticator\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` [$__range])) * 0)) / sum (count_over_time({namespace=\"insight\", container=\"authenticator\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` [$__range]))))",
                   "legendFormat": "authenticator",
                   "queryType": "instant",
                   "refId": "B"
@@ -3469,7 +3469,7 @@ dashboards:
                     "type": "loki",
                     "uid": "loki"
                   },
-                  "expr": "100 * (1 - ((sum (count_over_time({namespace=\"insight\", container=\"identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | status >= 400 [$__range])) or (sum (count_over_time({namespace=\"insight\", container=\"identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range])) * 0)) / sum (count_over_time({namespace=\"insight\", container=\"identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range]))))",
+                  "expr": "100 * (1 - ((sum (count_over_time({namespace=\"insight\", container=\"identity-resolution\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` | fields_status >= 400 [$__range])) or (sum (count_over_time({namespace=\"insight\", container=\"identity-resolution\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` [$__range])) * 0)) / sum (count_over_time({namespace=\"insight\", container=\"identity-resolution\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` [$__range]))))",
                   "legendFormat": "identity-resolution",
                   "queryType": "instant",
                   "refId": "C"
@@ -3533,7 +3533,7 @@ dashboards:
                     "type": "loki",
                     "uid": "loki"
                   },
-                  "expr": "sum (count_over_time({namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [$__range]))",
+                  "expr": "sum (count_over_time({namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` [$__range]))",
                   "queryType": "instant",
                   "refId": "A"
                 }
@@ -3612,7 +3612,7 @@ dashboards:
                     "type": "loki",
                     "uid": "loki"
                   },
-                  "expr": "sum (count_over_time({namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | status >= 400 [$__range]))",
+                  "expr": "sum (count_over_time({namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` | fields_status >= 400 [$__range]))",
                   "queryType": "instant",
                   "refId": "A"
                 }
@@ -3667,7 +3667,7 @@ dashboards:
                     "type": "loki",
                     "uid": "loki"
                   },
-                  "expr": "sum by (container) (count_over_time({namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` [1m]))",
+                  "expr": "sum by (container) (count_over_time({namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` [1m]))",
                   "interval": "1m",
                   "legendFormat": "{{container}}",
                   "queryType": "range",
@@ -3719,7 +3719,7 @@ dashboards:
                     "type": "loki",
                     "uid": "loki"
                   },
-                  "expr": "quantile_over_time(0.95, {namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | unwrap duration [$__auto]) by (container)",
+                  "expr": "quantile_over_time(0.95, {namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` | unwrap fields_duration [$__auto]) by (container)",
                   "legendFormat": "{{container}}",
                   "queryType": "range",
                   "refId": "A"
@@ -3752,7 +3752,7 @@ dashboards:
                     "type": "loki",
                     "uid": "loki"
                   },
-                  "expr": "{namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | logfmt | user_agent=~`kube-probe.*` | uri=~`/health.*` | status >= 400 | line_format `{{.container}} {{.status}} {{.uri}} {{.duration}}us`",
+                  "expr": "{namespace=\"insight\", container=~\"analytics|authenticator|identity-resolution\"} | json | fields_user_agent=~`kube-probe.*` | fields_uri=~`/health.*` | fields_status >= 400 | line_format `{{.container}} {{.fields_status}} {{.fields_uri}} {{.fields_duration}}us`",
                   "queryType": "range",
                   "refId": "A"
                 }

--- a/src/backend/services/analytics/helm/templates/configmap.yaml
+++ b/src/backend/services/analytics/helm/templates/configmap.yaml
@@ -23,9 +23,11 @@ data:
 
     logging:
       default:
-        # The install-wide knob: global.observability.logs.level — the same
-        # value the platform CM publishes as INSIGHT_LOG_LEVEL.
+        # The install-wide knobs: global.observability.logs.{level,format} —
+        # the same values the platform CM publishes as INSIGHT_LOG_LEVEL /
+        # INSIGHT_LOG_FORMAT.
         console_level: {{ ((((.Values.global).observability).logs).level) | default "info" }}
+        console_format: {{ ((((.Values.global).observability).logs).format) | default "json" }}
 
     opentelemetry:
       resource:

--- a/src/backend/services/authenticator/helm/templates/configmap.yaml
+++ b/src/backend/services/authenticator/helm/templates/configmap.yaml
@@ -28,9 +28,11 @@ data:
 
     logging:
       default:
-        # The install-wide knob: global.observability.logs.level — the same
-        # value the platform CM publishes as INSIGHT_LOG_LEVEL.
+        # The install-wide knobs: global.observability.logs.{level,format} —
+        # the same values the platform CM publishes as INSIGHT_LOG_LEVEL /
+        # INSIGHT_LOG_FORMAT.
         console_level: {{ ((((.Values.global).observability).logs).level) | default "info" }}
+        console_format: {{ ((((.Values.global).observability).logs).format) | default "json" }}
 
     opentelemetry:
       resource:

--- a/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
+++ b/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
@@ -11,9 +11,11 @@ data:
 
     logging:
       default:
-        # The install-wide knob: global.observability.logs.level — the same
-        # value the platform CM publishes as INSIGHT_LOG_LEVEL.
+        # The install-wide knobs: global.observability.logs.{level,format} —
+        # the same values the platform CM publishes as INSIGHT_LOG_LEVEL /
+        # INSIGHT_LOG_FORMAT.
         console_level: {{ ((((.Values.global).observability).logs).level) | default "info" }}
+        console_format: {{ ((((.Values.global).observability).logs).format) | default "json" }}
 
     opentelemetry:
       resource:

--- a/src/backend/services/identity-resolution/helm/templates/configmap.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/configmap.yaml
@@ -22,9 +22,11 @@ data:
 
     logging:
       default:
-        # The install-wide knob: global.observability.logs.level — the same
-        # value the platform CM publishes as INSIGHT_LOG_LEVEL.
+        # The install-wide knobs: global.observability.logs.{level,format} —
+        # the same values the platform CM publishes as INSIGHT_LOG_LEVEL /
+        # INSIGHT_LOG_FORMAT.
         console_level: {{ ((((.Values.global).observability).logs).level) | default "info" }}
+        console_format: {{ ((((.Values.global).observability).logs).format) | default "json" }}
 
     opentelemetry:
       resource:

--- a/src/backend/services/identity-resolution/helm/tests/test_umbrella_log_level_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_umbrella_log_level_contract.py
@@ -1,10 +1,12 @@
-"""One log-level knob across the install (insight#2488, AC-2).
+"""One log-level knob and one line format across the install (insight#2488,
+AC-1 + AC-2).
 
-The umbrella publishes `global.observability.logs.level` twice: as
-INSIGHT_LOG_LEVEL in the platform ConfigMap and as `logging.default.
-console_level` in every gears service's rendered config. These tests hold the
-two surfaces to the same value, so no service can grow a level knob of its
-own without failing here.
+The umbrella publishes `global.observability.logs.{level,format}` twice: as
+INSIGHT_LOG_LEVEL / INSIGHT_LOG_FORMAT in the platform ConfigMap and as
+`logging.default.{console_level,console_format}` in every gears service's
+rendered config. These tests hold the two surfaces to the same value per
+service, so no service can grow a knob or a line shape of its own — or drop
+out of the contract — without failing here.
 """
 
 from __future__ import annotations
@@ -13,16 +15,38 @@ import re
 
 from conftest import TENANT, UMBRELLA, UMBRELLA_BASE, render
 
-GEARS_SERVICES = 5  # identity-resolution, analytics, authenticator, previews, git-cli-proxy
+GEARS_SERVICES = {"analytics", "authenticator", "gitCliProxy", "identityResolution", "previews"}
 
 
-def rendered_console_levels(stdout: str) -> list[str]:
-    return re.findall(r"console_level:\s*(\S+)", stdout)
+def rendered_per_service(stdout: str, key: str) -> dict[str, list[str]]:
+    """Map each gears subchart to the values of `key` its configmap renders."""
+    per_service: dict[str, list[str]] = {}
+    for doc in stdout.split("\n---\n"):
+        source = re.search(r"# Source: insight/charts/([^/]+)/templates/configmap\.yaml", doc)
+        values = re.findall(rf"{key}:\s*(\S+)", doc)
+        if source and values:
+            per_service.setdefault(source.group(1), []).extend(values)
+    return per_service
+
+
+def assert_every_service_renders_exactly(stdout: str, key: str, expected: str) -> None:
+    per_service = rendered_per_service(stdout, key)
+    assert set(per_service) == GEARS_SERVICES, (
+        f"services rendering {key}: {sorted(per_service)}, expected {sorted(GEARS_SERVICES)}"
+    )
+    for service, values in per_service.items():
+        assert values == [expected], f"{service} rendered {key}: {values}, expected [{expected!r}]"
 
 
 def rendered_platform_level(stdout: str) -> str:
     match = re.search(r'INSIGHT_LOG_LEVEL:\s*"?(\w+)"?', stdout)
     assert match, "the platform ConfigMap should publish INSIGHT_LOG_LEVEL"
+    return match.group(1)
+
+
+def rendered_platform_format(stdout: str) -> str:
+    match = re.search(r'INSIGHT_LOG_FORMAT:\s*"?(\w+)"?', stdout)
+    assert match, "the platform ConfigMap should publish INSIGHT_LOG_FORMAT"
     return match.group(1)
 
 
@@ -37,11 +61,7 @@ def test_the_one_knob_reaches_every_service_config(umbrella_deps) -> None:
     )
     assert code == 0, err
 
-    levels = rendered_console_levels(out)
-    assert len(levels) >= GEARS_SERVICES, (
-        f"expected a console_level from each of the {GEARS_SERVICES} gears services, found {len(levels)}"
-    )
-    assert set(levels) == {"debug"}, f"a service kept a level of its own: {levels}"
+    assert_every_service_renders_exactly(out, "console_level", "debug")
     assert rendered_platform_level(out) == "debug"
 
 
@@ -49,5 +69,40 @@ def test_the_default_is_info_on_both_surfaces(umbrella_deps) -> None:
     code, out, err = render(UMBRELLA, *UMBRELLA_BASE, "--set", f"global.tenantDefaultId={TENANT}")
     assert code == 0, err
 
-    assert set(rendered_console_levels(out)) == {"info"}
+    assert_every_service_renders_exactly(out, "console_level", "info")
     assert rendered_platform_level(out) == "info"
+
+
+def test_the_one_format_reaches_every_service_config(umbrella_deps) -> None:
+    code, out, err = render(
+        UMBRELLA,
+        *UMBRELLA_BASE,
+        "--set",
+        f"global.tenantDefaultId={TENANT}",
+        "--set",
+        "global.observability.logs.format=text",
+    )
+    assert code == 0, err
+
+    assert_every_service_renders_exactly(out, "console_format", "text")
+    assert rendered_platform_format(out) == "text"
+
+
+def test_the_default_format_is_json_on_both_surfaces(umbrella_deps) -> None:
+    code, out, err = render(UMBRELLA, *UMBRELLA_BASE, "--set", f"global.tenantDefaultId={TENANT}")
+    assert code == 0, err
+
+    assert_every_service_renders_exactly(out, "console_format", "json")
+    assert rendered_platform_format(out) == "json"
+
+
+def test_a_legacy_top_level_format_override_cannot_split_the_surfaces(umbrella_deps) -> None:
+    """The gears subcharts never see the top-level observability block, so the
+    platform ConfigMap must not honour it for the format either."""
+    code, out, err = render(
+        UMBRELLA, *UMBRELLA_BASE, "--set", f"global.tenantDefaultId={TENANT}", "--set", "observability.logs.format=text"
+    )
+    assert code == 0, err
+
+    assert_every_service_renders_exactly(out, "console_format", "json")
+    assert rendered_platform_format(out) == "json"

--- a/src/backend/services/previews/helm/templates/configmap.yaml
+++ b/src/backend/services/previews/helm/templates/configmap.yaml
@@ -21,9 +21,11 @@ data:
 
     logging:
       default:
-        # The install-wide knob: global.observability.logs.level — the same
-        # value the platform CM publishes as INSIGHT_LOG_LEVEL.
+        # The install-wide knobs: global.observability.logs.{level,format} —
+        # the same values the platform CM publishes as INSIGHT_LOG_LEVEL /
+        # INSIGHT_LOG_FORMAT.
         console_level: {{ ((((.Values.global).observability).logs).level) | default "info" }}
+        console_format: {{ ((((.Values.global).observability).logs).format) | default "json" }}
 
     gears:
       api-gateway:


### PR DESCRIPTION
Closes #3189. Part of #2488 (AC-1 for Rust, AC-5).

**Why.** The five gears services still write human-text log lines, so Alloy — which promotes `level` only from JSON — labels none of them, and the Logs dashboards undercount every Rust error.

**What changed.** The service configmaps render `logging.default.console_format` from a new `global.observability.logs.format` knob (default `json`), the same umbrella path as the level knob (#3170); the platform ConfigMap publishes it as `INSIGHT_LOG_FORMAT`, and the contract suite holds both surfaces to one value. Alloy lowercases the extracted level (the toolkit emits `"level":"INFO"` uppercase, dashboards match lowercase), the uptime dashboard's healthcheck queries move from `| logfmt` over the old text access log to `| json` over the `fields_*` keys, and the Logs dashboard notes stop claiming Rust lines carry no level label. HELM_DEPLOY.md now states the default destination: with no collector configured, JSON lines land on each pod's own stdout/stderr, read via `kubectl logs`.

**Error-rate panel denominator fixed in passing.** It divided errors by errors (always 100%); the denominator now counts all of the service's lines, matching the panel's own description.

**Out of scope.** Python jobs and the SPA (#3190, #3191); required fields and leak checks (rest of #2488). Compose/dev configs stay `text` for local readability.

**Verified.** New format-parity contract tests plus the full identity-resolution/previews/git-cli-proxy helm suites (92 passed); grafana/alloy values re-parsed as YAML and every embedded dashboard as JSON. Not run: a live stand with the JSON pipeline end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an install-wide log format setting supporting JSON or text output.
  * Applied the selected format consistently across platform and services, with JSON as the default.
  * Normalized log levels to lowercase for more reliable filtering and labeling.

* **Bug Fixes**
  * Corrected dashboard error-rate calculations to include all log lines.
  * Updated uptime dashboards to parse JSON-formatted logs correctly.
  * Clarified that level-based counts only include logs with level labels.

* **Documentation**
  * Added deployment guidance for viewing logs and configuring log level and format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->