### PR TITLE
feat(people): improve manager roster sorting and filtering

### DIFF
--- a/src/frontend/src/components/org-tree.test.tsx
+++ b/src/frontend/src/components/org-tree.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PeopleListItem } from "@/api/identity-client";
@@ -47,9 +48,20 @@ vi.mock("@/components/ui/sidebar", () => ({
   SidebarMenuItem: ({ children }: { children?: React.ReactNode }) => (
     <li>{children}</li>
   ),
-  SidebarMenuButton: ({ children }: { children?: React.ReactNode }) => (
-    <span>{children}</span>
-  ),
+  SidebarMenuButton: ({
+    children,
+    render,
+  }: {
+    children?: React.ReactNode;
+    render?: React.ReactElement;
+  }) =>
+    render ? (
+      <a href="/person" onClick={(event) => event.preventDefault()}>
+        {children}
+      </a>
+    ) : (
+      <button>{children}</button>
+    ),
 }));
 
 function person(
@@ -107,6 +119,53 @@ describe("OrgTree", () => {
     expect(screen.getByText("Lead Person")).toBeInTheDocument();
     // Nothing is active, so the lead's reports stay folded away.
     expect(screen.queryByText("Deep Person")).not.toBeInTheDocument();
+  });
+
+  it("opens and closes reports without following the person link", async () => {
+    const user = userEvent.setup();
+    render(<OrgTree />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Expand Lead Person" }),
+    );
+    expect(screen.getByText("Deep Person")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("link", { name: "Lead Person" }));
+    expect(screen.getByText("Deep Person")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Collapse Lead Person" }),
+    );
+    expect(screen.queryByText("Deep Person")).not.toBeInTheDocument();
+  });
+
+  it("allows the root row to collapse and reopen", async () => {
+    const user = userEvent.setup();
+    render(<OrgTree />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Collapse Root Person" }),
+    );
+    expect(screen.queryByText("Lead Person")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Expand Root Person" }),
+    );
+    expect(screen.getByText("Lead Person")).toBeInTheDocument();
+  });
+
+  it("restores manual expansion after search is cleared", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<OrgTree />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Collapse Root Person" }),
+    );
+    rerender(<OrgTree query="Deep" />);
+    expect(screen.getByText("Deep Person")).toBeInTheDocument();
+
+    rerender(<OrgTree query="" />);
+    expect(screen.queryByText("Lead Person")).not.toBeInTheDocument();
   });
 
   it("reveals a deep match and the managers above it, and nothing else", () => {

--- a/src/frontend/src/components/org-tree.test.tsx
+++ b/src/frontend/src/components/org-tree.test.tsx
@@ -51,16 +51,28 @@ vi.mock("@/components/ui/sidebar", () => ({
   SidebarMenuButton: ({
     children,
     render,
+    className,
+    isActive: _isActive,
+    ...props
   }: {
     children?: React.ReactNode;
     render?: React.ReactElement;
-  }) =>
+    className?: string;
+    isActive?: boolean;
+  } & React.ComponentProps<"button">) =>
     render ? (
-      <a href="/person" onClick={(event) => event.preventDefault()}>
+      <a
+        href="/person"
+        data-sidebar="menu-button"
+        className={className}
+        onClick={(event) => event.preventDefault()}
+      >
         {children}
       </a>
     ) : (
-      <button>{children}</button>
+      <button data-sidebar="menu-button" className={className} {...props}>
+        {children}
+      </button>
     ),
 }));
 
