### PR TITLE
fix(gold): give the uncollected-diff path the source id its sibling carries

### DIFF
--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -290,11 +290,11 @@ unattributed_line_measures AS (
         metric_date,
         line_measure.1 AS measure_key,
         line_measure.2 AS value,
-        -- Written out rather than spliced into source_dimensions: this must
-        -- equal category_source_dimensions key for key, and a literal says so
-        -- at the one place a reader compares them. A different order would not
-        -- fail — it would split one logical dimension set into two breakdown
-        -- rows under `GROUP BY … dimensions`.
+        -- INVARIANT: the same KEYS as category_source_dimensions, which the
+        -- file-derived rows of these same measures carry. A breakdown groups
+        -- by a hidden source-id key as well as the visible ones, so a key
+        -- missing here splits one repository into two rows — a reader
+        -- comparing the two literals is what keeps them in step.
         CAST(
             [
                 tuple('branch_scope', branch_scope_value, branch_scope_label),
@@ -303,6 +303,7 @@ unattributed_line_measures AS (
                 tuple('change_type', '__unknown__', 'Unknown'),
                 tuple('repository', repository_value, repository_label),
                 tuple('project', project_value, project_label),
+                tuple('source_id', coalesce(toString(source_id), ''), coalesce(toString(source_id), '')),
                 tuple('source', source_value, source_label)
             ] AS Array(Tuple(key String, value String, label Nullable(String)))
         ) AS dimensions

--- a/src/ingestion/tests/e2e/metrics/git_default_branch_lines_added.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_default_branch_lines_added.test.yaml
@@ -1,0 +1,148 @@
+spec_version: 1
+description: >
+  Metric: git.default_branch_lines_added — every line added by a commit that
+  reached the repository's default branch, #3048.
+
+  How it's computed (bronze → silver → gold):
+    • bronze: the file rows a commit reported, or none at all when the
+      connector never collected its diff
+    • silver: one class row per commit and per file change
+    • gold:   the lines come from the FILE rows when there are any, and from
+      the commit's own stats when there are none — two emission paths, one
+      measure, and each builds its own dimension tuple
+
+  The second path is what this fixture is for, and ONE of its assertions is a
+  regression guard rather than coverage. `git_uncollected_file_changes` owns
+  that path for the unscoped measures and asserts none of the branch-scoped
+  ones, so nothing said the fallback reaches this measure at all.
+
+  A repository breakdown groups by a hidden source-id key as well as by the
+  dimensions asked for, so a fallback row missing that key answers as its own
+  repository: two rows carrying one repository's name, splitting its lines
+  between them, one of them unlinkable. `size(items) == 1` in the second case
+  is what fails when that key goes missing again — the first case passes
+  either way, because a request without `repository` never groups by it.
+
+  The key itself is not directly assertable: it reaches the response only as
+  the repository dimension's link, which needs an external source registered
+  and the rig registers none. The row count is what stands in.
+
+  Cases: the two paths summing into one figure and one category split; the
+  repository split, where both paths must answer with a single row; and an
+  empty window.
+
+  The rig resolves `view: breakdown` to exactly one view per metric, so each
+  split needs its own case.
+
+  Fixture — erin only, one repository, every commit's scope carried by the
+  connector's own flag rather than by a branch row or a merged request:
+    * dbla-diffed, landed, diff collected
+        src/a.rs   +11  code
+        docs/a.md  +20  docs
+    * dbla-blind, landed, NO file rows at all — its own stats say +30, and
+      that is the only record of them
+    * dbla-wip, not landed, diff collected
+        src/b.rs   +7   code, and it belongs to the other scope
+
+  So the metric reads 11 + 20 + 30 = 61, its category split is code 11, docs
+  20 and unknown 30, and the repository holding all of it is one repository.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_github.commits:
+    # Commit-level stats reach no measure asserted here unless a commit has no
+    # collected file rows at all, which is what dbla-blind is for.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: dbla-diffed, repository: "https://github.com/acme/dbla.git", sha: dbla-diffed, authored_date: "2026-10-01T09:00:00Z", committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 31, changed_files: 2, is_in_default_branch: true}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: dbla-blind, repository: "https://github.com/acme/dbla.git", sha: dbla-blind, authored_date: "2026-10-01T09:10:00Z", committed_date: "2026-10-01T09:10:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 30, changed_files: 1, is_in_default_branch: true}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: dbla-wip, repository: "https://github.com/acme/dbla.git", sha: dbla-wip, authored_date: "2026-10-01T09:20:00Z", committed_date: "2026-10-01T09:20:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 7, changed_files: 1, is_in_default_branch: false}
+
+  bronze_github.file_changes:
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: dbla-f-a, repository: "https://github.com/acme/dbla.git", sha: dbla-diffed, filename: src/a.rs, status: modified, additions: 11, deletions: 0, pre_image_oid: db1a0000000000000000000000000000000000a1, post_image_oid: db1a0000000000000000000000000000000000a2}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: dbla-f-doc, repository: "https://github.com/acme/dbla.git", sha: dbla-diffed, filename: docs/a.md, status: added, additions: 20, deletions: 0, post_image_oid: db1a0000000000000000000000000000000000b1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: dbla-f-b, repository: "https://github.com/acme/dbla.git", sha: dbla-wip, filename: src/b.rs, status: modified, additions: 7, deletions: 0, pre_image_oid: db1a0000000000000000000000000000000000c1, post_image_oid: db1a0000000000000000000000000000000000c2}
+
+cases:
+  - name: A commit with no collected diff still reports its lines, under an unknown category
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.default_branch_lines_added
+            views:
+              - {view: period}
+              - {view: breakdown, dimensions: [category]}
+          - metric_key: git.non_default_branch_lines_added
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      # 11 + 20 from the file rows, 30 from the commit that has none.
+      - metric: git.default_branch_lines_added
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 61}
+      - metric: git.non_default_branch_lines_added
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 7}
+      - metric: git.default_branch_lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: category, value: code}}
+        equal: {value: 11}
+      - metric: git.default_branch_lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: category, value: docs}}
+        equal: {value: 20}
+      # The fallback path cannot classify, so its lines arrive here rather
+      # than being dropped or guessed into a real category.
+      - metric: git.default_branch_lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: category, value: __unknown__}}
+        equal: {value: 30}
+      - metric: git.default_branch_lines_added
+        view: breakdown
+        assert: "size(items) == 3"
+
+  - name: One repository answers with one row whichever path its lines came from
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.default_branch_lines_added
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      - metric: git.default_branch_lines_added
+        view: breakdown
+        assert: "size(items) == 1"
+      - metric: git.default_branch_lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:acme/dbla"}}
+        equal: {value: 61}
+
+  - name: An empty window is null, not zero
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-12-01", to: "2026-12-31"}
+        metrics:
+          - metric_key: git.default_branch_lines_added
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      - metric: git.default_branch_lines_added
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: null}


