### PR TITLE
fix(gold): keep the git file-change build inside its ClickHouse memory ceiling

### DIFF
--- a/src/ingestion/gold/git_commit_file_changes.sql
+++ b/src/ingestion/gold/git_commit_file_changes.sql
@@ -14,8 +14,37 @@
 -- repo-qualified attach would leave the rows recorded under the repository
 -- that lost the collapse matching no commit and contributing nothing. One
 -- hash is one diff, so any repository's rows describe the commit — the
--- LIMIT 1 BY collapses the per-repository copies, and every row carries the
--- surviving commit's coordinates.
+-- collapse below keeps one copy, and every row carries the surviving commit's
+-- coordinates.
+WITH collapsed_file_changes AS (
+    SELECT
+        tenant_id,
+        data_source,
+        commit_hash,
+        file_path,
+        pre_image_oid,
+        post_image_oid,
+        -- SAFETY: ONE argMin over a tuple, never one per column. Copies of a
+        -- change can tie on the repository coordinates, and independent argMin
+        -- calls are then free to take each column from a different copy and
+        -- emit a row no repository reported.
+        argMin(
+            (file_extension, change_type, lines_added, lines_removed),
+            (source_id, project_key, repo_slug)
+        ) AS carrier
+    FROM {{ ref('class_git_file_changes') }} FINAL
+    -- INVARIANT: change_type is grouped case-folded and read back raw. Two
+    -- spellings of one change are one change, and keeping both would double
+    -- the path's lines wherever a reader folds the case itself.
+    GROUP BY
+        tenant_id,
+        data_source,
+        commit_hash,
+        file_path,
+        lower(change_type),
+        pre_image_oid,
+        post_image_oid
+)
 SELECT
     commits.tenant_id AS tenant_id,
     commits.source_id AS source_id,
@@ -26,23 +55,14 @@ SELECT
     commits.committer_date AS committer_date,
     raw_file_change.data_source AS data_source,
     raw_file_change.file_path AS file_path,
-    raw_file_change.file_extension AS file_extension,
-    raw_file_change.change_type AS change_type,
-    raw_file_change.lines_added AS lines_added,
-    raw_file_change.lines_removed AS lines_removed,
+    tupleElement(raw_file_change.carrier, 1) AS file_extension,
+    tupleElement(raw_file_change.carrier, 2) AS change_type,
+    tupleElement(raw_file_change.carrier, 3) AS lines_added,
+    tupleElement(raw_file_change.carrier, 4) AS lines_removed,
     raw_file_change.pre_image_oid AS pre_image_oid,
     raw_file_change.post_image_oid AS post_image_oid
-FROM {{ ref('class_git_file_changes') }} AS raw_file_change FINAL
+FROM collapsed_file_changes AS raw_file_change
 INNER JOIN {{ ref('git_authored_commits') }} AS commits
     ON commits.tenant_id = raw_file_change.tenant_id
     AND commits.data_source = raw_file_change.data_source
     AND commits.commit_hash = raw_file_change.commit_hash
-ORDER BY raw_file_change.source_id, raw_file_change.project_key, raw_file_change.repo_slug
-LIMIT 1 BY
-    tenant_id,
-    data_source,
-    commit_hash,
-    file_path,
-    lower(change_type),
-    pre_image_oid,
-    post_image_oid

