### PR TITLE
test(e2e): pin the two rules git.default_branch_code_lines intersects

### DIFF
--- a/src/ingestion/tests/e2e/metrics/git_default_branch_code_lines.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_default_branch_code_lines.test.yaml
@@ -1,0 +1,217 @@
+spec_version: 1
+description: >
+  Metric: git.default_branch_code_lines — code lines whose commit reached the
+  repository's default branch, #3046.
+
+  How it's computed (bronze → silver → gold):
+    • bronze: one row per file a commit touched, plus the flag its connector
+      set for that commit and the requests the repository merged
+    • silver: one class row per commit, per file change and per request
+    • gold:   one row per content per path, classified from its PATH, carried
+      by the commit that first held it — and that commit's branch scope is the
+      connector's flag OR membership of the default-branch set, which a merged
+      request into the default branch and matching content both confer
+
+  Two neighbours already own most of that. `git_branch_scope.test.yaml` owns
+  the flag and the merged-request heal across the branch-scoped pairs;
+  `git_code_lines.test.yaml` owns the classifier. What neither asserts is this
+  measure's own emission: `default_code_lines_added` is built from a different
+  dimension tuple than the unscoped line measures, and nothing breaks it down
+  at all — so its splits are unasserted even though the totals beside them are
+  not.
+
+  Cases: the intersection of the two rules, with the opposite scope and the
+  code total that bound it; a landed test file, which raises the unclassified
+  default total and not this one; the change-type split, which is also the
+  oracle for which of two carriers of one content survived; the extension
+  split; and an empty window.
+
+  The rig resolves `view: breakdown` to exactly one view per metric, so each
+  split needs its own case.
+
+  Fixture — erin only, in one repository whose default branch is `main`:
+    * dbcl-landed, flag says landed
+        src/a.rs        +12 modified  code and landed — counts
+        tests/a_test.rs +40 added     landed, but the classifier calls it test
+    * dbcl-wip, flag says otherwise, no request
+        src/b.rs        +7  modified  code, but nothing says it landed
+    * dbcl-pr, flag says otherwise, carried by a request merged into `main`
+        src/c.go        +5  renamed   the request is what makes it land
+    * dbcl-branch, flag says otherwise, reachable from no branch
+        src/d.rs        +9  ADDED     shares its content with the row below
+    * dbcl-squash, flag says landed, two hours later
+        src/d.rs        +9  MODIFIED  the same content, so one of the two rows
+                                      is dropped and the other keeps the nine
+                                      lines
+
+  So the metric reads 12 + 5 + 9 = 26 against a code total of 33, and the
+  other scope holds the remaining 7.
+
+  INVARIANT: the two carriers of `src/d.rs` must keep DIFFERENT change types.
+  Both are inside the default scope — one by the flag, one by the content
+  heal — so no total can say which row survived; only the change-type split
+  can. `added: 9` is therefore the assertion that the earliest carrier won,
+  and a dedup that preferred the later one reads `modified: 21` instead.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_github.branches:
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: dbcl-br-main, repository: "https://github.com/acme/dbcl.git", name: main, head_sha: head-main, is_default: true}
+
+  bronze_github.commits:
+    # Commit-level stats reach no measure asserted here: the fallback that
+    # reads them fires only for a commit with no collected file rows.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: dbcl-landed, repository: "https://github.com/acme/dbcl.git", sha: dbcl-landed, authored_date: "2026-10-01T09:00:00Z", committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 52, changed_files: 2, is_in_default_branch: true}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: dbcl-wip, repository: "https://github.com/acme/dbcl.git", sha: dbcl-wip, authored_date: "2026-10-01T09:10:00Z", committed_date: "2026-10-01T09:10:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 7, changed_files: 1, is_in_default_branch: false}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: dbcl-pr, repository: "https://github.com/acme/dbcl.git", sha: dbcl-pr, authored_date: "2026-10-01T09:20:00Z", committed_date: "2026-10-01T09:20:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 5, changed_files: 1, is_in_default_branch: false}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: dbcl-branch, repository: "https://github.com/acme/dbcl.git", sha: dbcl-branch, authored_date: "2026-10-01T09:30:00Z", committed_date: "2026-10-01T09:30:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 9, changed_files: 1, is_in_default_branch: false}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: dbcl-squash, repository: "https://github.com/acme/dbcl.git", sha: dbcl-squash, authored_date: "2026-10-01T11:30:00Z", committed_date: "2026-10-01T11:30:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 9, changed_files: 1, is_in_default_branch: true}
+
+  bronze_github.file_changes:
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: dbcl-f-a, repository: "https://github.com/acme/dbcl.git", sha: dbcl-landed, filename: src/a.rs, status: modified, additions: 12, deletions: 0, pre_image_oid: dbc10000000000000000000000000000000000a1, post_image_oid: dbc10000000000000000000000000000000000a2}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: dbcl-f-atest, repository: "https://github.com/acme/dbcl.git", sha: dbcl-landed, filename: tests/a_test.rs, status: added, additions: 40, deletions: 0, post_image_oid: dbc10000000000000000000000000000000000b1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: dbcl-f-b, repository: "https://github.com/acme/dbcl.git", sha: dbcl-wip, filename: src/b.rs, status: modified, additions: 7, deletions: 0, pre_image_oid: dbc10000000000000000000000000000000000c1, post_image_oid: dbc10000000000000000000000000000000000c2}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: dbcl-f-c, repository: "https://github.com/acme/dbcl.git", sha: dbcl-pr, filename: src/c.go, status: renamed, additions: 5, deletions: 0, pre_image_oid: dbc10000000000000000000000000000000000d1, post_image_oid: dbc10000000000000000000000000000000000d2}
+    # One content, two carriers. Their change types differ on purpose: that
+    # is the only signal telling which row the dedup kept.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: dbcl-f-d-branch, repository: "https://github.com/acme/dbcl.git", sha: dbcl-branch, filename: src/d.rs, status: added, additions: 9, deletions: 0, post_image_oid: dbc10000000000000000000000000000000000e1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: dbcl-f-d-squash, repository: "https://github.com/acme/dbcl.git", sha: dbcl-squash, filename: src/d.rs, status: modified, additions: 9, deletions: 0, post_image_oid: dbc10000000000000000000000000000000000e1}
+
+  bronze_github.pull_requests:
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: dbcl-pr-1, repo_full_name: acme/dbcl, id: 71, number: 71, author_login: erin, base_ref: main, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: dbcl-merge}
+
+  bronze_github.pull_request_commits:
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: dbcl-lnk-1, sha: dbcl-pr, pull_number: 71, repo_full_name: acme/dbcl, author_email: erin@example.com, is_merge: false}
+
+cases:
+  - name: A line counts only if it is code and its commit landed
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.default_branch_code_lines
+            views:
+              - {view: period}
+          - metric_key: git.non_default_branch_code_lines
+            views:
+              - {view: period}
+          - metric_key: git.code_lines
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      # 12 by the flag, 5 by the merged request, 9 by the content. Repointing
+      # the request's link row reads 21; dropping the classifier reads 66.
+      - metric: git.default_branch_code_lines
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 26}
+      # src/b.rs is code that nothing says has landed.
+      - metric: git.non_default_branch_code_lines
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 7}
+      - metric: git.code_lines
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 33}
+
+  - name: A test file that landed raises the default-branch total but not its code lines
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.default_branch_lines_added
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      # tests/a_test.rs landed, so it is inside the unclassified default-branch
+      # total — 12 + 40 + 5 + 9 — while contributing nothing to the code one.
+      - metric: git.default_branch_lines_added
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 66}
+
+  - name: Each change type carries only the landed code lines of its own files
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.default_branch_code_lines
+            views:
+              - {view: breakdown, dimensions: [change_type]}
+    expect:
+      - assert: "status == 200"
+      - metric: git.default_branch_code_lines
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: change_type, value: modified}}
+        equal: {value: 12}
+      - metric: git.default_branch_code_lines
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: change_type, value: added}}
+        equal: {value: 9}
+      - metric: git.default_branch_code_lines
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: change_type, value: renamed}}
+        equal: {value: 5}
+      # A line that lost its classification would arrive under this key.
+      - metric: git.default_branch_code_lines
+        view: breakdown
+        assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'change_type' && d.value == '__unknown__'))"
+
+  - name: An extension counts only the landed lines of the code files sharing it
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.default_branch_code_lines
+            views:
+              - {view: breakdown, dimensions: [file_extension]}
+    expect:
+      - assert: "status == 200"
+      # src/b.rs is an rs file too, so a scope that stopped excluding it
+      # would raise this to 28.
+      - metric: git.default_branch_code_lines
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: file_extension, value: rs}}
+        equal: {value: 21}
+      - metric: git.default_branch_code_lines
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: file_extension, value: go}}
+        equal: {value: 5}
+      - metric: git.default_branch_code_lines
+        view: breakdown
+        assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'file_extension' && d.value == '__unknown__'))"
+
+  - name: An empty window is null, not zero
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-12-01", to: "2026-12-31"}
+        metrics:
+          - metric_key: git.default_branch_code_lines
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      - metric: git.default_branch_code_lines
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: null}


