### PR TITLE
test(datapath): pin the merge lost to a merged state with no close time

### DIFF
--- a/tests/datapath/metrics/git/git_active_days.test.yaml
+++ b/tests/datapath/metrics/git/git_active_days.test.yaml
@@ -46,8 +46,8 @@ description: >
   on is a property of the stand — while the fact that they land on the SAME
   date holds under every timezone.
 
-  The rig resolves `view: breakdown` and `view: timeseries` to exactly one
-  view per metric, so each split and each bucket needs its own case.
+  The API rejects a metric that requests the same view twice, so each split
+  and each bucket needs its own case.
 
 bronze:
   bronze_bamboohr.employees:

--- a/tests/datapath/metrics/git/git_code_lines.test.yaml
+++ b/tests/datapath/metrics/git/git_code_lines.test.yaml
@@ -26,8 +26,8 @@ description: >
   reports. So the category split of the unclassified total carries that one
   claim, and it is asserted on `git.lines_added` in the same request.
 
-  The rig resolves `view: breakdown` to exactly one view per metric, so each
-  split needs its own case.
+  The API rejects a metric that requests the same view twice, so each split
+  needs its own case.
 
   Cases: what the classifier admits and what it keeps out, with the category
   split that separates docs from config; the branch-scope, change-type and

--- a/tests/datapath/metrics/git/git_default_branch_code_lines.test.yaml
+++ b/tests/datapath/metrics/git/git_default_branch_code_lines.test.yaml
@@ -26,8 +26,8 @@ description: >
   oracle for which of two carriers of one content survived; the extension
   split; and an empty window.
 
-  The rig resolves `view: breakdown` to exactly one view per metric, so each
-  split needs its own case.
+  The API rejects a metric that requests the same view twice, so each split
+  needs its own case.
 
   Fixture — erin only, in one repository whose default branch is `main`:
     * dbcl-landed, flag says landed

--- a/tests/datapath/metrics/git/git_default_branch_commits.test.yaml
+++ b/tests/datapath/metrics/git/git_default_branch_commits.test.yaml
@@ -23,8 +23,8 @@ description: >
   merged request reports; the repository split that separates them; and an
   empty window.
 
-  The rig resolves `view: breakdown` to exactly one view per metric, so the
-  split needs its own case.
+  The API rejects a metric that requests the same view twice, so the split
+  needs its own case.
 
   Fixture — erin only. Every branch commit's flag says it did not land, every
   squash's flag says it did, and every request merged into `main`.

--- a/tests/datapath/metrics/git/git_default_branch_lines_added.test.yaml
+++ b/tests/datapath/metrics/git/git_default_branch_lines_added.test.yaml
@@ -31,8 +31,8 @@ description: >
   repository split, where both paths must answer with a single row; and an
   empty window.
 
-  The rig resolves `view: breakdown` to exactly one view per metric, so each
-  split needs its own case.
+  The API rejects a metric that requests the same view twice, so each split
+  needs its own case.
 
   Fixture — erin only, one repository, every commit's scope carried by the
   connector's own flag rather than by a branch row or a merged request:

--- a/tests/datapath/metrics/git/git_prs_merged.test.yaml
+++ b/tests/datapath/metrics/git/git_prs_merged.test.yaml
@@ -10,8 +10,11 @@ description: >
     • gold:   a request in the MERGED state with a known close time contributes
       exactly 1, dated by the CLOSE, and is attributed to the request's AUTHOR
 
-  Cases: a merged request counts once on its merge day; an open one and a
-  closed-but-never-merged one never count; the author receives the request even
+  Cases: a merged request counts once on its merge day; an open one, a
+  closed-but-never-merged one and a request whose state says merged while its
+  close time is missing never count — a Bitbucket one whose terminal event
+  never arrived, and a GitLab one reported merged with neither
+  timestamp; the author receives the request even
   when its commits were written by somebody else; the branch-scope split says
   where the request was aimed; GitLab counts only the merged state; Bitbucket
   dates the request by the terminal merge event and drops the declined one; and
