### PR TITLE
test(e2e): pin that the default branch is resolved per repository, and from the flag

### DIFF
--- a/src/ingestion/tests/e2e/metrics/git_default_branch_prs_created.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_default_branch_prs_created.test.yaml
@@ -1,0 +1,231 @@
+spec_version: 1
+description: >
+  Metric: git.default_branch_prs_created — requests opened against the
+  repository's own default branch, #3050.
+
+  How it's computed (bronze → silver → gold):
+    • bronze: each request's destination branch, and the branch list the
+      connector reports per repository
+    • silver: one class row per request and per branch
+    • gold:   the destination is compared against THAT repository's declared
+      default branch, and the scope picks one of the pair — so default plus
+      other always equals the total, by construction rather than by
+      reconciliation
+
+  Only two specs assert this comparison: `git_branch_scope` across all four
+  views of both created metrics, and `git_prs_merged` as the branch-scope split
+  on merges. Both use ONE repository whose default is `main` and give every
+  request a destination — so a comparison hardcoded to `main`, one that let an
+  empty destination match an unknown default, or one that stopped selecting
+  branches on the default flag at all, passes both.
+
+  The comparison also uses the repository's CURRENT declared default, so
+  renaming a default branch reclassifies requests opened before the rename —
+  which this metric's own explanation ("does not move afterwards") denies. The
+  rig seeds one branch state per run and rebuilds once, so no fixture can
+  express a rename: recorded here, not asserted.
+
+  Cases: the comparison across three repositories that disagree about what
+  their default branch is, for requests opened and for requests merged; the
+  destination split, which is where a hardcoded branch name shows; the
+  repository split, where a repository that reported no branches contributes
+  to one scope and not the other; and an empty window.
+
+  The rig resolves `view: breakdown` to exactly one view per metric, so each
+  split needs its own case.
+
+  Fixture — erin only, six requests over three repositories:
+    * acme/mainline, default `main`
+        91 → main         counts
+        92 → release/1.x  does not
+    * acme/legacy, default `master`
+        93 → master       counts — its default is not `main`
+        94 → main         does NOT count: `main` is nothing special here, and
+                          a comparison hardcoded to it would count this one
+    * acme/nodefault, NO branch list reported
+        95 → trunk        does not count: the default is unknown
+        96 → (empty)      does not count either. This is the sharper one —
+                          with an unknown default, dropping the guard on an
+                          empty destination compares one blank against
+                          another and promotes it. GitHub cannot itself emit
+                          an empty destination; bitbucket and gitlab can, and
+                          all three normalise a missing one to blank
+
+  So the metric reads 2 for requests opened and 1 for requests merged, and the
+  other scope 4 and 1. Three wrong readings, each caught by a different rule:
+  hardcoding `main` leaves both totals unchanged and is caught by the
+  destination split, where `main` reads twice and `master` matches no row;
+  dropping the empty-destination guard reads 3; and selecting branches without
+  the default flag answers `dev` for acme/mainline and reads 1.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_github.branches:
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: dbpc-br-mainline, repository: "https://github.com/acme/mainline.git", name: main, is_default: true}
+    # INVARIANT: `dev` sorts BEFORE `main`. The default is resolved as a min()
+    # over the rows flagged default, so a filter that stopped selecting on the
+    # flag would answer `dev` here and drop request 91 out of this scope.
+    # Renaming this branch to anything after `main` disarms that guard.
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: dbpc-br-mainline-dev, repository: "https://github.com/acme/mainline.git", name: dev, is_default: false}
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: dbpc-br-legacy, repository: "https://github.com/acme/legacy.git", name: master, is_default: true}
+    # acme/nodefault reports no branches at all, so its default is unknown.
+
+  bronze_github.pull_requests:
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-91, repo_full_name: acme/mainline, number: 91, author_login: erin, base_ref: main, created_at: "2026-10-01T09:00:00Z", state: open, closed_at: "", merged_at: "", merge_commit_sha: ""}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-92, repo_full_name: acme/mainline, number: 92, author_login: erin, base_ref: release/1.x, created_at: "2026-10-01T09:10:00Z", state: open, closed_at: "", merged_at: "", merge_commit_sha: ""}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-93, repo_full_name: acme/legacy, number: 93, author_login: erin, base_ref: master, created_at: "2026-10-01T09:20:00Z", state: closed, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: dbpc-m93}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-94, repo_full_name: acme/legacy, number: 94, author_login: erin, base_ref: main, created_at: "2026-10-01T09:30:00Z", state: closed, closed_at: "2026-10-01T12:10:00Z", merged_at: "2026-10-01T12:10:00Z", merge_commit_sha: dbpc-m94}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-95, repo_full_name: acme/nodefault, number: 95, author_login: erin, base_ref: trunk, created_at: "2026-10-01T09:40:00Z", state: open, closed_at: "", merged_at: "", merge_commit_sha: ""}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-96, repo_full_name: acme/nodefault, number: 96, author_login: erin, base_ref: "", created_at: "2026-10-01T09:50:00Z", state: open, closed_at: "", merged_at: "", merge_commit_sha: ""}
+
+  bronze_github.pull_request_diff_stats:
+    # A request reaches a person only through this row: bronze pull_requests
+    # carries the author's login and no address.
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-91, repo_full_name: acme/mainline, pull_number: 91, author_email: erin@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-92, repo_full_name: acme/mainline, pull_number: 92, author_email: erin@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-93, repo_full_name: acme/legacy, pull_number: 93, author_email: erin@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-94, repo_full_name: acme/legacy, pull_number: 94, author_email: erin@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-95, repo_full_name: acme/nodefault, pull_number: 95, author_email: erin@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-96, repo_full_name: acme/nodefault, pull_number: 96, author_email: erin@example.com}
+
+cases:
+  - name: A destination counts only against its own repository's default branch
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.default_branch_prs_created
+            views:
+              - {view: period}
+          - metric_key: git.non_default_branch_prs_created
+            views:
+              - {view: period}
+          - metric_key: git.prs_created
+            views:
+              - {view: period}
+          - metric_key: git.default_branch_prs_merged
+            views:
+              - {view: period}
+          - metric_key: git.non_default_branch_prs_merged
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      # 91 into main and 93 into master. Letting an empty destination match an
+      # unknown default reads 3.
+      - metric: git.default_branch_prs_created
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 2}
+      # 92, 94, 95 and 96 — a release branch, a branch that is default
+      # somewhere else, an unknown default, and no destination at all.
+      - metric: git.non_default_branch_prs_created
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 4}
+      # The pair partitions the total rather than merely bounding it.
+      - metric: git.prs_created
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 6}
+      # 93 and 94 also merged, so the merged pair reads the same comparison
+      # against a default branch that is not `main` — dated by the merge
+      # rather than by the opening.
+      - metric: git.default_branch_prs_merged
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 1}
+      - metric: git.non_default_branch_prs_merged
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 1}
+
+  - name: Two repositories can disagree about which branch name is the default one
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.default_branch_prs_created
+            views:
+              - {view: breakdown, dimensions: [destination_branch]}
+    expect:
+      - assert: "status == 200"
+      # One each. A comparison hardcoded to `main` keeps the total at 2 but
+      # reads `main` twice and `master` not at all, which is what these two
+      # rules catch and the total cannot.
+      - metric: git.default_branch_prs_created
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: destination_branch, value: main}}
+        equal: {value: 1}
+      - metric: git.default_branch_prs_created
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: destination_branch, value: master}}
+        equal: {value: 1}
+      - metric: git.default_branch_prs_created
+        view: breakdown
+        assert: "size(items) == 2"
+
+  - name: A repository that reported no branches contributes nothing to this scope
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.default_branch_prs_created
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.non_default_branch_prs_created
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      - metric: git.default_branch_prs_created
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:acme/mainline"}}
+        equal: {value: 1}
+      - metric: git.default_branch_prs_created
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:acme/legacy"}}
+        equal: {value: 1}
+      - metric: git.default_branch_prs_created
+        view: breakdown
+        assert: "size(items) == 2"
+      # acme/nodefault opened two requests and neither can be measured against
+      # a default branch it never reported. Both halves are needed: without
+      # the positive rule, the absence below is satisfied by a repository that
+      # never reached the breakdown at all.
+      - metric: git.non_default_branch_prs_created
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:acme/nodefault"}}
+        equal: {value: 2}
+      - metric: git.default_branch_prs_created
+        view: breakdown
+        assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'repository' && d.value == 'git-test:acme/nodefault'))"
+
+  - name: An empty window is null, not zero
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-12-01", to: "2026-12-31"}
+        metrics:
+          - metric_key: git.default_branch_prs_created
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      - metric: git.default_branch_prs_created
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: null}


