### PR TITLE
fix(observability): tpl-safe level lowercasing in the Alloy pipeline

### DIFF
--- a/deploy/gitops/system/alloy/values.yaml
+++ b/deploy/gitops/system/alloy/values.yaml
@@ -90,16 +90,43 @@ alloy:
       // ── Parse OUR structured JSON to promote `level` to a label.
       //    Non-JSON lines (raw Airbyte / dbt output) fall through the
       //    stage untouched — they still arrive in Loki, just without a
-      //    `level` label. The gears services (tracing-subscriber JSON)
-      //    write "INFO"/"ERROR" uppercase; lowercase before labelling so
-      //    every dashboard and alert matches one spelling.
+      //    `level` label. Lowercased before labelling — the gears services
+      //    (tracing-subscriber JSON) write "INFO"/"ERROR" uppercase.
       loki.process "parse" {
         stage.json {
           expressions = { level = "level" }
         }
-        stage.template {
-          source   = "level"
-          template = "{{ ToLower .Value }}"
+        // WORKAROUND: the chart tpl-renders this config, so no Go-template
+        // funcs here (ToLower breaks the render) — literal per-level replaces.
+        stage.replace {
+          source     = "level"
+          expression = "^(?i)(trace)$"
+          replace    = "trace"
+        }
+        stage.replace {
+          source     = "level"
+          expression = "^(?i)(debug)$"
+          replace    = "debug"
+        }
+        stage.replace {
+          source     = "level"
+          expression = "^(?i)(info|information|notice)$"
+          replace    = "info"
+        }
+        stage.replace {
+          source     = "level"
+          expression = "^(?i)(warn|warning)$"
+          replace    = "warn"
+        }
+        stage.replace {
+          source     = "level"
+          expression = "^(?i)(error|err)$"
+          replace    = "error"
+        }
+        stage.replace {
+          source     = "level"
+          expression = "^(?i)(fatal|crit|alert|emerg|panic)$"
+          replace    = "fatal"
         }
         stage.labels {
           values = { level = "" }


### PR DESCRIPTION
**Why.** The alloy chart pipes `configMap.content` through Helm `tpl`, so the `stage.template` with `{{ ToLower .Value }}` merged in #3193 fails the render (`function "ToLower" not defined`).

**What changed.** Literal case-insensitive `stage.replace` rules per level instead — the same tpl-safe normalization the internal environment overlays already use, folding INFO/Information/notice-style variants onto one lowercase vocabulary.

**Verified.** Values parse as YAML; the replace block mirrors a config already rendering and running under the same chart.
