### PR TITLE
test(datapath): pin that the default branch is resolved per repository, and from the flag

### DIFF
--- a/tests/datapath/metrics/git/git_default_branch_prs_created.test.yaml
+++ b/tests/datapath/metrics/git/git_default_branch_prs_created.test.yaml
@@ -1,0 +1,92 @@
+spec_version: 1
+description: >
+  Metric: git.default_branch_prs_created — requests opened against the
+  repository's own default branch, #3050.
+
+  How it's computed (bronze → silver → gold):
+    • bronze: each request's destination branch, and the branch list the
+      connector reports per repository
+    • silver: one class row per request and per branch
+    • gold:   the destination is compared against THAT repository's declared
+      default branch, and the scope picks one of the pair — so default plus
+      other always equals the total, by construction rather than by
+      reconciliation
+
+  Only two specs assert this comparison: `git_branch_scope` across all four
+  views of both created metrics, and `git_prs_merged` as the branch-scope split
+  on merges. Both use ONE repository whose default is `main` and give every
+  request a destination — so a comparison hardcoded to `main`, one that let an
+  empty destination match an unknown default, or one that stopped selecting
+  branches on the default flag at all, passes both.
+
+  The comparison also uses the repository's CURRENT declared default, so
+  renaming a default branch reclassifies requests opened before the rename —
+  which this metric's own explanation ("does not move afterwards") denies. The
+  rig seeds one branch state per run and rebuilds once, so no fixture can
+  express a rename: recorded here, not asserted.
+
+  Cases: the comparison across three repositories that disagree about what
+  their default branch is, for requests opened and for requests merged; the
+  destination split, which is where a hardcoded branch name shows; the
+  repository split, where a repository that reported no branches contributes
+  to one scope and not the other; and an empty window.
+
+  A request carries at most one breakdown view per metric, so each split is
+  asked for in a call of its own.
+
+  Fixture — erin only, six requests over three repositories:
+    * acme/mainline, default `main`
+        91 → main         counts
+        92 → release/1.x  does not
+    * acme/legacy, default `master`
+        93 → master       counts — its default is not `main`
+        94 → main         does NOT count: `main` is nothing special here, and
+                          a comparison hardcoded to it would count this one
+    * acme/nodefault, NO branch list reported
+        95 → trunk        does not count: the default is unknown
+        96 → (empty)      does not count either. This is the sharper one —
+                          with an unknown default, dropping the guard on an
+                          empty destination compares one blank against
+                          another and promotes it. GitHub cannot itself emit
+                          an empty destination; bitbucket and gitlab can, and
+                          all three normalise a missing one to blank
+
+  So the metric reads 2 for requests opened and 1 for requests merged, and the
+  other scope 4 and 1. Three wrong readings, each caught by a different rule:
+  hardcoding `main` leaves both totals unchanged and is caught by the
+  destination split, where `main` reads twice and `master` matches no row;
+  dropping the empty-destination guard reads 3; and selecting branches without
+  the default flag answers `dev` for acme/mainline and reads 1.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: ../templates/people.yaml#/templates/erin
+
+  bronze_github.branches:
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: dbpc-br-mainline, repository: "https://github.com/acme/mainline.git", name: main, is_default: true}
+    # INVARIANT: `dev` sorts BEFORE `main`. The default is resolved as a min()
+    # over the rows flagged default, so a filter that stopped selecting on the
+    # flag would answer `dev` here and drop request 91 out of this scope.
+    # Renaming this branch to anything after `main` disarms that guard.
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: dbpc-br-mainline-dev, repository: "https://github.com/acme/mainline.git", name: dev, is_default: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: dbpc-br-legacy, repository: "https://github.com/acme/legacy.git", name: master, is_default: true}
+    # acme/nodefault reports no branches at all, so its default is unknown.
+
+  bronze_github.pull_requests:
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-91, repo_full_name: acme/mainline, number: 91, author_login: erin, base_ref: main, created_at: "2026-10-01T09:00:00Z", state: open, closed_at: "", merged_at: "", merge_commit_sha: ""}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-92, repo_full_name: acme/mainline, number: 92, author_login: erin, base_ref: release/1.x, created_at: "2026-10-01T09:10:00Z", state: open, closed_at: "", merged_at: "", merge_commit_sha: ""}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-93, repo_full_name: acme/legacy, number: 93, author_login: erin, base_ref: master, created_at: "2026-10-01T09:20:00Z", state: closed, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: dbpc-m93}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-94, repo_full_name: acme/legacy, number: 94, author_login: erin, base_ref: main, created_at: "2026-10-01T09:30:00Z", state: closed, closed_at: "2026-10-01T12:10:00Z", merged_at: "2026-10-01T12:10:00Z", merge_commit_sha: dbpc-m94}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-95, repo_full_name: acme/nodefault, number: 95, author_login: erin, base_ref: trunk, created_at: "2026-10-01T09:40:00Z", state: open, closed_at: "", merged_at: "", merge_commit_sha: ""}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: dbpc-pr-96, repo_full_name: acme/nodefault, number: 96, author_login: erin, base_ref: "", created_at: "2026-10-01T09:50:00Z", state: open, closed_at: "", merged_at: "", merge_commit_sha: ""}
+
+  bronze_github.pull_request_diff_stats:
+    # A request reaches a person only through this row: bronze pull_requests
+    # carries the author's login and no address.
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-91, repo_full_name: acme/mainline, pull_number: 91, author_email: erin@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-92, repo_full_name: acme/mainline, pull_number: 92, author_email: erin@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-93, repo_full_name: acme/legacy, pull_number: 93, author_email: erin@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-94, repo_full_name: acme/legacy, pull_number: 94, author_email: erin@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-95, repo_full_name: acme/nodefault, pull_number: 95, author_email: erin@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: dbpc-ds-96, repo_full_name: acme/nodefault, pull_number: 96, author_email: erin@example.com}
+

