### PR TITLE
fix(git-cli-proxy, connectors): shed served windows without repacking the skeleton, and resume a superseded walk from its cursor (release-2026.08)

### DIFF
--- a/src/backend/services/git-cli-proxy/src/engine/meta.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/meta.rs
@@ -44,6 +44,12 @@ pub struct RepoMeta {
     /// and is only ever evicted whole.
     #[serde(default)]
     pub full_clone: bool,
+    /// Packs holding the blobless skeleton: the clone's, every fetch's, and
+    /// the last consolidation's. Any other pack is a served window.
+    /// INVARIANT: empty means unknown, never "no skeleton" — a purge then
+    /// falls back to the repack instead of deleting packs it cannot classify.
+    #[serde(default)]
+    pub skeleton_packs: Vec<String>,
 }
 
 const META_FILE: &str = "meta.json";
@@ -178,6 +184,7 @@ mod tests {
             generation: 3,
             cred_fingerprints: vec!["deadbeef".to_owned()],
             full_clone: false,
+            skeleton_packs: vec!["pack-0000".to_owned()],
         }
     }
 

--- a/src/backend/services/git-cli-proxy/src/engine/store.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/store.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -713,6 +713,7 @@ impl RepoStore {
             last_accessed_at_epoch_s: now,
             size_bytes: cloned_bytes,
             skeleton_bytes: cloned_bytes,
+            skeleton_packs: pack_names(git_dir).into_iter().collect(),
             generation: 1,
             incarnation: self.mint_incarnation(),
             cred_fingerprints: vec![creds.fingerprint()],
@@ -762,6 +763,7 @@ impl RepoStore {
 
         let before = self.ref_digest(git_dir).await;
         let previous = RepoMeta::load(entry_dir);
+        let packs_before = pack_names(git_dir);
 
         // Park the metadata before the refs can move. A crash between the
         // `--atomic` fetch and the meta publish would otherwise leave the OLD
@@ -852,6 +854,13 @@ impl RepoStore {
             cred_fingerprints: RepoMeta::proofs_with(previous.as_ref(), creds.fingerprint()),
             // A plain fetch never changes the entry's clone shape.
             full_clone: previous.as_ref().is_some_and(|m| m.full_clone),
+            skeleton_packs: skeleton_packs_after_fetch(
+                previous
+                    .as_ref()
+                    .map_or(&[], |m| m.skeleton_packs.as_slice()),
+                &packs_before,
+                &pack_names(git_dir),
+            ),
         };
         publish_meta(&meta, entry_dir)?;
         discard_parked_meta(entry_dir);
@@ -981,6 +990,7 @@ impl RepoStore {
                 .map_or_else(|| self.mint_incarnation(), |m| m.incarnation.clone()),
             cred_fingerprints: RepoMeta::proofs_with(previous.as_ref(), creds.fingerprint()),
             full_clone: true,
+            skeleton_packs: pack_names(&git_dir).into_iter().collect(),
         };
         publish_meta(&meta, &entry_dir)?;
         discard_parked_meta(&entry_dir);
@@ -1123,12 +1133,27 @@ impl RepoStore {
         };
         self.settle_purge_debt(&key.dir_name()).await;
 
+        let shed = match self.shed_window_packs(&entry_dir).await {
+            WindowShed::Settled { freed: 0 } => {
+                self.settle_purge_failures(&key.dir_name()).await;
+                tracing::debug!(dir = %key.dir_name(), "no window to shed; skeleton size re-baselined");
+                return;
+            }
+            WindowShed::Settled { freed } => {
+                self.settle_purge_failures(&key.dir_name()).await;
+                metrics::record_eviction(EvictionTier::Blob);
+                tracing::info!(dir = %key.dir_name(), freed_bytes = freed, "purged a served window");
+                return;
+            }
+            WindowShed::RepackDue { freed } => freed,
+        };
+
         let permit = self.heavy_permit().await;
         match self.repack_blobless(&entry_dir, &permit).await {
             Ok(freed) => {
                 self.settle_purge_failures(&key.dir_name()).await;
                 metrics::record_eviction(EvictionTier::Blob);
-                tracing::info!(dir = %key.dir_name(), freed_bytes = freed, "purged a served window");
+                tracing::info!(dir = %key.dir_name(), freed_bytes = shed + freed, "purged a served window and consolidated the skeleton");
             }
             Err(e) => {
                 let failures = self.record_purge_failure(&key.dir_name()).await;
@@ -1298,6 +1323,9 @@ impl RepoStore {
         {
             return Ok(());
         }
+        if let WindowShed::Settled { .. } = self.shed_window_packs(entry_dir).await {
+            return Ok(());
+        }
         self.repack_blobless(entry_dir, permit).await.map(|_| ())
     }
 
@@ -1392,6 +1420,7 @@ impl RepoStore {
         if let Some(mut meta) = RepoMeta::load(entry_dir) {
             meta.size_bytes = purged;
             meta.skeleton_bytes = purged;
+            meta.skeleton_packs = pack_names(&git_dir).into_iter().collect();
             if let Err(e) = meta.store(entry_dir) {
                 tracing::warn!(error = %e, "could not record the purged size; the planner will overstate this entry");
             }
@@ -1709,6 +1738,11 @@ impl RepoStore {
 
         // Never wait: the only caller holds the admission lock, and a permit
         // held by a clone would stall every admission behind that clone.
+        match self.shed_window_packs(&entry_dir).await {
+            WindowShed::Settled { freed: 0 } => return Ok(BlobPurge::Skipped),
+            WindowShed::Settled { .. } => return Ok(BlobPurge::Purged),
+            WindowShed::RepackDue { .. } => {}
+        }
         let Ok(permit) = self.heavy.try_acquire() else {
             return Ok(BlobPurge::PermitBusy);
         };
@@ -1808,13 +1842,118 @@ fn discard_parked_meta(entry_dir: &Path) {
 
 /// How many packs the entry's object store currently holds. Cheap: one
 /// directory listing, no tree walk.
+/// What deleting an entry's window packs left behind.
+#[derive(Debug)]
+enum WindowShed {
+    /// The skeleton alone remains, in few enough packs.
+    Settled { freed: u64 },
+    /// The windows are gone (or could not be told apart), and the skeleton
+    /// itself still needs a repack.
+    RepackDue { freed: u64 },
+}
+
+impl RepoStore {
+    /// Shed every served window by deleting its packs. A promisor fetch
+    /// always indexes what it receives into a pack of its own, so the blobs
+    /// of a window never share a file with the skeleton, and dropping them is
+    /// a few unlinks whatever the size of the history — unlike a repack.
+    /// INVARIANT: the caller holds the entry's write lock.
+    async fn shed_window_packs(&self, entry_dir: &Path) -> WindowShed {
+        let Some(mut meta) = RepoMeta::load(entry_dir) else {
+            return WindowShed::RepackDue { freed: 0 };
+        };
+        if meta.skeleton_packs.is_empty() {
+            return WindowShed::RepackDue { freed: 0 };
+        }
+
+        let git_dir = entry_dir.join("repo.git");
+        let before = dir_size_off_reactor(git_dir.clone()).await;
+        let doomed = window_pack_files(&git_dir, &meta.skeleton_packs);
+        let remaining = {
+            let git_dir = git_dir.clone();
+            tokio::task::spawn_blocking(move || {
+                for path in doomed {
+                    let _ = std::fs::remove_file(path);
+                }
+                dir_size(&git_dir)
+            })
+            .await
+            .unwrap_or(before)
+        };
+
+        // INVARIANT: with every window pack gone, the remaining bytes are the skeleton.
+        meta.size_bytes = remaining;
+        meta.skeleton_bytes = remaining;
+        if let Err(e) = meta.store(entry_dir) {
+            tracing::warn!(error = %e, "could not record the shed size; the planner will overstate this entry");
+        }
+
+        let freed = before.saturating_sub(remaining);
+        if needs_consolidation(remaining, remaining, pack_count(&git_dir)) {
+            WindowShed::RepackDue { freed }
+        } else {
+            WindowShed::Settled { freed }
+        }
+    }
+}
+
+/// The skeleton packs after a fetch: those recorded before plus whatever the
+/// fetch wrote. An entry with no recorded skeleton keeps none — its packs
+/// cannot be told apart after the fact, and a shed must never guess.
+fn skeleton_packs_after_fetch(
+    recorded: &[String],
+    before: &BTreeSet<String>,
+    after: &BTreeSet<String>,
+) -> Vec<String> {
+    if recorded.is_empty() {
+        return Vec::new();
+    }
+    recorded
+        .iter()
+        .cloned()
+        .chain(after.difference(before).cloned())
+        .collect()
+}
+
+/// Every file of every pack that is not part of the skeleton: the served
+/// windows with their `.idx`, `.rev` and `.promisor` siblings.
+fn window_pack_files(git_dir: &Path, skeleton_packs: &[String]) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(git_dir.join("objects").join("pack")) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                return false;
+            };
+            let stem = name.split('.').next().unwrap_or(name);
+            stem.starts_with("pack-") && !skeleton_packs.iter().any(|kept| kept == stem)
+        })
+        .collect()
+}
+
+/// Stems (`pack-<hash>`) of every pack in the object store.
+fn pack_names(git_dir: &Path) -> BTreeSet<String> {
+    std::fs::read_dir(git_dir.join("objects").join("pack")).map_or_else(
+        |_| BTreeSet::new(),
+        |entries| {
+            entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|path| path.extension().is_some_and(|ext| ext == "pack"))
+                .filter_map(|path| {
+                    path.file_stem()
+                        .map(|stem| stem.to_string_lossy().into_owned())
+                })
+                .collect()
+        },
+    )
+}
+
 fn pack_count(git_dir: &Path) -> usize {
-    std::fs::read_dir(git_dir.join("objects").join("pack")).map_or(0, |entries| {
-        entries
-            .filter_map(Result::ok)
-            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "pack"))
-            .count()
-    })
+    pack_names(git_dir).len()
 }
 
 fn publish_meta(meta: &RepoMeta, entry_dir: &Path) -> Result<(), GitError> {
@@ -2184,6 +2323,34 @@ pub(crate) mod tests {
 
     /// Commit a large blob at origin, clone it into `f`, and prefetch the
     /// blob so the entry carries window weight above its skeleton.
+    /// A second store over the fixture's cache whose heavy budget no repack
+    /// can meet — the failure the exhaustion rules are about, made certain.
+    fn store_whose_repack_cannot_finish(f: &Fixture) -> Arc<RepoStore> {
+        match RepoStore::open_cache(
+            &f.root.join("cache"),
+            2,
+            None,
+            Budget {
+                total_bytes: u64::MAX,
+            },
+            u64::MAX,
+        ) {
+            Ok(s) => Arc::new(s.with_heavy_timeout(Duration::from_millis(1))),
+            Err(e) => panic!("second store: {e}"),
+        }
+    }
+
+    /// Make an entry look like one written before its packs were tracked.
+    fn forget_skeleton_packs(entry_dir: &Path) {
+        let Some(mut meta) = RepoMeta::load(entry_dir) else {
+            panic!("meta must exist")
+        };
+        meta.skeleton_packs.clear();
+        if let Err(e) = meta.store(entry_dir) {
+            panic!("meta store: {e}");
+        }
+    }
+
     async fn fetch_blobs_into(f: Fixture) -> (Fixture, CacheKey, u64) {
         sh(
             &f.root.join("origin"),
@@ -2785,7 +2952,7 @@ pub(crate) mod tests {
         };
         assert!(
             meta.size_bytes < skeleton * 2,
-            "the repack must have run: {} vs skeleton {skeleton}",
+            "the purge must have run: {} vs skeleton {skeleton}",
             meta.size_bytes
         );
         assert!(
@@ -2893,32 +3060,21 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn a_purge_that_keeps_failing_evicts_the_entry_instead_of_looping() {
-        // A repack that cannot finish inside the heavy budget will not finish
-        // next time either, and every window served meanwhile makes the pack
-        // bigger: retried in place it leaves the entry over its cap and
-        // unservable for good. The second failure evicts, and the next open
-        // re-clones the skeleton.
+        // An entry whose packs were never recorded can only be purged by a
+        // repack. One that cannot finish inside the heavy budget will not
+        // finish next time either, and every window served meanwhile makes
+        // the pack bigger: retried in place it leaves the entry over its cap
+        // and unservable for good. The second failure evicts, and the next
+        // open re-clones the skeleton.
         let (f, k, _) = entry_with_fetched_blobs("purge-exhausted").await;
         let entry_dir = f.store.entry_dir(&k);
         assert!(
             entry_dir.join("repo.git").is_dir(),
             "the fixture must hold a clone"
         );
+        forget_skeleton_packs(&entry_dir);
 
-        // A second store over the same cache whose heavy budget no repack can
-        // meet — the failure this rule is about, made certain.
-        let failing = match RepoStore::open_cache(
-            &f.root.join("cache"),
-            2,
-            None,
-            Budget {
-                total_bytes: u64::MAX,
-            },
-            u64::MAX,
-        ) {
-            Ok(s) => Arc::new(s.with_heavy_timeout(Duration::from_millis(1))),
-            Err(e) => panic!("second store: {e}"),
-        };
+        let failing = store_whose_repack_cannot_finish(&f);
 
         failing.purge_if_drifted(&k).await;
         assert!(
@@ -2942,6 +3098,219 @@ pub(crate) mod tests {
         assert!(
             RepoMeta::load(&entry_dir).is_some(),
             "and publishes fresh metadata for the skeleton"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_purge_sheds_the_window_by_deleting_its_packs_and_never_repacks_the_skeleton() {
+        // The blobs of a served window arrive in packs of their own, so
+        // shedding them is unlinking files. A skeleton too large to repack
+        // inside the heavy budget must still purge — and stay.
+        let (f, k, skeleton) = entry_with_fetched_blobs("shed-by-deletion").await;
+        let entry_dir = f.store.entry_dir(&k);
+        let git_dir = entry_dir.join("repo.git");
+        let Some(before) = RepoMeta::load(&entry_dir) else {
+            panic!("meta must exist")
+        };
+        assert!(
+            !before.skeleton_packs.is_empty(),
+            "a clone must record its skeleton packs"
+        );
+        assert!(
+            pack_count(&git_dir) > before.skeleton_packs.len(),
+            "the prefetch must have added a window pack"
+        );
+
+        store_whose_repack_cannot_finish(&f)
+            .purge_if_drifted(&k)
+            .await;
+
+        assert!(git_dir.is_dir(), "a shed is not an eviction");
+        let skeleton_packs: BTreeSet<String> = before.skeleton_packs.iter().cloned().collect();
+        assert_eq!(
+            pack_names(&git_dir),
+            skeleton_packs,
+            "only the skeleton packs may remain"
+        );
+        let Some(after) = RepoMeta::load(&entry_dir) else {
+            panic!("meta must survive a shed")
+        };
+        assert!(
+            after.size_bytes < skeleton * 2,
+            "the window's weight must be gone: {} vs skeleton {skeleton}",
+            after.size_bytes
+        );
+        assert_eq!(
+            after.size_bytes,
+            dir_size(&git_dir),
+            "accounting must match the disk"
+        );
+        assert_eq!(
+            after.generation, before.generation,
+            "a shed changes no snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_fetched_pack_joins_the_skeleton_and_survives_the_shed() {
+        let (f, k, _) = entry_with_fetched_blobs("shed-keeps-fetch").await;
+        let entry_dir = f.store.entry_dir(&k);
+        let git_dir = entry_dir.join("repo.git");
+
+        sh(
+            &f.root.join("origin"),
+            "echo later > later.txt && git add later.txt && \
+             GIT_AUTHOR_DATE='2026-08-03T10:00:00+0000' \
+             GIT_COMMITTER_DATE='2026-08-03T10:00:00+0000' git commit -qm later",
+        );
+        let guard = match f.store.open(&k, &creds(), always_fetch()).await {
+            Ok(g) => g,
+            Err(e) => panic!("fetch: {e}"),
+        };
+        let head = head_of(guard.git_dir());
+        if let Err(e) = crate::engine::read::blobs::prefetch(
+            f.store.runner(),
+            guard.git_dir(),
+            std::slice::from_ref(&head),
+            &creds(),
+            u64::MAX,
+        )
+        .await
+        {
+            panic!("prefetch: {e}");
+        }
+        drop(guard);
+        let Some(meta) = RepoMeta::load(&entry_dir) else {
+            panic!("meta must exist")
+        };
+        assert_eq!(
+            meta.skeleton_packs.len(),
+            2,
+            "the fetch's pack must join the skeleton: {:?}",
+            meta.skeleton_packs
+        );
+
+        store_whose_repack_cannot_finish(&f)
+            .purge_if_drifted(&k)
+            .await;
+
+        assert_eq!(
+            pack_names(&git_dir).len(),
+            2,
+            "the clone's and the fetch's packs stay; the windows go"
+        );
+        sh(&git_dir, &format!("git cat-file -e {head}^{{tree}}"));
+    }
+
+    #[tokio::test]
+    async fn an_entry_that_predates_pack_tracking_is_never_shed_by_guesswork() {
+        // Without a recorded skeleton no pack can be told from a window: the
+        // repack is the only purge such an entry gets, and a failed one
+        // leaves every pack in place.
+        let (f, k, _) = entry_with_fetched_blobs("shed-legacy").await;
+        let entry_dir = f.store.entry_dir(&k);
+        let git_dir = entry_dir.join("repo.git");
+        forget_skeleton_packs(&entry_dir);
+        let packs = pack_names(&git_dir);
+
+        store_whose_repack_cannot_finish(&f)
+            .purge_if_drifted(&k)
+            .await;
+
+        assert!(git_dir.is_dir(), "one failed purge is a retry");
+        assert_eq!(
+            pack_names(&git_dir),
+            packs,
+            "no pack may be deleted on a guess"
+        );
+    }
+
+    #[test]
+    fn a_fetch_extends_a_recorded_skeleton_and_leaves_an_unrecorded_one_alone() {
+        struct Case {
+            rule: &'static str,
+            recorded: &'static [&'static str],
+            before: &'static [&'static str],
+            after: &'static [&'static str],
+            expected: &'static [&'static str],
+        }
+        let owned =
+            |names: &[&str]| -> Vec<String> { names.iter().map(|n| (*n).to_owned()).collect() };
+        let cases = [
+            Case {
+                rule: "unrecorded stays unrecorded",
+                recorded: &[],
+                before: &["pack-a"],
+                after: &["pack-a", "pack-f"],
+                expected: &[],
+            },
+            Case {
+                rule: "the fetch's pack is added",
+                recorded: &["pack-a"],
+                before: &["pack-a"],
+                after: &["pack-a", "pack-f"],
+                expected: &["pack-a", "pack-f"],
+            },
+            Case {
+                rule: "a window present throughout is not",
+                recorded: &["pack-a"],
+                before: &["pack-a", "pack-w"],
+                after: &["pack-a", "pack-w", "pack-f"],
+                expected: &["pack-a", "pack-f"],
+            },
+            Case {
+                rule: "a fetch that wrote nothing adds nothing",
+                recorded: &["pack-a"],
+                before: &["pack-a"],
+                after: &["pack-a"],
+                expected: &["pack-a"],
+            },
+        ];
+        for case in cases {
+            let before: BTreeSet<String> = owned(case.before).into_iter().collect();
+            let after: BTreeSet<String> = owned(case.after).into_iter().collect();
+            assert_eq!(
+                skeleton_packs_after_fetch(&owned(case.recorded), &before, &after),
+                owned(case.expected),
+                "{}",
+                case.rule
+            );
+        }
+    }
+
+    #[test]
+    fn a_window_pack_is_doomed_with_all_its_siblings_and_nothing_else() {
+        let f = fixture("window-files");
+        let git_dir = f.root.join("packs");
+        let pack_dir = git_dir.join("objects").join("pack");
+        if let Err(e) = std::fs::create_dir_all(&pack_dir) {
+            panic!("pack dir: {e}");
+        }
+        for name in [
+            "pack-a.pack",
+            "pack-a.idx",
+            "pack-a.promisor",
+            "pack-w.pack",
+            "pack-w.idx",
+            "pack-w.rev",
+            "pack-w.promisor",
+            "multi-pack-index",
+        ] {
+            if let Err(e) = std::fs::write(pack_dir.join(name), b"x") {
+                panic!("write {name}: {e}");
+            }
+        }
+
+        let mut doomed: Vec<String> = window_pack_files(&git_dir, &["pack-a".to_owned()])
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        doomed.sort();
+
+        assert_eq!(
+            doomed,
+            ["pack-w.idx", "pack-w.pack", "pack-w.promisor", "pack-w.rev"],
+            "every file of the window pack and only those"
         );
     }
 
@@ -3543,6 +3912,7 @@ pub(crate) mod tests {
         let k = key(&f);
         let guard = open_until_ready(&f, &k, refresh()).await;
         drop(guard);
+        forget_skeleton_packs(&f.store.entry_dir(&k));
 
         // Clones or fetches elsewhere hold every heavy permit.
         let Ok(_held) = f.store.heavy.try_acquire_many(2) else {

--- a/src/ingestion/connectors/collaboration/zoom/connector.yaml
+++ b/src/ingestion/connectors/collaboration/zoom/connector.yaml
@@ -1,4 +1,4 @@
-version: 6.60.9
+version: 7.0.4
 
 type: DeclarativeSource
 

--- a/src/ingestion/connectors/collaboration/zoom/descriptor.yaml
+++ b/src/ingestion/connectors/collaboration/zoom/descriptor.yaml
@@ -6,7 +6,7 @@ name: zoom
 # pre-fix manifest and every zoom sync kept dying on the blocked meeting UUID.
 # Patch bump per ADR-0015: republish + catalog re-discover, NO full-refresh
 # (bronze→silver semantics unchanged).
-version: "1.2.1"
+version: "1.2.2"
 schedule: 0 3 * * *
 dbt_select: tag:zoom+
 workflow: sync

--- a/src/ingestion/connectors/collaboration/zoom/tests/config.py
+++ b/src/ingestion/connectors/collaboration/zoom/tests/config.py
@@ -25,12 +25,6 @@ MEETING_SLICES = [
     ("2026-06-01", "2026-07-01"),
 ]
 
-# The inline `_meetings` PARENT of participants is read through the CDK's
-# synchronous path (SubstreamPartitionRouter.read_only_records), whose slice
-# generator does NOT absorb the remainder into the last slice — it emits the
-# plain step layout with a 1-day tail. Same window pin, different tail shape.
-PARENT_MEETING_SLICES = MEETING_SLICES[:-1] + [("2026-06-01", "2026-06-30"), ("2026-07-01", "2026-07-01")]
-
 
 def metrics_params(from_date: str, to_date: str, page_token: str | None = None) -> dict:
     params = {"type": "past", "page_size": "100", "from": from_date, "to": to_date}
@@ -39,12 +33,12 @@ def metrics_params(from_date: str, to_date: str, page_token: str | None = None) 
     return params
 
 
-def mock_meeting_slices(http_mocker, non_empty: dict, slices=MEETING_SLICES) -> None:
+def mock_meeting_slices(http_mocker, non_empty: dict) -> None:
     """Register every expected meetings slice; slices whose `from` date is not
     a key of `non_empty` serve an empty page. Exact from/to matchers mean an
     out-of-window request (the job-529 failure mode) matches nothing and fails
     the test."""
-    for from_date, to_date in slices:
+    for from_date, to_date in MEETING_SLICES:
         http_mocker.get(
             HttpRequest(METRICS_URL, query_params=metrics_params(from_date, to_date)),
             non_empty.get(from_date, HttpResponse(body=json.dumps({"meetings": []}), status_code=200)),

--- a/src/ingestion/connectors/collaboration/zoom/tests/test_participants.py
+++ b/src/ingestion/connectors/collaboration/zoom/tests/test_participants.py
@@ -44,15 +44,7 @@ from __future__ import annotations
 import json
 
 import freezegun
-from config import (
-    FROZEN_NOW,
-    METRICS_URL,
-    PARENT_MEETING_SLICES,
-    ZoomConfigBuilder,
-    metrics_params,
-    mock_meeting_slices,
-    mock_token,
-)
+from config import FROZEN_NOW, METRICS_URL, ZoomConfigBuilder, metrics_params, mock_meeting_slices, mock_token
 from connector_tests import HttpMocker, HttpRequest, HttpResponse, assert_records_conform, load_fixture, read_stream
 
 _STREAM = "participants"
@@ -82,11 +74,10 @@ def _participants_page(participants: list[dict], next_token: str | None = None) 
 
 def _mock_parent(http_mocker: HttpMocker, meetings: list[dict]) -> None:
     """The inline `_meetings` parent slices the same now-150d window as the
-    top-level meetings stream (PARENT_MEETING_SLICES — the sync read path emits
-    a 1-day tail instead of absorbing it); all parent meetings are served in
-    the 2026-06-01 slice, the other slices are empty. Exact from/to matchers
-    keep the job-529 window pin on the parent path too."""
-    mock_meeting_slices(http_mocker, {"2026-06-01": _meetings_page(meetings)}, slices=PARENT_MEETING_SLICES)
+    top-level meetings stream; all parent meetings are served in the
+    2026-06-01 slice, the other slices are empty. Exact from/to matchers keep
+    the window pin on the parent path too."""
+    mock_meeting_slices(http_mocker, {"2026-06-01": _meetings_page(meetings)})
 
 
 def _participants_url(escaped_uuid: str) -> str:
@@ -195,7 +186,7 @@ def test_parent_state_persisted_in_child_state(http_mocker: HttpMocker) -> None:
     final_state = output.state_messages[-1].state.stream.stream_state.__dict__
     assert "__ab_no_cursor_state_message" not in final_state
     parent_state = final_state.get("parent_state")
-    assert parent_state == {"_meetings": {"end_time": "2026-06-15T10:30:00Z"}}, parent_state
+    assert parent_state == {"_meetings": {"end_time": "2026-06-15"}}, parent_state
 
 
 @freezegun.freeze_time(_NOW)
@@ -251,7 +242,7 @@ def test_resume_enumerates_parent_from_saved_cursor(http_mocker: HttpMocker) -> 
         assert not second.errors
         assert [r.record.data["participant_uuid"] for r in second.records] == ["part-2"]
         final_state = second.state_messages[-1].state.stream.stream_state.__dict__
-        assert final_state.get("parent_state") == {"_meetings": {"end_time": "2026-06-20T10:30:00Z"}}
+        assert final_state.get("parent_state") == {"_meetings": {"end_time": "2026-06-20"}}
 
 
 # The meeting uuid Cloudflare's WAF started blocking on dev-vhc on 2026-07-23,
@@ -307,7 +298,7 @@ def test_cloudflare_blocked_meeting_is_skipped(http_mocker: HttpMocker) -> None:
     assert not output.errors
     assert [r.record.data["participant_uuid"] for r in output.records] == ["part-good"]
     final_state = output.state_messages[-1].state.stream.stream_state.__dict__
-    assert final_state.get("parent_state") == {"_meetings": {"end_time": "2026-06-16T10:30:00Z"}}
+    assert final_state.get("parent_state") == {"_meetings": {"end_time": "2026-06-16"}}
 
 
 @freezegun.freeze_time(_NOW)

--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -119,15 +119,15 @@ definitions:
         error_message: >-
           Skipping this repository: gone or refused at origin (404), or
           larger than cache.maxRepoBytes (413). Other repositories continue.
-      # The pinned snapshot was superseded mid-walk. RETRY would replay
-      # the same dead page token and 409 again; a response filter cannot
-      # reset it. Rerunning the sync resumes each partition from its own
-      # stored cursor against a fresh snapshot.
+      # The pinned snapshot was superseded mid-walk: a refresh or an eviction
+      # bumped the generation, so the page token is dead. RETRY would replay
+      # it and 409 again; RESET_PAGINATION restarts the partition's walk from
+      # its first page, and the retriever's `pagination_reset` narrows that
+      # restart to the last cursor value already seen.
       - type: HttpResponseFilter
         http_codes: [409]
-        action: FAIL
-        error_message: >-
-          Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+        action: RESET_PAGINATION
+        error_message: Proxy snapshot changed mid-walk; restarting the walk from the last record already seen
       - type: HttpResponseFilter
         http_codes: [500, 502, 503, 504]
         action: RETRY
@@ -471,6 +471,9 @@ streams:
           type: RequestOption
           field_name: page_token
           inject_into: request_parameter
+      pagination_reset:
+        type: PaginationReset
+        action: SPLIT_USING_CURSOR
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -668,6 +671,9 @@ streams:
           type: RequestOption
           field_name: page_token
           inject_into: request_parameter
+      pagination_reset:
+        type: PaginationReset
+        action: SPLIT_USING_CURSOR
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -839,6 +845,9 @@ streams:
           type: RequestOption
           field_name: page_token
           inject_into: request_parameter
+      pagination_reset:
+        type: PaginationReset
+        action: RESET
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -3281,6 +3290,9 @@ streams:
                     type: RequestOption
                     field_name: page_token
                     inject_into: request_parameter
+                pagination_reset:
+                  type: PaginationReset
+                  action: RESET
                 partition_router:
                   type: SubstreamPartitionRouter
                   parent_stream_configs:

--- a/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
@@ -12,7 +12,7 @@ name: bitbucket-cloud
 #   same reason as github 6.0.0 — the patch id has been in Bronze all along,
 #   but staging never re-reads Bronze, so the column heals to NULL on existing
 #   rows and a NULL identity never folds.
-version: "5.0.1"
+version: "5.0.2"
 # A slot of its own: replication pods sharing a slot with other connector
 # syncs can be starved of workers, which surfaces as startup and activity
 # timeouts rather than as a connector error.

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
@@ -224,3 +224,46 @@ def test_every_requester_declares_an_error_handler() -> None:
         if "error_handler" not in requester
     ]
     assert not bare, f"requesters relying on the CDK default error handler: {bare}"
+
+
+_PROXY_RESET_ACTIONS = {
+    "/v1/commits": "SPLIT_USING_CURSOR",
+    "/v1/file-changes": "SPLIT_USING_CURSOR",
+    "/v1/branches": "RESET",
+    "/v1/authors": "RESET",
+}
+
+
+def _proxy_retrievers(node, out=None):
+    """Every SimpleRetriever whose requester targets the git proxy."""
+    if out is None:
+        out = []
+    if isinstance(node, dict):
+        requester = node.get("requester", {})
+        if node.get("type") == "SimpleRetriever" and "git_proxy_url" in str(requester.get("url_base", "")):
+            out.append(node)
+        for value in node.values():
+            _proxy_retrievers(value, out)
+    elif isinstance(node, list):
+        for item in node:
+            _proxy_retrievers(item, out)
+    return out
+
+
+def test_a_superseded_proxy_snapshot_restarts_the_walk_instead_of_failing_it() -> None:
+    """A 409 means the page token points into a snapshot the proxy no longer
+    holds. Failing the partition freezes its cursor until the next run; a
+    pagination reset restarts the walk, and a walk the proxy orders by the
+    cursor restarts from the last value already seen. Commits and file
+    changes come out ordered by committed_date; branches and authors carry
+    no such order, so their restart is from the first page."""
+    manifest = yaml.safe_load((connector_dir(_CONNECTOR) / "connector.yaml").read_text())
+    retrievers = _proxy_retrievers(manifest["streams"])
+    assert {r["requester"]["path"] for r in retrievers} == set(_PROXY_RESET_ACTIONS)
+    for retriever in retrievers:
+        path = retriever["requester"]["path"]
+        filters = retriever["requester"]["error_handler"]["response_filters"]
+        on_409 = [f["action"] for f in filters if 409 in f.get("http_codes", [])]
+        assert on_409 == ["RESET_PAGINATION"], f"{path}: a 409 must reset pagination, got {on_409}"
+        reset = retriever.get("pagination_reset")
+        assert reset == {"type": "PaginationReset", "action": _PROXY_RESET_ACTIONS[path]}, f"{path}: {reset}"

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
@@ -15,12 +15,13 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable
+from datetime import datetime
 from typing import Any
 from urllib.parse import unquote_plus
 
 import freezegun
 import pytest
-from airbyte_cdk.models import AirbyteMessage
+from airbyte_cdk.models import AirbyteMessage, SyncMode
 from config import BB_URL, PROXY_URL, BitbucketCloudConfigBuilder
 
 from connector_tests import (
@@ -35,6 +36,10 @@ from connector_tests import (
 _CONNECTOR = "git/bitbucket-cloud"
 _REPOS_URL = f"{BB_URL}/repositories/acme"
 _FROZEN = "2026-07-01T00:00:00Z"
+
+
+def _instant(stamp: str) -> datetime:
+    return datetime.fromisoformat(stamp.replace("Z", "+00:00"))
 
 
 def _no_literal_none(records: Iterable[AirbyteMessage]) -> None:
@@ -741,8 +746,10 @@ def test_pr_detail_state_advances_so_a_later_sync_resumes(http_mocker: HttpMocke
     assert stored.startswith("2026-06-20T10:00:00"), (
         f"the stamped parent date is what the cursor stores: {state}"
     )
-    # The parent's own state is what a later sync resumes from.
-    assert state["parent_state"]["pull_requests_for_diffstat"]["state"]["updated_on"] == updated
+    # The parent's own state is what a later sync resumes from. The CDK writes
+    # it in its own datetime format, so the instant is what must match.
+    resumed = state["parent_state"]["pull_requests_for_diffstat"]["state"]["updated_on"]
+    assert _instant(resumed) == _instant(updated), f"parent state must carry the listed PR's date: {state}"
 
 
 @freezegun.freeze_time(_FROZEN)
@@ -889,3 +896,67 @@ def test_an_excluded_repository_is_never_asked_of_the_proxy(
     assert walked, "the kept repository was never walked"
     assert all("acme/app.git" in u for u in walked), walked
     assert not any("rospecs" in u for u in walked), walked
+
+
+def _commit_row(sha: str, committed: str) -> dict[str, Any]:
+    return {
+        "sha": sha,
+        "message": "feat: x",
+        "authored_date": committed,
+        "committed_date": committed,
+        "author_name": "Dev",
+        "author_email": "dev@example.com",
+        "committer_name": "Dev",
+        "committer_email": "dev@example.com",
+        "parent_hashes": [],
+        "is_merge": False,
+        "additions": 1,
+        "deletions": 0,
+        "changed_files": 1,
+        "is_in_default_branch": True,
+        "patch_id": None,
+    }
+
+
+def _commits_page(*rows: dict[str, Any], next_page_token: str | None) -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps({"items": list(rows), "next_page_token": next_page_token}), status_code=200
+    )
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_superseded_snapshot_restarts_the_walk_from_the_last_commit_seen(
+    http_mocker: HttpMocker,
+) -> None:
+    """Mid-walk the proxy answers 409: the snapshot the page token points into
+    is gone. The partition must not die on it — the walk restarts from the
+    first page, narrowed to the last committed_date already seen, so nothing
+    before it is fetched twice and nothing after it is lost."""
+    config = BitbucketCloudConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_repo_with_clone()]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/commits", query_params=ANY_QUERY_PARAMS),
+        [
+            _commits_page(
+                _commit_row("a" * 40, "2026-06-10T10:00:00+0000"),
+                _commit_row("b" * 40, "2026-06-11T10:00:00+0000"),
+                next_page_token="gen1-page2",
+            ),
+            HttpResponse(body=json.dumps({"error": "snapshot changed"}), status_code=409),
+            _commits_page(_commit_row("c" * 40, "2026-06-12T10:00:00+0000"), next_page_token=None),
+        ],
+    )
+
+    output = read_stream(_CONNECTOR, "commits", config, sync_mode=SyncMode.incremental)
+
+    assert not output.errors
+    assert [r.record.data["sha"] for r in output.records] == ["a" * 40, "b" * 40, "c" * 40]
+    calls = [unquote_plus(r.url) for r in http_mocker._mocker.request_history if "/v1/commits" in r.url]
+    assert len(calls) == 3, calls
+    assert "page_token=gen1-page2" in calls[1], calls[1]
+    assert "page_token" not in calls[2], f"the restart must begin from the first page: {calls[2]}"
+    assert "since=2026-06-11T10:00:00" in calls[2], f"narrowed to the last committed_date seen: {calls[2]}"
+    assert_records_conform(output.records, _CONNECTOR, "commits", strict=True)

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -234,13 +234,15 @@ definitions:
         error_message: >-
           Skipping this repository: gone or refused at origin (404), or
           larger than cache.maxRepoBytes (413). Other repositories continue.
-      # The pinned snapshot was superseded mid-walk. RETRY would replay the
-      # same dead page token and 409 again; rerunning the sync resumes each
-      # partition from its own stored cursor against a fresh snapshot.
+      # The pinned snapshot was superseded mid-walk: a refresh or an eviction
+      # bumped the generation, so the page token is dead. RETRY would replay
+      # it and 409 again; RESET_PAGINATION restarts the partition's walk from
+      # its first page, and the retriever's `pagination_reset` narrows that
+      # restart to the last cursor value already seen.
       - type: HttpResponseFilter
         http_codes: [409]
-        action: FAIL
-        error_message: Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+        action: RESET_PAGINATION
+        error_message: Proxy snapshot changed mid-walk; restarting the walk from the last record already seen
       - type: HttpResponseFilter
         http_codes: [500, 502, 503, 504]
         action: RETRY
@@ -591,6 +593,9 @@ streams:
           type: RequestOption
           field_name: page_token
           inject_into: request_parameter
+      pagination_reset:
+        type: PaginationReset
+        action: SPLIT_USING_CURSOR
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -703,6 +708,9 @@ streams:
           type: RequestOption
           field_name: page_token
           inject_into: request_parameter
+      pagination_reset:
+        type: PaginationReset
+        action: SPLIT_USING_CURSOR
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -796,6 +804,9 @@ streams:
           type: RequestOption
           field_name: page_token
           inject_into: request_parameter
+      pagination_reset:
+        type: PaginationReset
+        action: RESET
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -923,6 +934,9 @@ streams:
                     type: RequestOption
                     field_name: page_token
                     inject_into: request_parameter
+                pagination_reset:
+                  type: PaginationReset
+                  action: RESET
                 partition_router:
                   type: SubstreamPartitionRouter
                   parent_stream_configs:
@@ -1101,12 +1115,11 @@ streams:
       datetime_format: "%Y-%m-%dT%H:%M:%SZ"
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
-      # VERIFIED against the CDK: the data-feed stop halts pagination at the
-      # first record older than the slice start, but the boundary PAGE's tail
-      # still emits — up to one page of pre-start_date rows per partition
-      # lands in bronze. Do NOT "fix" this with a record_filter: the stop
-      # condition evaluates POST-filter records, so filtering the old tail
-      # away would keep pagination walking through all history instead.
+      # The data-feed stop halts pagination at the first record older than
+      # the slice start, and the cursor's own window check drops the boundary
+      # page's older tail. Do NOT add a record_filter for that tail: the stop
+      # condition evaluates POST-filter records, so filtering would keep
+      # pagination walking through all history instead.
       is_data_feed: true
       lookback_window: P1D
       start_datetime:
@@ -1342,12 +1355,11 @@ streams:
                 # sets `incremental_dependency`, which is what makes the bound
                 # affordable: this walk is paid once, and later syncs resume
                 # from the stored state rather than re-reading the window.
-                # VERIFIED against the CDK: the data-feed stop halts pagination at the
-                # first record older than the slice start, but the boundary PAGE's tail
-                # still emits — up to one page of pre-start_date rows per partition
-                # lands in bronze. Do NOT "fix" this with a record_filter: the stop
-                # condition evaluates POST-filter records, so filtering the old tail
-                # away would keep pagination walking through all history instead.
+                # The data-feed stop halts pagination at the first record older than
+                # the slice start, and the cursor's own window check drops the boundary
+                # page's older tail. Do NOT add a record_filter for that tail: the stop
+                # condition evaluates POST-filter records, so filtering would keep
+                # pagination walking through all history instead.
                 is_data_feed: true
                 start_datetime:
                   type: MinMaxDatetime
@@ -1701,12 +1713,11 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ config['github_start_date'] }}"
         datetime_format: "%Y-%m-%d"
-      # VERIFIED against the CDK: the data-feed stop halts pagination at the
-      # first record older than the slice start, but the boundary PAGE's tail
-      # still emits — up to one page of pre-start_date rows per partition
-      # lands in bronze. Do NOT "fix" this with a record_filter: the stop
-      # condition evaluates POST-filter records, so filtering the old tail
-      # away would keep pagination walking through all history instead.
+      # The data-feed stop halts pagination at the first record older than
+      # the slice start, and the cursor's own window check drops the boundary
+      # page's older tail. Do NOT add a record_filter for that tail: the stop
+      # condition evaluates POST-filter records, so filtering would keep
+      # pagination walking through all history instead.
       is_data_feed: true
     transformations:
       - type: AddFields
@@ -2863,12 +2874,11 @@ streams:
         - "%Y-%m-%dT%H:%M:%S%z"
       # created_at is immutable: no lookback; the data-feed stop is what
       # bounds newest-first pagination at the stored state.
-      # VERIFIED against the CDK: the data-feed stop halts pagination at the
-      # first record older than the slice start, but the boundary PAGE's tail
-      # still emits — up to one page of pre-start_date rows per partition
-      # lands in bronze. Do NOT "fix" this with a record_filter: the stop
-      # condition evaluates POST-filter records, so filtering the old tail
-      # away would keep pagination walking through all history instead.
+      # The data-feed stop halts pagination at the first record older than
+      # the slice start, and the cursor's own window check drops the boundary
+      # page's older tail. Do NOT add a record_filter for that tail: the stop
+      # condition evaluates POST-filter records, so filtering would keep
+      # pagination walking through all history instead.
       is_data_feed: true
       start_datetime:
         type: MinMaxDatetime
@@ -3045,12 +3055,11 @@ streams:
                 # period the deployment does. The child carries a cursor and
                 # sets `incremental_dependency`, so this walk is paid once and
                 # later syncs resume from the stored state.
-                # VERIFIED against the CDK: the data-feed stop halts pagination at the
-                # first record older than the slice start, but the boundary PAGE's tail
-                # still emits — up to one page of pre-start_date rows per partition
-                # lands in bronze. Do NOT "fix" this with a record_filter: the stop
-                # condition evaluates POST-filter records, so filtering the old tail
-                # away would keep pagination walking through all history instead.
+                # The data-feed stop halts pagination at the first record older than
+                # the slice start, and the cursor's own window check drops the boundary
+                # page's older tail. Do NOT add a record_filter for that tail: the stop
+                # condition evaluates POST-filter records, so filtering would keep
+                # pagination walking through all history instead.
                 is_data_feed: true
                 start_datetime:
                   type: MinMaxDatetime

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -14,7 +14,7 @@ name: github
 #   staging never re-reads Bronze, so the column heals to NULL on existing
 #   rows, and a NULL identity never folds. Only the one-shot scoped
 #   `dbt --full-refresh` a major bump dispatches re-materializes the history.
-version: "6.0.1"
+version: "6.0.2"
 schedule: "0 */4 * * *"
 workflow: sync
 

--- a/src/ingestion/connectors/git/github/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github/tests/test_github_streams.py
@@ -240,12 +240,13 @@ def test_pull_requests_trim_body_and_hoist_author(http_mocker: HttpMocker) -> No
 
 
 @freezegun.freeze_time(_FROZEN)
-def test_data_feed_stops_at_start_date_but_boundary_page_tail_emits(http_mocker: HttpMocker) -> None:
+def test_data_feed_stops_at_start_date_and_drops_the_boundary_page_tail(http_mocker: HttpMocker) -> None:
     """First-sync data-feed behavior, pinned: pagination stops at the first
     record older than start_date (the Link-next page is never mocked, so a
-    fetch would fail the test) — but the boundary page's old tail still
-    emits. A record_filter must never be added to "fix" the tail: the stop
-    condition sees post-filter records, so it would unbound pagination."""
+    fetch would fail the test), and the boundary page's older tail is
+    dropped by the cursor's own window check. No record_filter is needed
+    for that, and none must be added: the stop condition sees post-filter
+    records, so a filter would unbound pagination."""
     config = GithubConfigBuilder().build()
     http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
 
@@ -278,8 +279,7 @@ def test_data_feed_stops_at_start_date_but_boundary_page_tail_emits(http_mocker:
 
     assert not output.errors, "page 2 must never be fetched"
     nums = [r.record.data["number"] for r in output.records]
-    assert 31 in nums
-    assert 30 in nums, "boundary-page tail is expected to emit (accepted, documented)"
+    assert nums == [31], f"the in-window record emits, the older tail does not: {nums}"
 
 
 @freezegun.freeze_time(_FROZEN)
@@ -1360,3 +1360,46 @@ def test_issue_types_catalogue_gives_the_type_a_stable_key(http_mocker: HttpMock
     assert by_id["IT_bug"]["unique_key"].endswith(":acme:issue_type:IT_bug")
     _no_literal_none(output.records)
     assert_records_conform(output.records, _CONNECTOR, "issue_types", strict=True)
+
+
+_PROXY_RESET_ACTIONS = {
+    "/v1/commits": "SPLIT_USING_CURSOR",
+    "/v1/file-changes": "SPLIT_USING_CURSOR",
+    "/v1/branches": "RESET",
+    "/v1/authors": "RESET",
+}
+
+
+def _proxy_retrievers(node, out=None):
+    """Every SimpleRetriever whose requester targets the git proxy."""
+    if out is None:
+        out = []
+    if isinstance(node, dict):
+        requester = node.get("requester", {})
+        if node.get("type") == "SimpleRetriever" and "git_proxy_url" in str(requester.get("url_base", "")):
+            out.append(node)
+        for value in node.values():
+            _proxy_retrievers(value, out)
+    elif isinstance(node, list):
+        for item in node:
+            _proxy_retrievers(item, out)
+    return out
+
+
+def test_a_superseded_proxy_snapshot_restarts_the_walk_instead_of_failing_it() -> None:
+    """A 409 means the page token points into a snapshot the proxy no longer
+    holds. Failing the partition freezes its cursor until the next run; a
+    pagination reset restarts the walk, and a walk the proxy orders by the
+    cursor restarts from the last value already seen. Commits and file
+    changes come out ordered by committed_date; branches and authors carry
+    no such order, so their restart is from the first page."""
+    manifest = load_manifest(_CONNECTOR)
+    retrievers = _proxy_retrievers(manifest["streams"])
+    assert {r["requester"]["path"] for r in retrievers} == set(_PROXY_RESET_ACTIONS)
+    for retriever in retrievers:
+        path = retriever["requester"]["path"]
+        filters = retriever["requester"]["error_handler"]["response_filters"]
+        on_409 = [f["action"] for f in filters if 409 in f.get("http_codes", [])]
+        assert on_409 == ["RESET_PAGINATION"], f"{path}: a 409 must reset pagination, got {on_409}"
+        reset = retriever.get("pagination_reset")
+        assert reset == {"type": "PaginationReset", "action": _PROXY_RESET_ACTIONS[path]}, f"{path}: {reset}"

--- a/src/ingestion/tests/connectors/README.md
+++ b/src/ingestion/tests/connectors/README.md
@@ -81,8 +81,8 @@ written to the GitHub job summary on CI).
   `load_fixture(__file__, "name.json", **overrides)` and override only the
   fields the case exercises. Shapes come from real API payloads, values are
   synthetic — never commit real customer data, tokens, or hostnames.
-- The `airbyte-cdk` pin must match the `version:` header of the nocode
-  manifests (currently the 6.60.x line); bump them in lockstep.
+- The `airbyte-cdk` pin tracks the `airbyte/source-declarative-manifest` image
+  line the deployed nocode connectors run on; bump it with the runtime.
 - CDK interpolation literal-evals rendered Jinja values: a numeric-string id in
   `{{ record['id'] }}` becomes an `int` in the emitted record (and in the
   generated schema — cf. `jira_projects.project_id: number`).

--- a/src/ingestion/tests/connectors/pyproject.toml
+++ b/src/ingestion/tests/connectors/pyproject.toml
@@ -7,18 +7,19 @@ name = "insight-connector-tests"
 version = "0.1.0"
 description = "Mock-server test harness for Insight nocode (declarative-YAML) connectors"
 readme = "README.md"
-# airbyte-cdk 6.60.x supports 3.10-3.12; CI runs 3.12.
+# CI runs 3.12.
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    # Pinned to the line matching the `version:` header of the nocode connector
-    # manifests (currently 6.60.9). Bump in lockstep with manifest version bumps.
-    "airbyte-cdk>=6.60.9,<7",
+    # The line of the `airbyte/source-declarative-manifest` image the deployed
+    # nocode connectors run on; the mock suites must validate and behave as
+    # that runtime does. Bump in lockstep with the runtime, not the manifests.
+    "airbyte-cdk>=7.27.0,<8",
     "pytest>=8.0",
     "freezegun>=1.5",
     # HttpMocker's transport backend — an optional extra of the CDK, required here.
     "requests-mock>=1.11",
-    # airbyte-cdk 6.60.x itself pins jsonschema >=4.17.3,<4.27 — stay inside it.
-    "jsonschema>=4.17.3,<4.27",
+    # Inside the CDK's own jsonschema range.
+    "jsonschema>=4.17.3,<5.0",
     "pyyaml>=6.0",
 ]
 
@@ -31,15 +32,9 @@ dev = [
 # Do not resolve a version published in the last week: a freshly pushed release is
 # where a compromised maintainer account shows up first.
 exclude-newer = "7 days"
-# airbyte-cdk 6.60.x pins nltk and langchain-core to exact versions carrying fixed
-# CRITICALs (CVE-2025-14009, CVE-2025-68664). Neither is reachable from the mock
-# harness: nltk serves the file-based unstructured parser and langchain-core the
-# vector-db sink, and no nocode manifest uses either.
 override-dependencies = [
-    "nltk>=3.9.3",
-    "langchain-core>=0.3.81",
-    # airbyte-cdk 6.60.x resolves cryptography 44.0.3, which carries a Bleichenbacher
-    # timing oracle in PKCS#1 v1.5 decryption (CVE-2026-26007) and GHSA-537c-gmf6-5ccf.
+    # airbyte-cdk's cryptography floor (44.0.0) admits a Bleichenbacher timing
+    # oracle in PKCS#1 v1.5 decryption (CVE-2026-26007) and GHSA-537c-gmf6-5ccf.
     # The harness never handles a key or a TLS handshake of its own -- requests-mock
     # intercepts every call before the transport -- but the CDK's connector-builder
     # secret handling imports it, so the version still ships.


### PR DESCRIPTION
Backport of #3258 to release-2026.08; #3249 already carries the first commit of that branch.

**Why.** A repository whose purge cannot finish inside the heavy budget loops through 429s, and since #3249 is evicted mid-walk instead, so the connector's continuation answers 409 and the partition fails. Repack cost follows the skeleton (commits and trees), not the served blob weight, so a large repository never gets under its cap.

**What changed.** A purge now sheds served windows by deleting the packs those fetches produced and never repacks the skeleton; the entry records its skeleton packs after every fetch so the shed knows what to keep. The github and bitbucket-cloud manifests answer a superseded snapshot with `RESET_PAGINATION` and `PaginationReset: SPLIT_USING_CURSOR`, restarting the partition from the last cursor seen instead of failing it.

**The mock harness now tracks the deployed runtime line (CDK 7), and zoom's manifest moves to `7.0.4` with it.** `PaginationReset` is a 7.x manifest feature. Zoom's tests pin two CDK 7 behaviours of the inline parent; a saved 6.x-shaped state still resumes correctly under 7.

**The github test file took only the proxy-reset hunk.** The rest of that file on main covers streams this branch does not carry.

**Verified.** `cargo test -p git-cli-proxy`, `cargo fmt --check`, clippy pedantic clean on this branch; github, bitbucket-cloud and zoom mock suites plus harness meta tests green under airbyte-cdk 7.28.3. The other release suites were not rerun here.
