### PR TITLE
fix(gold): give CI evidence the source the drilldown resolves its links against

### DIFF
--- a/src/ingestion/gold/ci_metric_evidence.sql
+++ b/src/ingestion/gold/ci_metric_evidence.sql
@@ -34,6 +34,7 @@ runs AS (
         branch,
         started_at,
         duration_s,
+        data_source,
         toDate(started_at) AS metric_date,
         -- Whether the run's head commit was ever collected by the commits
         -- stream. PR runs build synthetic merge refs and fork commits the
@@ -68,11 +69,14 @@ run_rows AS (
         started_at,
         duration_s,
         commit_known,
+        replaceOne(data_source, 'insight_', '') AS source_value,
+        {{ git_source_label('source_value') }} AS source_label,
         -- Labels are what surfaces display; the results builder substitutes
         -- a literal "Unknown" for a NULL label, so every dimension carries one.
         CAST(
             [
                 tuple('repository', repo_full_name, toNullable(repo_full_name)),
+                tuple('source', source_value, source_label),
                 tuple('pipeline', pipeline_key, toNullable(pipeline_name)),
                 tuple('trigger', trigger_category, toNullable(trigger_category)),
                 tuple('outcome', outcome, toNullable(outcome)),
@@ -117,9 +121,12 @@ deployment_rows AS (
             d.is_transient = 1, 'preview',
             'static'
         ) AS env_kind,
+        replaceOne(d.data_source, 'insight_', '') AS source_value,
+        {{ git_source_label('source_value') }} AS source_label,
         CAST(
             [
                 tuple('repository', d.repo_full_name, toNullable(d.repo_full_name)),
+                tuple('source', source_value, source_label),
                 tuple('environment', d.environment, toNullable(d.environment)),
                 tuple('outcome', if(coalesce(o.state, '') = '', 'pending', o.state), toNullable(if(coalesce(o.state, '') = '', 'pending', o.state))),
                 tuple(
@@ -138,7 +145,8 @@ deployment_rows AS (
             environment,
             is_production,
             is_transient,
-            created_at
+            created_at,
+            data_source
         FROM {{ ref('class_git_deployments') }} FINAL
         WHERE created_at IS NOT NULL
     ) AS d
@@ -170,6 +178,7 @@ SELECT
     CAST(NULL AS Nullable(String)) AS subject_key,
     run_dimensions AS dimensions,
     map(
+        'source_id', coalesce(toString(source_id), ''),
         'repository', repo_full_name,
         'pipeline', pipeline_key,
         'branch', branch,
@@ -217,6 +226,7 @@ SELECT
     CAST(NULL AS Nullable(String)) AS subject_key,
     deployment_dimensions AS dimensions,
     map(
+        'source_id', coalesce(toString(source_id), ''),
         'repository', repo_full_name,
         'environment', environment,
         'outcome', outcome,


### PR DESCRIPTION
Found while validating the git metrics under #3039 — the CI family shares the drilldown surface, and its repository column never linked anywhere.

## The defect

A drilldown row's repository becomes a link only when the row offers a `source` dimension naming the provider **and** a `source_id` among its details: the resolver reads the provider from the dimensions, the instance id from the details, and returns nothing at all when either is missing (`metric_drilldown/presentation.rs:296-328`).

CI evidence emitted neither, so the repository column was inert for every CI metric while the same column links out on the git side.

## The fix

Both emitting paths now carry them, derived exactly as the git evidence derives them:

- value — the connector's `data_source` with its `insight_` prefix stripped;
- label — the shared source-label macro;
- details — the row's own `source_id`.

Collected commits are left alone: that path emits no dimensions at all, so it shows no repository column to link from.

The relation is materialized as a table and the column set does not change, so this needs no migration — a gold rebuild is enough.

## Verified

On a compose test-stand instance:

- `--tree=tests/datapath/metrics/ci` → 14 passed, so no CI metric moved;
- both record kinds carry the pair in the built relation — run rows and deployment rows each report a `source` dimension (`github` / `GitHub`) and a details `source_id`, where before both were absent.

## Not asserted

The rendered link also depends on an external-source registry entry for the instance, and nothing in the data-path suite asserts a drilldown link today — the suite only calls `/v1/metric-results`. So this fixes the data half; the href itself stays unasserted. Giving the suite its first drilldown assertion is worth doing and is bigger than this change.

## Left out deliberately

The same finding has a second half: the repository value is a bare `owner/name`, so two CI sources holding a repository of the same name collide into one row. Fixing that means prefixing the value the way git does, which changes what groups together and what the interface shows, and needs the query reference and the front end checked with it. That belongs in its own change, not here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Reporting**
  * CI metric evidence now includes the originating source as a dimension for both CI runs and deployments.
  * Evidence details now include a source identifier for improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->