### PR TITLE
fix(frontend): order the roster by name

### DIFF
--- a/src/frontend/src/components/portal/team-state-view.test.tsx
+++ b/src/frontend/src/components/portal/team-state-view.test.tsx
@@ -166,6 +166,12 @@ describe("TeamStateView", () => {
     expect(screen.getAllByText("boss")).toHaveLength(2);
   });
 
+  it("labels each member row with its standing, so the behind-first order reads", () => {
+    render(<TeamStateView />);
+    expect(screen.getAllByText("2 of 2 behind peers")).toHaveLength(2);
+    expect(screen.getAllByText("2 of 2 ahead of peers")).toHaveLength(2);
+  });
+
   it("shows a manager with no reports as a one-person scope", () => {
     mocks.tree = person("boss");
     mocks.roster = peopleFromIdentityTree(mocks.tree);

--- a/src/frontend/src/components/portal/team-state-view.test.tsx
+++ b/src/frontend/src/components/portal/team-state-view.test.tsx
@@ -166,6 +166,24 @@ describe("TeamStateView", () => {
     expect(screen.getAllByText("boss")).toHaveLength(2);
   });
 
+  it("lists the roster by name, like the org tree beside it", () => {
+    // d and boss trail both metrics, so a standing order would float them up.
+    mocks.grid.byKey = new Map([
+      ["git.commits", metric("git.commits", [[pid("boss"), 20], [pid("a"), 50], [pid("b"), 40], [pid("c"), 30], [pid("d"), 10]], { label: "Commits" })],
+      ["collab.focus_time_pct", metric("collab.focus_time_pct", [[pid("boss"), 50], [pid("a"), 80], [pid("b"), 70], [pid("c"), 60], [pid("d"), 40]], {
+        computation: "avg",
+        label: "Focus Time",
+        format: "percent",
+      } as never)],
+    ]);
+
+    render(<TeamStateView />);
+
+    expect(
+      screen.getAllByRole("rowheader").map((th) => th.textContent),
+    ).toEqual(["a", "b", "boss", "c", "d"]);
+  });
+
   it("shows a manager with no reports as a one-person scope", () => {
     mocks.tree = person("boss");
     mocks.roster = peopleFromIdentityTree(mocks.tree);

--- a/src/frontend/src/components/portal/team-state-view.test.tsx
+++ b/src/frontend/src/components/portal/team-state-view.test.tsx
@@ -166,12 +166,6 @@ describe("TeamStateView", () => {
     expect(screen.getAllByText("boss")).toHaveLength(2);
   });
 
-  it("labels each member row with its standing, so the behind-first order reads", () => {
-    render(<TeamStateView />);
-    expect(screen.getAllByText("2 of 2 behind peers")).toHaveLength(2);
-    expect(screen.getAllByText("2 of 2 ahead of peers")).toHaveLength(2);
-  });
-
   it("shows a manager with no reports as a one-person scope", () => {
     mocks.tree = person("boss");
     mocks.roster = peopleFromIdentityTree(mocks.tree);

--- a/src/frontend/src/components/portal/team-state-view.tsx
+++ b/src/frontend/src/components/portal/team-state-view.tsx
@@ -257,6 +257,7 @@ export function TeamStateView() {
               metricKeys={shownKeys}
               byKey={heatByKey}
               previousByKey={grid.previousByKey}
+              showIssues
               caption={`${teamName || "Team"} — people × metrics`}
               cohortLabel={cohortLabel}
             />

--- a/src/frontend/src/components/portal/team-state-view.tsx
+++ b/src/frontend/src/components/portal/team-state-view.tsx
@@ -257,7 +257,6 @@ export function TeamStateView() {
               metricKeys={shownKeys}
               byKey={heatByKey}
               previousByKey={grid.previousByKey}
-              showIssues
               caption={`${teamName || "Team"} — people × metrics`}
               cohortLabel={cohortLabel}
             />

--- a/src/frontend/src/components/widgets/dashboard/members-grid.test.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Names link to the IC page; navigation isn't exercised here, so stub Link
 // to a plain anchor with the `$person` param interpolated.
@@ -32,9 +32,14 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   };
 });
 
+const settings = vi.hoisted(() => ({ focusMode: "all" }));
 vi.mock("@/hooks/use-settings", () => ({
-  useSettings: () => ({ focusMode: "all" }),
+  useSettings: () => ({ focusMode: settings.focusMode }),
 }));
+
+afterEach(() => {
+  settings.focusMode = "all";
+});
 
 import type { MetricResult } from "@/api/metric-results-client";
 import { MembersGrid } from "@/components/widgets/dashboard/members-grid";
@@ -104,6 +109,28 @@ describe("MembersGrid", () => {
       />,
     );
     expect(screen.getByText("Top 25%").closest("div")).toHaveClass("px-3");
+  });
+
+  it("names only the standings the active focus actually paints", () => {
+    settings.focusMode = "rewards";
+    render(
+      <MembersGrid
+        members={MEMBERS}
+        metricKeys={["ai.active_days"]}
+        byKey={byKeyFor(
+          metric("ai.active_days", [
+            { id: "ann@x.com", value: 20 },
+            { id: "bo@x.com", value: 8 },
+            { id: "cy@x.com", value: 2 },
+          ]),
+        )}
+        caption="Members grid"
+      />,
+    );
+    expect(screen.getByText("Top 25%")).toBeInTheDocument();
+    expect(screen.getByText("Everything else")).toBeInTheDocument();
+    expect(screen.queryByText("Bottom 25%")).not.toBeInTheDocument();
+    expect(screen.queryByText("Near the median")).not.toBeInTheDocument();
   });
 
   it("renders a semantic table: sortable metric columns, member row headers linking to the IC view", () => {

--- a/src/frontend/src/components/widgets/dashboard/members-grid.test.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 // Names link to the IC page; navigation isn't exercised here, so stub Link
 // to a plain anchor with the `$person` param interpolated.
@@ -32,14 +32,9 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
   };
 });
 
-const settings = vi.hoisted(() => ({ focusMode: "all" }));
 vi.mock("@/hooks/use-settings", () => ({
-  useSettings: () => ({ focusMode: settings.focusMode }),
+  useSettings: () => ({ focusMode: "all" }),
 }));
-
-afterEach(() => {
-  settings.focusMode = "all";
-});
 
 import type { MetricResult } from "@/api/metric-results-client";
 import { MembersGrid } from "@/components/widgets/dashboard/members-grid";
@@ -109,28 +104,6 @@ describe("MembersGrid", () => {
       />,
     );
     expect(screen.getByText("Top 25%").closest("div")).toHaveClass("px-3");
-  });
-
-  it("names only the standings the active focus actually paints", () => {
-    settings.focusMode = "rewards";
-    render(
-      <MembersGrid
-        members={MEMBERS}
-        metricKeys={["ai.active_days"]}
-        byKey={byKeyFor(
-          metric("ai.active_days", [
-            { id: "ann@x.com", value: 20 },
-            { id: "bo@x.com", value: 8 },
-            { id: "cy@x.com", value: 2 },
-          ]),
-        )}
-        caption="Members grid"
-      />,
-    );
-    expect(screen.getByText("Top 25%")).toBeInTheDocument();
-    expect(screen.getByText("Everything else")).toBeInTheDocument();
-    expect(screen.queryByText("Bottom 25%")).not.toBeInTheDocument();
-    expect(screen.queryByText("Near the median")).not.toBeInTheDocument();
   });
 
   it("renders a semantic table: sortable metric columns, member row headers linking to the IC view", () => {

--- a/src/frontend/src/components/widgets/dashboard/members-grid.test.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.test.tsx
@@ -287,10 +287,10 @@ describe("MembersGrid", () => {
     expect(rowHeaders[2]).toHaveTextContent("near the median");
   });
 
-  it("defaults to most-trailing-first from its own cells when no facet is given", () => {
+  it("defaults to name order when no facet explains a standing order", () => {
     render(
       <MembersGrid
-        members={MEMBERS}
+        members={[MEMBERS[2]!, MEMBERS[0]!, MEMBERS[1]!]}
         metricKeys={["ai.active_days"]}
         byKey={byKeyFor(
           metric("ai.active_days", [
@@ -305,7 +305,7 @@ describe("MembersGrid", () => {
     const names = screen
       .getAllByRole("rowheader")
       .map((th) => th.textContent);
-    expect(names).toEqual(["Cy", "Ann", "Bo"]);
+    expect(names).toEqual(["Ann", "Bo", "Cy"]);
   });
 
   it("shows a trend arrow against the previous period", () => {

--- a/src/frontend/src/components/widgets/dashboard/members-grid.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.tsx
@@ -471,7 +471,7 @@ export function MembersGrid({
           </tbody>
         </table>
       </div>
-      <Legend />
+      <Legend focusMode={focusMode} />
     </div>
   );
 }
@@ -795,13 +795,28 @@ function ColumnHeader({
   );
 }
 
-function Legend() {
+const FOCUS_LEGEND: Record<FocusMode, PeerStatusWithNeutral[]> = {
+  all: ["top", "in_pack", "bottom", "neutral"],
+  critical: ["bottom"],
+  rewards: ["top"],
+  neutral: [],
+};
+
+function Legend({ focusMode }: { focusMode: FocusMode }) {
+  const shown = FOCUS_LEGEND[focusMode];
+  if (shown.length === 0) return null;
   return (
     <div className="flex flex-wrap items-center gap-4 px-3 text-xs text-muted-foreground">
-      <LegendSwatch className={PEER_FILL.top}>Top 25%</LegendSwatch>
-      <LegendSwatch className={PEER_FILL.in_pack}>Near the median</LegendSwatch>
-      <LegendSwatch className={PEER_FILL.bottom}>Bottom 25%</LegendSwatch>
-      <LegendSwatch className={PEER_FILL.neutral}>No comparison</LegendSwatch>
+      {shown.map((status) => (
+        <LegendSwatch key={status} className={PEER_FILL[status]}>
+          {PEER_LABEL[status]}
+        </LegendSwatch>
+      ))}
+      {focusMode === "all" ? null : (
+        <LegendSwatch className={PEER_FILL.neutral}>
+          Everything else
+        </LegendSwatch>
+      )}
     </div>
   );
 }

--- a/src/frontend/src/components/widgets/dashboard/members-grid.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.tsx
@@ -471,7 +471,7 @@ export function MembersGrid({
           </tbody>
         </table>
       </div>
-      <Legend focusMode={focusMode} />
+      <Legend />
     </div>
   );
 }
@@ -795,28 +795,13 @@ function ColumnHeader({
   );
 }
 
-const FOCUS_LEGEND: Record<FocusMode, PeerStatusWithNeutral[]> = {
-  all: ["top", "in_pack", "bottom", "neutral"],
-  critical: ["bottom"],
-  rewards: ["top"],
-  neutral: [],
-};
-
-function Legend({ focusMode }: { focusMode: FocusMode }) {
-  const shown = FOCUS_LEGEND[focusMode];
-  if (shown.length === 0) return null;
+function Legend() {
   return (
     <div className="flex flex-wrap items-center gap-4 px-3 text-xs text-muted-foreground">
-      {shown.map((status) => (
-        <LegendSwatch key={status} className={PEER_FILL[status]}>
-          {PEER_LABEL[status]}
-        </LegendSwatch>
-      ))}
-      {focusMode === "all" ? null : (
-        <LegendSwatch className={PEER_FILL.neutral}>
-          Everything else
-        </LegendSwatch>
-      )}
+      <LegendSwatch className={PEER_FILL.top}>Top 25%</LegendSwatch>
+      <LegendSwatch className={PEER_FILL.in_pack}>Near the median</LegendSwatch>
+      <LegendSwatch className={PEER_FILL.bottom}>Bottom 25%</LegendSwatch>
+      <LegendSwatch className={PEER_FILL.neutral}>No comparison</LegendSwatch>
     </div>
   );
 }

--- a/src/frontend/src/components/widgets/dashboard/members-grid.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.tsx
@@ -227,10 +227,10 @@ export function MembersGrid({
 }: MembersGridProps) {
   const { focusMode } = useSettings();
   const hasIssuesFacet = showIssues ?? countsByMember != null;
-  const [sort, setSort] = useState<SortState>({
-    key: "issues",
+  const [sort, setSort] = useState<SortState>(() => ({
+    key: hasIssuesFacet ? "issues" : "name",
     reversed: false,
-  });
+  }));
 
   const toggleSort = (key: SortKey) => {
     setSort((current) =>


### PR DESCRIPTION
**Why.** The People roster's Members list opens in an order nothing on screen explains — behind-peers first — while the org tree next to it is A→Z. Rows read as unordered.

**What changed.** The grid defaults to name order whenever the standing facet is off, which is exactly the roster: no chip names a standing, and the Person header offers only a name toggle. Views that do show the facet — AI & Cost, the group drilldowns — keep behind-first.

**Screenshots.** People roster on the MSW mock roster, same data either side.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-3199-assets/before-all.png" width="440"> | <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-3199-assets/after-name.png" width="440"> |

**Verified.** `pnpm test` (2357), `pnpm lint`, `pnpm typecheck` — green. Screenshots from `pnpm dev` on the mock roster, no deployed data.