@@ -78,12 +81,21 @@ bronze:
     - {$ref: ../templates/gitlab_git.yaml#/templates/merge_request, unique_key: gl-mr-202, iid: 202, id: 90202, state: closed, author_id: 700, author_username: bob-gl, created_at: "2026-09-20T08:00:00Z", closed_at: "2026-10-01T10:00:00Z"}
     # Still open.
     - {$ref: ../templates/gitlab_git.yaml#/templates/merge_request, unique_key: gl-mr-203, iid: 203, id: 90203, state: opened, author_id: 700, author_username: bob-gl, created_at: "2026-09-20T08:00:00Z"}
+    # Reported merged with neither timestamp. GitLab copies the state straight
+    # from the source and derives the close time from those two fields alone,
+    # so the state a Bitbucket request reaches by losing its terminal event is
+    # reachable here too — nothing in the connector forbids this shape.
+    - {$ref: ../templates/gitlab_git.yaml#/templates/merge_request, unique_key: gl-mr-204, iid: 204, id: 90204, author_id: 700, author_username: bob-gl, created_at: "2026-09-20T08:00:00Z", updated_at: "2026-10-02T13:00:00Z", merge_commit_sha: gl-merge-204}
 
   bronze_bitbucket_cloud.pull_requests:
     # `updated_on` deliberately sits on a LATER day than the merge event, so the
     # metric's date can only be right if it came from the activity row.
     - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:301", id: 301, author_display_name: Carol Gamma, author_account_id: carol-acct, created_on: "2026-09-25T08:00:00Z", updated_on: "2026-10-02T13:00:00Z", source_commit_sha: bb-src-301, destination_commit_sha: bb-dst-301, merge_commit_sha: bb-merge-301}
     - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:302", id: 302, state: DECLINED, author_display_name: Carol Gamma, author_account_id: carol-acct, created_on: "2026-09-25T08:00:00Z", updated_on: "2026-10-02T13:00:00Z", source_commit_sha: bb-src-302, destination_commit_sha: bb-dst-302}
+    # Reported MERGED, and no terminal event was ever collected for it, so
+    # nothing says when it closed. Bitbucket takes the close time from the
+    # activity stream alone — see the gap this leaves in the module.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:303", id: 303, author_display_name: Carol Gamma, author_account_id: carol-acct, created_on: "2026-09-25T08:00:00Z", updated_on: "2026-10-02T13:00:00Z", source_commit_sha: bb-src-303, destination_commit_sha: bb-dst-303, merge_commit_sha: bb-merge-303}
 
   bronze_bitbucket_cloud.pull_request_activity:
     # A Bitbucket pull request records no close time of its own; the terminal

--- a/tests/datapath/metrics/git/test_git_code_lines.py
+++ b/tests/datapath/metrics/git/test_git_code_lines.py
@@ -136,7 +136,12 @@ def test_a_rename_is_its_own_change_type_and_carries_only_its_edited_lines(
 def test_an_extension_gathers_every_code_file_sharing_it(spec: SpecRun) -> None:
     """`rs` spans app, moved and wip; `go` is util's alone. `test/single.rs` is an rs file
     the classifier calls test: were that rule to stop firing, rs would read 38. The other
-    extensions appear at all only for a comparable reason, so none may have a row."""
+    extensions appear at all only for a comparable reason, so none may have a row.
+
+    The absence guard is the weaker half: extensions are compared lower-case because gold
+    lower-cases them, so a regression losing BOTH the classifier's case-insensitivity and
+    that lower-casing would slip past it. The total asserted in the first case is what
+    catches that one."""
     r = spec.call(
         {
             "url": "/v1/metric-results",

--- a/tests/datapath/metrics/git/test_git_default_branch_prs_created.py
+++ b/tests/datapath/metrics/git/test_git_default_branch_prs_created.py
@@ -134,6 +134,12 @@ def test_a_repository_that_reported_no_branches_reaches_one_scope_only(spec: Spe
         dimensions={"key": "repository", "value": "git-test:acme/nodefault"},
     ).equals(value=2)
 
+    # The opposite scope needs its own cardinality check: the rows it holds for
+    # the other two repositories are never selected, so nothing else counts them
+    # and a leaked dimension value would pass unseen.
+    missed = r.breakdown("git.non_default_branch_prs_created")
+    assert len(missed) == 3, f"the opposite scope gained or lost a repository: {missed!r}"
+
     landed = r.breakdown("git.default_branch_prs_created")
     assert len(landed) == 2, f"a third repository appeared: {landed!r}"
     assert not any(

--- a/tests/datapath/metrics/git/test_git_file_change_content_identity.py
+++ b/tests/datapath/metrics/git/test_git_file_change_content_identity.py
@@ -65,7 +65,10 @@ def test_a_change_counts_once_per_content_however_many_commits_carry_it(spec: Sp
 
 def test_the_repeat_of_an_earlier_content_reports_no_lines_of_its_own(spec: SpecRun) -> None:
     """November holds one commit whose only file change repeats content October already
-    counted: the commit counts, the repository gets no lines row, and the commit's size is 0."""
+    counted: the commit counts, the repository gets no lines row, and the commit's size is 0.
+
+    The size is asserted without a repository dimension, so the window is what isolates it:
+    November holds exactly this fixture's one commit."""
     r = spec.call(
         {
             "url": "/v1/metric-results",

--- a/tests/datapath/metrics/git/test_git_prs_merged.py
+++ b/tests/datapath/metrics/git/test_git_prs_merged.py
@@ -3,7 +3,8 @@
 Each connector says a request landed its own way — GitHub's and GitLab's merged_at, and
 Bitbucket's terminal update event — and silver normalises all three to one state and one
 close time. Gold counts a request in the merged state with a known close time exactly once,
-so an open one, a closed-but-never-merged one and a re-synced duplicate all stay out.
+so an open one, a closed-but-never-merged one, a re-synced duplicate and a request whose
+state says merged while its close time is missing all stay out.
 """
 
 from __future__ import annotations
@@ -98,7 +99,8 @@ def test_the_branch_scope_split_says_where_each_request_was_aimed(spec: SpecRun)
 
 
 def test_a_gitlab_merge_request_counts_only_in_the_merged_state(spec: SpecRun) -> None:
-    """bob's merged request counts; his closed-without-merging and open ones do not."""
+    """The one of bob's requests that reports a merge time counts; his
+    closed-without-merging and open ones do not."""
     r = spec.call(
         {
             "url": "/v1/metric-results",
@@ -136,8 +138,9 @@ def test_a_gitlab_merge_request_counts_only_in_the_merged_state(spec: SpecRun) -
 def test_a_bitbucket_request_is_dated_by_its_terminal_merge_event_and_a_declined_one_is_dropped(
     spec: SpecRun,
 ) -> None:
-    """carol's one merged request reaches her through her account binding alone, and its
-    bucket is the merge event's day rather than the request's own later update."""
+    """The one of carol's requests that carries a terminal merge event reaches her through
+    her account binding alone, and its bucket is that event's day rather than the
+    request's own later update."""
     r = spec.call(
         {
             "url": "/v1/metric-results",
@@ -170,6 +173,81 @@ def test_a_bitbucket_request_is_dated_by_its_terminal_merge_event_and_a_declined
         entity_id=CAROL,
         dimensions={"key": "source", "value": "bitbucket_cloud"},
     ).equals(value=1)
+
+
+def test_a_merged_state_without_a_close_time_counts_for_nobody(spec: SpecRun) -> None:
+    """A request whose state says merged while its close time is missing has no date to be
+    filed under, and the gate drops it rather than guessing one from the request's own
+    last update.
+
+    Both halves of the pair are seeded, because the two connectors reach the state by
+    different routes: Bitbucket takes the close time from the activity stream and from
+    nowhere else, so a request reported MERGED whose terminal event was never collected
+    has none; GitLab copies the state from the source and derives the close time from
+    merged_at and closed_at alone, so a request reported merged with neither is in the
+    same position. Only GitHub is immune by construction — there the merged state IS a
+    non-empty merge timestamp.
+    """
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [BOB, CAROL]},
+                "period": {"from": "2026-10-01", "to": "2026-10-02"},
+                "metrics": [
+                    {
+                        "metric_key": "git.prs_merged",
+                        "views": [{"view": "period"}, {"view": "timeseries", "bucket": "day"}],
+                    }
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    for entity in (BOB, CAROL):
+        r.row("git.prs_merged", "period", entity_id=entity).equals(value=1)
+
+        series = r.row("git.prs_merged", "timeseries", entity_id=entity)
+        series.contains(points={"bucket_start": "2026-10-01", "value": 1})
+        filed = [
+            point
+            for point in series.fields["points"]
+            if point["bucket_start"] == "2026-10-02" and point["value"]
+        ]
+        assert not filed, (
+            f"{entity}: the request with no close time was filed under its update day: {filed!r}"
+        )
+
+
+def test_a_merged_state_without_a_close_time_is_not_dated_at_the_epoch(
+    spec: SpecRun,
+) -> None:
+    """The drop is a drop, not a displacement onto an absurd date: the window that holds
+    the start of the epoch is empty for both authors.
+
+    This is what fails if a missing close time ever stops resolving to a null and starts
+    resolving to a type default instead — the request would be counted and filed at the
+    epoch, where an assertion scoped to the requests' own days can never look. A period
+    may not exceed 400 days, so the epoch needs a window of its own rather than one wide
+    enough to hold every date at once.
+    """
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [BOB, CAROL]},
+                "period": {"from": "1970-01-01", "to": "1970-12-31"},
+                "metrics": [{"metric_key": "git.prs_merged", "views": [{"view": "period"}]}],
+            },
+        }
+    )
+    assert r.status == 200
+
+    for entity in (BOB, CAROL):
+        r.row("git.prs_merged", "period", entity_id=entity).equals(value=None)
 
 
 def test_the_window_the_requests_were_created_in_holds_no_merges(spec: SpecRun) -> None:


### PR DESCRIPTION
Closes part of #3051.

## Why there is no spec of its own

`git.default_branch_prs_merged` needs no new spec. `test_git_branch_scope` already requests period, peer, a daily timeseries and the destination-branch breakdown for both halves of the scoped pair, #3290 gave it a non-`main` default to resolve, and the scoped and unscoped keys are emitted from the same pull-request row by the same `ARRAY JOIN` with the same observation time — so a gate or dating regression fails `test_git_prs_merged` first. A seventh file would duplicate a sibling and add run time, not coverage.

## What was actually missing

The gate is `state = 'MERGED' AND closed_on IS NOT NULL`. Nothing in the suite reached the second half: every seeded request that reports a merge reports a close time too, so a merge without one was never served.

Two of the three connectors can reach that state, by different routes:

- **Bitbucket** takes the close time from the activity stream and from nowhere else (`bitbucket_cloud__pull_requests.sql:69-71`), so a request the API reports as merged whose terminal event was never collected has none.
- **GitLab** copies the state straight from the source and derives the close time from `merged_at` and `closed_at` alone (`gitlab__pull_requests.sql:44-49`, `:62`), so a request reported merged with neither is in the same position. Nothing in the connector or a dbt test forbids that shape.
- **GitHub** is immune by construction (`github__pull_requests.sql:38-43`, `:58`): there the merged state IS a non-empty merge timestamp.

## What this adds

One request per reachable connector, and two tests:

- each author's total counts only the request that carries a close time, and no bucket appears on the day the dropped one was last updated;
- the window holding the start of the epoch is empty for both — a missing close time must resolve to a null, not to a type default. A period may not exceed 400 days, so the epoch needs a window of its own rather than one wide enough to hold every date at once.

Three docstrings that said "one merged request" were corrected: after this fixture two of each author's requests report a merge and only one counts.

## Verified

Both mutations were applied to a working tree, run, and restored byte-identically (`git diff` empty afterwards):

- `gitlab__pull_requests.sql:62` → `COALESCE(mr.closed_at, mr.merged_at, mr.updated_at)`: the author reads 2 instead of 1; the new test and the GitLab dating test beside it both fail.
- the same line → `COALESCE(mr.closed_at, mr.merged_at, '1970-01-01T00:00:00Z')`: the epoch test fails, and only it.

`--tree=tests/datapath/metrics/git` is green on the restored tree.

## Not asserted

Dropping a merge because its terminal event never arrived is worth a decision, not asserted here as a defect. These tests pin today's behaviour so a change to it is visible; whether the gate should fall back to another timestamp is a product question for #3051.

## Riding along: three repairs from a review of the merged git specs

Unrelated to this metric, small enough not to deserve a PR of their own. Second commit.

- `test_git_default_branch_prs_created.py` — the opposite branch scope's repository breakdown holds three rows and only one was ever selected, so nothing counted the view and a leaked dimension value would have passed unseen. The landed side already had that check; the two halves are now symmetric.
- Two explanatory comments were dropped when the suite moved to its current layout, and are restored to the modules that inherited the assertions. One says why the extension-absence guard in `test_git_code_lines.py` is the weaker half — extensions are compared lower-case because gold lower-cases them, so a regression losing both the classifier's case-insensitivity and that lower-casing slips past it, and the total in the first case is what catches it. The other says why a commit size may be asserted without a repository dimension in `test_git_file_change_content_identity.py`: the window holds exactly one commit.
- Five spec descriptions credited the rig for rejecting a metric that requests the same view twice. The API rejects it.

`--tree=tests/datapath/metrics/git` → 103 passed with both commits applied; `ruff check` and `ruff format --check` clean across the tree.