### PR DESCRIPTION
Part of #3039, and the coverage half of #3046. Follows #3185 (`git.active_days`) and #3186 (`git.code_lines`).

**Why.** `git_branch_scope.test.yaml` owns the connector flag and the merged-request heal; `git_code_lines.test.yaml` owns the classifier. Neither asserts them together on this measure, and neither breaks it down at all — `default_code_lines_added` is emitted from a different dimension tuple than the unscoped line measures, so a change-type or extension split on it was unasserted while the totals beside it were not.

**What changed.** One fixture where each way of landing carries its own code file and a landed test file sits beside them, so the two ways of being excluded stay distinguishable: 26 against a code total of 33, with the remaining 7 in the opposite scope.

**The two carriers of one content differ by change type on purpose.** Both sit inside the default scope — one by the connector's flag, one by the content heal — so no total can say which row the dedup kept. The first draft of this test asserted only totals, and review proved it passed with the dates flipped *and* with the branch's file row deleted outright: half the fixture was inert. Making the carriers `added` and `modified` turns the change-type split into the oracle for the survivor, and both of those mutations now fail.

**Verified.** `./e2e.sh test -k git_` — 25 passed. Mutations that each turn it red: the branch commit dated after the squash; its file row removed; the request's link row repointed at an absent commit (reads 21); the test file moved out of `tests/` (66); and the total moved by one.

**Out of scope.** The `project` and `repository` splits, which a single-repository fixture cannot make discriminating.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for default-branch code-line metrics.
  * Validates totals across scoped and unscoped periods, including empty time windows.
  * Covers code-change type and file-extension breakdowns.
  * Verifies handling of test files, merged pull requests, duplicate content carriers, and unknown classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->