### PR TITLE
ci(e2e): let one workflow own the required E2E check

### DIFF
--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -31,9 +31,14 @@ name: E2E — Bronze to API
 on:
   # Merge-queue builds: the queue's gh-readonly-queue/* branches emit merge_group,
   # and the required "Run E2E suite" check must report there or every queued PR
-  # times out and is evicted. On a pull request the same check name is emitted
-  # by e2e-stand.yml as a deferral to the queue.
+  # times out and is evicted. On a pull request the umbrella below emits the same
+  # check as a deferral to the queue, so one workflow owns the name in both places.
   merge_group:
+  # No `paths:` filter: GitHub leaves a required check whose workflow never ran
+  # pending forever, so every pull request runs the cheap `changes` job and the
+  # umbrella, which defers the suite itself to the queue.
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 # A new push obsoletes any run still in flight for the same ref — cancel it so a
@@ -51,9 +56,8 @@ permissions:
   actions: read
 
 jobs:
-  # `e2e-suite` is the reusable workflow's aggregate result. The caller emits
-  # the stable "Run E2E suite" pull-request check; merge_group runs emit it
-  # directly here.
+  # `e2e-suite` is the aggregate that emits the stable "Run E2E suite" check:
+  # a deferral on a pull request, the verdict in the merge queue.
   #
   # Skipping cascades by default `needs` semantics: `changes` says irrelevant →
   # `e2e-datapath` skips → `metric-coverage-gate` skips. The umbrella tells that
@@ -139,7 +143,7 @@ jobs:
   e2e-datapath:
     name: data path (shard ${{ matrix.shard }})
     needs: changes
-    if: ${{ needs.changes.outputs.relevant == 'true' }}
+    if: ${{ needs.changes.outputs.relevant == 'true' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     # Compiling the backend from this tree is the slow path; pulling the
     # pinned images is not. Same split e2e-stand.yml makes.
@@ -340,6 +344,7 @@ jobs:
       # two apart, and it would also fold in `changes`'s own result.
       - name: Require every data-path shard and the gate to have succeeded
         env:
+          EVENT: ${{ github.event_name }}
           CHANGES: ${{ needs.changes.result }}
           RELEVANT: ${{ needs.changes.outputs.relevant }}
           # Matrix aggregate: 'success' only when EVERY shard passed.
@@ -349,7 +354,7 @@ jobs:
           GATE: ${{ needs.metric-coverage-gate.result }}
         run: |
           set -euo pipefail
-          echo "changes=$CHANGES relevant=$RELEVANT suite=$SUITE gate=$GATE"
+          echo "event=$EVENT changes=$CHANGES relevant=$RELEVANT suite=$SUITE gate=$GATE"
 
           # Fail closed. A `changes` job that did not succeed leaves `relevant`
           # empty, which would otherwise read as "irrelevant" and green a
@@ -359,7 +364,9 @@ jobs:
             exit 1
           fi
 
-          if [ "$RELEVANT" != "true" ]; then
+          if [ "$EVENT" = "pull_request" ]; then
+            echo "the data-path suite runs in the merge queue; deferred there."
+          elif [ "$RELEVANT" != "true" ]; then
             echo "nothing on the bronze → dbt → ClickHouse → analytics path changed — nothing to prove."
           else
             for lane in "suite=$SUITE" "gate=$GATE"; do

--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -2,9 +2,9 @@ name: E2E — Compose stand
 
 # The deployed-stand suite (tests/stand) run against a real compose stack: ghcr
 # images pinned to each component's chart appVersion, a real Keycloak login, and
-# gold data dbt actually built. Distinct from e2e-bronze-to-api.yml, which
-# exercises the in-process ingestion rig and now carries one blocking gate
-# (metric coverage) — that workflow is untouched by this one.
+# gold data dbt actually built. Distinct from e2e-bronze-to-api.yml, which runs
+# the data-path suite on minimal stands of its own and carries the metric
+# coverage gate — that workflow is untouched by this one.
 #
 # Nothing here builds by default: `test-stand up` pulls the frontend and the
 # four backend services at their charts' appVersions, which name main's build.
@@ -189,22 +189,6 @@ jobs:
       id-token: write
       attestations: write
     uses: ./.github/workflows/build-images.yml
-
-  bronze-to-api-report:
-    name: Run E2E suite
-    needs: changes
-    if: github.event_name == 'pull_request' && !cancelled()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Defer Bronze-to-API to the merge queue
-        env:
-          CHANGES: ${{ needs.changes.result }}
-        run: |
-          if [ "$CHANGES" != success ]; then
-            echo "::error::stand relevance could not be evaluated ($CHANGES)."
-            exit 1
-          fi
-          echo "Bronze-to-API is deferred to the merge queue."
 
   gateway:
     name: Gateway checks


### PR DESCRIPTION
**Why.** Two workflows emit the required `Run E2E suite` check: the data-path workflow in the merge queue, and the stand workflow on pull requests as a deferral, so the name has two owners to keep in step.

**What changed.** The data-path workflow runs on pull requests too and its umbrella emits the deferral itself; the stand workflow's deferral job is gone.

**No ruleset edit is needed.** The ruleset requires the check by name and integration, and both stay. Stacked on #3167 because it edits the same workflow; retarget to `main` once that merges.

**Verified.** On a pull-request event of this branch, only the data-path workflow emitted `Run E2E suite`, as the deferral, with its shards and gate skipped; the stand workflow emitted no such check. A dispatch run on the same commit took the verdict path: five shards and the gate green.

https://claude.ai/code/session_01Dh5gzjkqaVsQ226rFnZAHx