--- a/tests/datapath/metrics/git/test_git_default_branch_prs_created.py
+++ b/tests/datapath/metrics/git/test_git_default_branch_prs_created.py
@@ -1,0 +1,162 @@
+"""Requests opened against the repository's own default branch.
+
+The destination is compared against THAT repository's declared default, and the scope
+picks one of the pair, so default plus other always equals the total. Three wrong
+readings pass the two specs that already assert this comparison, because both use one
+repository whose default is `main` with every request carrying a destination: a
+comparison hardcoded to `main`, one letting an empty destination match an unknown
+default, and one that stops selecting branches on the default flag at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_datapath.spec_runner import SpecRun
+
+pytestmark = pytest.mark.fixture
+
+SPEC = "git_default_branch_prs_created"
+
+ERIN = "erin@example.com"
+WINDOW = {"from": "2026-10-01", "to": "2026-10-02"}
+
+
+def test_a_destination_counts_only_against_its_own_repositorys_default(spec: SpecRun) -> None:
+    """91 into `main` and 93 into `master` count; the other four do not.
+
+    Letting an empty destination match an unknown default reads 3. The merged pair
+    rides the same requests, dated by the merge rather than by the opening.
+    """
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [ERIN]},
+                "period": WINDOW,
+                "metrics": [
+                    {"metric_key": "git.default_branch_prs_created", "views": [{"view": "period"}]},
+                    {
+                        "metric_key": "git.non_default_branch_prs_created",
+                        "views": [{"view": "period"}],
+                    },
+                    {"metric_key": "git.prs_created", "views": [{"view": "period"}]},
+                    {"metric_key": "git.default_branch_prs_merged", "views": [{"view": "period"}]},
+                    {
+                        "metric_key": "git.non_default_branch_prs_merged",
+                        "views": [{"view": "period"}],
+                    },
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.default_branch_prs_created", "period", entity_id=ERIN).equals(value=2)
+    r.row("git.non_default_branch_prs_created", "period", entity_id=ERIN).equals(value=4)
+    # The pair partitions the total rather than merely bounding it.
+    r.row("git.prs_created", "period", entity_id=ERIN).equals(value=6)
+
+    r.row("git.default_branch_prs_merged", "period", entity_id=ERIN).equals(value=1)
+    r.row("git.non_default_branch_prs_merged", "period", entity_id=ERIN).equals(value=1)
+
+
+def test_two_repositories_can_disagree_about_the_default_branch_name(spec: SpecRun) -> None:
+    """One each. A comparison hardcoded to `main` keeps the total at 2 but reads `main`
+    twice and `master` not at all, which only this split can see."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [ERIN]},
+                "period": WINDOW,
+                "metrics": [
+                    {
+                        "metric_key": "git.default_branch_prs_created",
+                        "views": [{"view": "breakdown", "dimensions": ["destination_branch"]}],
+                    }
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    for destination in ("main", "master"):
+        r.row(
+            "git.default_branch_prs_created",
+            "breakdown",
+            entity_id=ERIN,
+            dimensions={"key": "destination_branch", "value": destination},
+        ).equals(value=1)
+
+    destinations = r.breakdown("git.default_branch_prs_created")
+    assert len(destinations) == 2, f"a third destination appeared: {destinations!r}"
+
+
+def test_a_repository_that_reported_no_branches_reaches_one_scope_only(spec: SpecRun) -> None:
+    """Both halves are needed: without the positive rule on the other scope, the absence
+    below is satisfied by a repository that never reached the breakdown at all."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [ERIN]},
+                "period": WINDOW,
+                "metrics": [
+                    {
+                        "metric_key": "git.default_branch_prs_created",
+                        "views": [{"view": "breakdown", "dimensions": ["repository"]}],
+                    },
+                    {
+                        "metric_key": "git.non_default_branch_prs_created",
+                        "views": [{"view": "breakdown", "dimensions": ["repository"]}],
+                    },
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    for repository in ("git-test:acme/mainline", "git-test:acme/legacy"):
+        r.row(
+            "git.default_branch_prs_created",
+            "breakdown",
+            entity_id=ERIN,
+            dimensions={"key": "repository", "value": repository},
+        ).equals(value=1)
+
+    r.row(
+        "git.non_default_branch_prs_created",
+        "breakdown",
+        entity_id=ERIN,
+        dimensions={"key": "repository", "value": "git-test:acme/nodefault"},
+    ).equals(value=2)
+
+    landed = r.breakdown("git.default_branch_prs_created")
+    assert len(landed) == 2, f"a third repository appeared: {landed!r}"
+    assert not any(
+        dimension.get("value") == "git-test:acme/nodefault"
+        for entry in landed
+        for dimension in entry.get("dimensions", [])
+    ), f"a repository that reported no branches reached this scope: {landed!r}"
+
+
+def test_an_empty_window_is_null_not_zero(spec: SpecRun) -> None:
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [ERIN]},
+                "period": {"from": "2026-12-01", "to": "2026-12-31"},
+                "metrics": [
+                    {"metric_key": "git.default_branch_prs_created", "views": [{"view": "period"}]}
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.default_branch_prs_created", "period", entity_id=ERIN).equals(value=None)


### PR DESCRIPTION
Part of #3039, and the coverage half of #3050. Replaces #3286, which targeted the pre-migration path. Follows #3185, #3186, #3253, #3254 and #3256.

**Why.** Only two specs assert this comparison — `git_branch_scope` across four views, `git_prs_merged` as the branch-scope split on merges — and both use one repository whose default is `main` with every request carrying a destination. Three wrong readings pass both: a comparison hardcoded to `main`, one letting an empty destination match an unknown default, and one that stops selecting branches on the default flag at all.

**The third is the one worth reading.** Removing `WHERE is_default = 1` from `repository_default_branches` — the line that makes that CTE mean *default* branch — leaves every spec in the branch-scope family green, because with the filter gone the CTE degrades to a `min()` over all branches and every existing fixture's alphabetically-first branch happens to be its default. With this seed in place that mutation fails three of the four tests here.

**What changed.** Three repositories that disagree about their default — `main`, `master`, and none reported at all — with six requests, two of which also merge so the merged pair rides the same seed rather than a near-duplicate one. Each wrong reading is caught by a different assertion: the destination split catches the hardcoded name (`main` reads twice, `master` matches no row); the period total catches the empty-destination guard; and a non-default branch sorting *before* `main` catches the missing flag filter.

**The repository test needs both halves.** Its negative assertion — that the branchless repository contributes nothing to this scope — passes for the wrong reason on its own: strip that repository's author rows and it never reaches the breakdown at all. A positive rule on the opposite scope holds those two requests alive.

**Recorded, not asserted.** The comparison uses the repository's *current* declared default, so renaming one reclassifies requests opened before the rename — which the metric's own explanation ("does not move afterwards") denies. The suite seeds one branch state per module, so no fixture can express a rename; the description says so where the next reader will find it.

**Verified.** `test-stand test --tree=tests/datapath/metrics/git --instance=datapath` — 97 passed. Two model mutations, each restored byte-identically: the dropped default-flag filter and the dropped empty-destination guard, three of four tests red on each. `ruff check` and `ruff format --check` clean.

**Out of scope.** `repository_default_branches` resolves a repository claiming two default branches by `min(branch_name)`, i.e. alphabetically rather than by recency. No fixture in the suite has two such rows, and this one does not add the case — worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for pull requests created against each repository’s declared default branch, including repositories using different default branch names.
  - Added validation for repositories without branch data and empty time windows.
  - Added checks ensuring requests are correctly separated between default and non-default branch metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->