### PR TITLE
feat(datasets): give datasets a home, a registry and a discovery API

### DIFF
--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -107,6 +107,18 @@ path = "docs/components/backend/analytics/specs/connector-health/DESIGN.md"
 name = "Connector Health Design"
 traceability = "DOCS-ONLY"
 
+[[systems.artifacts]]
+kind = "PRD"
+path = "docs/domain/query-engine/PRD.md"
+name = "Query Engine PRD"
+traceability = "DOCS-ONLY"
+
+[[systems.artifacts]]
+kind = "DESIGN"
+path = "docs/domain/query-engine/DESIGN.md"
+name = "Query Engine Design"
+traceability = "DOCS-ONLY"
+
 [[systems]]
 name = "Identity Service"
 slug = "identity-svc"

--- a/docs/domain/query-engine/DESIGN.md
+++ b/docs/domain/query-engine/DESIGN.md
@@ -1,0 +1,932 @@
+---
+version: 2.1
+status: proposed
+date: 2026-09-08
+---
+
+# Technical Design — Query Engine
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-design-query-engine`
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+  - [3.8 Deployment Topology](#38-deployment-topology)
+- [4. Additional context](#4-additional-context)
+  - [Capability semantics](#capability-semantics)
+  - [Saved queries](#saved-queries)
+  - [Non-goals](#non-goals)
+- [5. Traceability](#5-traceability)
+
+<!-- /toc -->
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+One question contract over declared datasets. Each question compiles to one bounded,
+parameterised ClickHouse scan per dataset and answers a typed table. The rules the schema
+does not carry — session tenancy, duplicate-free reads, NULL folding, UTC day boundaries,
+caps — are compiler steps applied to every question and pinned by rendered-SQL tests.
+
+Three pure layers around one I/O shell. *Declarations*: what may be asked, validated at
+build time against the warehouse column snapshot. *Validation*: bind a request or refuse it
+with every violation named. *Compilation*: SQL text with engine-owned identifiers, caller
+values bound. The shell runs the statement under a byte ceiling and a concurrency permit and
+assembles the answer. Realises [PRD.md](PRD.md); migration in [MIGRATION.md](MIGRATION.md).
+
+### 1.2 Architecture Drivers
+
+**ADRs**: none yet; the first is expected with access policies.
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+|-------------|------------------|
+| `cpt-insightspec-qe-fr-ask` | request → plan → compile → one scan; no metric definition in the path |
+| `cpt-insightspec-qe-fr-group` | a labelled dimension answers `<field>_label` beside its value; every stable column declared |
+| `cpt-insightspec-qe-fr-filter` | tagged filter variants; patterns bound as parameters, `match` compiled at validation; operator/target mismatch refused |
+| `cpt-insightspec-qe-fr-fold` | `OrNull` folds; `count` alone reports 0 |
+| `cpt-insightspec-qe-fr-bounds` | window cap; `LIMIT limit + 1` with `flags.truncated`; chunked byte ceiling; semaphore |
+| `cpt-insightspec-qe-fr-discover` | `GET /v1/datasets` from declarations; storage names never leave the service |
+| `cpt-insightspec-qe-fr-field-metadata` | declaration gains label, description, unit; values endpoint under the same gate |
+| `cpt-insightspec-qe-fr-refusal` | whole plan checked first; one `Violation {field, reason, detail}` per problem |
+| `cpt-insightspec-qe-fr-boolean` | `any`/`all`/`not` variants → parenthesised predicates |
+| `cpt-insightspec-qe-fr-relative-window` | resolved at plan time; answer reports `resolved_window` |
+| `cpt-insightspec-qe-fr-derived` | `classify` → one `multiIf`; `time_part` → date-part function in the query zone |
+| `cpt-insightspec-qe-fr-richer-folds` | more fold and window variants over the same plan (§4) |
+| `cpt-insightspec-qe-fr-time-intelligence` | zone, week start, fiscal start as compiler inputs to every boundary |
+| `cpt-insightspec-qe-fr-rows` | sibling row-level shape over the same predicates, keyed on `row_identity` |
+| `cpt-insightspec-qe-fr-saved` | stored request re-planned on every read |
+| `cpt-insightspec-qe-fr-cross-dataset` | one scan per dataset aligned on conformed dimensions; lookups joined on a unique key |
+| `cpt-insightspec-qe-fr-own-datasets` | runtime declarations validated against a live catalog, tenant-scoped, approval-gated before sharing |
+| `cpt-insightspec-qe-fr-funnels` | aggregate families over ClickHouse `windowFunnel`, `retention` |
+| `cpt-insightspec-qe-fr-admin-gate` | `require_admin` before every query and discovery handler |
+| `cpt-insightspec-qe-fr-access-policies` | policy predicates bound from the caller context at plan time, before any capability |
+
+#### NFR Allocation
+
+| NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
+|--------|-------------|--------------|-----------------|----------------------|
+| `cpt-insightspec-qe-nfr-correctness` | correct by construction | compiler | tenancy predicate first; `FINAL` per read discipline; `OrNull` folds; `toDate(x, 'UTC')`; no `=` on nullable keys | rendered-SQL goldens; stand reconciliations |
+| `cpt-insightspec-qe-nfr-bounded` | bounded cost | validation, executor, handler | 731-day window; 10 000 rows; 16 MiB chunked ceiling; 8-permit semaphore → 429 | unit tests per cap; stand 400/429 cases |
+| `cpt-insightspec-qe-nfr-latency` | interactive latency | gold datasets, compiler | flat pre-joined relations; one scan; partitioned by month, sorted by tenant | stand timing; ClickHouse query log |
+| `cpt-insightspec-qe-nfr-contract` | stable contract | contract DTOs | tagged unions with `deny_unknown_fields`; OpenAPI generated from types; CI drift gate | drift check; stand schema generation |
+| `cpt-insightspec-qe-nfr-person-data` | person columns classified | declarations, executor | person columns named in the declaration; no engine store or cache; gate then policies govern reads | declaration tests; no persistence in the engine |
+
+### 1.3 Architecture Layers
+
+```text
+constructor ──HTTP──▶ gateway ──▶ analytics service
+                                   ├─ api     gate · extract · respond
+                                   ├─ domain  declarations · validation · compile · answer
+                                   └─ infra   bounded fetch · metrics ──▶ ClickHouse gold
+ingestion (dbt) ─────────────────────────────────────────────────────▶ ClickHouse gold
+```
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-tech-layers`
+
+| Layer | Responsibility | Technology |
+|-------|---------------|------------|
+| Presentation | constructor: form → request; answer → table and chart | React, TanStack Query |
+| Application | handlers: admin gate, extraction, error envelopes | Rust, axum, canonical errors |
+| Domain | declarations, validation, compilation, answer assembly | Rust, pure functions |
+| Infrastructure | bounded ClickHouse fetch, metrics, identity client | Rust, clickhouse client |
+| Data | gold datasets from silver class relations | dbt, ClickHouse MergeTree |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### A contract, not SQL, from callers
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-contract`
+
+Callers send a small typed document. Only engine-owned identifiers reach SQL text; every
+caller value binds. This is what makes tenancy, read discipline, NULL semantics, caps and
+row policies enforceable without a SQL parser.
+
+#### Declarations are the truth
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-declarations`
+
+What may be asked is declared per dataset and validated against the column snapshot at build
+time. Every stable-valued column is a dimension. A request cannot name what no declaration
+does.
+
+#### Refuse by name
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-refusals`
+
+Check the whole request, then report every violation with field, machine reason and
+admissible set. Server faults (unusable declarations, warehouse errors) are 500s, never
+dressed as request errors.
+
+#### Correct by construction
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-correctness`
+
+Rules the schema does not carry live in the compiler, pinned by exact rendered-SQL tests.
+
+### 2.2 Constraints
+
+#### Tenancy binds from the session
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-tenancy`
+
+First predicate of every scan is the tenant from the security context. No request member
+names a tenant; unknown members are refused.
+
+#### Admin-only until access policies land
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-admin-gate`
+
+Datasets carry person columns and declare no access policy yet: `POST /v1/query` and both
+`GET /v1/datasets` routes refuse non-administrators. The change declaring the first policy
+must specify what replaces the minimum-peer suppression of the metric surfaces.
+
+#### Bounded on every axis
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-bounds`
+
+Window ≤ 731 days inside the `Date` range; rows ≤ 10 000 plus one fetched to flag
+truncation; answer ≤ 16 MiB enforced while receiving; 8 scans in flight per process; filter,
+aggregate, axis, order counts and pattern lengths capped by contract constants.
+
+#### Gold relations only
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-gold-only`
+
+A declaration binds an `insight.*` relation whose columns exist in the embedded snapshot. No
+bronze, no silver, no query-time joins beyond a future declared lookup, no writes.
+
+#### Security and operations dispositions
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-constraint-inherited-platform`
+
+- **Authentication**: gateway and identity establish the session; the engine trusts the
+  `SecurityContext` it receives and never authenticates.
+- **Data protection**: TLS and tenant isolation inherited from the platform; person columns
+  classified in declarations; column masking arrives with access policies.
+- **Threats**: injection via operands — mitigated by binding every caller value; over-broad
+  exposure before policies — mitigated by the admin gate; resource exhaustion — mitigated by
+  the caps above; malformed regex — compiled at validation.
+- **Audit**: latency and error class recorded per question; who-asked-what audit is open
+  and tracked under access policies.
+- **Capacity and recovery**: the engine holds no state; capacity is the warehouse's and
+  ingestion's concern; recovery is redeploy.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: Rust types, YAML dataset declarations, JSON column snapshot.
+
+**Location**: `src/backend/services/analytics/src/domain/query/`
+
+**Core Entities**:
+
+| Entity | Description | Schema |
+|--------|-------------|--------|
+| Dataset | key, relation, read discipline, tenant field, time fields, dimensions (label, absent value), measurables, row identity | `datasets/*.yaml`, `datasets/declaration.rs` |
+| FieldCatalog | warehouse columns and engines declarations validate against | `field_catalog/columns.snapshot.json` |
+| QueryRequest | tagged request document | `contract/dto.rs` |
+| QueryPlan | request bound to its dataset; answer columns with sources | `plan.rs` |
+| CompiledQuery | statement text and positional bindings | `compile/mod.rs` |
+| QueryAnswer | typed columns, rows, flags | `contract/dto.rs`, `answer.rs` |
+| Violation | field, machine reason, sentence | `violation.rs` |
+
+**Relationships**:
+- Dataset → FieldCatalog: validated at build time.
+- QueryRequest → QueryPlan: `validation::plan` binds or refuses.
+- QueryPlan → CompiledQuery: `compile` renders.
+- CompiledQuery → QueryAnswer: executor returns rows; `answer::assemble` maps aliases.
+
+### 3.2 Component Model
+
+```text
+request ─▶ api (gate) ─▶ validation ─▶ compile ─▶ executor ─▶ ClickHouse
+                            │                        │
+                       declarations                answer ─▶ response
+```
+
+#### Declarations and catalog
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-declarations`
+
+##### Why this component exists
+
+What may be asked must be fixed and checked against the warehouse before any request.
+
+##### Responsibility scope
+
+Load the snapshot; parse dataset YAML; validate columns, type classes, nullability, labels,
+read discipline against engine family, default time field, row identity; expose
+`product_datasets()` and `dataset(key)`.
+
+##### Responsibility boundaries
+
+No runtime warehouse reads; no knowledge of requests. A failing declaration makes every
+query a 500, never a 400.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-validation` — read by
+- `cpt-insightspec-qe-component-api` — described on discovery routes
+
+#### Validation
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-validation`
+
+##### Why this component exists
+
+A request is untrusted until every reference resolves and every rule holds.
+
+##### Responsibility scope
+
+Bind filters, axes, aggregates, order, window to the declaration; check operand types and
+operator/target pairs; compile `match` patterns; enforce caps; build answer columns (value,
+label, bucket, aggregate) with sources; return a `QueryPlan` or every `Violation`.
+
+##### Responsibility boundaries
+
+No SQL, no connection. `PlanError` separates a refused request from unusable declarations.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-declarations` — depends on
+- `cpt-insightspec-qe-component-compiler` — hands the plan to
+
+#### Compiler
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-compiler`
+
+##### Why this component exists
+
+Apply the correctness rules once, to every question.
+
+##### Responsibility scope
+
+Render one statement: positional aliases; `FINAL` per read discipline; `OrNull` folds;
+`toDate(x, 'UTC')`; dimension values via `toString` and the absent sentinel; every caller
+value as `?`; tenancy, window, filters in that order; `GROUP BY` group columns;
+deterministic `ORDER BY`; `LIMIT limit + 1`.
+
+##### Responsibility boundaries
+
+Never sees a raw request or a connection; no authorization logic.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-validation` — consumes its plan
+- `cpt-insightspec-qe-component-executor` — hands the statement to
+
+#### Executor and answer
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-executor`
+
+##### Why this component exists
+
+One place talks to the warehouse for questions, so every bound is enforced there.
+
+##### Responsibility scope
+
+Bind parameters; run under a fetch timeout; collect chunks against the byte ceiling; decode
+off the async runtime; record latency and error class. `answer::assemble` maps aliases to
+columns, drops the extra row, sets `flags.truncated`.
+
+##### Responsibility boundaries
+
+Does not interpret the request; a ceiling breach is a typed error the handler maps.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-compiler` — depends on
+- `cpt-insightspec-qe-component-api` — called by
+
+#### API
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-api`
+
+##### Why this component exists
+
+HTTP edge: authorization, extraction, error envelopes.
+
+##### Responsibility scope
+
+`POST /v1/query`: admin gate, permit, plan, compile, fetch, assemble; refusals →
+field-violation envelope, byte ceiling → `limit` violation, exhaustion → 429, else 500.
+`GET /v1/datasets`, `GET /v1/datasets/{key}`: admin gate, describe.
+
+##### Responsibility boundaries
+
+No business logic, no SQL.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-validation` — calls
+- `cpt-insightspec-qe-component-executor` — calls
+- `cpt-insightspec-qe-component-constructor` — serves
+
+#### Constructor page
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-component-constructor`
+
+##### Why this component exists
+
+Administrators ask questions without writing JSON.
+
+##### Responsibility scope
+
+Read descriptions; keep a form draft; build the request (measurable operands as numbers,
+dimension operands and patterns as text); run; render table and chart; show each violation
+beside its input and the truncation flag.
+
+##### Responsibility boundaries
+
+No metric semantics, no invented labels, no persistence.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-api` — calls
+
+#### Access policies
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-component-access-policies`
+
+##### Why this component exists
+
+Row visibility is enforced where rows are planned, from facts identity supplies.
+
+##### Responsibility scope
+
+Per dataset: dataset access (roles or allow list); row policies (dimension bound to a caller
+attribute: visible people, team repositories); column policies (dropped or masked per role).
+Applied at plan time before any capability. *Needs design* (§4).
+
+##### Responsibility boundaries
+
+Never decides who the caller is; refuses when a needed fact is missing.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-validation` — extends the plan
+- `cpt-insightspec-qe-component-declarations` — declared beside datasets
+
+### 3.3 API Contracts
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-interface-query-api`
+
+- **Contracts**: `cpt-insightspec-qe-contract-caller-context`
+- **PRD interface**: `cpt-insightspec-qe-interface-query`
+- **Technology**: REST/OpenAPI, JSON, RFC 9457 problem envelopes
+- **Location**: [openapi.json](../../components/backend/analytics/openapi.json) — the
+  authority for what is accepted today
+
+**Endpoints Overview**:
+
+| Method | Path | Description | Stability |
+|--------|------|-------------|-----------|
+| `POST` | `/v1/query` | answer one question over a declared dataset | unstable (admin-only) |
+| `GET` | `/v1/datasets` | describe every dataset | unstable |
+| `GET` | `/v1/datasets/{key}` | describe one dataset | unstable |
+
+The request below is the design target; §4 says which members are shipped. Today's accepted
+members: `dataset`, `filters`, `group_by`, `aggregates` (with `filter`), `time` with
+`field`/`from`/`to`/`grain` (day, week, month), `order`, `limit`. Everything else is refused
+as unknown until its change lands.
+
+```jsonc
+POST /v1/query
+{
+  "dataset": "…",                       // or "saved": "<saved-query name>"
+
+  // Every list below is a discriminated union: the tag (`op`, `axis`, `fn`)
+  // selects the variant, and a variant carries exactly the operands it takes.
+  // An operand belonging to another variant is refused at deserialization, so
+  // no arity or "required together" rule is checked at runtime.
+
+  "filters": [
+    { "op": "eq",       "field": "…", "value": … },
+    { "op": "in",       "field": "…", "values": [ … ] },
+    { "op": "gt",       "field": "…", "value": … },
+    { "op": "gte",      "field": "…", "value": … },
+    { "op": "lt",       "field": "…", "value": … },
+    { "op": "lte",      "field": "…", "value": … },
+    { "op": "between",  "field": "…", "low": …, "high": … },
+    { "op": "not_null", "field": "…" },
+    { "op": "like",     "field": "…", "value": "%/tests/%", "case_insensitive": false },
+    { "op": "match",    "field": "…", "value": "\\.(test|spec)\\.", "case_insensitive": false },
+    // Boolean groups nest any filter, including other groups. The top-level
+    // list is an implicit `all`.
+    { "op": "any", "filters": [ … ] },
+    { "op": "all", "filters": [ … ] },
+    { "op": "not", "filter": { … } }
+  ],
+
+  "group_by": [
+    { "axis": "dimension", "field": "…" },
+    { "axis": "bin_width", "field": "…", "width": 10 },
+    { "axis": "bin_edges", "field": "…", "edges": [ … ] },
+    { "axis": "bin_count", "field": "…", "count": 20 },
+    { "axis": "time" },                                 // the time bucket as a group axis
+    { "axis": "time_part", "part": "hour|day_of_week|day_of_month|week_of_year|month_of_year|quarter_of_year" },
+    // A derived dimension: the first matching case names the group, `else`
+    // catches the rest. Cases take any filter shape over the named field.
+    { "axis": "classify", "name": "…", "field": "…",
+      "cases": [ { "label": "tests", "filter": { "op": "match", "value": "…" } } ],
+      "else": "other" }
+  ],
+
+  "aggregates": [
+    // Every variant also takes the optional members `filter` (a conditional
+    // fold, one filter variant above), `fill` (zero|null — what an empty
+    // bucket reports on a dense axis) and `per_period` (last|first|min|max —
+    // semi-additive: fold inside each period first).
+    { "fn": "count",          "name": "…" },            // folds rows, reads no column
+    { "fn": "count_distinct", "name": "…", "field": "…", "approx": false },   // approx: HyperLogLog, cheap over wide columns
+    { "fn": "sum",            "name": "…", "field": "…" },
+    { "fn": "avg",            "name": "…", "field": "…" },
+    { "fn": "min",            "name": "…", "field": "…" },
+    { "fn": "max",            "name": "…", "field": "…" },
+    { "fn": "median",         "name": "…", "field": "…" },
+    { "fn": "quantile",       "name": "…", "field": "…", "q": 0.9 },
+    { "fn": "stddev",         "name": "…", "field": "…" }
+  ],
+
+  "expressions": [ { "name": "…", "expr": "a / nullif(b, 0) * 100" } ],   // over aggregate names only
+
+  "windows": [
+    // `of` is an aggregate or expression name; `over` names the partition
+    // dimensions. Only a moving average carries a frame.
+    { "fn": "running_sum", "name": "…", "of": "…", "over": ["…"] },
+    { "fn": "moving_avg",  "name": "…", "of": "…", "over": ["…"], "frame": 3 },
+    { "fn": "rank",        "name": "…", "of": "…", "over": ["…"] },
+    { "fn": "delta",       "name": "…", "of": "…", "over": ["…"] },
+    { "fn": "pct_change",  "name": "…", "of": "…", "over": ["…"] },
+    { "fn": "share",       "name": "…", "of": "…", "over": ["…"] }   // this row's part of its partition's total, 0..1
+  ],
+
+  // The filter variants above, over aggregate and expression names.
+  "having": [ { "op": "gt", "target": "…", "value": … } ],
+
+  "time": {
+    "field": "…",                       // defaults to the dataset's declared default
+    // Exactly one of `from`/`to` or `relative`. A relative window resolves
+    // against the request's day in `timezone`, so a saved query stays current.
+    "from": "2026-01-01", "to": "2026-03-31",
+    "relative": { "last": 12, "unit": "day|week|month|quarter|year", "include_current": false },
+    //           or { "period": "this|previous", "unit": "…", "to_date": true }
+    "grain": "day|week|month|quarter|year",
+    "timezone": "Europe/Berlin",        // bucket boundaries in this zone; default UTC
+    "week_start": "monday|sunday",
+    "fiscal_year_start": "04-01",       // month-day; shifts quarter and year buckets and periods
+    "to_date": true,                    // clip every bucket at the equivalent point of the last one
+    "fill": "dense|sparse"              // dense: every bucket in range appears; sparse: only buckets with rows
+  },
+
+  "compare": { "offset": "period|month|quarter|year", "aligned": true },
+
+  "top": { "n": 5, "by": "…", "per": ["…"], "remainder": true },
+
+  "totals": [ [], ["team"] ],           // grouping sets: [] = grand total
+
+  "order": [ { "by": "…", "dir": "asc|desc" } ],
+  "limit": 1000,
+  "cursor": "…"
+}
+```
+
+Answer:
+
+```jsonc
+{
+  "columns": [ { "name": "…", "kind": "dimension|label|bucket|aggregate|expression|window|total_marker", "type": "…" } ],
+  "rows":    [ [ … ], … ],
+  "flags":   {
+    "truncated": true,          // more groups matched than `limit` admits; rows are the first `limit` in order
+    "incomplete_period": true,  // the window's last bucket is not over yet
+    "data_through": "2026-03-30T22:10:00Z",   // the newest event time the scanned relation holds
+    "resolved_window": { "from": "…", "to": "…" }  // what a relative window became, so a chart can label it
+  },
+  "next_cursor": "…"
+}
+```
+
+### 3.4 Internal Dependencies
+
+| Dependency Module | Interface Used | Purpose |
+|-------------------|----------------|----------|
+| identity client | `is_admin` over the forwarded session | admin gate; later the caller context |
+| insight-clickhouse | bound query, bytes cursor | executor fetch |
+| toolkit canonical errors | resource-scoped builders | violation, permission, quota envelopes |
+| toolkit security | `SecurityContext` | the tenant every scan binds |
+
+**Dependency Rules** (per project conventions):
+- No circular dependencies
+- Always use SDK modules for inter-module communication
+- No cross-category sideways deps except through contracts
+- Only integration/adapter modules talk to external systems
+- `SecurityContext` must be propagated across all in-process calls
+
+### 3.5 External Dependencies
+
+#### ClickHouse
+
+| Dependency Module | Interface Used | Purpose |
+|-------------------|---------------|---------|
+| executor | HTTP query, positional bindings, `JSONEachRow` | runs the scan |
+| declarations | column snapshot dumped at build time | validates datasets offline |
+
+**Dependency Rules** (per project conventions):
+- No circular dependencies
+- Always use SDK modules for inter-module communication
+- No cross-category sideways deps except through contracts
+- Only integration/adapter modules talk to external systems
+- `SecurityContext` must be propagated across all in-process calls
+
+### 3.6 Interactions & Sequences
+
+#### Answer a question
+
+**ID**: `cpt-insightspec-qe-seq-answer`
+
+**Use cases**: `cpt-insightspec-qe-usecase-build-chart`, `cpt-insightspec-qe-usecase-own-category`
+
+**Actors**: `cpt-insightspec-qe-actor-admin`, `cpt-insightspec-qe-actor-constructor`
+
+```mermaid
+sequenceDiagram
+    Constructor ->> API: POST /v1/query
+    API ->> Identity: is admin?
+    Identity -->> API: yes
+    API ->> Validation: plan(request)
+    Validation ->> Declarations: dataset(key)
+    Validation -->> API: QueryPlan | violations
+    API ->> Compiler: compile(plan, tenant)
+    API ->> Executor: fetch (permit, byte ceiling)
+    Executor ->> ClickHouse: statement
+    ClickHouse -->> Executor: rows
+    API ->> Answer: assemble
+    API -->> Constructor: QueryAnswer | problem+json
+```
+
+**Description**: a refusal returns before any connection is touched.
+
+#### Discover the datasets
+
+**ID**: `cpt-insightspec-qe-seq-discover`
+
+**Use cases**: `cpt-insightspec-qe-usecase-build-chart`
+
+**Actors**: `cpt-insightspec-qe-actor-constructor`
+
+```mermaid
+sequenceDiagram
+    Constructor ->> API: GET /v1/datasets
+    API ->> Identity: is admin?
+    Identity -->> API: yes
+    API ->> Declarations: product_datasets()
+    API -->> Constructor: descriptions
+```
+
+**Description**: served from declarations loaded at boot; no warehouse read.
+
+### 3.7 Database schemas & tables
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-db-gold-datasets`
+
+Flat gold relations, one per dataset, built by dbt from silver class relations with dedup and
+attribution applied once. Column docs in the ingestion `schema.yml`.
+
+#### Table: git_commits
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-dbtable-git-commits`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| tenant_id | Nullable(String) | tenant |
+| commit_hash | String | the commit |
+| author_email, author_name | String | author and label |
+| authored_at, authored_date | DateTime, Date | event time and day |
+| branch_scope, repository, project, source (+ `_label`) | String | inherited dimensions |
+| message | String | commit message |
+| lines_added, lines_removed | Nullable(Int64) | own contribution after content dedup |
+
+**PK**: (tenant_id, author_email, authored_at)
+
+**Constraints**: one row per (tenant, source, commit_hash), dbt-tested
+
+**Additional info**: partitioned by month of authored_date
+
+#### Table: git_file_changes
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-dbtable-git-file-changes`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| tenant_id, commit_hash, file_path | Nullable(String), String, String | identity with change_type |
+| author_email, author_name, authored_at, authored_date | String, String, DateTime, Date | inherited from the commit |
+| category, file_extension, change_type (+ `_label`) | String | file dimensions |
+| branch_scope, repository, project, source (+ `_label`) | String | inherited dimensions |
+| lines_added, lines_removed | Nullable(Int64) | summed over folded content identities |
+
+**PK**: (tenant_id, author_email, authored_at)
+
+**Constraints**: one row per (tenant, source, commit_hash, file_path, change_type),
+dbt-tested
+
+**Additional info**: built from `git_authored_file_changes`
+
+#### Table: git_authored_file_changes
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-dbtable-git-authored-file-changes`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| tenant_id, data_source, commit_hash, file_path | Nullable(String), String, String, String | attach key and path |
+| source_id, project_key, repo_slug | Nullable(String), String, String | surviving commit's coordinates |
+| file_extension, change_type | String | as collected |
+| lines_added, lines_removed | Nullable(Int64) | as collected |
+
+**PK**: (tenant_id, data_source, commit_hash)
+
+**Constraints**: one row per change content, earliest commit wins; superseded changes excluded
+
+**Additional info**: the shared dedup the metric evidence and the datasets read; its sort runs
+once per build
+
+### 3.8 Deployment Topology
+
+Part of the analytics service; no extra deployable. Gold relations are built by the deploy
+hook's `dbt run --select tag:gold`.
+
+## 4. Additional context
+
+### Capability semantics
+
+Each capability: request shape, answer shape, null rule, cap, refusal. Refusals are typed
+violations naming the field.
+
+Inventory. *Shipped*: served today. *Specified*: shape settled, awaits its change. *Needs
+design*: sketch; the section says what is open. Nothing leaves this table without a note.
+
+| Capability | Status |
+|---|---|
+| Filters: `eq`, `in`, comparisons, `between`, `not_null` | shipped |
+| Pattern filters: `like`, `match` | shipped |
+| Boolean filter groups: `any`, `all`, `not` | specified |
+| Case-insensitive patterns | specified |
+| Dimension and time group axes | shipped |
+| Date-part axes | specified |
+| Bins as dimensions | specified |
+| Derived dimensions (`classify`) | specified |
+| `count`, `sum`, `avg`, `min`, `max` with a conditional filter | shipped |
+| `count_distinct` (exact and approximate), `median`, `quantile`, `stddev` | specified |
+| Expressions over aggregate names | specified |
+| Windows: running sum, moving average, rank, delta, percent change | specified |
+| Share of total | specified |
+| `having` | specified |
+| Top groups with remainder | specified |
+| Dense fill | specified |
+| Fixed window, UTC, day/week/month grain | shipped |
+| Relative windows | specified |
+| Timezone, week start, to-date, compare windows | specified |
+| Fiscal calendars | specified |
+| Grouping sets and totals | specified |
+| Semi-additive aggregates | specified |
+| Truncation flag | shipped |
+| Cursors | specified |
+| Rows behind a cell (drilldown shape) | needs design |
+| Multiple datasets in one query over conformed dimensions | needs design |
+| Runtime-defined datasets (derived, promoted, bring-your-own) | needs design |
+| Discovery: datasets, dimensions, measurables, limits | shipped |
+| Discovery: field labels, descriptions, units | specified |
+| Discovery: dimension value lookup | specified |
+| Freshness (`data_through`) | specified |
+| Saved queries | specified |
+| Access policies: dataset, row, column | needs design |
+| Enrichment lookups (customer-declared dimensions) | needs design |
+| Funnels and retention | needs design |
+
+#### Filters and having
+
+Row filters narrow the scan before aggregation; `having` narrows groups after it over
+aggregate and expression names. Unknown field or target → refused with the admissible set.
+Values always bind.
+
+Arity is enforced by shape: each operator is a variant with exactly its operands, so "two
+values for `eq`" cannot be expressed. Only `in` has a length to check: 1 to the cap.
+
+A dimension compares as the text the answer reports: `eq`, `in`, `not_null`, `like`
+(`%`, `_`), `match` (RE2, unanchored). Patterns bind, are length-capped, and `match` is
+compiled at validation. Ordered tests on a dimension and patterns on a measurable are refused
+naming the operator.
+
+Every stable-valued column is a dimension, `file_path` and `commit_hash` included; caps
+bound a wide group-by like a narrow one.
+
+#### Boolean filter logic
+
+Top-level `filters` is an implicit `all`. `any`, `all`, `not` are filter variants: nest
+anywhere a filter may appear. Compile to parenthesised predicates, never reordered. Caps:
+total filters and nesting depth. Empty groups refused. `case_insensitive` → `ILIKE` or a
+case-insensitive regex; default case-sensitive.
+
+#### Multiple aggregates and conformed dimensions
+
+`count` folds rows (no field); the others read a measurable. Names are unique, snake_case,
+and also unique against group columns. Several datasets in one request align on shared group
+axes; see *Multiple datasets*. Caps: datasets per query, aggregates per query.
+
+#### Expressions
+
+Arithmetic over aggregate names: four operations, parentheses, numeric literals, `nullif`.
+Parsed to an AST, rendered from the AST; a non-round-tripping string is refused. NULL
+propagates; division by zero is NULL via `nullif`.
+
+#### Windows
+
+Over the answer's buckets after aggregation, partitioned by named dimensions: running sum,
+moving average with a bounded frame, rank, delta, percent change. Refused over a sparse axis
+unless fill is dense. First bucket's delta is NULL.
+
+#### Top groups and the remainder
+
+`top` ranks groups by an aggregate within each `per` partition, keeps `n`, and with
+`remainder` folds the rest into one row with a declared label. Ties break on the group value.
+The remainder's aggregates are computed over the underlying rows or merged states, never
+from finalized scalars. `n` is capped.
+
+#### Fill and dense axes
+
+`time.fill: dense` materialises every bucket in the window; each aggregate's `fill` (zero or
+null) says what an empty bucket reports. Sparse is the default.
+
+#### Time intelligence
+
+Boundaries in the query's timezone with its week start. `to_date` clips every bucket at the
+point the last one reached. `compare.aligned` shifts by whole periods keeping the day count.
+The answer flags an incomplete final bucket.
+
+Windows are fixed (`from`/`to`) or relative: last N units (optionally including the current
+one) or a calendar period (`this`/`previous` unit, `to_date`). Resolved at plan time in the
+query zone; the answer reports `resolved_window`. Same span cap. `fiscal_year_start` shifts
+quarter and year buckets and periods; tenant settings supply defaults.
+
+#### Grouping sets and totals
+
+`totals` lists grouping sets; `[]` is the grand total. Total rows carry a marker column and
+sort after detail rows.
+
+#### Bins as dimensions
+
+Numeric or temporal field binned by fixed `width`, explicit `edges`, or a `count` of equal
+buckets. A bin is an ordinary group axis. Distributions are one bin axis plus a count.
+
+#### Date parts as axes
+
+`time_part`: hour, day of week, day of month, week of year, month of year, quarter of year,
+in the query zone with its week and fiscal start. Ordinary dimension; may sit beside `time`.
+Numeric column with a declared label form.
+
+#### Derived dimensions
+
+`classify`: ordered cases (label + filter over one field) plus `else`; first match wins.
+One `multiIf`; behaves as a group axis in filters, `top`, totals. Caps: case count, pattern
+length. Same `name` twice is a duplicate.
+
+#### Distinct counts
+
+`count_distinct` over a dimension; exact by default, `approx: true` uses HyperLogLog and the
+column type says so. Empty group → 0. `median`, `quantile`, `stddev` fold measurables and
+report NULL over nothing.
+
+#### Share of total
+
+`share` window: `of` divided by the partition's sum, 0..1; empty `over` = whole answer. Zero
+total → NULL. Composes with `top` (remainder's share is the rest) and grouping sets.
+
+#### Semi-additive aggregates
+
+`per_period` (last, first, min, max) folds inside each period first, then across; seat-day
+and headcount shapes.
+
+#### Cursors over grouped answers
+
+An answer past `limit` returns a keyset cursor over its own order, made total with the group
+columns. Bound to the query fingerprint; a cursor with a different query is refused.
+
+#### Discovery: field metadata and value lookup
+
+`GET /v1/datasets` carries label, description and (measurables) unit and format hint per
+field, and marks wide dimensions. `GET /v1/datasets/{key}/dimensions/{field}/values?q=`
+answers distinct values with labels, prefix-narrowed, capped, under tenant and — once
+policies land — the caller's visibility. Same gate as queries.
+
+#### Freshness
+
+`flags.data_through`: newest event time the scanned relation holds for the tenant.
+
+#### Access policies
+
+*Needs design.* Identity supplies the caller context (subject, roles, visible people, team
+memberships, tenant settings); the engine enforces declared policies at plan time. Three
+kinds: dataset access (roles or allow list); row policy (dimension ← caller attribute, e.g.
+`author_email ← visible_people`, `repository ← team_repositories`), applied to every scan
+whatever the query selects, refused when the attribute is missing; column policy (dropped or
+masked per role). Open: where team-to-resource facts live; replacement for minimum-peer
+suppression; how a saved question records the policy it was validated under. Admin-only
+until the first policy lands.
+
+#### Enrichment lookups
+
+*Needs design.* Customer relation keyed on a conformed dimension (repository → product,
+person → cost centre), declared as a lookup, joined at plan time; its columns become
+dimensions on every dataset sharing the key. Non-unique key refused (fan-out); unmatched key
+→ absent sentinel. Open: upload/sync path; tenant- vs per-user scope.
+
+#### Funnels and retention
+
+*Needs design.* Aggregate families over datasets declaring an actor key and event time,
+backed by `windowFunnel`, `retention`, `sequenceMatch`. Funnel: ordered step filters plus a
+window → actors reaching each step. Retention: entry filter, return filter, period. Group by
+any dimension. Open: strict vs any-order steps; exposing a step's actor set for drilldown.
+
+#### Runtime-defined datasets
+
+*Needs design.* Three forms, one validation path. **Derived**: a declaration over an existing
+dataset — prefilter, subset of fields, renames, `classify` axes — compiled by composing the
+parent's plan; inherits the parent's access policies. **Promoted**: a saved query becomes a
+dataset; its answer columns are the new dimensions and measurables, so it compiles as a
+subquery. **Bring-your-own**: a relation the tenant points at or uploads, declared like a
+shipped dataset.
+
+Rules for all three: validated by the same code that validates the shipped declarations;
+refused with the same field-named violations; stored per tenant; re-validated when the
+warehouse beneath changes; usable by its author immediately, and by anyone else only after an
+administrator approves it and its access policies are set. An assistant that authors a
+declaration is a caller like any other, subject to the same gate.
+
+Open: the field catalog stops being a build-time snapshot for these — reading the live
+catalog per validation needs a cache and an invalidation rule; whether a derived dataset's
+parent may be dropped; how deep composition may nest before the compiler refuses; per-tenant
+quotas on how many exist; whether a promoted saved query is stored as its request or frozen
+as SQL.
+
+#### Rows behind a cell
+
+*Needs design.* Row-level shape over the same dataset, filters and window: declared columns
+instead of groups and folds, `row_identity` as page key, cursors, sort by any reported
+column. Open: mode of `POST /v1/query` or sibling route (preference: sibling); how a cell's
+group values become filters.
+
+#### Multiple datasets in one query
+
+*Needs design.* Several datasets with conformed dimensions; one scan each, aligned on shared
+axes. Open: declaring conformance; refusing mismatched grains; making fan-out impossible.
+Row-level joins stay out.
+
+### Saved queries
+
+A saved query is a named request with a dataset and a version. Read re-runs validation; a
+dataset change that invalidates it is a refusal naming the field, never a reinterpretation.
+On run, a request may *replace* `time`, `order`, `limit`, `cursor`, `top`, `totals`,
+`fill`, `compare`; may *append* `filters` (AND-ed); may not touch `dataset`, `group_by`,
+`aggregates`, `expressions`, `windows`, `having`. Versioned; the metric library becomes the
+shipped set of saved queries.
+
+### Non-goals
+
+- Undeclared joins in the query; joins live in the modeled relation or a declared lookup.
+- Pivot, layout, conditional formatting.
+- OData or GraphQL as the native contract.
+- Chart-type-specific endpoints; a chart the contract cannot feed is a contract gap.
+- Path analysis and sessionization.
+- Joins to relations nobody declared: that is the SQL console, admin-only.
+
+## 5. Traceability
+
+- **PRD**: [PRD.md](PRD.md)
+- **Migration map**: [MIGRATION.md](MIGRATION.md)
+- **Contract**: [openapi.json](../../components/backend/analytics/openapi.json)

--- a/docs/domain/query-engine/MIGRATION.md
+++ b/docs/domain/query-engine/MIGRATION.md
@@ -1,0 +1,57 @@
+# Migration: current serving surface to the query engine
+
+Companion to [DESIGN.md](DESIGN.md). The design reads timeless; this file
+carries the mapping from what serves today to what the engine becomes, and is
+deleted when the migration completes.
+
+## What generalizes (machinery kept, renamed under the contract)
+
+| Today | Becomes | Notes |
+|---|---|---|
+| Values total / timeseries / rollup grains | one `query` with `group_by` + optional `{time: true}` axis | grain enum dissolves into group-axis composition |
+| Distributions endpoint (histogram, quantiles) | `bin` group axis + `quantile` aggregates | no separate surface |
+| Compare windows (previous period / month / quarter / year) | `compare.aligned` | the equal-day-count rule is already implemented and tested |
+| Group-cap "Other" folding | `top` with `remainder` | the ranking CTE, deterministic ties, and remainder fold survive as-is |
+| Rows evidence pages (keyset + server sort) | unchanged | already generic |
+| Ratio / derived metric computations | `expressions` over aggregate names | AST-rendered instead of two computation kinds |
+| Percentile / stddev metrics | `quantile` / `stddev` aggregates | per-event row discipline unchanged |
+| Seat-month/seat-day style period folds | `per_period` semi-additive aggregates | the hand-built shape becomes a contract feature |
+| Measure cache (deferred PR) | refresh engine behind saved queries | its four review findings get fixed in that role |
+| Metric definitions + seeds | saved queries + the OTB library | definitions store and versioning survive; the metric key stops being the API's spine |
+| Dry-run validation endpoint | saved-query validation | same violation-list loop |
+| Discovery catalog | dataset + saved-query catalog | advertises declarations, not metric capabilities |
+
+## What dies
+
+- **Peer comparison views and endpoint** — cohort spreads, target-vs-peers,
+  the minimum-peer floor. A dashboard wanting a spread composes queries.
+- **Capped-timeseries as a bespoke view kind** — subsumed by `top`.
+- **Person-entity machinery as the API spine** — identity resolution and
+  visibility become the declared entity policy of person-shaped datasets;
+  datasets without the declaration carry none of it.
+- **Metric-centric query shape** — requests name datasets (or saved queries), not
+  metric keys; direction/format/labels move wholly into rendering metadata.
+- **Grain/fold advertisement per metric** — the catalog describes datasets
+  and saved queries; admissibility falls out of the contract, not per-key
+  capability lists.
+
+## What stays out of scope for this rebuild
+
+- Ingestion layout and the field-catalog snapshot gate stay exactly as they
+  are; the engine consumes the same catalog the current compiler does.
+- Dataset authoring remains repository-owned (declarations in the seeds and
+  roles files); no runtime authoring surface is part of this migration.
+
+## Sequencing
+
+1. Land the current stack (store, compiler, query surface, discovery catalog,
+   families) — it is the kernel: the compiler's tenancy, null, identity, and
+   read-discipline rules transfer verbatim.
+2. Introduce `/v1/query` beside the existing surface, implementing the
+   contract capability by capability; the existing endpoints keep serving
+   until their consumers move.
+3. Re-express the OTB metrics as saved queries; the transcription corpus (105
+   metrics with exact legacy reconciliation) becomes the regression suite for
+   the new contract.
+4. Retire the metric-centric endpoints and the dead view kinds; the deferred
+   cache PR lands re-aimed at saved-query refresh.

--- a/docs/domain/query-engine/PRD.md
+++ b/docs/domain/query-engine/PRD.md
@@ -1,0 +1,673 @@
+---
+version: 1.2
+status: proposed
+date: 2026-09-08
+---
+
+# PRD — Query Engine
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Module-Specific Environment Constraints](#31-module-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 Asking a question](#51-asking-a-question)
+  - [5.2 Knowing what can be asked](#52-knowing-what-can-be-asked)
+  - [5.3 Being told what went wrong](#53-being-told-what-went-wrong)
+  - [5.4 Questions we cannot answer yet](#54-questions-we-cannot-answer-yet)
+  - [5.5 Who is allowed to ask](#55-who-is-allowed-to-ask)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 NFR Inclusions](#61-nfr-inclusions)
+  - [6.2 NFR Exclusions](#62-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+
+<!-- /toc -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Let a person ask their own question of the data the product already collects — narrow it,
+break it down, count or add something up, watch it over time — and get a table they can turn
+into a chart. Nobody has to build that question into the product first.
+
+Built by [DESIGN.md](DESIGN.md). What happens to today's charts is in
+[MIGRATION.md](MIGRATION.md).
+
+### 1.2 Background / Problem Statement
+
+Every chart in the product is a pre-built metric. Someone decided in advance what it counts,
+what you can break it down by, and how far back it looks. A question nobody anticipated —
+"how much of our change volume goes into test files, by file type, on GitHub only" — needs
+new code and a release. The person with the question has to ask an engineer and wait.
+
+A page that lets people build their own charts cannot exist either, because there is nothing
+for it to offer: no list of what can be broken down, filtered or counted, no readable names,
+no idea how far back it may look.
+
+There is a SQL console, but only administrators who know the warehouse can use it. It cannot
+be opened to everyone: raw SQL cannot be made to respect who is allowed to see whose data,
+and it gives no protection against the mistakes that quietly produce a wrong number.
+
+### 1.3 Goals (Business Outcomes)
+
+- A new question takes minutes, not a release. Today: one release cycle from question to
+  chart. Target: the same working session.
+- Answers are right without the asker knowing anything about the warehouse — no double
+  counting, no invented zeroes, no data from another organisation, days that start and end
+  at the same moment for everyone.
+- When a question cannot be answered, the page says which part is wrong and what would work
+  instead.
+- A saved question either still means what it meant, or it stops and says so. It never
+  quietly starts answering something else.
+- Once we can enforce who may see whose data, the same page opens to leads, not just
+  administrators.
+- People — and, later, an assistant working on their behalf — add data sets of their own
+  rather than waiting for the product to ship one.
+
+### 1.4 Glossary
+
+| Term | Meaning |
+|---|---|
+| **Data set** | one kind of thing you can ask about, such as commits or file changes |
+| **Breakdown** | splitting an answer into rows: per person, per repository, per week |
+| **Measure** | something you can count or add up: commits, lines added |
+| **Filter** | a condition that keeps only the rows you mean |
+| **Time window** | the from–to dates every question must state |
+| **Time step** | how wide each bar or point is: a day, a week, a month |
+| **Rejection** | an answer the system refuses to give, saying which part of the question is wrong |
+| **Access rule** | who may ask about a data set, and which rows their answers may include |
+| **Constructor** | the page where an administrator builds a question and sees the result |
+| **Own data set** | a data set someone adds themselves at runtime, rather than one the product shipped |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Instance administrator
+
+**ID**: `cpt-insightspec-qe-actor-admin`
+
+**Role**: runs one installation of the product; today the only person allowed to ask.
+**Needs**: answer a new question the same day, and understand a rejection without asking an
+engineer.
+
+#### Team lead
+
+**ID**: `cpt-insightspec-qe-actor-lead`
+
+**Role**: looks at numbers about the people they are responsible for, and only those people.
+**Needs**: their limits applied automatically, and charts that keep working over time.
+
+#### Dashboard author
+
+**ID**: `cpt-insightspec-qe-actor-author`
+
+**Role**: builds charts and saved questions for other people to read.
+**Needs**: to see what can be asked — the available breakdowns, measures and limits.
+
+### 2.2 System Actors
+
+#### Constructor page
+
+**ID**: `cpt-insightspec-qe-actor-constructor`
+
+**Role**: shows what can be asked, turns a filled-in form into a question, draws the answer.
+
+#### Identity service
+
+**ID**: `cpt-insightspec-qe-actor-identity`
+
+**Role**: says who is asking, what they are allowed to do, and whose data they may see.
+
+#### Warehouse
+
+**ID**: `cpt-insightspec-qe-actor-warehouse`
+
+**Role**: stores the prepared data and answers each question.
+
+## 3. Operational Concept & Environment
+
+### 3.1 Module-Specific Environment Constraints
+
+- Reads only prepared, ready-to-query data. It never touches raw collected data and never
+  changes anything.
+- A data set can only be offered if it really exists in the warehouse; a mismatch is caught
+  when the product is built, not when someone asks.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Asking a question: filters, breakdowns including over time, counts and totals with their
+  own conditions, sorting, a row limit, a required time window.
+- Seeing what can be asked: the data sets, their breakdowns and readable names, their
+  measures, and the limits a question must stay inside.
+- Getting a clear answer: a table with readable names beside the values, and a note when the
+  answer was cut short.
+- Clear rejections that point at the part of the question to fix.
+- An administrator-only page for building questions.
+- A named list of what comes next, as requirements: or/not conditions, rolling time windows,
+  your own categories, unique counts, percentages of a total, running and moving figures,
+  subtotals, paging, saved questions, access rules, your own reference data, funnels, and
+  data sets people add themselves.
+
+### 4.2 Out of Scope
+
+- Letting people write SQL; the administrator SQL console stays as it is.
+- How a chart looks: chart types, layouts, formatting.
+- Step-by-step journey analysis over individual event streams.
+- Alerts and notifications about an answer.
+- Switching the existing charts over before this can do what they do
+  ([MIGRATION.md](MIGRATION.md)).
+
+## 5. Functional Requirements
+
+### 5.1 Asking a question
+
+#### Ask a data set directly
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-ask`
+
+The system **MUST** answer a question that names a data set, a time window and at least one
+thing to count, plus optional filters, breakdowns, sorting and a row limit — with nothing
+built in advance.
+
+**Rationale**: the whole point; a question should not need a release.
+
+**Actors**: `cpt-insightspec-qe-actor-admin`, `cpt-insightspec-qe-actor-constructor`
+
+#### Break down by anything, including time
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-group`
+
+The system **MUST** allow a breakdown by any offered column and by day, week or month, and
+**MUST** return the readable name beside the value it stands for.
+
+**Rationale**: a chart needs a stable value to key on and a name a person can read.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Narrow to the rows you mean
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-filter`
+
+The system **MUST** filter by exact value, a list of values, greater or less than, a range,
+"has a value", and text patterns (simple wildcards or a regular expression). It **MUST**
+reject a greater-or-less-than test on text and a text pattern on a number.
+
+**Rationale**: the asker decides what "test files" means. A comparison on the wrong kind of
+column gives a wrong answer that looks right.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Count and total, with conditions
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-fold`
+
+The system **MUST** count rows and compute totals, averages, smallest and largest, each
+optionally over just the rows a condition selects. When nothing matched, the cell **MUST** be
+blank rather than a zero — except a count, where zero is the true answer.
+
+**Rationale**: one question can answer several columns at once, and a made-up zero is a wrong
+number.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Keep every answer within safe limits
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-bounds`
+
+The system **MUST** require a time window of at most 731 days (two years), limit how many
+rows an answer holds, how large it may be and how many questions run at once, and **MUST**
+say when an answer was cut at the row limit.
+
+**Rationale**: everyone shares one warehouse, and a chart that was cut short without saying
+so is misleading.
+
+**Actors**: `cpt-insightspec-qe-actor-admin`
+
+### 5.2 Knowing what can be asked
+
+#### Describe what is available
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-discover`
+
+The system **MUST** describe every data set it offers — its breakdowns and their readable
+names, its measures, its date columns, and the limits — without revealing how or where the
+data is stored.
+
+**Rationale**: a page that builds questions needs a list to build from.
+
+**Actors**: `cpt-insightspec-qe-actor-constructor`
+
+#### Readable names and value suggestions
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-field-metadata`
+
+The system **MUST** provide a readable name, a short description and, for measures, a unit;
+and **MUST** suggest the values a column actually holds as someone types.
+
+**Rationale**: wording belongs to the product, not to each page; nobody should type a
+repository name from memory.
+
+**Actors**: `cpt-insightspec-qe-actor-constructor`
+
+### 5.3 Being told what went wrong
+
+#### Point at every problem at once
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-refusal`
+
+The system **MUST** check the whole question before rejecting it, and report every problem
+with the part of the question it concerns, a code a page can act on, and — where there is a
+list of valid choices — that list.
+
+**Rationale**: a page can highlight the wrong boxes; a person reads one clear message.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+### 5.4 Questions we cannot answer yet
+
+#### And, or, not
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-boolean`
+
+The system **MUST** allow conditions combined with "any of", "all of" and "not", nested as
+deeply as needed.
+
+**Rationale**: "GitHub or GitLab, but not bots" cannot be said with "and" alone.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Rolling time windows
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-relative-window`
+
+The system **MUST** accept windows stated relative to today — the last twelve weeks, this
+month, the previous quarter, the year so far — and report the actual dates it used.
+
+**Rationale**: a saved chart with fixed dates is out of date tomorrow.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Your own categories, and parts of a date
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-derived`
+
+The system **MUST** allow a breakdown by categories the asker defines with their own rules,
+and by parts of a date such as day of the week or hour.
+
+**Rationale**: everyone's definition of "test code" or "core service" differs.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### The rest of the usual chart maths
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-richer-folds`
+
+The system **MUST** offer unique counts (exact and estimated), medians and percentiles,
+spread, arithmetic between computed columns, running and moving figures, percentage of a
+total, a top-N with everything else grouped as "other", empty periods shown as gaps or
+zeroes, subtotals and grand totals, and measures counted once per period such as headcount.
+
+**Rationale**: this is what today's charts already do and what anyone building a chart
+expects.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Calendars and comparisons
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-time-intelligence`
+
+The system **MUST** work in a chosen time zone, with a chosen first day of the week and start
+of the financial year, and **MUST** compare a period against the same stretch of the period
+before it.
+
+**Rationale**: "versus last quarter" comes up in every review.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### See more, and look behind a number
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-rows`
+
+The system **MUST** let a reader page past the row limit, and **MUST** show the individual
+records behind any single figure in an answer.
+
+**Rationale**: a number nobody can open is a number nobody trusts.
+
+**Actors**: `cpt-insightspec-qe-actor-lead`
+
+#### Save a question and share it
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-saved`
+
+The system **MUST** save a question under a name, re-check it every time it is opened, let a
+reader change the dates, sorting and row limit and add their own filters, and refuse changes
+that would make it a different question.
+
+**Rationale**: a dashboard is a set of saved questions; they must break loudly rather than
+drift.
+
+**Actors**: `cpt-insightspec-qe-actor-author`, `cpt-insightspec-qe-actor-lead`
+
+#### Combine sources, and bring your own reference data
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-cross-dataset`
+
+The system **MUST** answer one question spanning several data sets that share a breakdown,
+without inflating any number, and **MUST** let a customer's own reference list — repository
+to product line, person to cost centre — be used as a breakdown everywhere it fits.
+
+**Rationale**: real questions cross sources, and product lines and cost centres are facts
+only the customer has.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Add a data set of your own
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-own-datasets`
+
+The system **MUST** let someone add a data set at runtime, in three forms: a narrowed or
+relabelled version of an existing one with their own categories added; a saved question other
+people can then break down further; and their own table or uploaded list, described so the
+product knows what may be asked of it. An assistant may write any of these on a person's
+behalf.
+
+Whatever the form, the product **MUST** check it the same way it checks the ones it ships,
+refuse it in the same words when it does not fit the data, keep it inside the organisation
+that made it, and re-check it whenever the data underneath changes shape. A new data set is
+usable immediately by whoever created it; before anyone else may use it, an administrator
+**MUST** approve it and its access rules **MUST** be set.
+
+**Rationale**: the questions worth asking outgrow any list we ship, and the people asking
+should not have to wait for us.
+
+**Actors**: `cpt-insightspec-qe-actor-author`, `cpt-insightspec-qe-actor-admin`
+
+#### Funnels and return rates
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-funnels`
+
+The system **MUST** count how many people, deals or tickets reached each step of a sequence
+within a period, and how many came back after a first action.
+
+**Rationale**: deal stages, ticket transitions and the life of a pull request are all
+funnels.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+### 5.5 Who is allowed to ask
+
+#### Administrators only, for now
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-admin-gate`
+
+The system **MUST** refuse both questions and the list of what can be asked to anyone who is
+not an administrator of the installation, until access rules exist for the data sets that
+describe people.
+
+**Rationale**: these data sets show what named people did.
+
+**Actors**: `cpt-insightspec-qe-actor-admin`, `cpt-insightspec-qe-actor-lead`
+
+#### Access rules
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-access-policies`
+
+For each data set the system **MUST** enforce who may ask about it at all, which rows may
+count towards their answers — based on facts about the asker, such as the people they manage
+or the repositories their teams own — and which columns they may see. This **MUST** apply to
+every question, no matter how it is broken down.
+
+**Rationale**: a count per repository is still a count of people's work; what a chart is
+grouped by must not change who is visible in it.
+
+**Actors**: `cpt-insightspec-qe-actor-lead`, `cpt-insightspec-qe-actor-identity`
+
+## 6. Non-Functional Requirements
+
+### 6.1 NFR Inclusions
+
+#### Right answers without expert knowledge
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-correctness`
+
+Every answer **MUST** cover only the asker's own organisation, count nothing twice, leave a
+cell blank when nothing matched, and treat a day as the same stretch of time for everyone.
+There **MUST** be no way for a question to switch any of this off.
+
+**Threshold**: no exceptions; checked by tests that compare answers which must agree.
+
+**Rationale**: this is why the product answers questions itself instead of handing out SQL.
+
+#### Predictable cost
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-bounded`
+
+A question **MUST** stay within stated limits, and be rejected rather than run when it would
+exceed them.
+
+**Threshold**: time window at most 731 days; at most 10 000 rows; at most 16 MiB per answer;
+8 questions at once per server, with the rest asked to retry shortly.
+
+**Rationale**: the warehouse is shared with everything else the product does.
+
+#### Fast enough to explore
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-nfr-latency`
+
+An ordinary question **SHOULD** come back within two seconds for 95 out of 100 asks on a
+reference installation.
+
+**Threshold**: 2 seconds at the 95th percentile, up to four breakdowns, one year of data.
+
+**Rationale**: building a chart is a back-and-forth; waiting breaks it.
+
+#### A promise that does not shift
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-contract`
+
+What can be asked and what comes back **MUST** be published in a form other software can
+check against, and anything unrecognised in a question **MUST** be rejected rather than
+ignored.
+
+**Threshold**: the published description accepts exactly what the product accepts; any
+divergence stops the build.
+
+**Rationale**: a page built against the description must not disagree with the product.
+
+#### People's data stays handled as people's data
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-person-data`
+
+Columns that identify a person **MUST** be shown only to those the access rules allow, and
+**MUST NOT** be copied or stored anywhere by this part of the product. Keeping and deleting
+that data stays where it already happens.
+
+**Threshold**: nothing stored here; person columns marked as such where data sets are
+described.
+
+**Rationale**: no second copy of people's activity with a life of its own.
+
+### 6.2 NFR Exclusions
+
+- **Working offline**: it reads live data; there is nothing to work from offline.
+- **Storing anything reliably**: it stores nothing until saved questions arrive.
+- **Signing in**: handled before a question reaches it.
+- **Uptime and recovery targets**: inherited from the service it lives in; it holds no data
+  of its own to recover.
+- **Accessibility, translation, phones**: the page is administrator-only today and follows
+  the product's usual standards; revisited when leads get access.
+- **Certifications**: none beyond the product's own.
+- **Monitoring**: speed and failures are recorded with the rest of the service; nothing
+  special is needed here.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### The question and answer format
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-interface-query`
+
+**Type**: the published request and answer format of the analytics API
+
+**Stability**: still changing while administrator-only; settles when access rules arrive
+
+**Description**: the one way to ask a data set a question, and to find out what can be asked.
+
+**Breaking Change Policy**: anything already accepted keeps its meaning; new options are
+added, never substituted.
+
+### 7.2 External Integration Contracts
+
+#### Who is asking
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-contract-caller-context`
+
+**Direction**: required from the identity service
+
+**Protocol/Format**: the asker's permissions, the people they may see, the teams they belong
+to, resolved for each question
+
+**Compatibility**: if a fact an access rule needs is missing, the question is refused — never
+answered more widely.
+
+## 8. Use Cases
+
+#### Build a chart nobody planned for
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-usecase-build-chart`
+
+**Actor**: `cpt-insightspec-qe-actor-admin`
+
+**Preconditions**:
+- The person is an administrator; data sets are available.
+
+**Main Flow**:
+1. The page lists the data sets and, for the chosen one, what can be broken down, filtered
+   and counted.
+2. The administrator picks dates, breakdowns, what to count, any filters, and asks.
+3. The product either points at what is wrong, or returns a table with readable names and a
+   note if it was cut short.
+4. The page draws the table and a chart from that answer alone.
+
+**Postconditions**:
+- A chart exists that nobody built into the product.
+
+**Alternative Flows**:
+- **Something is wrong**: each problem is shown next to the box it belongs to; nothing is
+  answered.
+- **Too many rows**: the answer is cut and says so.
+
+#### Decide for yourself what counts as test code
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-usecase-own-category`
+
+**Actor**: `cpt-insightspec-qe-actor-author`
+
+**Preconditions**:
+- File changes can be filtered by path.
+
+**Main Flow**:
+1. The author adds a second column counting only the changes whose path matches their own
+   pattern.
+2. The product checks the pattern makes sense and counts only those rows.
+
+**Postconditions**:
+- One table shows the matching lines beside the total, per file type, using the author's own
+  definition.
+
+**Alternative Flows**:
+- **The pattern is not valid**: the answer is refused, pointing at the pattern.
+
+#### A lead sees only their own team
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-usecase-lead-visibility`
+
+**Actor**: `cpt-insightspec-qe-actor-lead`
+
+**Preconditions**:
+- The data set has an access rule tying it to the people the asker may see.
+
+**Main Flow**:
+1. The lead opens a saved chart broken down by repository.
+2. The product applies the rule before counting anything, so only their people are included.
+
+**Postconditions**:
+- The same saved chart is correct for two different leads, and different for each.
+
+**Alternative Flows**:
+- **The product cannot tell who the lead may see**: the question is refused, not widened.
+
+## 9. Acceptance Criteria
+
+- [x] An administrator answers a question about each available data set from the page, with
+  nothing built in advance.
+- [x] Answers that must agree do agree on a test installation: the weeks add up to the whole
+  period; filtering to one value matches what the breakdown showed for it; a pattern matches
+  what the exact values match.
+- [x] Someone who is not an administrator is refused, both the questions and the list.
+- [x] Every refusal names the part of the question that is wrong.
+- [ ] A saved question is refused after the data behind it changes shape, instead of
+  answering something different.
+- [ ] A lead's answer includes only people they may see, however the chart is broken down.
+
+## 10. Dependencies
+
+| Dependency | Description | Criticality |
+|------------|-------------|-------------|
+| Prepared data sets | the ready-to-query tables, built with the counting rules already applied | p1 |
+| Record of what the warehouse holds | checked when the product is built, so a data set cannot promise a column that is not there | p1 |
+| Identity service | says who is an administrator today; who may see whom, later | p1 |
+| Published API description | what the page and the automated tests are built from | p1 |
+
+## 11. Assumptions
+
+- The product ships the first data sets; people add their own later, and both kinds are
+  checked and treated the same way.
+- Administrators may see everything in their own organisation; the restriction is for
+  everyone else.
+- The test installation contains data for every data set, so the checks mean something.
+- Cost depends on the dates and row limit rather than on how large the customer is; those
+  limits are the lever if an installation outgrows them.
+
+**Open questions**
+
+| Question | Owner | Resolve by |
+|---|---|---|
+| Where do we record which teams own which repositories? | product + backend | before the first access rule |
+| What protects small groups from being singled out once leads can ask? | product | before the page opens to leads |
+| Which data sets come after commits and file changes, in what order? | product | after the constructor page |
+| Who may add a data set, and what does approval look like when an assistant wrote it? | product | when own data sets start |
+| Is "show me the records behind this number" part of the same request or its own? | backend | when that work starts |
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| What people want to ask outpaces what we support | they go back to asking engineers, or to SQL | the list in DESIGN is the backlog, in priority order; the SQL console stays for administrators |
+| Access rules take longer than expected | charts stay administrator-only | access rules are the first thing after the basics; the restriction is deliberate, not a default |
+| A very broad question is slow on a large customer | exploring becomes painful | limits on dates, rows, size and how many run at once; the "cut short" note tells the asker to narrow it |
+| The data behind a saved question changes shape | wrong answers or errors | data sets are checked when the product is built; saved questions are re-checked each time they are opened |
+| Someone's own data set is wrong, slow or too revealing | bad numbers spread, or data leaks past its audience | the same checks and limits as a shipped data set; usable by its author alone until an administrator approves it and its access rules are set |


### PR DESCRIPTION
**Why.** A data set is the unit everything else stands on: one kind of thing people can ask about, at one stated grain, with the counting rules already applied. Until now there was no such unit — only pre-built metrics over tables nobody outside the pipeline could interpret, so every new question meant a developer reading warehouse schemas.

**What changed.** Data sets get a home, a registry and a way to be discovered.

**A data set is one folder.** `src/ingestion/datasets/<key>/` holds the model that materializes it, its dbt properties and grain test, its declaration, and a README saying what one row is. Deliberately outside the medallion layout: a data set is a product-level thing, and the layers underneath it may change. dbt gains the folder as a model path; `.dbtignore` keeps `dataset.yaml` out of dbt's hands.

**The declaration says what may be asked.** Grain, the columns that may be grouped or filtered with the label that travels beside each, the columns that may be folded, the columns carrying event time, and how the relation must be read to be duplicate-free. One validator checks every declaration against the warehouse's column catalogue and refuses it by field name — a mismatch fails a test run rather than a request.

**Two data sets to start.** `git_commits` (one row per commit somebody wrote) and `git_file_changes` (one row per path a commit touched), both over a shared authored-change relation that applies the content dedup once, so line totals agree with the metric evidence.

**Discovery.** `GET /v1/datasets` and `GET /v1/datasets/{key}` describe what can be asked about, without revealing database, relation, read discipline, tenancy column or row identity. Admin-only until access rules land.

**Shipped declarations travel in the image.** The datasets folder reaches the analytics build as a named additional build context, so the build script can embed every `dataset.yaml` without widening the build context. Data sets people add at runtime will join the same registry from the service's own store — one loader, one validator, one list.

**Out of scope.** Asking questions: [#3187](https://github.com/constructorfabric/insight/pull/3187) stacks on this and adds `POST /v1/query`.

**Docs.** `docs/domain/datasets/` — PRD (what a data set is to a person, and the roadmap for ones people add) and DESIGN (anatomy, rules, registry, lifecycle, how to add one).

**Verified.** 872 unit tests, clippy and rustfmt clean, no build warnings; `dbt parse` and `dbt ls` see both data sets from the new path; `cfs validate` and `cfs validate-toc` pass for both documents; OpenAPI and stand schemas regenerated; ruff clean.
