### PR TITLE
feat(frontend): hold the roster's column headings on scroll

### DIFF
--- a/src/frontend/src/components/widgets/dashboard/members-grid.stories.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.stories.tsx
@@ -28,7 +28,11 @@ const MEMBERS = [
   { entityId: "019e27bc-dec0-7626-81a9-c5524662a6b0", displayName: "Bo Ng" },
 ];
 
-function metric(key: string, shortLabel: string): MetricResult {
+function metric(
+  key: string,
+  shortLabel: string,
+  members: typeof MEMBERS = MEMBERS
+): MetricResult {
   return {
     metric_key: key,
     label: `${shortLabel} over the period`,
@@ -40,14 +44,14 @@ function metric(key: string, shortLabel: string): MetricResult {
     views: [
       {
         view: "period",
-        values: MEMBERS.map((m, index) => ({
+        values: members.map((m, index) => ({
           entity_id: m.entityId,
           value: 100 + index,
         })),
       },
       {
         view: "peer",
-        values: MEMBERS.map((m, index) => ({
+        values: members.map((m, index) => ({
           entity_id: m.entityId,
           target_value: 100 + index,
           p25: 50,
@@ -160,5 +164,66 @@ export const TestWideRosterKeepsTheComfortableNameColumn: Story = {
       width,
       `the member column is ${width}px on a ${CARD_PX_WIDE}px card`
     ).toBe(256);
+  },
+};
+
+const LONG_ROSTER = Array.from({ length: 40 }, (_, index) => ({
+  entityId: `019e27bc-dec0-7626-81a9-c5524662${String(index).padStart(4, "0")}`,
+  displayName: `Member ${index + 1}`,
+}));
+
+const LONG_RESULTS = RESULTS.map((result) =>
+  metric(result.metric_key, result.short_label!, LONG_ROSTER)
+);
+
+/** Every heading stays in the DOM when it scrolls away, so only geometry sees this. */
+export const TestHeadingsHoldWhileTheRosterScrolls: Story = {
+  tags: ["test"],
+  args: {
+    members: LONG_ROSTER,
+    metricKeys: LONG_RESULTS.map((r) => r.metric_key),
+    byKey: normalizeMetricResults(LONG_RESULTS),
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: CARD_PX_WIDE }}>
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvas }) => {
+    const table = canvas.getByRole("table", { name: "Members grid" });
+    const scroller = table.parentElement!;
+
+    scroller.scrollTop = 400;
+    scroller.scrollLeft = 300;
+    await expect(
+      scroller.scrollTop,
+      "the roster does not scroll vertically, so nothing can hold on scroll"
+    ).toBeGreaterThan(0);
+
+    const box = scroller.getBoundingClientRect();
+    const metricHeader = canvas
+      .getByRole("button", {
+        name: "Commits over the period — sort by this column",
+      })
+      .closest("th")!;
+    const memberHeader = table.querySelector("thead th")!;
+
+    const drop = metricHeader.getBoundingClientRect().top - box.top;
+    await expect(
+      Math.abs(drop),
+      `the metric heading sits ${Math.round(drop)}px from the top of the roster`
+    ).toBeLessThanOrEqual(1);
+
+    const corner = memberHeader.getBoundingClientRect();
+    await expect(
+      Math.abs(corner.top - box.top),
+      "the Person heading left the top of the roster"
+    ).toBeLessThanOrEqual(1);
+    await expect(
+      Math.abs(corner.left - box.left),
+      "the Person heading left the start of the roster"
+    ).toBeLessThanOrEqual(1);
   },
 };

--- a/src/frontend/src/components/widgets/dashboard/members-grid.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.tsx
@@ -78,6 +78,16 @@ const MEMBER_COL_WIDTH =
 const MEMBER_COL_CELL =
   "sticky start-0 z-10 w-[var(--member-col,16rem)] bg-card text-left";
 
+/**
+ * INVARIANT: the cap is what gives the roster a scrollport of its own. The
+ * headings stick to it, never to the page, so without a height they cannot
+ * hold at all.
+ */
+const ROSTER_SCROLLPORT = "max-h-[75svh] overflow-auto";
+
+const HEADING_CELL =
+  "sticky top-0 z-20 bg-card shadow-[0_4px_0_0_var(--card)]";
+
 const METRIC_COL_PX = 108;
 
 export interface MembersGridMember {
@@ -376,7 +386,7 @@ export function MembersGrid({
 
   return (
     <div className={cn("@container flex flex-col gap-3", className)}>
-      <div className={cn("overflow-x-auto", MEMBER_COL_WIDTH)}>
+      <div className={cn(ROSTER_SCROLLPORT, MEMBER_COL_WIDTH)}>
         {/* Fixed layout so metric columns are uniform — auto layout sizes
             each column to its own content, making them ragged. The member
             column takes a fixed width; the metric columns split the rest
@@ -396,7 +406,7 @@ export function MembersGrid({
               <th
                 scope="col"
                 aria-sort={memberDirection}
-                className={cn(MEMBER_COL_CELL, "px-2")}
+                className={cn(MEMBER_COL_CELL, HEADING_CELL, "z-30 px-2")}
               >
                 {hasIssuesFacet ? (
                   // Two member orderings (issues / name) → a small header menu,
@@ -446,7 +456,7 @@ export function MembersGrid({
                   key={col.key}
                   scope="col"
                   aria-sort={directionFor(col.key)}
-                  className="p-0"
+                  className={cn(HEADING_CELL, "p-0")}
                 >
                   <ColumnHeader
                     col={col}


### PR DESCRIPTION
**Why.** Scrolled past the first screen, the members roster is a wall of numbers under no headings — the metric headings leave with the page. The names column already held its place sideways.

**What changed.** The roster's wrapper is capped at `75svh`, so it scrolls in a box of its own, and the headings pin to its top edge while the rows pass under; the Person heading holds the corner in both directions.

**A height cap, not the page's own scroll.** A sticky heading pins to its nearest scrollport, and the wrapper is already one because it scrolls sideways — the page's scroll could never reach it. Reverting is one class.

Same rows at the bottom of an 18-person roster, before and after:

![Before](https://raw.githubusercontent.com/constructorfabric/insight/pr-3200-assets/roster-before.png)

![After](https://raw.githubusercontent.com/constructorfabric/insight/pr-3200-assets/roster-after.png)

Scrolled both ways — the headings and the names column hold together:

![Scrolled both ways](https://raw.githubusercontent.com/constructorfabric/insight/pr-3200-assets/roster-both-axes.png)

**Verified.** `pnpm test` (2356), `pnpm test:storybook:ci` (32, including a new geometry story that scrolls the roster both ways), `pnpm lint`, `pnpm typecheck`; checked by hand in the People roster at 1440×900 against mock data.
