### PR TITLE
fix(git-cli-proxy, connectors): backport the cache heal, pack-leak fix and connection retry ladder to release-2026.08

### DIFF
--- a/src/backend/services/git-cli-proxy/src/engine/store.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/store.rs
@@ -589,6 +589,20 @@ impl RepoStore {
         if let Some(meta) = fresh_meta(&entry_dir, &fingerprint, max_staleness) {
             return Ok(meta.generation);
         }
+        // INVARIANT: meta.json is the publish marker — an entry without it was
+        // never published and must read as absent, or a fetch runs forever
+        // against whatever a crash left in repo.git and every request 500s.
+        if git_dir.is_dir() && RepoMeta::load(&entry_dir).is_none() {
+            match std::fs::remove_dir_all(&entry_dir) {
+                Ok(()) => {
+                    self.drift.lock().await.remove(&key.dir_name());
+                    tracing::warn!(dir = %key.dir_name(), "removed an entry without readable metadata; re-cloning");
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, dir = %key.dir_name(), "could not remove a metadata-less entry; it stays unserveable");
+                }
+            }
+        }
         if git_dir.is_dir() {
             self.fetch(key, &entry_dir, &git_dir, creds).await
         } else {
@@ -1284,7 +1298,10 @@ impl RepoStore {
             self.tmp_counter.fetch_add(1, Ordering::Relaxed)
         ));
         std::fs::create_dir_all(&evicted)?;
-        let filter_to = format!("--filter-to={}", evicted.display());
+        // WORKAROUND: git uses --filter-to as a pack base name, not a
+        // directory — packs land as `<value>-<sha>.pack` siblings of it.
+        // Pointing the base inside the directory keeps them collectable.
+        let filter_to = format!("--filter-to={}", evicted.join("pack").display());
 
         remove_promisor_markers(&git_dir);
         let repacked = self
@@ -2439,6 +2456,39 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn a_metadata_less_entry_is_recloned_not_fetched() {
+        // meta.json is written last, so an entry without it was never
+        // published. Routing it to fetch runs git against whatever a crash
+        // left in repo.git and answers 500 on every request until a restart
+        // sweeps the entry; refresh must apply the startup sweep's rule.
+        let f = fixture("meta-less-heal");
+        let k = key(&f);
+        drop(open_until_ready(&f, &k, refresh()).await);
+
+        let entry_dir = f.store.entry_dir(&k);
+        let git_dir = entry_dir.join("repo.git");
+        if let Err(e) = std::fs::remove_file(entry_dir.join("meta.json")) {
+            panic!("stage: {e}");
+        }
+        if let Err(e) = std::fs::remove_dir_all(&git_dir) {
+            panic!("stage: {e}");
+        }
+        if let Err(e) = std::fs::create_dir_all(git_dir.join("objects")) {
+            panic!("stage: {e}");
+        }
+
+        let guard = open_until_ready(&f, &k, refresh()).await;
+        assert!(
+            guard.git_dir().join("HEAD").is_file(),
+            "the entry must come back as a working clone"
+        );
+        assert!(
+            RepoMeta::load(&entry_dir).is_some(),
+            "the re-clone must publish fresh metadata"
+        );
+    }
+
+    #[tokio::test]
     async fn the_index_is_counted_by_the_entry_accounting() {
         let f = fixture("index-accounting");
         let k = key(&f);
@@ -2501,6 +2551,30 @@ pub(crate) mod tests {
             after.size_bytes,
             dir_size(&entry_dir.join("repo.git")),
             "accounting must match the disk after a purge"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_purge_leaves_nothing_behind_in_the_staging_dir() {
+        // The evicted pack must land inside the per-purge directory the
+        // repack deletes. Left beside it, the packs accumulate in tmp/ until
+        // the next restart — invisible to the reclaim planner, which only
+        // walks repos/, so the budget never sees the loss.
+        let (f, k, _) = entry_with_fetched_blobs("purge-staging").await;
+        f.store.purge_if_drifted(&k).await;
+
+        let tmp = f.root.join("cache").join("tmp");
+        let leftovers: Vec<String> = std::fs::read_dir(&tmp)
+            .map(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .map(|e| e.file_name().to_string_lossy().into_owned())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(
+            leftovers.is_empty(),
+            "a purge must collect everything it staged: {leftovers:?}"
         );
     }
 

--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -95,6 +95,12 @@ definitions:
       - type: WaitTimeFromHeader
         header: Retry-After
         max_waiting_time_in_seconds: 600
+      # Fallback for failures that carry no response and so no header — a
+      # connection refused or reset while the proxy restarts during a deploy.
+      # Without it the request dies after two immediate tries; the ladder
+      # rides out any restart shorter than the CDK's overall retry ceiling.
+      - type: ExponentialBackoffStrategy
+        factor: 5
     response_filters:
       # The repository is being cloned in the background: the proxy is
       # working, the caller waits.

--- a/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
@@ -12,7 +12,7 @@ name: bitbucket-cloud
 #   same reason as github 6.0.0 — the patch id has been in Bronze all along,
 #   but staging never re-reads Bronze, so the column heals to NULL on existing
 #   rows and a NULL identity never folds.
-version: "5.0.0"
+version: "5.0.1"
 # A slot of its own: replication pods sharing a slot with other connector
 # syncs can be starved of workers, which surfaces as startup and activity
 # timeouts rather than as a connector error.

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -212,6 +212,12 @@ definitions:
       - type: WaitTimeFromHeader
         header: Retry-After
         max_waiting_time_in_seconds: 600
+      # Fallback for failures that carry no response and so no header — a
+      # connection refused or reset while the proxy restarts during a deploy.
+      # Without it the request dies after two immediate tries; the ladder
+      # rides out any restart shorter than the CDK's overall retry ceiling.
+      - type: ExponentialBackoffStrategy
+        factor: 5
     response_filters:
       # The repository is being cloned or purged in the background: the proxy
       # is working, the caller waits.

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -14,7 +14,7 @@ name: github
 #   staging never re-reads Bronze, so the column heals to NULL on existing
 #   rows, and a NULL identity never folds. Only the one-shot scoped
 #   `dbt --full-refresh` a major bump dispatches re-materializes the history.
-version: "6.0.0"
+version: "6.0.1"
 schedule: "0 */4 * * *"
 workflow: sync
 


### PR DESCRIPTION
Backport of #2972 and #3137 into `release-2026.08`, one cherry-picked commit each.

**Why.** The release track has the long-poll, read-budget and serve-cap fixes but not these two, and installs on it still show both symptoms: evicted packs stranding in the proxy's `tmp/` where the reclaim planner cannot see the loss, and a proxy restart killing every in-flight partition because the connectors' proxy error handler had no backoff for responseless failures.

**What changed.** #2972: a metadata-less cache entry is re-cloned instead of fetched into forever, and `repack --filter-to` stages evicted packs inside the directory the purge deletes. #3137: both git connectors' proxy error handlers gain the `ExponentialBackoffStrategy` fallback so connection failures ladder instead of dying in two tries. Descriptor patch bumps on this track: bitbucket-cloud 5.0.1, github 6.0.1 (release is on 6.0.0; that version line was the only conflict).

**Verified.** `cargo test -p git-cli-proxy` (217 lib + 20 boot), helm contract suite (27), connector mock suites for bitbucket-cloud and github — all green on this branch.