--- a/src/ingestion/gold/git_deduplicated_file_changes.sql
+++ b/src/ingestion/gold/git_deduplicated_file_changes.sql
@@ -1,0 +1,105 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'data_source', 'commit_hash'],
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- One row per change CONTENT, not per commit that carries it. The same content
+-- entering a repository on two lines of history — a branch whose copy of a
+-- tree also landed on the default branch, a cherry-pick, a squash that
+-- re-applies its branch's whole span, a reverted-then-restored file — is one
+-- authored change, and summing every carrier's diff would count those lines
+-- more than once. `git_file_content_identity` is what "same content" means.
+--
+-- Earliest commit wins, so the value lands in the period the content was first
+-- authored and does not move when a later commit repeats it.
+--
+-- The commit_hash tie-breaker keeps rows whose identity is UNKNOWN (a source
+-- that reports no oid, or a row collected before the proxy did) distinct per
+-- commit: without it every such row for one path would collapse into one,
+-- because an unknown identity equals every other unknown identity.
+--
+-- The superseded set is the case content identity alone cannot reach: a squash
+-- whose branch was only PARTLY collected carries the collected commits' work
+-- under a span no single commit made, so nothing folds it. See
+-- git_superseded_file_changes.
+--
+-- A model rather than a CTE of the evidence build: the collapse spans every
+-- collected file change, and a CTE would run it once per reference inside a
+-- query already holding the rest of that build.
+WITH collected_file_changes AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        commit_hash,
+        data_source,
+        file_path,
+        file_extension,
+        change_type,
+        lines_added,
+        lines_removed,
+        observed_at,
+        committer_date,
+        {{ git_file_content_identity('post_image_oid', 'pre_image_oid') }} AS content_identity,
+        if(
+            coalesce(pre_image_oid, '') = ''
+                AND coalesce(post_image_oid, '') = '',
+            commit_hash,
+            ''
+        ) AS unknown_content_carrier
+    FROM {{ ref('git_commit_file_changes') }}
+    WHERE (tenant_id, data_source, commit_hash, file_path) NOT IN (
+        SELECT tenant_id, data_source, commit_hash, file_path
+        FROM {{ ref('git_superseded_file_changes') }}
+    )
+),
+earliest_carriers AS (
+    SELECT
+        tenant_id,
+        data_source,
+        project_key,
+        repo_slug,
+        file_path,
+        -- INVARIANT: committer_date breaks the tie, and must stay ahead of the
+        -- hash. observed_at is the AUTHOR date, which a rebase preserves — so
+        -- the copy and its original tie there, and without this the survivor
+        -- (and with it the repository and branch scope the lines are filed
+        -- under) would be decided by comparing hashes. #3153
+        --
+        -- SAFETY: ONE argMin over a tuple, never one per column. Carriers can
+        -- tie on all three ordering fields, and independent argMin calls are
+        -- then free to take each column from a different carrier and emit a
+        -- row no commit reported.
+        argMin(
+            (source_id, commit_hash, file_extension, change_type, lines_added, lines_removed),
+            (observed_at, committer_date, commit_hash)
+        ) AS carrier
+    FROM collected_file_changes
+    GROUP BY
+        tenant_id,
+        data_source,
+        project_key,
+        repo_slug,
+        file_path,
+        content_identity,
+        unknown_content_carrier
+)
+SELECT
+    tenant_id,
+    tupleElement(carrier, 1) AS source_id,
+    project_key,
+    repo_slug,
+    tupleElement(carrier, 2) AS commit_hash,
+    data_source,
+    file_path,
+    tupleElement(carrier, 3) AS file_extension,
+    tupleElement(carrier, 4) AS change_type,
+    tupleElement(carrier, 5) AS lines_added,
+    tupleElement(carrier, 6) AS lines_removed
+FROM earliest_carriers

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -1,16 +1,4 @@
-{# 3 GiB, and spill thresholds to match: this build outgrew the shared 2 GiB
-   ceiling and failed the post-upgrade migration hook with MEMORY_LIMIT_EXCEEDED,
-   taking the whole deploy down with it. Same pairing the other heavy gold
-   models carry (task_issue_state, task_status_spans, account_attribute_values).
-   Raising the ceiling buys headroom, not a cure — the inputs keep growing. #}
-{{ metric_evidence_table(
-    join_use_nulls=1,
-    query_settings_overrides={
-        'max_memory_usage': 3221225472,
-        'max_bytes_before_external_group_by': 805306368,
-        'max_bytes_before_external_sort': 805306368
-    }
-) }}
+{{ metric_evidence_table(join_use_nulls=1) }}
 
 -- Resolution happens at READ time, and account-first: a row naming its author's
 -- account (pull requests) resolves through that binding, everything else
@@ -57,63 +45,6 @@ repository_default_branches AS (
     WHERE is_default = 1
     GROUP BY tenant_id, source_id, project_key, repo_slug
 ),
--- One row per change CONTENT, not per commit that carries it. The same content
--- entering a repository on two lines of history — a branch whose copy of a
--- tree also landed on the default branch, a cherry-pick, a squash that
--- re-applies its branch's whole span, a reverted-then-restored file — is one
--- authored change, and summing every carrier's diff would count those lines
--- more than once. `git_file_content_identity` is what "same content" means.
---
--- Earliest commit wins, so the value lands in the period the content was first
--- authored and does not move when a later commit repeats it.
---
--- The commit_hash tie-breaker keeps rows whose identity is UNKNOWN (a source
--- that reports no oid, or a row collected before the proxy did) distinct per
--- commit: without it every such row for one path would collapse into one,
--- because LIMIT 1 BY reads their NULL keys as equal.
---
--- The superseded set is the case content identity alone cannot reach: a squash
--- whose branch was only PARTLY collected carries the collected commits' work
--- under a span no single commit made, so nothing folds it. See
--- git_superseded_file_changes.
-deduplicated_file_changes AS (
-    SELECT
-        tenant_id,
-        source_id,
-        project_key,
-        repo_slug,
-        commit_hash,
-        data_source,
-        file_path,
-        file_extension,
-        change_type,
-        lines_added,
-        lines_removed
-    FROM {{ ref('git_commit_file_changes') }}
-    WHERE (tenant_id, data_source, commit_hash, file_path) NOT IN (
-        SELECT tenant_id, data_source, commit_hash, file_path
-        FROM {{ ref('git_superseded_file_changes') }}
-    )
-    -- INVARIANT: committer_date breaks the tie, and must stay ahead of the
-    -- hash. observed_at is the AUTHOR date, which a rebase preserves — so the
-    -- copy and its original tie there, and without this the survivor (and with
-    -- it the repository and branch scope the lines are filed under) would be
-    -- decided by comparing hashes. #3153
-    ORDER BY observed_at, committer_date, commit_hash
-    LIMIT 1 BY
-        tenant_id,
-        data_source,
-        project_key,
-        repo_slug,
-        file_path,
-        {{ git_file_content_identity('post_image_oid', 'pre_image_oid') }},
-        if(
-            coalesce(pre_image_oid, '') = ''
-                AND coalesce(post_image_oid, '') = '',
-            commit_hash,
-            ''
-        )
-),
 -- A commit's own line stats, less the lines of the file changes that lost the
 -- content dedup. The stats stay the base — a source can report a commit's
 -- totals without reporting its file changes at all — and only what the dedup
@@ -128,7 +59,7 @@ authored_commit_file_lines AS (
         commit_hash,
         sum(lines_added) AS lines_added,
         sum(lines_removed) AS lines_removed
-    FROM deduplicated_file_changes
+    FROM {{ ref('git_deduplicated_file_changes') }}
     GROUP BY tenant_id, data_source, commit_hash
 ),
 authored_commits AS (
@@ -262,7 +193,7 @@ file_changes_source AS (
             ) AS change_type_label,
             sum(lines_added) AS lines_added,
             sum(lines_removed) AS lines_removed
-        FROM deduplicated_file_changes AS raw_file_change
+        FROM {{ ref('git_deduplicated_file_changes') }} AS raw_file_change
         GROUP BY tenant_id, source_id, project_key, repo_slug, commit_hash, category, file_extension_value, file_extension_label, change_type_value, change_type_label
     ) AS file_changes
     INNER JOIN {{ ref('git_authored_commits') }} AS commits

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -113,6 +113,47 @@ models:
         tests:
           - not_null
 
+  - name: git_deduplicated_file_changes
+    description: >
+      The collected file changes reduced to one row per change CONTENT within a
+      repository and path, with the earliest carrying commit kept, and the
+      superseded merge-result paths removed. This is the set every git size
+      measure sums: a cherry-pick, a squash and a rebase copy all describe one
+      authored change, and counting each carrier would report those lines more
+      than once. Materialized so the collapse runs once per build in its own
+      query budget rather than once per reference inside the evidence build.
+    columns:
+      - name: tenant_id
+        description: >
+          Tenant isolation field. Nullable on the git class relations and
+          preserved as such here, so no not_null test.
+      - name: source_id
+        description: "Connector instance of the surviving carrier"
+      - name: project_key
+        description: "Project the repository belongs to"
+      - name: repo_slug
+        description: "Repository the content entered"
+      - name: commit_hash
+        description: "Earliest commit that carries the content"
+        tests:
+          - not_null
+      - name: data_source
+        description: "Git source discriminator (insight_github, insight_gitlab, ...)"
+        tests:
+          - not_null
+      - name: file_path
+        description: "Path the content was written to"
+        tests:
+          - not_null
+      - name: file_extension
+        description: "Extension of file_path, lowercased, empty when it has none"
+      - name: change_type
+        description: "Vendor change type as reported (added, modified, renamed, ...)"
+      - name: lines_added
+        description: "Added lines of the surviving carrier's diff for the path"
+      - name: lines_removed
+        description: "Removed lines of the surviving carrier's diff for the path"
+
   - name: git_default_branch_commits
     description: >
       Commits that reached a repository's default branch, either through a


### PR DESCRIPTION
**Why.** Once a git source's collected file changes reach a few million rows the gold build fails with `MEMORY_LIMIT_EXCEEDED`, and the deploy hook that runs `dbt run --select tag:gold` fails with it. Two models sorted their entire result to pick one row per key.

**What changed.** Both now aggregate instead of sorting. `git_commit_file_changes` collapses the per-repository copies of a change with `argMin` on the file-change side, before the commit join. The content dedup moves out of `git_metric_evidence` into its own model, `git_deduplicated_file_changes`, so it runs once per build rather than once per reference inside the evidence query.

**One `argMin` over a tuple, never one per column.** Carriers can tie on every ordering field, and independent `argMin` calls would then be free to take each column from a different carrier and emit a row no commit reported.

**The evidence model's 3 GiB override is removed, not raised.** With the dedup extracted it belongs back on the shared serving budget; a ceiling that has to be raised each time the inputs double is not a fix.

Old and new SQL were run side by side against a seeded stand. Identical row counts, identical order-insensitive row checksums, identical line-sum totals:

| model | rows | full-row checksum | lines added | lines removed |
|---|---|---|---|---|
| `git_commit_file_changes` old / new | 139260 / 139260 | equal | 10787602 / 10787602 | 3665839 / 3665839 |
| content dedup old / new | 132665 / 132665 | equal | 10049061 / 10049061 | 3590552 / 3590552 |

`EXPLAIN PIPELINE` confirms the shape change: the old plan carries `PartialSortingTransform`, `MergeSortingTransform` and `LimitByTransform`, the new one only `AggregatingTransform`, which spills under the `max_bytes_before_external_group_by` the serving settings already set.

**Out of scope.** `src/ingestion/scripts/connectors-ddl/insight.sql` is generated by `bootstrap-db/dump-ddl.sh` and will pick up the new gold relation on its next regeneration. Gold tables are rebuilt by the deploy's dbt run, so no migration accompanies this.

**Verified.** `dbt parse` clean; DAG resolves with `git_metric_evidence`, `git_metric_observations` and `identity_resolution_coverage` downstream of the new model; equivalence and pipeline checks above. The metric specs under `src/ingestion/tests/e2e/metrics/` were not run here, and the memory ceiling was not re-exercised at multi-million-row scale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deduplicated Git file-change dataset that counts copied changes—such as cherry-picks, squashes, and rebases—once per repository and file path.
  * Preserved the earliest commit carrying each unique file change and retained associated line-change metrics.

* **Bug Fixes**
  * Improved consistency of file metadata and change-type handling when processing Git commit data.
  * Removed duplicate file-change records from metric evidence calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->