### PR TITLE
fix(observability): absence alert watches target_info, not the RED counter

### DIFF
--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -11860,8 +11860,8 @@ alerting:
         annotations:
           summary: "{{ \"{{ $labels.job }}\" }} is serving over 2% 5xx (and at least 5 in 15m) \u2014\
             \ Insight \xB7 RED by service"
-      - uid: insight-red-telemetry-absent
-        title: RED telemetry missing for a known service
+      - uid: insight-otlp-telemetry-absent
+        title: Telemetry missing for a known service
         condition: C
         data:
         - refId: A
@@ -11871,8 +11871,8 @@ alerting:
           datasourceUid: vm
           model:
             refId: A
-            expr: absent(http_server_request_duration_seconds_count{job="insight-analytics"}) or absent(http_server_request_duration_seconds_count{job="insight-authenticator"})
-              or absent(http_server_request_duration_seconds_count{job="insight-identity-resolution"})
+            expr: absent(target_info{job="insight-analytics"}) or absent(target_info{job="insight-authenticator"})
+              or absent(target_info{job="insight-identity-resolution"})
             instant: true
             range: false
         - refId: B
@@ -11905,8 +11905,7 @@ alerting:
         labels:
           severity: critical
         annotations:
-          summary: '{{ "{{ $labels.job }}" }} stopped exporting RED telemetry (or the OTLP pipeline is
-            down)'
+          summary: '{{ "{{ $labels.job }}" }} stopped exporting telemetry (service or OTLP pipeline down)'
       - uid: insight-gateway-exporter-absent
         title: Gateway nginx exporter not reporting
         condition: C


### PR DESCRIPTION
Part of #2895.

**Why.** The telemetry-absence alert fired for an idle service after a deploy: a fresh pod emits no RED series until its first request (and probe routes are deliberately dropped from RED), so "restarted and untouched" was indistinguishable from "pipeline dead".

**What changed.** The rule watches `target_info`, which the OTLP→prometheus path exports per resource regardless of traffic; renamed `insight-otlp-telemetry-absent` since it now covers all telemetry, not RED specifically. Per-service `absent()` clauses keep the `job` label in the notification.

**Verified.** `target_info` present per job on a live stand (two instances each); helm template with the pinned chart renders clean. Mirror pair in the operator gitops repo (cross-linked).