### PR TITLE
feat(observability): request lines carry correlation id, tenant, service and version

### DIFF
--- a/deploy/HELM_DEPLOY.md
+++ b/deploy/HELM_DEPLOY.md
@@ -408,6 +408,14 @@ Then open `https://<HOST>` — the host from Step 1 — and confirm the login re
 
 On a default install no log collector is configured (`global.observability.otlp.endpoint` is empty), and the umbrella never installs one. Every pod then writes its log lines to its own standard output/error and nowhere else; read them with `kubectl -n insight logs deploy/<service>`. The five gears services emit JSON (one object per line), governed by two install-wide knobs: `global.observability.logs.level` (`info` by default) and `global.observability.logs.format` (`json` by default; set `text` for human-readable lines, at the cost of any collector's level parsing). The gateway, frontend and ingestion workflow pods keep formats of their own for now (constructorfabric/insight#2488 tracks converging them).
 
+A line a gears service writes while handling a request carries, in its `spans` chain under the `log_ctx` entry:
+
+- `correlation_id` — echoed from the `X-Correlation-Id` the request arrived with (on `/api` routes the gateway mints it as sole author and logs the same value as `correlation_id`, so one id joins the edge and every service); a request without one falls back to its `x-request-id`;
+- `tenant_id` — present only on authenticated requests;
+- `service` and `version` — from the service's `opentelemetry.resource` config (`service_name` and the `service.version` attribute, which the chart sets to the image tag) — the same identity traces carry.
+
+Startup and background lines carry none of these yet — that requires a gears toolkit change, tracked in constructorfabric/insight#2488.
+
 ## Step 6 — Configure connectors (optional)
 
 Configure connectors after the app is up. Each connector is a single Kubernetes Secret; the `insight-reconcile-loop` CronWorkflow discovers it and provisions the Airbyte source automatically, so there is nothing else to run.

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -136,6 +136,7 @@ dependencies = [
  "hex",
  "insight-clickhouse",
  "insight-http-metrics",
+ "insight-log-context",
  "insight-migration",
  "jsonwebtoken",
  "opentelemetry",
@@ -546,6 +547,7 @@ dependencies = [
  "clap",
  "futures",
  "insight-http-metrics",
+ "insight-log-context",
  "jsonwebtoken",
  "openidconnect",
  "opentelemetry",
@@ -3054,6 +3056,7 @@ dependencies = [
  "clap",
  "hex",
  "insight-http-metrics",
+ "insight-log-context",
  "opentelemetry",
  "reqwest 0.12.28",
  "rustix",
@@ -3068,6 +3071,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "utoipa",
+ "uuid",
 ]
 
 [[package]]
@@ -3612,6 +3616,7 @@ dependencies = [
  "clickhouse",
  "insight-clickhouse",
  "insight-http-metrics",
+ "insight-log-context",
  "insight-migration",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -3719,6 +3724,21 @@ dependencies = [
  "opentelemetry_sdk",
  "tokio",
  "tower",
+]
+
+[[package]]
+name = "insight-log-context"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "cf-gears-toolkit-security",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -5141,6 +5161,7 @@ dependencies = [
  "cf-gears-types-registry",
  "chrono",
  "clap",
+ "insight-log-context",
  "k8s-openapi",
  "kube",
  "regex-lite",

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "libs/insight-clickhouse",
     "libs/insight-http-metrics",
+    "libs/insight-log-context",
     "libs/insight-migration",
     "libs/authenticator-sdk",
     "services/analytics",
@@ -152,6 +153,7 @@ opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "http-proto",
 # Internal crates
 insight-clickhouse = { path = "libs/insight-clickhouse" }
 insight-http-metrics = { path = "libs/insight-http-metrics" }
+insight-log-context = { path = "libs/insight-log-context" }
 insight-migration = { path = "libs/insight-migration" }
 authenticator-sdk = { path = "libs/authenticator-sdk" }
 

--- a/src/backend/libs/insight-log-context/Cargo.toml
+++ b/src/backend/libs/insight-log-context/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "insight-log-context"
+version = "0.1.0"
+description = "Request-scoped log context span: correlation id echo, tenant, service name and version"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+# Line-capture helper for the per-service contract tests (insight#2488 AC-3).
+test-support = ["dep:serde_json", "dep:thiserror", "dep:tokio", "dep:tracing-subscriber"]
+
+[dependencies]
+axum = { workspace = true }
+toolkit-security = { workspace = true }
+tower = "0.5"
+tracing = { workspace = true }
+uuid = { workspace = true }
+
+serde_json = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tower = { version = "0.5", features = ["util"] }
+tracing-subscriber = { workspace = true }

--- a/src/backend/libs/insight-log-context/src/lib.rs
+++ b/src/backend/libs/insight-log-context/src/lib.rs
@@ -1,0 +1,120 @@
+//! `log_ctx` span around each service's routes: every request-scoped line
+//! carries `correlation_id` (echoed from the gateway's `X-Correlation-Id`,
+//! `x-request-id` as fallback — never minted here), `tenant_id` when
+//! authenticated, and the `service` / `version` set once at startup from the
+//! config's `opentelemetry.resource` (see [`init_identity`]).
+
+use std::sync::OnceLock;
+use std::task::{Context, Poll};
+
+use axum::http::Request;
+use toolkit_security::SecurityContext;
+use tower::{Layer, Service};
+use tracing::field::Empty;
+use tracing::instrument::{Instrument, Instrumented};
+
+pub const CORRELATION_ID_HEADER: &str = "x-correlation-id";
+pub const REQUEST_ID_HEADER: &str = "x-request-id";
+pub const VERSION_ATTRIBUTE: &str = "service.version";
+
+#[derive(Debug)]
+struct ServiceIdentity {
+    service: String,
+    version: Option<String>,
+}
+
+static IDENTITY: OnceLock<ServiceIdentity> = OnceLock::new();
+
+/// [`init_identity`] from the config's `opentelemetry.resource` fields.
+pub fn init_identity_from_resource(
+    service_name: &str,
+    attributes: &std::collections::BTreeMap<String, String>,
+) {
+    init_identity(
+        service_name,
+        attributes.get(VERSION_ATTRIBUTE).map(String::as_str),
+    );
+}
+
+/// Set once from `main`, before the server starts. Later calls are ignored.
+pub fn init_identity(service: &str, version: Option<&str>) {
+    let _ = IDENTITY.set(ServiceIdentity {
+        service: service.to_owned(),
+        version: version.map(str::to_owned),
+    });
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LogContextLayer;
+
+impl LogContextLayer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<S> Layer<S> for LogContextLayer {
+    type Service = LogContextService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        LogContextService { inner }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LogContextService<S> {
+    inner: S,
+}
+
+impl<S, B> Service<Request<B>> for LogContextService<S>
+where
+    S: Service<Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Instrumented<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let header = |name: &str| {
+            req.headers()
+                .get(name)
+                .and_then(|value| value.to_str().ok())
+        };
+        let correlation_id = header(CORRELATION_ID_HEADER)
+            .or_else(|| header(REQUEST_ID_HEADER))
+            .unwrap_or_default();
+
+        let span = tracing::info_span!(
+            "log_ctx",
+            service = Empty,
+            version = Empty,
+            correlation_id = %correlation_id,
+            tenant_id = Empty,
+        );
+        if let Some(identity) = IDENTITY.get() {
+            span.record("service", identity.service.as_str());
+            if let Some(version) = &identity.version {
+                span.record("version", version.as_str());
+            }
+        }
+        if let Some(security) = req.extensions().get::<SecurityContext>() {
+            span.record(
+                "tenant_id",
+                tracing::field::display(security.subject_tenant_id()),
+            );
+        }
+
+        self.inner.call(req).instrument(span)
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
+
+#[cfg(test)]
+mod tests;

--- a/src/backend/libs/insight-log-context/src/test_support.rs
+++ b/src/backend/libs/insight-log-context/src/test_support.rs
@@ -1,0 +1,131 @@
+//! Fires one request through a probe route wrapped in a [`LogContextLayer`]
+//! and returns the captured JSON probe line plus its `log_ctx` span fields.
+
+use std::io;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::Request;
+use axum::routing::get;
+use toolkit_security::SecurityContext;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::LogContextLayer;
+
+pub const PROBE_MESSAGE: &str = "log context probe line";
+
+#[derive(Debug, thiserror::Error)]
+pub enum CaptureError {
+    #[error("probe request could not be built or served: {0}")]
+    Request(String),
+    #[error("runtime: {0}")]
+    Runtime(#[from] io::Error),
+    #[error("captured output is not JSON lines: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("no line carrying the probe message was captured")]
+    ProbeLineMissing,
+    #[error("the probe line carries no log_ctx span")]
+    LogCtxSpanMissing,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for SharedWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // SAFETY: a poisoned buffer is still appendable — the writer never leaves it torn.
+        let mut inner = self.0.lock().unwrap_or_else(PoisonError::into_inner);
+        inner.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedWriter {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+async fn probe_handler() -> &'static str {
+    tracing::info!("{PROBE_MESSAGE}");
+    "ok"
+}
+
+/// # Errors
+/// The probe line is missing from the captured output or carries no `log_ctx`
+/// span — either means the layer is not doing its job.
+pub fn capture_probe_line(
+    layer: LogContextLayer,
+    headers: &[(&str, &str)],
+    tenant: Option<Uuid>,
+) -> Result<(serde_json::Value, serde_json::Value), CaptureError> {
+    let writer = SharedWriter::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(writer.clone())
+        .with_max_level(tracing::Level::TRACE)
+        .finish();
+
+    let app = Router::new()
+        .route("/probe", get(probe_handler))
+        .layer(layer);
+
+    let mut request = Request::builder().uri("/probe");
+    for (name, value) in headers {
+        request = request.header(*name, *value);
+    }
+    if let Some(tenant_id) = tenant {
+        let security = SecurityContext::builder()
+            .subject_id(Uuid::from_u128(1))
+            .subject_tenant_id(tenant_id)
+            .build()
+            .map_err(|e| CaptureError::Request(e.to_string()))?;
+        request = request.extension(security);
+    }
+    let request = request
+        .body(Body::empty())
+        .map_err(|e| CaptureError::Request(e.to_string()))?;
+
+    let runtime = tokio::runtime::Builder::new_current_thread().build()?;
+    tracing::subscriber::with_default(subscriber, || {
+        runtime
+            .block_on(app.oneshot(request))
+            .map_err(|e| CaptureError::Request(e.to_string()))
+    })?;
+
+    let captured = writer.0.lock().unwrap_or_else(PoisonError::into_inner);
+    let lines = String::from_utf8_lossy(&captured)
+        .lines()
+        .map(serde_json::from_str::<serde_json::Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let probe_line = lines
+        .into_iter()
+        .find(|line| {
+            line.pointer("/fields/message")
+                .and_then(serde_json::Value::as_str)
+                == Some(PROBE_MESSAGE)
+        })
+        .ok_or(CaptureError::ProbeLineMissing)?;
+
+    let log_ctx = probe_line
+        .pointer("/spans")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|spans| {
+            spans.iter().find(|span| {
+                span.get("name").and_then(serde_json::Value::as_str) == Some("log_ctx")
+            })
+        })
+        .cloned()
+        .ok_or(CaptureError::LogCtxSpanMissing)?;
+
+    Ok((probe_line, log_ctx))
+}

--- a/src/backend/libs/insight-log-context/src/tests.rs
+++ b/src/backend/libs/insight-log-context/src/tests.rs
@@ -1,0 +1,84 @@
+use uuid::Uuid;
+
+use crate::test_support::capture_probe_line;
+use crate::{
+    CORRELATION_ID_HEADER, LogContextLayer, REQUEST_ID_HEADER, init_identity_from_resource,
+};
+
+type R = Result<(), Box<dyn std::error::Error>>;
+
+// One process-wide identity: every test in this binary sees these values.
+fn layer() -> LogContextLayer {
+    let attributes =
+        std::collections::BTreeMap::from([("service.version".to_owned(), "9.9.9".to_owned())]);
+    init_identity_from_resource("probe-service", &attributes);
+    LogContextLayer::new()
+}
+
+fn field<'a>(span: &'a serde_json::Value, name: &str) -> Option<&'a str> {
+    span.get(name).and_then(serde_json::Value::as_str)
+}
+
+#[test]
+fn a_request_line_carries_service_version_tenant_and_correlation_id() -> R {
+    let tenant = Uuid::from_u128(42);
+
+    let (_, log_ctx) = capture_probe_line(
+        layer(),
+        &[(CORRELATION_ID_HEADER, "corr-under-test")],
+        Some(tenant),
+    )?;
+
+    assert_eq!(field(&log_ctx, "service"), Some("probe-service"));
+    assert_eq!(field(&log_ctx, "version"), Some("9.9.9"));
+    assert_eq!(field(&log_ctx, "correlation_id"), Some("corr-under-test"));
+    assert_eq!(
+        field(&log_ctx, "tenant_id"),
+        Some(tenant.to_string().as_str())
+    );
+    Ok(())
+}
+
+#[test]
+fn the_correlation_id_is_echoed_not_minted() -> R {
+    let (_, first) = capture_probe_line(layer(), &[(CORRELATION_ID_HEADER, "echo-me-1")], None)?;
+    let (_, second) = capture_probe_line(layer(), &[(CORRELATION_ID_HEADER, "echo-me-2")], None)?;
+
+    assert_eq!(field(&first, "correlation_id"), Some("echo-me-1"));
+    assert_eq!(field(&second, "correlation_id"), Some("echo-me-2"));
+    Ok(())
+}
+
+#[test]
+fn without_a_gateway_id_the_request_id_is_the_fallback() -> R {
+    let (_, log_ctx) = capture_probe_line(layer(), &[(REQUEST_ID_HEADER, "rid-fallback")], None)?;
+
+    assert_eq!(field(&log_ctx, "correlation_id"), Some("rid-fallback"));
+    Ok(())
+}
+
+#[test]
+fn the_gateway_id_wins_over_the_request_id() -> R {
+    let (_, log_ctx) = capture_probe_line(
+        layer(),
+        &[
+            (CORRELATION_ID_HEADER, "corr-wins"),
+            (REQUEST_ID_HEADER, "rid-loses"),
+        ],
+        None,
+    )?;
+
+    assert_eq!(field(&log_ctx, "correlation_id"), Some("corr-wins"));
+    Ok(())
+}
+
+#[test]
+fn without_a_security_context_the_tenant_field_is_absent() -> R {
+    let (_, log_ctx) = capture_probe_line(layer(), &[(CORRELATION_ID_HEADER, "corr")], None)?;
+
+    assert!(
+        log_ctx.get("tenant_id").is_none(),
+        "unauthenticated request grew a tenant: {log_ctx}"
+    );
+    Ok(())
+}

--- a/src/backend/services/analytics/Cargo.toml
+++ b/src/backend/services/analytics/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 insight-clickhouse = { workspace = true }
 insight-http-metrics = { workspace = true }
+insight-log-context = { workspace = true }
 insight-migration = { workspace = true }
 # Direct `clickhouse` dep is for the `Row` derive on `system.columns` probe
 # rows (Refs #521 schema-validator). `insight-clickhouse` wraps the client
@@ -88,6 +89,7 @@ opentelemetry = { workspace = true }
 clap = { workspace = true }
 
 [dev-dependencies]
+insight-log-context = { workspace = true, features = ["test-support"] }
 # `tower::ServiceExt::oneshot` for driving the Axum router in the HTTP
 # integration tests. Same dev-dep pattern as api-gateway's proxy tests.
 tower = { version = "0.5", features = ["util"] }

--- a/src/backend/services/analytics/Dockerfile
+++ b/src/backend/services/analytics/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY libs/insight-clickhouse/Cargo.toml ./libs/insight-clickhouse/Cargo.toml
 COPY libs/insight-http-metrics/Cargo.toml ./libs/insight-http-metrics/Cargo.toml
+COPY libs/insight-log-context/Cargo.toml ./libs/insight-log-context/Cargo.toml
 COPY libs/authenticator-sdk/Cargo.toml ./libs/authenticator-sdk/Cargo.toml
 COPY libs/insight-migration/Cargo.toml ./libs/insight-migration/Cargo.toml
 COPY services/analytics/Cargo.toml ./services/analytics/Cargo.toml
@@ -37,6 +38,7 @@ COPY tools/routegen/Cargo.toml ./tools/routegen/Cargo.toml
 
 RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/src/lib.rs && \
     mkdir -p libs/insight-http-metrics/src && echo "" > libs/insight-http-metrics/src/lib.rs && \
+    mkdir -p libs/insight-log-context/src && echo "" > libs/insight-log-context/src/lib.rs && \
     mkdir -p libs/authenticator-sdk/src && echo "" > libs/authenticator-sdk/src/lib.rs && \
     mkdir -p libs/insight-migration/src && echo "" > libs/insight-migration/src/lib.rs && \
     mkdir -p services/analytics/src && echo "fn main() {}" > services/analytics/src/main.rs && \
@@ -49,7 +51,7 @@ RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/sr
 RUN cargo build --release --bin analytics 2>/dev/null || true
 
 # --- Source layer ---
-RUN rm -rf libs/insight-clickhouse/src libs/insight-http-metrics/src libs/insight-migration/src services/analytics/src \
+RUN rm -rf libs/insight-clickhouse/src libs/insight-http-metrics/src libs/insight-log-context/src libs/insight-migration/src services/analytics/src \
     target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
     target/release/analytics target/release/deps/analytics* \
     target/release/deps/insight_clickhouse* target/release/deps/libinsight_clickhouse* \
@@ -57,6 +59,7 @@ RUN rm -rf libs/insight-clickhouse/src libs/insight-http-metrics/src libs/insigh
 
 COPY libs/insight-clickhouse/src/ ./libs/insight-clickhouse/src/
 COPY libs/insight-http-metrics/src/ ./libs/insight-http-metrics/src/
+COPY libs/insight-log-context/src/ ./libs/insight-log-context/src/
 COPY libs/insight-migration/src/ ./libs/insight-migration/src/
 COPY services/analytics/src/ ./services/analytics/src/
 COPY services/analytics/config/ ./services/analytics/config/

--- a/src/backend/services/analytics/Dockerfile
+++ b/src/backend/services/analytics/Dockerfile
@@ -53,6 +53,7 @@ RUN cargo build --release --bin analytics 2>/dev/null || true
 # --- Source layer ---
 RUN rm -rf libs/insight-clickhouse/src libs/insight-http-metrics/src libs/insight-log-context/src libs/insight-migration/src services/analytics/src \
     target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
+    target/release/deps/insight_log_context* target/release/deps/libinsight_log_context* \
     target/release/analytics target/release/deps/analytics* \
     target/release/deps/insight_clickhouse* target/release/deps/libinsight_clickhouse* \
     target/release/deps/insight_migration* target/release/deps/libinsight_migration*

--- a/src/backend/services/analytics/helm/templates/configmap.yaml
+++ b/src/backend/services/analytics/helm/templates/configmap.yaml
@@ -32,6 +32,10 @@ data:
     opentelemetry:
       resource:
         service_name: "insight-analytics"
+        attributes:
+          # The release the pod runs; the log_ctx span and the OTel resource
+          # both read it (semconv service.version).
+          service.version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
       exporter:
         kind: {{ .Values.opentelemetry.exporter.kind }}
         {{- with .Values.opentelemetry.exporter.endpoint }}

--- a/src/backend/services/analytics/src/api/log_context_tests.rs
+++ b/src/backend/services/analytics/src/api/log_context_tests.rs
@@ -1,0 +1,23 @@
+use insight_log_context::test_support::capture_probe_line;
+use insight_log_context::{CORRELATION_ID_HEADER, LogContextLayer, init_identity};
+use uuid::Uuid;
+
+type R = Result<(), Box<dyn std::error::Error>>;
+
+#[test]
+fn request_lines_carry_the_identity_and_echo_the_arriving_id() -> R {
+    init_identity("insight-analytics", Some("2026.01.01-test"));
+    let tenant = Uuid::from_u128(7);
+
+    let (_, log_ctx) = capture_probe_line(
+        LogContextLayer::new(),
+        &[(CORRELATION_ID_HEADER, "corr-3190")],
+        Some(tenant),
+    )?;
+
+    assert_eq!(log_ctx["service"], "insight-analytics");
+    assert_eq!(log_ctx["version"], "2026.01.01-test");
+    assert_eq!(log_ctx["correlation_id"], "corr-3190");
+    assert_eq!(log_ctx["tenant_id"], tenant.to_string());
+    Ok(())
+}

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -132,10 +132,14 @@ pub fn register_routes(
 ) -> Router {
     let api = build_operations(Router::new(), openapi)
         .layer(Extension(state))
-        .layer(insight_http_metrics::ServerMetricsLayer::new("analytics"));
+        .layer(insight_http_metrics::ServerMetricsLayer::new("analytics"))
+        .layer(insight_log_context::LogContextLayer::new());
 
     host_router.merge(api)
 }
+
+#[cfg(test)]
+mod log_context_tests;
 
 /// `OpenAPI` document metadata — the stable API-contract identity baked into
 /// the committed `docs/components/backend/analytics/openapi.json` and the

--- a/src/backend/services/analytics/src/main.rs
+++ b/src/backend/services/analytics/src/main.rs
@@ -117,7 +117,14 @@ async fn main() -> Result<()> {
     }
 
     match cli.command.unwrap_or(Commands::Run) {
-        Commands::Run => run_server(config).await,
+        Commands::Run => {
+            let resource = &config.opentelemetry.resource;
+            insight_log_context::init_identity_from_resource(
+                &resource.service_name,
+                &resource.attributes,
+            );
+            run_server(config).await
+        }
         Commands::Migrate => {
             init_subcommand_logging();
             gear::run_migrate(&config).await

--- a/src/backend/services/authenticator/Cargo.toml
+++ b/src/backend/services/authenticator/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 authenticator-sdk = { workspace = true }
 insight-http-metrics = { workspace = true }
+insight-log-context = { workspace = true }
 
 # ToolKit host runtime. The authenticator runs as a gears-rust host: routes are
 # declared via `OperationBuilder` and served by the `api-gateway` system gear
@@ -80,6 +81,7 @@ base64 = "0.23"
 rand = "0.10"
 
 [dev-dependencies]
+insight-log-context = { workspace = true, features = ["test-support"] }
 tower = { version = "0.5", features = ["util"] }
 # Parse the dev config in a test so a YAML mistake in the service-token registry
 # fails fast, not only at container boot.

--- a/src/backend/services/authenticator/Dockerfile
+++ b/src/backend/services/authenticator/Dockerfile
@@ -52,6 +52,7 @@ RUN cargo build --release --bin authenticator 2>/dev/null || true
 # --- Source layer ---
 RUN rm -rf libs/authenticator-sdk/src libs/insight-http-metrics/src libs/insight-log-context/src services/authenticator/src \
     target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
+    target/release/deps/insight_log_context* target/release/deps/libinsight_log_context* \
     target/release/authenticator target/release/deps/authenticator* \
     target/release/deps/libauthenticator*
 

--- a/src/backend/services/authenticator/Dockerfile
+++ b/src/backend/services/authenticator/Dockerfile
@@ -21,6 +21,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY libs/insight-clickhouse/Cargo.toml ./libs/insight-clickhouse/Cargo.toml
 COPY libs/insight-http-metrics/Cargo.toml ./libs/insight-http-metrics/Cargo.toml
+COPY libs/insight-log-context/Cargo.toml ./libs/insight-log-context/Cargo.toml
 COPY libs/authenticator-sdk/Cargo.toml ./libs/authenticator-sdk/Cargo.toml
 COPY libs/insight-migration/Cargo.toml ./libs/insight-migration/Cargo.toml
 COPY services/analytics/Cargo.toml ./services/analytics/Cargo.toml
@@ -36,6 +37,7 @@ COPY tools/routegen/Cargo.toml ./tools/routegen/Cargo.toml
 
 RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/src/lib.rs && \
     mkdir -p libs/insight-http-metrics/src && echo "" > libs/insight-http-metrics/src/lib.rs && \
+    mkdir -p libs/insight-log-context/src && echo "" > libs/insight-log-context/src/lib.rs && \
     mkdir -p libs/authenticator-sdk/src && echo "" > libs/authenticator-sdk/src/lib.rs && \
     mkdir -p libs/insight-migration/src && echo "" > libs/insight-migration/src/lib.rs && \
     mkdir -p services/analytics/src && echo "fn main() {}" > services/analytics/src/main.rs && \
@@ -48,13 +50,14 @@ RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/sr
 RUN cargo build --release --bin authenticator 2>/dev/null || true
 
 # --- Source layer ---
-RUN rm -rf libs/authenticator-sdk/src libs/insight-http-metrics/src services/authenticator/src \
+RUN rm -rf libs/authenticator-sdk/src libs/insight-http-metrics/src libs/insight-log-context/src services/authenticator/src \
     target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
     target/release/authenticator target/release/deps/authenticator* \
     target/release/deps/libauthenticator*
 
 COPY libs/authenticator-sdk/src/ ./libs/authenticator-sdk/src/
 COPY libs/insight-http-metrics/src/ ./libs/insight-http-metrics/src/
+COPY libs/insight-log-context/src/ ./libs/insight-log-context/src/
 COPY services/authenticator/src/ ./services/authenticator/src/
 COPY services/authenticator/config/ ./services/authenticator/config/
 

--- a/src/backend/services/authenticator/helm/templates/configmap.yaml
+++ b/src/backend/services/authenticator/helm/templates/configmap.yaml
@@ -37,6 +37,10 @@ data:
     opentelemetry:
       resource:
         service_name: "insight-authenticator"
+        attributes:
+          # The release the pod runs; the log_ctx span and the OTel resource
+          # both read it (semconv service.version).
+          service.version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
       exporter:
         kind: {{ .Values.opentelemetry.exporter.kind }}
         {{- with .Values.opentelemetry.exporter.endpoint }}

--- a/src/backend/services/authenticator/src/api/log_context_tests.rs
+++ b/src/backend/services/authenticator/src/api/log_context_tests.rs
@@ -1,0 +1,23 @@
+use insight_log_context::test_support::capture_probe_line;
+use insight_log_context::{CORRELATION_ID_HEADER, LogContextLayer, init_identity};
+use uuid::Uuid;
+
+type R = Result<(), Box<dyn std::error::Error>>;
+
+#[test]
+fn request_lines_carry_the_identity_and_echo_the_arriving_id() -> R {
+    init_identity("insight-authenticator", Some("2026.01.01-test"));
+    let tenant = Uuid::from_u128(7);
+
+    let (_, log_ctx) = capture_probe_line(
+        LogContextLayer::new(),
+        &[(CORRELATION_ID_HEADER, "corr-3190")],
+        Some(tenant),
+    )?;
+
+    assert_eq!(log_ctx["service"], "insight-authenticator");
+    assert_eq!(log_ctx["version"], "2026.01.01-test");
+    assert_eq!(log_ctx["correlation_id"], "corr-3190");
+    assert_eq!(log_ctx["tenant_id"], tenant.to_string());
+    Ok(())
+}

--- a/src/backend/services/authenticator/src/api/mod.rs
+++ b/src/backend/services/authenticator/src/api/mod.rs
@@ -58,9 +58,13 @@ pub fn register_routes(
         .layer(Extension(state))
         .layer(insight_http_metrics::ServerMetricsLayer::new(
             "authenticator",
-        ));
+        ))
+        .layer(insight_log_context::LogContextLayer::new());
     host_router.merge(api)
 }
+
+#[cfg(test)]
+mod log_context_tests;
 
 /// Declare every operation through the toolkit's `OperationBuilder` so each
 /// lands in the generated OpenAPI (the machine-checkable subrequest contract),

--- a/src/backend/services/authenticator/src/main.rs
+++ b/src/backend/services/authenticator/src/main.rs
@@ -109,7 +109,14 @@ async fn main() -> Result<()> {
     }
 
     match cli.command.unwrap_or(Commands::Run) {
-        Commands::Run => run_server(config).await,
+        Commands::Run => {
+            let resource = &config.opentelemetry.resource;
+            insight_log_context::init_identity_from_resource(
+                &resource.service_name,
+                &resource.attributes,
+            );
+            run_server(config).await
+        }
         Commands::Check => {
             // Loading + parsing the config already validated its shape.
             println!("configuration OK");

--- a/src/backend/services/git-cli-proxy/Cargo.toml
+++ b/src/backend/services/git-cli-proxy/Cargo.toml
@@ -25,6 +25,7 @@ toolkit-canonical-errors = { workspace = true }
 utoipa = { version = "5.5" }
 chrono = { workspace = true }
 insight-http-metrics = { workspace = true }
+insight-log-context = { workspace = true }
 opentelemetry = { workspace = true }
 # statvfs: the volume is the ground truth the per-entry accounting cannot
 # see. rustix rather than libc — the workspace forbids unsafe code.
@@ -61,6 +62,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
+insight-log-context = { workspace = true, features = ["test-support"] }
+uuid = { workspace = true }
 # `start_paused` virtual time, so the preparation-wait test does not sleep.
 tokio = { workspace = true, features = ["test-util"] }
 # `tower::ServiceExt::oneshot` for driving the Axum router in tests without a

--- a/src/backend/services/git-cli-proxy/Dockerfile
+++ b/src/backend/services/git-cli-proxy/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY libs/insight-clickhouse/Cargo.toml ./libs/insight-clickhouse/Cargo.toml
 COPY libs/insight-http-metrics/Cargo.toml ./libs/insight-http-metrics/Cargo.toml
+COPY libs/insight-log-context/Cargo.toml ./libs/insight-log-context/Cargo.toml
 COPY libs/authenticator-sdk/Cargo.toml ./libs/authenticator-sdk/Cargo.toml
 COPY libs/insight-migration/Cargo.toml ./libs/insight-migration/Cargo.toml
 COPY services/analytics/Cargo.toml ./services/analytics/Cargo.toml
@@ -31,6 +32,7 @@ COPY tools/routegen/Cargo.toml ./tools/routegen/Cargo.toml
 
 RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/src/lib.rs && \
     mkdir -p libs/insight-http-metrics/src && echo "" > libs/insight-http-metrics/src/lib.rs && \
+    mkdir -p libs/insight-log-context/src && echo "" > libs/insight-log-context/src/lib.rs && \
     mkdir -p libs/authenticator-sdk/src && echo "" > libs/authenticator-sdk/src/lib.rs && \
     mkdir -p libs/insight-migration/src && echo "" > libs/insight-migration/src/lib.rs && \
     mkdir -p services/analytics/src && echo "fn main() {}" > services/analytics/src/main.rs && \
@@ -43,11 +45,12 @@ RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/sr
 RUN cargo build --release --bin git-cli-proxy 2>/dev/null || true
 
 # --- Source layer ---
-RUN rm -rf libs/insight-http-metrics/src services/git-cli-proxy/src \
+RUN rm -rf libs/insight-http-metrics/src libs/insight-log-context/src services/git-cli-proxy/src \
     target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
     target/release/git-cli-proxy target/release/deps/git_cli_proxy*
 
 COPY libs/insight-http-metrics/src/ ./libs/insight-http-metrics/src/
+COPY libs/insight-log-context/src/ ./libs/insight-log-context/src/
 COPY services/git-cli-proxy/src/ ./services/git-cli-proxy/src/
 COPY services/git-cli-proxy/config/ ./services/git-cli-proxy/config/
 

--- a/src/backend/services/git-cli-proxy/Dockerfile
+++ b/src/backend/services/git-cli-proxy/Dockerfile
@@ -47,6 +47,7 @@ RUN cargo build --release --bin git-cli-proxy 2>/dev/null || true
 # --- Source layer ---
 RUN rm -rf libs/insight-http-metrics/src libs/insight-log-context/src services/git-cli-proxy/src \
     target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
+    target/release/deps/insight_log_context* target/release/deps/libinsight_log_context* \
     target/release/git-cli-proxy target/release/deps/git_cli_proxy*
 
 COPY libs/insight-http-metrics/src/ ./libs/insight-http-metrics/src/

--- a/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
+++ b/src/backend/services/git-cli-proxy/helm/templates/configmap.yaml
@@ -20,6 +20,10 @@ data:
     opentelemetry:
       resource:
         service_name: "insight-git-cli-proxy"
+        attributes:
+          # The release the pod runs; the log_ctx span and the OTel resource
+          # both read it (semconv service.version).
+          service.version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
       exporter:
         kind: {{ .Values.opentelemetry.exporter.kind }}
         {{- with .Values.opentelemetry.exporter.endpoint }}

--- a/src/backend/services/git-cli-proxy/src/api/log_context_tests.rs
+++ b/src/backend/services/git-cli-proxy/src/api/log_context_tests.rs
@@ -1,0 +1,23 @@
+use insight_log_context::test_support::capture_probe_line;
+use insight_log_context::{CORRELATION_ID_HEADER, LogContextLayer, init_identity};
+use uuid::Uuid;
+
+type R = Result<(), Box<dyn std::error::Error>>;
+
+#[test]
+fn request_lines_carry_the_identity_and_echo_the_arriving_id() -> R {
+    init_identity("insight-git-cli-proxy", Some("2026.01.01-test"));
+    let tenant = Uuid::from_u128(7);
+
+    let (_, log_ctx) = capture_probe_line(
+        LogContextLayer::new(),
+        &[(CORRELATION_ID_HEADER, "corr-3190")],
+        Some(tenant),
+    )?;
+
+    assert_eq!(log_ctx["service"], "insight-git-cli-proxy");
+    assert_eq!(log_ctx["version"], "2026.01.01-test");
+    assert_eq!(log_ctx["correlation_id"], "corr-3190");
+    assert_eq!(log_ctx["tenant_id"], tenant.to_string());
+    Ok(())
+}

--- a/src/backend/services/git-cli-proxy/src/api/mod.rs
+++ b/src/backend/services/git-cli-proxy/src/api/mod.rs
@@ -59,10 +59,14 @@ pub fn register_routes(
         .layer(axum::middleware::from_fn(observe))
         .layer(insight_http_metrics::ServerMetricsLayer::new(
             "git-cli-proxy",
-        ));
+        ))
+        .layer(insight_log_context::LogContextLayer::new());
 
     host_router.merge(v1)
 }
+
+#[cfg(test)]
+mod log_context_tests;
 
 /// Every wait a handler can make is individually bounded (git budgets, the
 /// in-connection preparation wait, the read-lock wait), but a hold that is

--- a/src/backend/services/git-cli-proxy/src/main.rs
+++ b/src/backend/services/git-cli-proxy/src/main.rs
@@ -54,7 +54,15 @@ async fn main() -> Result<()> {
     let load_config = || AppConfig::load_or_default(cli.config.as_ref());
 
     match command {
-        Commands::Run => run_server(load_config()?).await,
+        Commands::Run => {
+            let config = load_config()?;
+            let resource = &config.opentelemetry.resource;
+            insight_log_context::init_identity_from_resource(
+                &resource.service_name,
+                &resource.attributes,
+            );
+            run_server(config).await
+        }
         Commands::Openapi => print_openapi(),
     }
 }

--- a/src/backend/services/identity-resolution/Cargo.toml
+++ b/src/backend/services/identity-resolution/Cargo.toml
@@ -61,6 +61,7 @@ base64 = { workspace = true }
 # `Row` derive on the query row struct.
 insight-clickhouse = { workspace = true }
 insight-http-metrics = { workspace = true }
+insight-log-context = { workspace = true }
 insight-migration = { workspace = true }
 clickhouse = { workspace = true }
 
@@ -78,6 +79,7 @@ toolkit-canonical-errors = { workspace = true }
 utoipa = { version = "5.5", features = ["chrono", "uuid"] }
 
 [dev-dependencies]
+insight-log-context = { workspace = true, features = ["test-support"] }
 # `tower::ServiceExt::oneshot` for driving the Axum router in the HTTP
 # integration tests. Same dev-dep pattern as the analytics service.
 tower = { version = "0.5", features = ["util"] }

--- a/src/backend/services/identity-resolution/Dockerfile
+++ b/src/backend/services/identity-resolution/Dockerfile
@@ -46,6 +46,7 @@ RUN cargo build --release --bin identity-resolution 2>/dev/null || true
 # --- Source layer ---
 RUN rm -rf libs/insight-clickhouse/src libs/insight-http-metrics/src libs/insight-log-context/src libs/insight-migration/src services/identity-resolution/src \
     target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
+    target/release/deps/insight_log_context* target/release/deps/libinsight_log_context* \
     target/release/identity-resolution target/release/deps/identity_resolution* \
     target/release/deps/insight_clickhouse* target/release/deps/libinsight_clickhouse* \
     target/release/deps/insight_migration* target/release/deps/libinsight_migration*

--- a/src/backend/services/identity-resolution/Dockerfile
+++ b/src/backend/services/identity-resolution/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY libs/insight-clickhouse/Cargo.toml ./libs/insight-clickhouse/Cargo.toml
 COPY libs/insight-http-metrics/Cargo.toml ./libs/insight-http-metrics/Cargo.toml
+COPY libs/insight-log-context/Cargo.toml ./libs/insight-log-context/Cargo.toml
 COPY libs/authenticator-sdk/Cargo.toml ./libs/authenticator-sdk/Cargo.toml
 COPY libs/insight-migration/Cargo.toml ./libs/insight-migration/Cargo.toml
 COPY services/analytics/Cargo.toml ./services/analytics/Cargo.toml
@@ -30,6 +31,7 @@ COPY tools/routegen/Cargo.toml ./tools/routegen/Cargo.toml
 
 RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/src/lib.rs && \
     mkdir -p libs/insight-http-metrics/src && echo "" > libs/insight-http-metrics/src/lib.rs && \
+    mkdir -p libs/insight-log-context/src && echo "" > libs/insight-log-context/src/lib.rs && \
     mkdir -p libs/authenticator-sdk/src && echo "" > libs/authenticator-sdk/src/lib.rs && \
     mkdir -p libs/insight-migration/src && echo "" > libs/insight-migration/src/lib.rs && \
     mkdir -p services/analytics/src && echo "fn main() {}" > services/analytics/src/main.rs && \
@@ -42,7 +44,7 @@ RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/sr
 RUN cargo build --release --bin identity-resolution 2>/dev/null || true
 
 # --- Source layer ---
-RUN rm -rf libs/insight-clickhouse/src libs/insight-http-metrics/src libs/insight-migration/src services/identity-resolution/src \
+RUN rm -rf libs/insight-clickhouse/src libs/insight-http-metrics/src libs/insight-log-context/src libs/insight-migration/src services/identity-resolution/src \
     target/release/deps/insight_http_metrics* target/release/deps/libinsight_http_metrics* \
     target/release/identity-resolution target/release/deps/identity_resolution* \
     target/release/deps/insight_clickhouse* target/release/deps/libinsight_clickhouse* \
@@ -50,6 +52,7 @@ RUN rm -rf libs/insight-clickhouse/src libs/insight-http-metrics/src libs/insigh
 
 COPY libs/insight-clickhouse/src/ ./libs/insight-clickhouse/src/
 COPY libs/insight-http-metrics/src/ ./libs/insight-http-metrics/src/
+COPY libs/insight-log-context/src/ ./libs/insight-log-context/src/
 COPY libs/insight-migration/src/ ./libs/insight-migration/src/
 COPY services/identity-resolution/src/ ./services/identity-resolution/src/
 COPY services/identity-resolution/config/ ./services/identity-resolution/config/

--- a/src/backend/services/identity-resolution/helm/templates/configmap.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/configmap.yaml
@@ -31,6 +31,10 @@ data:
     opentelemetry:
       resource:
         service_name: "insight-identity-resolution"
+        attributes:
+          # The release the pod runs; the log_ctx span and the OTel resource
+          # both read it (semconv service.version).
+          service.version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
       exporter:
         kind: {{ .Values.opentelemetry.exporter.kind }}
         {{- with .Values.opentelemetry.exporter.endpoint }}

--- a/src/backend/services/identity-resolution/helm/tests/test_umbrella_log_context_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_umbrella_log_context_contract.py
@@ -1,0 +1,38 @@
+"""Every gears configmap pins service.version to the image tag the pod runs."""
+
+from __future__ import annotations
+
+import re
+
+from conftest import TENANT, UMBRELLA, UMBRELLA_BASE, render
+from test_umbrella_log_level_contract import GEARS_SERVICES
+
+VERSION_ATTR = re.compile(r'service\.version:\s*"([^"]*)"')
+IMAGE_TAG = re.compile(r'image: "[^"]+:([^":/@]+)"')
+
+
+def rendered_per_service(stdout: str, template: str, pattern: re.Pattern) -> dict[str, list[str]]:
+    per_service: dict[str, list[str]] = {}
+    for doc in stdout.split("\n---\n"):
+        source = re.search(rf"# Source: insight/charts/([^/]+)/templates/{template}", doc)
+        if source:
+            per_service.setdefault(source.group(1), []).extend(pattern.findall(doc))
+    return per_service
+
+
+def test_every_gears_configmap_pins_the_image_tag_as_service_version(umbrella_deps) -> None:
+    code, out, err = render(UMBRELLA, *UMBRELLA_BASE, "--set", f"global.tenantDefaultId={TENANT}")
+    assert code == 0, err
+
+    versions = rendered_per_service(out, r"configmap\.yaml", VERSION_ATTR)
+    tags = rendered_per_service(out, r"deployment\.yaml", IMAGE_TAG)
+    assert GEARS_SERVICES <= set(versions), (
+        f"configmaps with service.version: {sorted(versions)}, expected at least {sorted(GEARS_SERVICES)}"
+    )
+    for service in GEARS_SERVICES:
+        assert len(versions[service]) == 1, f"{service} renders service.version {len(versions[service])} times"
+        version = versions[service][0]
+        assert version, f"{service} renders an empty service.version"
+        assert version in tags.get(service, []), (
+            f"{service}: service.version {version!r} names no image the pod runs {tags.get(service)}"
+        )

--- a/src/backend/services/identity-resolution/src/api/log_context_tests.rs
+++ b/src/backend/services/identity-resolution/src/api/log_context_tests.rs
@@ -1,0 +1,23 @@
+use insight_log_context::test_support::capture_probe_line;
+use insight_log_context::{CORRELATION_ID_HEADER, LogContextLayer, init_identity};
+use uuid::Uuid;
+
+type R = Result<(), Box<dyn std::error::Error>>;
+
+#[test]
+fn request_lines_carry_the_identity_and_echo_the_arriving_id() -> R {
+    init_identity("insight-identity-resolution", Some("2026.01.01-test"));
+    let tenant = Uuid::from_u128(7);
+
+    let (_, log_ctx) = capture_probe_line(
+        LogContextLayer::new(),
+        &[(CORRELATION_ID_HEADER, "corr-3190")],
+        Some(tenant),
+    )?;
+
+    assert_eq!(log_ctx["service"], "insight-identity-resolution");
+    assert_eq!(log_ctx["version"], "2026.01.01-test");
+    assert_eq!(log_ctx["correlation_id"], "corr-3190");
+    assert_eq!(log_ctx["tenant_id"], tenant.to_string());
+    Ok(())
+}

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -57,10 +57,14 @@ pub fn register_routes(
         .layer(Extension(state))
         .layer(insight_http_metrics::ServerMetricsLayer::new(
             "identity-resolution",
-        ));
+        ))
+        .layer(insight_log_context::LogContextLayer::new());
 
     host_router.merge(api)
 }
+
+#[cfg(test)]
+mod log_context_tests;
 
 /// Title/version/description of the emitted document. Kept in step with the
 /// `openapi` block of `config/insight.yaml`, which the live gear reads: the two

--- a/src/backend/services/identity-resolution/src/main.rs
+++ b/src/backend/services/identity-resolution/src/main.rs
@@ -120,7 +120,15 @@ async fn main() -> Result<()> {
 
     match command {
         Commands::Openapi => print_openapi(),
-        Commands::Run => run_server(load_config()?).await,
+        Commands::Run => {
+            let config = load_config()?;
+            let resource = &config.opentelemetry.resource;
+            insight_log_context::init_identity_from_resource(
+                &resource.service_name,
+                &resource.attributes,
+            );
+            run_server(config).await
+        }
         Commands::Migrate => {
             init_subcommand_logging();
             gear::run_migrate(&load_config()?).await

--- a/src/backend/services/previews/Cargo.toml
+++ b/src/backend/services/previews/Cargo.toml
@@ -57,6 +57,10 @@ k8s-openapi = { workspace = true, features = ["latest"] }
 
 # HTTP surface: SecurityContext, RFC-9457 canonical errors, OpenAPI schemas.
 toolkit-security = { workspace = true }
+insight-log-context = { workspace = true }
 toolkit-canonical-errors = { workspace = true }
 # utoipa pinned to match the `ToSchema` the toolkit OperationBuilder compiles against.
 utoipa = { version = "5.5", features = ["chrono", "uuid"] }
+
+[dev-dependencies]
+insight-log-context = { workspace = true, features = ["test-support"] }

--- a/src/backend/services/previews/Dockerfile
+++ b/src/backend/services/previews/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY libs/insight-clickhouse/Cargo.toml ./libs/insight-clickhouse/Cargo.toml
 COPY libs/insight-http-metrics/Cargo.toml ./libs/insight-http-metrics/Cargo.toml
+COPY libs/insight-log-context/Cargo.toml ./libs/insight-log-context/Cargo.toml
 COPY libs/authenticator-sdk/Cargo.toml ./libs/authenticator-sdk/Cargo.toml
 COPY libs/insight-migration/Cargo.toml ./libs/insight-migration/Cargo.toml
 COPY services/analytics/Cargo.toml ./services/analytics/Cargo.toml
@@ -30,6 +31,7 @@ COPY tools/routegen/Cargo.toml ./tools/routegen/Cargo.toml
 
 RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/src/lib.rs && \
     mkdir -p libs/insight-http-metrics/src && echo "" > libs/insight-http-metrics/src/lib.rs && \
+    mkdir -p libs/insight-log-context/src && echo "" > libs/insight-log-context/src/lib.rs && \
     mkdir -p libs/authenticator-sdk/src && echo "" > libs/authenticator-sdk/src/lib.rs && \
     mkdir -p libs/insight-migration/src && echo "" > libs/insight-migration/src/lib.rs && \
     mkdir -p services/analytics/src && echo "fn main() {}" > services/analytics/src/main.rs && \
@@ -42,9 +44,11 @@ RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/sr
 RUN cargo build --release --bin previews 2>/dev/null || true
 
 # --- Source layer ---
-RUN rm -rf services/previews/src \
-    target/release/previews target/release/deps/previews*
+RUN rm -rf libs/insight-log-context/src services/previews/src \
+    target/release/previews target/release/deps/previews* \
+    target/release/deps/insight_log_context* target/release/deps/libinsight_log_context*
 
+COPY libs/insight-log-context/src/ ./libs/insight-log-context/src/
 COPY services/previews/src/ ./services/previews/src/
 COPY services/previews/config/ ./services/previews/config/
 

--- a/src/backend/services/previews/helm/templates/configmap.yaml
+++ b/src/backend/services/previews/helm/templates/configmap.yaml
@@ -27,6 +27,14 @@ data:
         console_level: {{ ((((.Values.global).observability).logs).level) | default "info" }}
         console_format: {{ ((((.Values.global).observability).logs).format) | default "json" }}
 
+    opentelemetry:
+      resource:
+        service_name: "insight-previews"
+        attributes:
+          # The release the pod runs; the log_ctx span and the OTel resource
+          # both read it (semconv service.version).
+          service.version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+
     gears:
       api-gateway:
         config:

--- a/src/backend/services/previews/src/api/log_context_tests.rs
+++ b/src/backend/services/previews/src/api/log_context_tests.rs
@@ -1,0 +1,23 @@
+use insight_log_context::test_support::capture_probe_line;
+use insight_log_context::{CORRELATION_ID_HEADER, LogContextLayer, init_identity};
+use uuid::Uuid;
+
+type R = Result<(), Box<dyn std::error::Error>>;
+
+#[test]
+fn request_lines_carry_the_identity_and_echo_the_arriving_id() -> R {
+    init_identity("insight-previews", Some("2026.01.01-test"));
+    let tenant = Uuid::from_u128(7);
+
+    let (_, log_ctx) = capture_probe_line(
+        LogContextLayer::new(),
+        &[(CORRELATION_ID_HEADER, "corr-3190")],
+        Some(tenant),
+    )?;
+
+    assert_eq!(log_ctx["service"], "insight-previews");
+    assert_eq!(log_ctx["version"], "2026.01.01-test");
+    assert_eq!(log_ctx["correlation_id"], "corr-3190");
+    assert_eq!(log_ctx["tenant_id"], tenant.to_string());
+    Ok(())
+}

--- a/src/backend/services/previews/src/api/mod.rs
+++ b/src/backend/services/previews/src/api/mod.rs
@@ -37,10 +37,15 @@ pub fn register_routes(
     openapi: &dyn OpenApiRegistry,
     state: Arc<AppState>,
 ) -> Router {
-    let api = build_operations(Router::new(), openapi).layer(Extension(state));
+    let api = build_operations(Router::new(), openapi)
+        .layer(Extension(state))
+        .layer(insight_log_context::LogContextLayer::new());
 
     host_router.merge(api)
 }
+
+#[cfg(test)]
+mod log_context_tests;
 
 /// Title/version/description of the emitted document. Kept in step with the
 /// `openapi` block of `config/insight.yaml`.

--- a/src/backend/services/previews/src/main.rs
+++ b/src/backend/services/previews/src/main.rs
@@ -66,7 +66,15 @@ async fn main() -> Result<()> {
 
     match command {
         Commands::Openapi => print_openapi(),
-        Commands::Run => run_server(AppConfig::load_or_default(cli.config.as_ref())?).await,
+        Commands::Run => {
+            let config = AppConfig::load_or_default(cli.config.as_ref())?;
+            let resource = &config.opentelemetry.resource;
+            insight_log_context::init_identity_from_resource(
+                &resource.service_name,
+                &resource.attributes,
+            );
+            run_server(config).await
+        }
     }
 }
 


### PR DESCRIPTION
Closes #3190. Part of #2488 (AC-3).

**Why.** No line a gears service writes names the service, version, tenant, or the correlation id — the gateway's `X-Correlation-Id` (its access log's join key) is echoed by nobody.

**What changed.** A shared tower layer (`insight-log-context`) wraps each service's routes in a `log_ctx` span carrying `correlation_id` echoed from the gateway's `X-Correlation-Id` (`x-request-id` fallback) — never minted — `tenant_id` when authenticated, and `service`/`version`. HELM_DEPLOY.md names the fields.

**Identity comes from the OTel resource, not a new knob.** Each configmap sets `opentelemetry.resource.attributes."service.version"` to the image tag next to the existing `service_name`; `main` passes both to the layer once at startup. Traces carry the same identity today, and a future toolkit upgrade reads the same keys to stamp every line top-level — at which point the span copies become pure deletion.

**Out of scope.** Startup/background lines (needs the toolkit change, #2488); correlation-id propagation on service-to-service calls.

**Verified.** 5 lib tests + one capture test per service (field set + echo) pass; identity-resolution helm suite (49, incl. a new configmap-pins-image-tag contract test) passes; clippy pedantic and rustfmt clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-request log context across analytics, authenticator, Git CLI proxy, identity resolution, and previews services.
  - Logs now include correlation ID, tenant ID for authenticated requests, service name, and service version.
  - Correlation IDs use the gateway value, with request ID fallback.
  - Service versions reflect the deployed image tag.

- **Documentation**
  - Updated deployment guidance with available log context fields and current limitations for startup and background logs.

- **Tests**
  - Added coverage for log context propagation and deployment version configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->