@@ -81,7 +93,7 @@ function rosterPerson(
   personId: string,
   displayName: string | null,
   managerPersonId: string | null,
-  username: string | null = null,
+  username: string | null = null
 ): PeopleListItem {
   return {
     person_id: personId,
@@ -125,16 +137,22 @@ describe("OrgTree", () => {
     const user = userEvent.setup();
     render(<OrgTree />);
 
-    await user.click(
-      screen.getByRole("button", { name: "Expand Lead Person" }),
+    const expand = screen.getByRole("button", { name: "Expand Lead Person" });
+    expect(expand).toHaveAttribute("data-sidebar", "menu-button");
+    expect(expand).toHaveClass("w-8", "shrink-0", "justify-center", "p-0");
+    expect(screen.getByRole("link", { name: "Lead Person" })).toHaveAttribute(
+      "data-sidebar",
+      "menu-button"
     );
+
+    await user.click(expand);
     expect(screen.getByText("Deep Person")).toBeInTheDocument();
 
     await user.click(screen.getByRole("link", { name: "Lead Person" }));
     expect(screen.getByText("Deep Person")).toBeInTheDocument();
 
     await user.click(
-      screen.getByRole("button", { name: "Collapse Lead Person" }),
+      screen.getByRole("button", { name: "Collapse Lead Person" })
     );
     expect(screen.queryByText("Deep Person")).not.toBeInTheDocument();
   });
@@ -144,12 +162,12 @@ describe("OrgTree", () => {
     render(<OrgTree />);
 
     await user.click(
-      screen.getByRole("button", { name: "Collapse Root Person" }),
+      screen.getByRole("button", { name: "Collapse Root Person" })
     );
     expect(screen.queryByText("Lead Person")).not.toBeInTheDocument();
 
     await user.click(
-      screen.getByRole("button", { name: "Expand Root Person" }),
+      screen.getByRole("button", { name: "Expand Root Person" })
     );
     expect(screen.getByText("Lead Person")).toBeInTheDocument();
   });
@@ -159,7 +177,7 @@ describe("OrgTree", () => {
     const { rerender } = render(<OrgTree />);
 
     await user.click(
-      screen.getByRole("button", { name: "Collapse Root Person" }),
+      screen.getByRole("button", { name: "Collapse Root Person" })
     );
     rerender(<OrgTree query="Deep" />);
     expect(screen.getByText("Deep Person")).toBeInTheDocument();
@@ -195,7 +213,12 @@ describe("OrgTree on an organisation with no reporting lines", () => {
     mocks.isFlat = true;
     // The tree the profile serves is the viewer alone — the shape that left
     // this pane showing one name beside a full Employees table.
-    mocks.viewer = { person_id: "root", display_name: "Me", email: "me@x", subordinates: [] } as IdentityPerson;
+    mocks.viewer = {
+      person_id: "root",
+      display_name: "Me",
+      email: "me@x",
+      subordinates: [],
+    } as IdentityPerson;
     mocks.roster = [
       rosterPerson("root", "Me", null),
       rosterPerson("p-ann", "Ann Dev", null),

--- a/src/frontend/src/components/org-tree.tsx
+++ b/src/frontend/src/components/org-tree.tsx
@@ -1,6 +1,6 @@
 import { Link, useRouterState } from "@tanstack/react-router";
 import { ChevronDown, ChevronRight, User, Users } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import type { PeopleListItem } from "@/api/identity-client";
 import { useViewer } from "@/auth";
@@ -40,6 +40,8 @@ function PersonNode({
   activePersonId,
   leadsToTeam,
   filter,
+  expansionOverrides,
+  onExpandedChange,
 }: {
   node: IdentityPerson;
   depth: number;
@@ -47,6 +49,8 @@ function PersonNode({
   /** Lead (has reports) links to their team roster instead of their own page. */
   leadsToTeam: boolean;
   filter: OrgTreeFilter | null;
+  expansionOverrides: ReadonlyMap<string, boolean>;
+  onExpandedChange: (personId: string, expanded: boolean) => void;
 }) {
   const { setScope } = usePortalNavActions();
   if (filter && !filter.visible.has(node.person_id)) return null;
@@ -60,7 +64,11 @@ function PersonNode({
       : false;
   // While filtering, the chain to a match is what the reader asked to see, so
   // it opens regardless of where they happen to be standing.
-  const open = filter ? true : depth === 0 || isActive || hasActiveDescendant;
+  const defaultOpen = depth === 0 || isActive || hasActiveDescendant;
+  const open = filter
+    ? true
+    : (expansionOverrides.get(node.person_id) ?? defaultOpen);
+  const label = personName(node) ?? UNNAMED_PERSON;
   // A lead's name lands on their team; an IC's on their own page. (The two
   // literal `to`s keep the typed router happy vs. a computed path.) Drilling
   // into a lead also *sets the org scope* (design §6) so the topbar badge and
@@ -78,22 +86,35 @@ function PersonNode({
   return (
     <>
       <SidebarMenuItem>
+        {hasReports ? (
+          filter ? (
+            <span
+              aria-hidden
+              className="absolute top-0 z-10 flex size-8 items-center justify-center [&>svg]:size-4"
+              style={{ left: `${0.5 + depth * 0.875}rem` }}
+            >
+              <ChevronDown />
+            </span>
+          ) : (
+            <button
+              type="button"
+              aria-expanded={open}
+              aria-label={`${open ? "Collapse" : "Expand"} ${label}`}
+              className="absolute top-0 z-10 flex size-8 items-center justify-center rounded-md text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4"
+              style={{ left: `${0.5 + depth * 0.875}rem` }}
+              onClick={() => onExpandedChange(node.person_id, !open)}
+            >
+              {open ? <ChevronDown /> : <ChevronRight />}
+            </button>
+          )
+        ) : null}
         <SidebarMenuButton
           isActive={isActive}
           render={link}
-          style={{ paddingLeft: `${0.5 + depth * 0.875}rem` }}
+          style={{ paddingLeft: `${2.5 + depth * 0.875}rem` }}
         >
-          {hasReports ? (
-            open ? (
-              <ChevronDown />
-            ) : (
-              <ChevronRight />
-            )
-          ) : (
-            <span className="w-4 shrink-0" />
-          )}
           {hasReports ? <Users /> : <User />}
-          <span className="truncate">{personName(node) ?? UNNAMED_PERSON}</span>
+          <span className="truncate">{label}</span>
         </SidebarMenuButton>
       </SidebarMenuItem>
       {hasReports && open
@@ -105,6 +126,8 @@ function PersonNode({
               activePersonId={activePersonId}
               leadsToTeam={leadsToTeam}
               filter={filter}
+              expansionOverrides={expansionOverrides}
+              onExpandedChange={onExpandedChange}
             />
           ))
         : null}
@@ -203,6 +226,17 @@ export function OrgTree({
     return null;
   }, [pathname, viewerPersonId]);
   const filter = useMemo(() => filterOrgTree(viewer, query), [viewer, query]);
+  const [expansionOverrides, setExpansionOverrides] = useState<
+    ReadonlyMap<string, boolean>
+  >(() => new Map());
+
+  const setExpanded = (personId: string, expanded: boolean) => {
+    setExpansionOverrides((current) => {
+      const next = new Map(current);
+      next.set(personId, expanded);
+      return next;
+    });
+  };
 
   if (isFlat) return <RosterList query={query} roster={roster} />;
   if (!viewer) return null;
@@ -222,6 +256,8 @@ export function OrgTree({
         activePersonId={activePersonId}
         leadsToTeam={leadsToTeam}
         filter={filter}
+        expansionOverrides={expansionOverrides}
+        onExpandedChange={setExpanded}
       />
     </SidebarMenu>
   );

--- a/src/frontend/src/components/org-tree.tsx
+++ b/src/frontend/src/components/org-tree.tsx
@@ -86,36 +86,41 @@ function PersonNode({
   return (
     <>
       <SidebarMenuItem>
-        {hasReports ? (
-          filter ? (
-            <span
-              aria-hidden
-              className="absolute top-0 z-10 flex size-8 items-center justify-center [&>svg]:size-4"
-              style={{ left: `${0.5 + depth * 0.875}rem` }}
-            >
-              <ChevronDown />
-            </span>
-          ) : (
-            <button
-              type="button"
-              aria-expanded={open}
-              aria-label={`${open ? "Collapse" : "Expand"} ${label}`}
-              className="absolute top-0 z-10 flex size-8 items-center justify-center rounded-md text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4"
-              style={{ left: `${0.5 + depth * 0.875}rem` }}
-              onClick={() => onExpandedChange(node.person_id, !open)}
-            >
-              {open ? <ChevronDown /> : <ChevronRight />}
-            </button>
-          )
-        ) : null}
-        <SidebarMenuButton
-          isActive={isActive}
-          render={link}
-          style={{ paddingLeft: `${2.5 + depth * 0.875}rem` }}
+        <div
+          className="flex min-w-0 items-center gap-1"
+          style={{ paddingLeft: `${0.5 + depth * 0.875}rem` }}
         >
-          {hasReports ? <Users /> : <User />}
-          <span className="truncate">{label}</span>
-        </SidebarMenuButton>
+          {hasReports ? (
+            filter ? (
+              <span
+                aria-hidden
+                className="flex size-8 shrink-0 items-center justify-center text-muted-foreground [&>svg]:size-4"
+              >
+                <ChevronDown />
+              </span>
+            ) : (
+              <SidebarMenuButton
+                type="button"
+                aria-expanded={open}
+                aria-label={`${open ? "Collapse" : "Expand"} ${label}`}
+                className="w-8 shrink-0 justify-center p-0 text-muted-foreground"
+                onClick={() => onExpandedChange(node.person_id, !open)}
+              >
+                {open ? <ChevronDown /> : <ChevronRight />}
+              </SidebarMenuButton>
+            )
+          ) : (
+            <span aria-hidden className="size-8 shrink-0" />
+          )}
+          <SidebarMenuButton
+            isActive={isActive}
+            render={link}
+            className="min-w-0 flex-1 ps-2"
+          >
+            {hasReports ? <Users /> : <User />}
+            <span className="truncate">{label}</span>
+          </SidebarMenuButton>
+        </div>
       </SidebarMenuItem>
       {hasReports && open
         ? node.subordinates.map((sub) => (
@@ -181,26 +186,26 @@ function RosterList({
     // Padding INSIDE the scroll region the pane owns, so the first and last
     // names clear its edges instead of touching them.
     <SidebarMenu className="pb-2">
-        {listed.map(({ person, label }) => (
-          <SidebarMenuItem key={person.person_id}>
-            <SidebarMenuButton
-              isActive={
-                activePersonId
-                  ? personIdEq(activePersonId, person.person_id)
-                  : false
-              }
-              render={
-                <Link
-                  to="/ic/$person/personal"
-                  params={{ person: person.person_id }}
-                />
-              }
-            >
-              <span className="w-4 shrink-0" />
-              <User />
-              <span className="truncate">{label}</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
+      {listed.map(({ person, label }) => (
+        <SidebarMenuItem key={person.person_id}>
+          <SidebarMenuButton
+            isActive={
+              activePersonId
+                ? personIdEq(activePersonId, person.person_id)
+                : false
+            }
+            render={
+              <Link
+                to="/ic/$person/personal"
+                params={{ person: person.person_id }}
+              />
+            }
+          >
+            <span className="w-4 shrink-0" />
+            <User />
+            <span className="truncate">{label}</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
       ))}
     </SidebarMenu>
   );
@@ -216,7 +221,7 @@ export function OrgTree({
   const { roster } = useVisibleRoster(true);
   const viewer = useMemo(
     () => (viewerPersonId ? rosterTree(roster, viewerPersonId) : null),
-    [roster, viewerPersonId],
+    [roster, viewerPersonId]
   );
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const activePersonId = useMemo(() => {

--- a/src/frontend/src/components/portal/ai-cost-view.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.tsx
@@ -389,7 +389,7 @@ export function AiCostView({ item }: { item: string | null }) {
       <div>
         <h1 className="text-lg font-semibold tracking-tight">AI &amp; Cost</h1>
         <p className="text-sm text-muted-foreground">
-          {teamName ? `${teamName}'s org` : "Org"} · {orgScope.count} people
+          {teamName ? `${teamName}'s org` : "Org"} · {orgScope.rosterCount} people
         </p>
       </div>
 

--- a/src/frontend/src/components/portal/context-pane.test.tsx
+++ b/src/frontend/src/components/portal/context-pane.test.tsx
@@ -78,6 +78,7 @@ beforeEach(() => {
     dispatchEvent: () => false,
   })) as unknown as typeof window.matchMedia;
   mocks.zone = { activeZone: "overview", activePerson: "boss@x" };
+  mocks.isFlat = false;
   mocks.standings = [];
   act(() => {
     portalRouter.set({ zone: undefined });
@@ -146,6 +147,29 @@ describe("ContextPane", () => {
     pane();
     expect(screen.getByText("People & org structure")).toBeInTheDocument();
     expect(screen.getByTestId("org-tree")).toBeInTheDocument();
+  });
+
+  it.each([
+    ["org chart", false],
+    ["flat roster", true],
+  ])("keeps the %s list in its own scroll region", (_policy, isFlat) => {
+    mocks.isFlat = isFlat;
+    mocks.zone = { activeZone: "people", activePerson: "boss@x" };
+
+    pane();
+
+    const search = screen.getByLabelText("Find someone in the org");
+    const scrollArea = screen
+      .getByTestId("org-tree")
+      .closest('[data-slot="scroll-area"]');
+
+    expect(scrollArea).not.toBeNull();
+    expect(scrollArea).toHaveClass("min-h-0", "flex-1");
+    expect(scrollArea).not.toContainElement(search);
+    expect(scrollArea?.closest('[data-slot="sidebar-group"]')).toHaveClass(
+      "min-h-0",
+      "flex-1"
+    );
   });
 
   it("renders Manage items", () => {

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -577,33 +577,16 @@ function WorkChart() {
     </div>
   );
 
-  // A roster is the whole organisation, so it takes the rest of the pane and
-  // scrolls there. The search sits ABOVE the scroll region, not inside it: a
-  // sticky-inside search put the scrollbar (and, mid-inertia, the rows) on top
-  // of it. The standard sidebar shape — fixed search, list scrolling below,
-  // scrollbar contained to the list.
-  if (isFlat) {
-    return (
-      // No group label: "WorkChart" names a structure a flat organisation does
-      // not have, and every other name for the roster restates the zone it
-      // already sits in. The search's own label says what the list is.
-      <SidebarGroup className="min-h-0 flex-1">
-        <SidebarGroupContent className="flex min-h-0 flex-1 flex-col gap-2">
-          {find}
-          <ScrollArea className="min-h-0 flex-1">
-            <OrgTree leadsToTeam query={query} />
-          </ScrollArea>
-        </SidebarGroupContent>
-      </SidebarGroup>
-    );
-  }
-
+  // WORKAROUND: Search stays outside ScrollArea because inertial scrolling can
+  // draw its scrollbar and rows over the search.
   return (
-    <SidebarGroup>
-      <SidebarGroupLabel>WorkChart</SidebarGroupLabel>
-      <SidebarGroupContent className="flex flex-col gap-2">
+    <SidebarGroup className="min-h-0 flex-1">
+      {isFlat ? null : <SidebarGroupLabel>WorkChart</SidebarGroupLabel>}
+      <SidebarGroupContent className="flex min-h-0 flex-1 flex-col gap-2">
         {find}
-        <OrgTree leadsToTeam query={query} />
+        <ScrollArea className="min-h-0 flex-1">
+          <OrgTree leadsToTeam query={query} />
+        </ScrollArea>
       </SidebarGroupContent>
     </SidebarGroup>
   );

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -597,7 +597,8 @@ export function DomainLensView({
             {scoped ? (scopedLabel ?? scoped) : config.title}
           </h1>
           <p className="text-sm text-muted-foreground">
-            {orgScope.count} {orgScope.count === 1 ? "person" : "people"} ·{" "}
+            {orgScope.rosterCount}{" "}
+            {orgScope.rosterCount === 1 ? "person" : "people"} ·{" "}
             {config.tagline ?? "trend & balance"}
           </p>
         </div>

--- a/src/frontend/src/components/portal/member-filter.test.tsx
+++ b/src/frontend/src/components/portal/member-filter.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { MemberFilter } from "./member-filter";
+import type { MemberSelection } from "./member-selection";
+
+const MEMBERS = [
+  { entityId: "manager", displayName: "Manager" },
+  { entityId: "zara", displayName: "Zara" },
+  { entityId: "alex", displayName: "Alex" },
+];
+
+describe("MemberFilter", () => {
+  it("searches the scoped options without changing the selection", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn<(selection: MemberSelection) => void>();
+    render(
+      <MemberFilter
+        members={MEMBERS}
+        selection={{ kind: "all" }}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Filter people, all 3 shown" }),
+    );
+    await user.type(screen.getByRole("searchbox", { name: "Find someone" }), "za");
+
+    expect(screen.getByRole("checkbox", { name: "Zara" })).toBeChecked();
+    expect(screen.queryByRole("checkbox", { name: "Manager" })).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("opens and applies actions from the keyboard", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn<(selection: MemberSelection) => void>();
+    render(
+      <MemberFilter
+        members={MEMBERS}
+        selection={{ kind: "all" }}
+        onChange={onChange}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Filter people, all 3 shown",
+    });
+    trigger.focus();
+    await user.keyboard("{Enter}");
+
+    const none = screen.getByRole("button", { name: "None" });
+    none.focus();
+    await user.keyboard("{Enter}");
+
+    expect(onChange).toHaveBeenCalledWith({
+      kind: "selected",
+      ids: new Set<string>(),
+    });
+  });
+
+  it("restores all scoped people", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn<(selection: MemberSelection) => void>();
+    render(
+      <MemberFilter
+        members={MEMBERS}
+        selection={{ kind: "selected", ids: new Set(["zara"]) }}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Filter people, 1 of 3 shown" }),
+    );
+    await user.click(screen.getByRole("button", { name: "All" }));
+
+    expect(onChange).toHaveBeenCalledWith({ kind: "all" });
+  });
+});

--- a/src/frontend/src/components/portal/member-filter.tsx
+++ b/src/frontend/src/components/portal/member-filter.tsx
@@ -1,0 +1,146 @@
+import { useMemo, useState } from "react";
+import { ListFilter, Search } from "lucide-react";
+
+import type { MembersGridMember } from "@/components/widgets/dashboard/members-grid";
+import {
+  selectedMembers,
+  type MemberSelection,
+} from "@/components/portal/member-selection";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface MemberFilterProps {
+  members: readonly MembersGridMember[];
+  selection: MemberSelection;
+  onChange: (selection: MemberSelection) => void;
+}
+
+export function MemberFilter({
+  members,
+  selection,
+  onChange,
+}: MemberFilterProps) {
+  const [query, setQuery] = useState("");
+  const selected = selectedMembers(members, selection);
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const options = useMemo(
+    () =>
+      normalizedQuery
+        ? members.filter((member) =>
+            member.displayName.toLocaleLowerCase().includes(normalizedQuery),
+          )
+        : members,
+    [members, normalizedQuery],
+  );
+  const allSelected = selection.kind === "all";
+  const label = allSelected
+    ? "All people"
+    : `${selected.length} of ${members.length} people`;
+  const accessibleLabel = allSelected
+    ? `Filter people, all ${members.length} shown`
+    : `Filter people, ${selected.length} of ${members.length} shown`;
+
+  const toggle = (entityId: string) => {
+    const ids = new Set(
+      selection.kind === "all"
+        ? members.map((member) => member.entityId)
+        : selection.ids,
+    );
+    if (!ids.delete(entityId)) ids.add(entityId);
+    onChange({ kind: "selected", ids });
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            icon={<ListFilter />}
+            aria-label={accessibleLabel}
+          >
+            {label}
+          </Button>
+        }
+      />
+      <PopoverContent align="end" className="w-72 gap-3 p-3">
+        <PopoverHeader className="flex-row items-center justify-between gap-2">
+          <PopoverTitle>People</PopoverTitle>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() => onChange({ kind: "all" })}
+            >
+              All
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() =>
+                onChange({ kind: "selected", ids: new Set<string>() })
+              }
+            >
+              None
+            </Button>
+          </div>
+        </PopoverHeader>
+
+        <div className="relative">
+          <Search
+            className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+          <Input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Find someone"
+            aria-label="Find someone"
+            className="ps-8"
+          />
+        </div>
+
+        <div className="max-h-64 space-y-1 overflow-y-auto">
+          {options.map((member, index) => {
+            const checked =
+              selection.kind === "all" || selection.ids.has(member.entityId);
+            const checkboxId = `member-filter-${index}`;
+
+            return (
+              <label
+                key={member.entityId}
+                htmlFor={checkboxId}
+                className="flex cursor-pointer items-center gap-2 rounded-sm px-1 py-1.5 text-sm hover:bg-muted"
+              >
+                <Checkbox
+                  id={checkboxId}
+                  checked={checked}
+                  onCheckedChange={() => toggle(member.entityId)}
+                />
+                <span className="min-w-0 truncate">{member.displayName}</span>
+              </label>
+            );
+          })}
+          {options.length === 0 ? (
+            <p className="px-1 py-4 text-center text-sm text-muted-foreground">
+              No people found.
+            </p>
+          ) : null}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/frontend/src/components/portal/member-selection.ts
+++ b/src/frontend/src/components/portal/member-selection.ts
@@ -1,0 +1,13 @@
+import type { MembersGridMember } from "@/components/widgets/dashboard/members-grid";
+
+export type MemberSelection =
+  | { kind: "all" }
+  | { kind: "selected"; ids: ReadonlySet<string> };
+
+export function selectedMembers(
+  members: readonly MembersGridMember[],
+  selection: MemberSelection,
+): MembersGridMember[] {
+  if (selection.kind === "all") return [...members];
+  return members.filter((member) => selection.ids.has(member.entityId));
+}

--- a/src/frontend/src/components/portal/person-header.test.tsx
+++ b/src/frontend/src/components/portal/person-header.test.tsx
@@ -25,7 +25,8 @@ const mocks = vi.hoisted(() => ({
     person_id: string;
     name: string;
     depth: number;
-    teamSize: number;
+    subtreeMemberCount: number;
+    directMemberCount: number;
   }>,
   icCalls: [] as string[],
   roster: [] as PeopleListItem[],
@@ -94,7 +95,13 @@ describe("PersonHeader", () => {
 
   it("offers the supervisor once they are inside the viewer's subtree", () => {
     mocks.managerNodes = [
-      { person_id: BOSS, name: "Boss", depth: 0, teamSize: 4 },
+      {
+        person_id: BOSS,
+        name: "Boss",
+        depth: 0,
+        subtreeMemberCount: 5,
+        directMemberCount: 5,
+      },
     ];
     mocks.roster.push(rosterPerson(BOSS, "Boss", null));
     render(<PersonHeader person={LEAD} />);
@@ -109,7 +116,13 @@ describe("PersonHeader", () => {
       supervisor_name: "Activity Name",
     });
     mocks.managerNodes = [
-      { person_id: BOSS, name: "Roster Boss", depth: 0, teamSize: 4 },
+      {
+        person_id: BOSS,
+        name: "Roster Boss",
+        depth: 0,
+        subtreeMemberCount: 5,
+        directMemberCount: 5,
+      },
     ];
     mocks.roster.push(rosterPerson(BOSS, "Roster Boss", null));
 

--- a/src/frontend/src/components/portal/scope-select.test.tsx
+++ b/src/frontend/src/components/portal/scope-select.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  directOnly: false,
+  scopeMemberCount: 8,
+}));
+
+vi.mock("@/lib/portal/portal-nav", () => ({
+  usePortalNavActions: () => ({ setScope: vi.fn() }),
+  usePortalScope: () => ({ root: null, directOnly: mocks.directOnly }),
+}));
+
+vi.mock("@/lib/portal/use-org-scope", () => ({
+  useOrgScope: () => ({
+    label: "Manager",
+    scopeMemberCount: mocks.scopeMemberCount,
+    pivotPersonId: "manager",
+    canDirectOnly: true,
+    managerNodes: [
+      {
+        person_id: "manager",
+        name: "Manager",
+        depth: 0,
+        subtreeMemberCount: 8,
+        directMemberCount: 3,
+      },
+      {
+        person_id: "nested",
+        name: "Nested manager",
+        depth: 1,
+        subtreeMemberCount: 5,
+        directMemberCount: 2,
+      },
+    ],
+  }),
+}));
+
+import { ScopeSelect } from "./scope-select";
+
+beforeEach(() => {
+  mocks.directOnly = false;
+  mocks.scopeMemberCount = 8;
+});
+
+describe("ScopeSelect", () => {
+  it("counts each manager inside their full scope", async () => {
+    const user = userEvent.setup();
+    render(<ScopeSelect />);
+
+    expect(
+      screen.getByRole("button", { name: "Scope: Manager, 8 people" }),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Scope: Manager, 8 people" }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Manager, 8 people" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Nested manager, 5 people" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows inclusive direct-scope counts in direct reports mode", async () => {
+    mocks.directOnly = true;
+    mocks.scopeMemberCount = 3;
+    const user = userEvent.setup();
+    render(<ScopeSelect />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Scope: Manager, 3 people" }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Manager, 3 people" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Nested manager, 2 people" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/scope-select.tsx
+++ b/src/frontend/src/components/portal/scope-select.tsx
@@ -25,7 +25,13 @@ import { cn } from "@/lib/utils";
 export function ScopeSelect() {
   const { setScope } = usePortalNavActions();
   const scope = usePortalScope();
-  const { label, count, managerNodes, pivotPersonId, canDirectOnly } = useOrgScope();
+  const {
+    label,
+    scopeMemberCount,
+    managerNodes,
+    pivotPersonId,
+    canDirectOnly,
+  } = useOrgScope();
   if (!managerNodes.length) return null;
 
   return (
@@ -34,6 +40,7 @@ export function ScopeSelect() {
         render={
           <button
             type="button"
+            aria-label={`Scope: ${label}, ${scopeMemberCount} people`}
             className="flex h-9 items-center gap-1.5 rounded-md border bg-background px-3 text-sm shadow-xs hover:bg-accent"
           >
             {/* Narrow screens keep only the identity of the scope: the word
@@ -41,29 +48,44 @@ export function ScopeSelect() {
                 the sticky bar has ~300px for three controls. */}
             <span className="hidden text-muted-foreground md:inline">Scope:</span>
             <span className="max-w-28 truncate font-medium md:max-w-40">{label}</span>
-            <span className="hidden text-muted-foreground md:inline">· {count}</span>
+            <span className="hidden text-muted-foreground md:inline">
+              · {scopeMemberCount}
+            </span>
             <ChevronDown className="size-4 text-muted-foreground" aria-hidden />
           </button>
         }
       />
       <PopoverContent align="end" className="w-72 p-1">
         <div className="max-h-80 overflow-y-auto">
-          {managerNodes.map((m) => (
-            <button
-              key={m.person_id}
-              type="button"
-              onClick={() => setScope({ root: m.depth === 0 ? null : m.person_id })}
-              className={cn(
-                "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent",
-                m.person_id === pivotPersonId && "bg-accent/60",
-              )}
-              style={{ paddingLeft: `${0.5 + m.depth * 0.875}rem` }}
-            >
-              <span className="min-w-0 flex-1 truncate">{m.name}</span>
-              <span className="text-xs text-muted-foreground">{m.teamSize}</span>
-              {m.person_id === pivotPersonId ? <Check className="size-4" aria-hidden /> : null}
-            </button>
-          ))}
+          {managerNodes.map((m) => {
+            const memberCount = scope.directOnly
+              ? m.directMemberCount
+              : m.subtreeMemberCount;
+
+            return (
+              <button
+                key={m.person_id}
+                type="button"
+                aria-label={`${m.name}, ${memberCount} people`}
+                onClick={() =>
+                  setScope({ root: m.depth === 0 ? null : m.person_id })
+                }
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent",
+                  m.person_id === pivotPersonId && "bg-accent/60",
+                )}
+                style={{ paddingLeft: `${0.5 + m.depth * 0.875}rem` }}
+              >
+                <span className="min-w-0 flex-1 truncate">{m.name}</span>
+                <span className="text-xs text-muted-foreground">
+                  {memberCount}
+                </span>
+                {m.person_id === pivotPersonId ? (
+                  <Check className="size-4" aria-hidden />
+                ) : null}
+              </button>
+            );
+          })}
         </div>
         {canDirectOnly ? (
           <label className="flex cursor-pointer items-center justify-between gap-2 border-t px-2 py-2 text-sm select-none">

--- a/src/frontend/src/components/portal/team-state-view.test.tsx
+++ b/src/frontend/src/components/portal/team-state-view.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@tanstack/react-router", async () => {
 import { portalRouter } from "@/test/portal-router";
 
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
@@ -134,6 +135,98 @@ describe("TeamStateView", () => {
         .getAllByRole("rowheader")
         .map((header) => header.textContent),
     ).toEqual(MEMBER_LABELS);
+    expect(
+      screen.getByRole("button", { name: "Filter people, all 5 shown" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows only selected people without changing the team scope", async () => {
+    const user = userEvent.setup();
+    render(<TeamStateView />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Filter people, all 5 shown" }),
+    );
+    await user.click(screen.getByRole("button", { name: "None" }));
+    await user.click(screen.getByRole("checkbox", { name: "boss" }));
+    await user.click(screen.getByRole("checkbox", { name: "c" }));
+
+    expect(
+      within(screen.getByRole("table"))
+        .getAllByRole("rowheader")
+        .map((header) => header.textContent),
+    ).toEqual(["boss", "c"]);
+    expect(screen.getByText(/5 people · state & attention/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Filter people, 2 of 5 shown" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an empty selection state and restores all people", async () => {
+    const user = userEvent.setup();
+    render(<TeamStateView />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Filter people, all 5 shown" }),
+    );
+    await user.click(screen.getByRole("button", { name: "None" }));
+
+    expect(screen.getByText("No people selected.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show all" }));
+    expect(
+      within(screen.getByRole("table"))
+        .getAllByRole("rowheader")
+        .map((header) => header.textContent),
+    ).toEqual(MEMBER_LABELS);
+  });
+
+  it("resets the selection when the manager scope changes", async () => {
+    const user = userEvent.setup();
+    render(<TeamStateView />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Filter people, all 5 shown" }),
+    );
+    await user.click(screen.getByRole("button", { name: "None" }));
+    await user.click(screen.getByRole("checkbox", { name: "boss" }));
+
+    act(() => portalRouter.set({ scope: pid("c") }));
+
+    expect(
+      screen.getByRole("button", { name: "Filter people, all 1 shown" }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("table"))
+        .getAllByRole("rowheader")
+        .map((header) => header.textContent),
+    ).toEqual(["c"]);
+  });
+
+  it("resets the selection when direct reports mode changes", async () => {
+    mocks.tree = person("boss", [
+      person("a", [person("c")]),
+      person("b"),
+    ]);
+    mocks.roster = peopleFromIdentityTree(mocks.tree);
+    const user = userEvent.setup();
+    render(<TeamStateView />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Filter people, all 4 shown" }),
+    );
+    await user.click(screen.getByRole("button", { name: "None" }));
+    await user.click(screen.getByRole("checkbox", { name: "boss" }));
+
+    act(() => portalRouter.set({ direct: true }));
+
+    expect(
+      screen.getByRole("button", { name: "Filter people, all 3 shown" }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("table"))
+        .getAllByRole("rowheader")
+        .map((header) => header.textContent),
+    ).toEqual(["boss", "a", "b"]);
   });
 
   it("sums counters into a team total and medians ratios — never the reverse", () => {

--- a/src/frontend/src/components/portal/team-state-view.test.tsx
+++ b/src/frontend/src/components/portal/team-state-view.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@tanstack/react-router", async () => {
 
 import { portalRouter } from "@/test/portal-router";
 
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
@@ -91,7 +91,7 @@ function metric(
 }
 
 // Roster entity ids: person UUIDs, the same key the metric grid returns.
-const LABELS = ["a", "b", "c", "d"];
+const LABELS = ["d", "a", "c", "b"];
 const MEMBER_LABELS = ["boss", ...LABELS];
 const MEMBER_IDS = MEMBER_LABELS.map(pid);
 
@@ -129,6 +129,11 @@ describe("TeamStateView", () => {
     for (const label of MEMBER_LABELS) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
+    expect(
+      within(screen.getByRole("table"))
+        .getAllByRole("rowheader")
+        .map((header) => header.textContent),
+    ).toEqual(MEMBER_LABELS);
   });
 
   it("sums counters into a team total and medians ratios — never the reverse", () => {

--- a/src/frontend/src/components/portal/team-state-view.tsx
+++ b/src/frontend/src/components/portal/team-state-view.tsx
@@ -1,9 +1,18 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { AttentionList } from "@/components/portal/attention-list";
+import { MemberFilter } from "@/components/portal/member-filter";
+import {
+  selectedMembers,
+  type MemberSelection,
+} from "@/components/portal/member-selection";
 import { personDisplayName } from "@/lib/identities/person-display";
 import { orgScopeGate } from "@/components/portal/org-scope-gate";
-import { MembersGrid } from "@/components/widgets/dashboard/members-grid";
+import {
+  MembersGrid,
+  type MembersGridProps,
+} from "@/components/widgets/dashboard/members-grid";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
 import { formatMetricValue } from "@/lib/format";
@@ -24,6 +33,7 @@ import {
 } from "@/lib/metrics/collection";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import {
+  usePortalScope,
   usePortalSlice,
 } from "@/lib/portal/portal-nav";
 import type { TeamMember } from "@/types/insight";
@@ -34,6 +44,50 @@ import { TEXT_FIGURE } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 
 const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
+
+function TeamMembersSection({ members, ...gridProps }: MembersGridProps) {
+  const [selection, setSelection] = useState<MemberSelection>({ kind: "all" });
+  const visibleMembers = useMemo(
+    () => selectedMembers(members, selection),
+    [members, selection],
+  );
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+          Members
+        </p>
+        <MemberFilter
+          members={members}
+          selection={selection}
+          onChange={setSelection}
+        />
+      </div>
+      {visibleMembers.length > 0 ? (
+        <Card>
+          <CardContent className="p-0">
+            <MembersGrid members={visibleMembers} {...gridProps} />
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="flex min-h-40 flex-col items-center justify-center gap-3 text-center">
+            <p className="text-sm text-muted-foreground">No people selected.</p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setSelection({ kind: "all" })}
+            >
+              Show all
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+    </section>
+  );
+}
 
 /**
  * Team-state dashboard — the People roster reframed for a lead: "what's the
@@ -50,6 +104,7 @@ export function TeamStateView() {
   const { period, dateRange } = usePortalPeriod();
 
   const orgScope = useOrgScope();
+  const portalScope = usePortalScope();
   const { pivot, roster } = orgScope;
 
   // INVARIANT: People evaluates the selected manager with the reports-only org scope.
@@ -75,6 +130,14 @@ export function TeamStateView() {
   );
   const personIdByEntity = useMemo(
     () => new Map(members.map((m) => [normalizePersonId(m.person_id), m.person_id])),
+    [members],
+  );
+  const gridMembers = useMemo(
+    () =>
+      members.map((member) => ({
+        entityId: normalizePersonId(member.person_id),
+        displayName: member.name,
+      })),
     [members],
   );
 
@@ -242,28 +305,16 @@ export function TeamStateView() {
       />
 
       {/* Detailed scan */}
-      <section className="flex flex-col gap-3">
-        <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
-          Members
-        </p>
-        <Card>
-          <CardContent className="p-0">
-            <MembersGrid
-              members={members.map((m) => ({
-                entityId: normalizePersonId(m.person_id),
-                displayName: m.name,
-                personId: m.person_id,
-              }))}
-              defaultSort="input"
-              metricKeys={shownKeys}
-              byKey={heatByKey}
-              previousByKey={grid.previousByKey}
-              caption={`${teamName || "Team"} — people × metrics`}
-              cohortLabel={cohortLabel}
-            />
-          </CardContent>
-        </Card>
-      </section>
+      <TeamMembersSection
+        key={`${orgScope.pivotPersonId}:${portalScope.directOnly}`}
+        members={gridMembers}
+        defaultSort="input"
+        metricKeys={shownKeys}
+        byKey={heatByKey}
+        previousByKey={grid.previousByKey}
+        caption={`${teamName || "Team"} — people × metrics`}
+        cohortLabel={cohortLabel}
+      />
     </div>
   );
 }

--- a/src/frontend/src/components/portal/team-state-view.tsx
+++ b/src/frontend/src/components/portal/team-state-view.tsx
@@ -254,6 +254,7 @@ export function TeamStateView() {
                 displayName: m.name,
                 personId: m.person_id,
               }))}
+              defaultSort="input"
               metricKeys={shownKeys}
               byKey={heatByKey}
               previousByKey={grid.previousByKey}

--- a/src/frontend/src/components/widgets/dashboard/members-grid.test.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.test.tsx
@@ -144,6 +144,61 @@ describe("MembersGrid", () => {
     expect(screen.queryByText(/near the median/)).not.toBeInTheDocument();
   });
 
+  it("cycles every column through ascending, descending, and input order", async () => {
+    const user = userEvent.setup();
+    render(
+      <MembersGrid
+        members={[MEMBERS[1]!, MEMBERS[2]!, MEMBERS[0]!]}
+        metricKeys={["ai.active_days"]}
+        byKey={byKeyFor(
+          metric("ai.active_days", [
+            { id: "ann@x.com", value: 8 },
+            { id: "bo@x.com", value: 20 },
+            { id: "cy@x.com", value: 2 },
+          ]),
+        )}
+        defaultSort="input"
+        caption="Members grid"
+      />,
+    );
+    const table = screen.getByRole("table", { name: "Members grid" });
+    const names = () =>
+      within(table)
+        .getAllByRole("rowheader")
+        .map((header) => header.textContent);
+    const personHeader = within(table).getAllByRole("columnheader")[0]!;
+    const personSort = within(personHeader).getByRole("button");
+    const metricHeader = within(table).getAllByRole("columnheader")[1]!;
+    const metricSort = within(metricHeader).getByRole("button");
+
+    expect(names()).toEqual(["Bo", "Cy", "Ann"]);
+    expect(personHeader).not.toHaveAttribute("aria-sort");
+
+    await user.click(personSort);
+    expect(names()).toEqual(["Ann", "Bo", "Cy"]);
+    expect(personHeader).toHaveAttribute("aria-sort", "ascending");
+
+    await user.click(personSort);
+    expect(names()).toEqual(["Cy", "Bo", "Ann"]);
+    expect(personHeader).toHaveAttribute("aria-sort", "descending");
+
+    await user.click(personSort);
+    expect(names()).toEqual(["Bo", "Cy", "Ann"]);
+    expect(personHeader).not.toHaveAttribute("aria-sort");
+
+    await user.click(metricSort);
+    expect(names()).toEqual(["Cy", "Ann", "Bo"]);
+    expect(metricHeader).toHaveAttribute("aria-sort", "ascending");
+
+    await user.click(metricSort);
+    expect(names()).toEqual(["Bo", "Ann", "Cy"]);
+    expect(metricHeader).toHaveAttribute("aria-sort", "descending");
+
+    await user.click(metricSort);
+    expect(names()).toEqual(["Bo", "Cy", "Ann"]);
+    expect(metricHeader).not.toHaveAttribute("aria-sort");
+  });
+
   it("skips metric keys absent from the results", () => {
     render(
       <MembersGrid
@@ -159,7 +214,7 @@ describe("MembersGrid", () => {
     expect(screen.getAllByRole("columnheader")).toHaveLength(2);
   });
 
-  it("sorts best-first on column click, flips on the second click, missing always last", async () => {
+  it("sorts ascending, descending, then resets while keeping missing values last", async () => {
     const user = userEvent.setup();
     render(
       <MembersGrid
@@ -184,18 +239,24 @@ describe("MembersGrid", () => {
       name: "Active AI days — sort by this column",
     });
     await user.click(sortButton);
-    // higher_is_better best-first: Bo (20), Ann (8); unmeasured Cy last.
-    expect(names()).toEqual(["Bo", "Ann", "Cy"]);
-    expect(
-      screen.getAllByRole("columnheader")[1],
-    ).toHaveAttribute("aria-sort", "descending");
+    expect(names()).toEqual(["Ann", "Bo", "Cy"]);
+    expect(screen.getAllByRole("columnheader")[1]).toHaveAttribute(
+      "aria-sort",
+      "ascending",
+    );
 
     await user.click(sortButton);
-    // Flipped: worst-first, but missing still sorts last.
+    expect(names()).toEqual(["Bo", "Ann", "Cy"]);
+    expect(screen.getAllByRole("columnheader")[1]).toHaveAttribute(
+      "aria-sort",
+      "descending",
+    );
+
+    await user.click(sortButton);
     expect(names()).toEqual(["Ann", "Bo", "Cy"]);
-    expect(
-      screen.getAllByRole("columnheader")[1],
-    ).toHaveAttribute("aria-sort", "ascending");
+    expect(screen.getAllByRole("columnheader")[1]).not.toHaveAttribute(
+      "aria-sort",
+    );
   });
 
   it("renders — for unobserved members and neutral for suppressed cohorts", () => {

--- a/src/frontend/src/components/widgets/dashboard/members-grid.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.tsx
@@ -98,6 +98,8 @@ export interface MembersGridMember {
 
 export interface MembersGridProps {
   members: MembersGridMember[];
+  /** Row order restored after a column completes its sort cycle. */
+  defaultSort?: "input" | "issues";
   /** Column metrics, in display order; keys absent from `byKey` are skipped. */
   metricKeys: readonly string[];
   /** Current-period value + peer standing per metric key. */
@@ -192,12 +194,11 @@ interface RowShape {
 }
 
 type SortKey = "name" | "issues" | string;
+type SortDirection = "ascending" | "descending";
 
-interface SortState {
-  key: SortKey;
-  /** Flipped by clicking the active column a second time. */
-  reversed: boolean;
-}
+type SortState =
+  | { key: null }
+  | { key: SortKey; direction: SortDirection };
 
 /** Cell text: bare number — the unit lives in the header tooltip and the
  *  cell popover, so ten columns of "141 commits / 707 lines" don't shout. */
@@ -225,6 +226,7 @@ function cellMissing(cell: CellShape | undefined): boolean {
  */
 export function MembersGrid({
   members,
+  defaultSort = "issues",
   metricKeys,
   byKey,
   previousByKey,
@@ -237,17 +239,23 @@ export function MembersGrid({
 }: MembersGridProps) {
   const { focusMode } = useSettings();
   const hasIssuesFacet = showIssues ?? countsByMember != null;
-  const [sort, setSort] = useState<SortState>({
-    key: "issues",
-    reversed: false,
-  });
+  const [sort, setSort] = useState<SortState>({ key: null });
 
-  const toggleSort = (key: SortKey) => {
-    setSort((current) =>
-      current.key === key
-        ? { key, reversed: !current.reversed }
-        : { key, reversed: false }
-    );
+  const toggleSort = (
+    key: SortKey,
+    firstDirection: SortDirection = "ascending",
+  ) => {
+    setSort((current) => {
+      if (current.key !== key) return { key, direction: firstDirection };
+      if (current.direction === firstDirection) {
+        return {
+          key,
+          direction:
+            firstDirection === "ascending" ? "descending" : "ascending",
+        };
+      }
+      return { key: null };
+    });
   };
 
   const columns = useMemo(
@@ -319,7 +327,18 @@ export function MembersGrid({
 
   const sortedRows = useMemo(() => {
     const copy = [...rows];
-    const flip = sort.reversed ? -1 : 1;
+    if (sort.key == null) {
+      if (defaultSort === "issues") {
+        copy.sort(
+          (a, b) =>
+            b.counts.bottom - a.counts.bottom ||
+            a.member.displayName.localeCompare(b.member.displayName),
+        );
+      }
+      return copy;
+    }
+
+    const flip = sort.direction === "descending" ? -1 : 1;
     if (sort.key === "name") {
       copy.sort(
         (a, b) =>
@@ -328,7 +347,7 @@ export function MembersGrid({
     } else if (sort.key === "issues") {
       copy.sort(
         (a, b) =>
-          flip * (b.counts.bottom - a.counts.bottom) ||
+          flip * (a.counts.bottom - b.counts.bottom) ||
           a.member.displayName.localeCompare(b.member.displayName)
       );
     } else {
@@ -344,38 +363,21 @@ export function MembersGrid({
           const aMissing = cellMissing(ac);
           const bMissing = cellMissing(bc);
           if (aMissing || bMissing) return Number(aMissing) - Number(bMissing);
-          // First click ranks best-first: lower-is-better puts smallest first;
-          // higher-is-better and neutral put largest first (neutral's order is
-          // arbitrary but stable — it implies no "best"). A second click flips.
-          const bestFirst =
-            betterWhenHigher(col.direction) === false
-              ? ac!.value! - bc!.value!
-              : bc!.value! - ac!.value!;
-          return flip * bestFirst;
+          return flip * (ac!.value! - bc!.value!);
         });
       }
     }
     return copy;
-  }, [rows, sort, columns]);
+  }, [rows, sort, columns, defaultSort]);
 
   /**
-   * The active-column sort order as a real value direction — drives both
-   * `aria-sort` and the header arrow. A metric column's first click sorts
-   * best-first, so the value direction depends on the metric's own
-   * better/worse direction (lower-is-better ascends first); name/issues
-   * ascend on the first click and descend on the flip.
+   * The active-column sort order drives both `aria-sort` and the header arrow.
    */
   const directionFor = (
     key: SortKey
   ): "ascending" | "descending" | undefined => {
     if (sort.key !== key) return undefined;
-    // Issues sorts most-first, so its unflipped order is descending; name
-    // sorts A→Z (ascending unflipped).
-    if (key === "issues") return sort.reversed ? "ascending" : "descending";
-    const col = columns.find((c) => c.key === key);
-    if (!col) return sort.reversed ? "descending" : "ascending";
-    const bestIsHigh = betterWhenHigher(col.direction) !== false;
-    return bestIsHigh !== sort.reversed ? "descending" : "ascending";
+    return sort.direction;
   };
 
   // Member-level orderings (name / issues) live on the Member header; metric
@@ -428,7 +430,9 @@ export function MembersGrid({
                       }
                     />
                     <DropdownMenuContent align="start">
-                      <DropdownMenuItem onClick={() => toggleSort("issues")}>
+                      <DropdownMenuItem
+                        onClick={() => toggleSort("issues", "descending")}
+                      >
                         Furthest behind
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={() => toggleSort("name")}>

--- a/src/frontend/src/lib/portal/portal-hooks.test.tsx
+++ b/src/frontend/src/lib/portal/portal-hooks.test.tsx
@@ -282,8 +282,8 @@ describe("usePersonCohort", () => {
 describe("useOrgScope", () => {
   it("resolves the viewer's subtree with counts and pivot id", () => {
     const { result } = renderHook(() => useOrgScope());
-    // count = people under the pivot, the pivot itself excluded
-    expect(result.current.count).toBe(3);
+    expect(result.current.rosterCount).toBe(3);
+    expect(result.current.scopeMemberCount).toBe(4);
     expect(result.current.pivotPersonId).toBe(BOSS);
     expect(result.current.isLoading).toBe(false);
   });
@@ -292,8 +292,8 @@ describe("useOrgScope", () => {
     act(() => portalRouter.set({ scope: B }));
     const { result } = renderHook(() => useOrgScope());
     expect(result.current.pivotPersonId).toBe(B);
-    // a leaf has no reports — org zones will gate on the empty roster
-    expect(result.current.count).toBe(0);
+    expect(result.current.rosterCount).toBe(0);
+    expect(result.current.scopeMemberCount).toBe(1);
   });
 
   it("surfaces identity errors and delegates refetch", () => {

--- a/src/frontend/src/lib/portal/use-org-scope.test.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.test.ts
@@ -54,7 +54,8 @@ describe("resolveScopeRoster", () => {
   it("defaults to the viewer's whole subtree", () => {
     const s = resolveScopeRoster(TREE, "p-ao", { root: null, directOnly: false });
     expect(s.label).toBe("Ao");
-    expect(s.count).toBe(5);
+    expect(s.rosterCount).toBe(5);
+    expect(s.scopeMemberCount).toBe(6);
   });
   it("scopes to a sub-lead's subtree", () => {
     const s = resolveScopeRoster(TREE, "p-ao", { root: "p-lead1", directOnly: false });
@@ -72,6 +73,8 @@ describe("resolveScopeRoster", () => {
       "p-ic1",
       "p-lead2",
     ]);
+    expect(s.rosterCount).toBe(2);
+    expect(s.scopeMemberCount).toBe(3);
   });
   it("falls back to the viewer when root is outside the tree", () => {
     const s = resolveScopeRoster(TREE, "p-ao", { root: "p-stranger", directOnly: false });
@@ -96,7 +99,8 @@ describe("resolveScopeRoster", () => {
       "·p-lead1",
       "··p-lead2",
     ]);
-    expect(s.managerNodes.map((m) => m.teamSize)).toEqual([5, 3, 1]);
+    expect(s.managerNodes.map((m) => m.subtreeMemberCount)).toEqual([6, 4, 2]);
+    expect(s.managerNodes.map((m) => m.directMemberCount)).toEqual([3, 3, 2]);
   });
 
   it("keeps the picker in outline order across branches, not by depth", () => {
@@ -115,7 +119,12 @@ describe("resolveScopeRoster", () => {
       "p-l2",
       "p-l2a",
     ]);
-    expect(s.managerNodes.map((m) => m.teamSize)).toEqual([6, 2, 1, 2, 1]);
+    expect(s.managerNodes.map((m) => m.subtreeMemberCount)).toEqual([
+      7, 3, 2, 3, 2,
+    ]);
+    expect(s.managerNodes.map((m) => m.directMemberCount)).toEqual([
+      3, 2, 2, 2, 2,
+    ]);
   });
 });
 
@@ -132,7 +141,8 @@ describe("flatOrgScope", () => {
     const scope = flatOrgScope(roster);
 
     expect(scope.roster?.map((r) => r.person_id)).toEqual(["p-me", "p-b", "p-c"]);
-    expect(scope.count).toBe(3);
+    expect(scope.rosterCount).toBe(3);
+    expect(scope.scopeMemberCount).toBe(3);
   });
 
   it("offers no manager nodes and no direct-only cut", () => {
@@ -184,6 +194,7 @@ describe("flatOrgScope", () => {
     const scope = flatOrgScope(null);
 
     expect(scope.roster).toBeNull();
-    expect(scope.count).toBe(0);
+    expect(scope.rosterCount).toBe(0);
+    expect(scope.scopeMemberCount).toBe(0);
   });
 });

--- a/src/frontend/src/lib/portal/use-org-scope.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.ts
@@ -23,17 +23,23 @@ export interface ManagerNode {
   person_id: string;
   name: string;
   depth: number;
-  teamSize: number;
+  /** Manager plus every descendant. */
+  subtreeMemberCount: number;
+  /** Manager plus direct reports. */
+  directMemberCount: number;
 }
 
 /** The scope resolved against the viewer's own subtree — the permission boundary. */
 export interface ResolvedScope {
   /** The scope pivot (root manager node); null while the tree loads. */
   pivot: IdentityPerson | null;
-  /** Everyone inside the scope (subtree or direct reports). */
+  /** Reports below the pivot (full subtree or direct reports). */
   roster: RosterEntry[] | null;
   label: string;
-  count: number;
+  /** Number of reports used by report-only analytics. */
+  rosterCount: number;
+  /** Number of people represented by the scope selector, pivot included. */
+  scopeMemberCount: number;
   /** All manager nodes of the viewer's tree, for the ScopeSelect picker. */
   managerNodes: ManagerNode[];
   /** Whether directOnly can change anything at this pivot. */
@@ -59,7 +65,8 @@ export function flatOrgScope(
       pivot: null,
       roster: null,
       label: WHOLE_ORG_LABEL,
-      count: 0,
+      rosterCount: 0,
+      scopeMemberCount: 0,
       managerNodes: [],
       canDirectOnly: false,
     };
@@ -79,7 +86,8 @@ export function flatOrgScope(
     pivot: null,
     roster: members,
     label: WHOLE_ORG_LABEL,
-    count: members.length,
+    rosterCount: members.length,
+    scopeMemberCount: members.length,
     managerNodes: [],
     canDirectOnly: false,
   };
@@ -100,7 +108,8 @@ export function resolveScopeRoster(
       pivot: null,
       roster: null,
       label: "",
-      count: 0,
+      rosterCount: 0,
+      scopeMemberCount: 0,
       managerNodes: [],
       canDirectOnly: false,
     };
@@ -116,9 +125,9 @@ export function resolveScopeRoster(
   const roster = scopeRosterToDirectReports(full, canDirectOnly && scope.directOnly);
 
   const managerNodes: ManagerNode[] = [];
-  // One pass: each call returns its own subtree size, so a team size costs one
-  // visit per node. Flattening per manager node re-walked that manager's whole
-  // subtree — O(n · depth), which degrades on a deep reporting chain.
+  // One pass: each call returns its inclusive subtree member count. Flattening
+  // per manager node re-walked that manager's whole subtree — O(n · depth),
+  // which degrades on a deep reporting chain.
   //
   // The entry is pushed BEFORE recursing and its size filled in after, so the
   // picker keeps its depth-first outline order (a lead, then that lead's leads).
@@ -129,14 +138,15 @@ export function resolveScopeRoster(
             person_id: node.person_id,
             name: personDisplayName(node),
             depth,
-            teamSize: 0,
+            subtreeMemberCount: 0,
+            directMemberCount: node.subordinates.length + 1,
           }
         : null;
     if (entry) managerNodes.push(entry);
-    let size = 0;
-    for (const sub of node.subordinates) size += 1 + walk(sub, depth + 1);
-    if (entry) entry.teamSize = size;
-    return size;
+    let memberCount = 1;
+    for (const sub of node.subordinates) memberCount += walk(sub, depth + 1);
+    if (entry) entry.subtreeMemberCount = memberCount;
+    return memberCount;
   };
   walk(viewerNode, 0);
 
@@ -144,7 +154,8 @@ export function resolveScopeRoster(
     pivot,
     roster,
     label: personDisplayName(pivot),
-    count: roster?.length ?? 0,
+    rosterCount: roster?.length ?? 0,
+    scopeMemberCount: (roster?.length ?? 0) + 1,
     managerNodes,
     canDirectOnly,
   };


### PR DESCRIPTION
**Why.** Manager view reordered people before a visible sort, could not return to WorkChart order, and lacked a selected-only view. WorkChart navigation and scrolling also made large teams awkward to browse.

**What changed.** Columns cycle through ascending, descending, and reset. Reset restores WorkChart order with the manager first. Selected-only filtering, inclusive scope counts, separate WorkChart controls, consistent row styling, and dedicated list scrolling were added.

**Default order follows WorkChart.** Explicit sorting replaces it until reset.

**WorkChart owns its scroll region.** Search and other sidebar navigation remain fixed for both visibility policies.

**Evidence.** 89 focused synthetic frontend tests cover sorting, filtering, counts, separate controls, and both scroll layouts.

**Verified.** Focused Vitest, ESLint, TypeScript, and diff checks passed.
