### PR TITLE
fix(frontend): give the settings button its own icon

### DIFF
--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -4,7 +4,7 @@ import {
   Layers,
   LayoutGrid,
   Search,
-  Settings2,
+  Settings,
 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -163,7 +163,7 @@ export function ContextPane() {
                 <PopoverTrigger
                   render={
                     <SidebarMenuButton>
-                      <Settings2 aria-hidden />
+                      <Settings aria-hidden />
                       <span>Settings</span>
                     </SidebarMenuButton>
                   }

--- a/src/frontend/src/components/portal/lens-rail.tsx
+++ b/src/frontend/src/components/portal/lens-rail.tsx
@@ -1,4 +1,4 @@
-import { Bug, Settings2, type LucideIcon } from "lucide-react";
+import { Bug, Settings, type LucideIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -273,7 +273,7 @@ export function LensRail() {
           <Popover open={settingsOpen} onOpenChange={setSettingsOpen}>
             <PopoverTrigger
               render={
-                <RailButton icon={Settings2} label="Settings" />
+                <RailButton icon={Settings} label="Settings" />
               }
             />
             <PopoverContent


### PR DESCRIPTION
**Why.** The rail carried the same sliders glyph twice — on the Manage zone and on the footer's settings button — so two rows of one sidebar read as the same destination.

**What changed.** The settings trigger takes lucide's `Settings` gear and Manage keeps `Settings2`. Same swap in the phone drawer's settings row, which shared the icon.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-3194-assets/rail-before.png" width="320"> | <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-3194-assets/rail-after.png" width="320"> |

<details>
<summary>Full rail, hovered</summary>

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-3194-assets/rail-before-full.png" width="480"> | <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-3194-assets/rail-after-full.png" width="480"> |

</details>

**Verified.** `pnpm typecheck` and `pnpm lint` clean; screenshots from a local dev server on mock data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated settings icons across the portal interface for a more consistent visual appearance.
  * No functional behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->