### PR DESCRIPTION
Found while writing test coverage for `git.default_branch_lines_added` (#3048, part of #3039). The coverage is the second half of this PR; the model fix is the first.

**Why.** Git line measures have two emission paths — the file rows a commit reported, and the commit's own stats when its diff was never collected. The fallback writes out its dimension tuple as a literal precisely so a reader can compare it with the file-derived one, and the comment above it says the two must match key for key. They have not since #2904 wrote that literal with seven keys, one day after #2899 had made `source_id` the eighth key of the tuple it must match.

**The symptom.** A breakdown adds a hidden source-id key to its grouping whenever the caller asks for `repository`. So a repository holding both a commit with a collected diff and one without answers with **two rows carrying its name**, splitting its lines between them, one of them unlinkable. Six metrics reach that path: `git.lines_added`, `git.lines_removed`, and their four branch-scoped variants. Only `view: breakdown` is affected — `period`, `timeseries`, ranking and drilldown never group by that key, and no ratio metric reads a dual-path measure, so nothing computes a wrong average.

**Adding the key is row-count neutral.** `source_id` is already the prefix of the `repository` value sitting beside it, so the grouping key it restores is functionally determined by one already present. A gold rebuild is the whole of the deploy: the column type is unchanged, so no ALTER, no migration and no DDL-snapshot diff.

**What the test guards, and what it does not.** One assertion — `size(items) == 1` on the repository breakdown — is the regression guard; reverting the fixed line turns it red. The rest of the fixture is coverage the metric lacked: that the fallback reaches the branch-scoped measure at all, and that its lines read under an unknown category rather than being dropped or guessed into a real one. The first case passes with the bug present, because a request without `repository` never groups by the hidden key — the PR body for a test-only change would be wrong to imply otherwise.

**Still broken, not fixed here.** `ci_metric_evidence.sql` emits a `repository` dimension with neither `source_id` nor `source`, so the repository link #2899 shipped is dead for all nine CI metrics that declare that dimension. It fails uniformly rather than splitting, so it is a different failure mode — worth its own issue, and worse in one respect: that model uses a bare repository name as the dimension value, so two CI sources sharing a repository name collide.

**Verified.** `./e2e.sh test -k git_` — 28 passed. With the fixed line reverted, the guard fails and everything else still passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected repository-level metric grouping so line counts are no longer split into duplicate rows.
  - Improved default-branch lines-added reporting when file-level change details are unavailable, including an unknown-category fallback.
  - Empty reporting windows now return `null` instead of zero for this metric.

- **Tests**
  - Added end-to-end coverage for landed commits, non-default branches, repository breakdowns, and empty time windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->