### PR DESCRIPTION
Part of #3039, and the coverage half of #3050. Follows #3185, #3186, #3253, #3254 and #3256.

**Why.** Only two specs assert this comparison — `git_branch_scope` across four views, `git_prs_merged` as the branch-scope split on merges — and both use one repository whose default is `main` with every request carrying a destination. Three wrong readings pass both: a comparison hardcoded to `main`, one letting an empty destination match an unknown default, and one that stops selecting branches on the default flag at all.

**The third is the one worth reading.** Removing `WHERE is_default = 1` from `repository_default_branches` — the line that makes that CTE mean *default* branch — leaves every test in the branch-scope family green today, because with the filter gone the CTE degrades to a `min()` over all branches and every existing fixture's alphabetically-first branch happens to be its default. With this fixture in place that mutation fails, and only this fixture fails on it.

**What changed.** Three repositories that disagree about their default — `main`, `master`, and none reported at all — with six requests, two of which also merge so the merged pair rides the same fixture rather than a near-duplicate one. Each wrong reading is caught by a different rule: the destination split catches the hardcoded name (`main` reads twice, `master` matches no row); the period total catches the empty-destination guard; and a non-default branch sorting *before* `main` catches the missing flag filter.

**The repository case needed both halves.** Its negative assertion — that the branchless repository contributes nothing to this scope — passes for the wrong reason on its own: strip that repository's author rows and it never reaches the breakdown at all. A positive rule on the opposite scope now holds those two requests alive.

**Recorded, not asserted.** The comparison uses the repository's *current* declared default, so renaming one reclassifies requests opened before the rename — which the metric's own explanation ("does not move afterwards") denies. The rig seeds one branch state per run, so no fixture can express a rename; the description says so where the next reader will find it.

**Verified.** `./e2e.sh test -k git_` — 28 passed. Three model mutations, each restored byte-identically: the hardcoded branch name, the dropped empty-destination guard, and the dropped default-flag filter.

**Out of scope.** `repository_default_branches` resolves a repository claiming two default branches by `min(branch_name)`, i.e. alphabetically rather than by recency. No fixture in the suite has two such rows, and this one does not add the case — worth its own issue.
