### PR TITLE
feat(datasets): declare, register and describe the queryable datasets

### DIFF
--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -109,6 +109,18 @@ traceability = "DOCS-ONLY"
 
 [[systems.artifacts]]
 kind = "PRD"
+path = "docs/domain/query-engine/PRD.md"
+name = "Query Engine PRD"
+traceability = "DOCS-ONLY"
+
+[[systems.artifacts]]
+kind = "DESIGN"
+path = "docs/domain/query-engine/DESIGN.md"
+name = "Query Engine Design"
+traceability = "DOCS-ONLY"
+
+[[systems.artifacts]]
+kind = "PRD"
 path = "docs/domain/datasets/PRD.md"
 name = "Data Sets PRD"
 traceability = "DOCS-ONLY"

--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -107,6 +107,18 @@ path = "docs/components/backend/analytics/specs/connector-health/DESIGN.md"
 name = "Connector Health Design"
 traceability = "DOCS-ONLY"
 
+[[systems.artifacts]]
+kind = "PRD"
+path = "docs/domain/datasets/PRD.md"
+name = "Data Sets PRD"
+traceability = "DOCS-ONLY"
+
+[[systems.artifacts]]
+kind = "DESIGN"
+path = "docs/domain/datasets/DESIGN.md"
+name = "Data Sets Design"
+traceability = "DOCS-ONLY"
+
 [[systems]]
 name = "Identity Service"
 slug = "identity-svc"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -120,6 +120,8 @@ jobs:
               - '.github/workflows/e2e-stand.yml'
               - 'src/backend/services/analytics/**'
               - 'src/backend/libs/insight-clickhouse/**'
+              # Shipped dataset declarations are embedded into the image.
+              - 'src/ingestion/datasets/**/dataset.yaml'
               # The shared entrypoint is baked into the image.
               - 'src/backend/docker-entrypoint.sh'
               - 'src/backend/Cargo.toml'
@@ -363,6 +365,8 @@ jobs:
         with:
           context: src/backend
           file: src/backend/services/analytics/Dockerfile
+          build-contexts: |
+            datasets=src/ingestion/datasets
           platforms: linux/${{ matrix.arch }}
           # PR and merge-group amd64 legs write a loadable tarball instead of
           # discarding the result. Other legs keep the push-by-digest output.

--- a/.github/workflows/connectors-ddl.yml
+++ b/.github/workflows/connectors-ddl.yml
@@ -32,18 +32,21 @@ name: connectors-ddl
 
 # Path-filtered: the contracts this lane guards can only move when something
 # under src/ingestion changes (connectors, dbt, migrations, the snapshot, the
-# bootstrap scripts) — or when the lane itself does.
+# bootstrap scripts), when the column snapshot the analytics field catalog
+# embeds changes — or when the lane itself does.
 on:
   pull_request:
     branches: [main]
     paths:
       - src/ingestion/**
+      - src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
       - .github/workflows/connectors-ddl.yml
       - .github/workflows/scripts/start-clickhouse.sh
   push:
     branches: [main]
     paths:
       - src/ingestion/**
+      - src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
       - .github/workflows/connectors-ddl.yml
       - .github/workflows/scripts/start-clickhouse.sh
   workflow_dispatch:
@@ -116,13 +119,19 @@ jobs:
         run: |
           set -euo pipefail
           "${BOOTSTRAP_DIR}/dump-ddl.sh"
+          # Both artifacts dump-ddl.sh writes: the cluster DDL a fresh install
+          # applies, and the column snapshot the analytics field catalog embeds.
+          DUMPED=(
+            src/ingestion/scripts/connectors-ddl
+            src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
+          )
           # --intent-to-add so a brand-new connector's .sql file (untracked, and
           # therefore invisible to a plain `git diff`) counts as drift too.
-          git add --intent-to-add --all -- src/ingestion/scripts/connectors-ddl
-          git diff -- src/ingestion/scripts/connectors-ddl > "$RUNNER_TEMP/connectors-ddl.diff"
+          git add --intent-to-add --all -- "${DUMPED[@]}"
+          git diff -- "${DUMPED[@]}" > "$RUNNER_TEMP/connectors-ddl.diff"
           if [[ -s "$RUNNER_TEMP/connectors-ddl.diff" ]]; then
             echo "::error title=connectors-ddl snapshot is stale::This branch's connectors/dbt/migrations produce different DDL than the committed snapshot. Regenerate and commit it — no credentials needed: the one-block recipe in src/ingestion/scripts/bootstrap-db/README.md (bootstrap-db.sh, then dump-ddl.sh). Full diff below and in the connectors-ddl-drift artifact."
-            git diff --stat -- src/ingestion/scripts/connectors-ddl
+            git diff --stat -- "${DUMPED[@]}"
             head -n 200 "$RUNNER_TEMP/connectors-ddl.diff"
             exit 1
           fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,6 +204,8 @@ services:
     build:
       context: src/backend
       dockerfile: services/analytics/Dockerfile
+      additional_contexts:
+        datasets: src/ingestion/datasets
     depends_on:
       mariadb: {condition: service_healthy, required: false}
     environment:
@@ -231,6 +233,8 @@ services:
     build:
       context: src/backend
       dockerfile: services/analytics/Dockerfile
+      additional_contexts:
+        datasets: src/ingestion/datasets
     depends_on:
       # required: false → compose skips this dependency when the local
       # profile isn't active (external MariaDB / ClickHouse modes).

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -2365,6 +2365,306 @@
         ],
         "type": "object"
       },
+      "Query": {
+        "additionalProperties": false,
+        "properties": {
+          "aggregates": {
+            "items": {
+              "$ref": "#/components/schemas/QueryAggregate"
+            },
+            "type": "array"
+          },
+          "dataset": {
+            "type": "string"
+          },
+          "filters": {
+            "description": "Row filters, narrowing the scan before aggregation.",
+            "items": {
+              "$ref": "#/components/schemas/QueryFilter"
+            },
+            "type": "array"
+          },
+          "group_by": {
+            "items": {
+              "$ref": "#/components/schemas/QueryGroupAxis"
+            },
+            "type": "array"
+          },
+          "limit": {
+            "description": "Row ceiling; a query over the cap is refused rather than clipped.",
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "order": {
+            "items": {
+              "$ref": "#/components/schemas/QueryOrder"
+            },
+            "type": "array"
+          },
+          "time": {
+            "$ref": "#/components/schemas/QueryTime",
+            "description": "The window every scan is bounded by, and the width of its buckets."
+          }
+        },
+        "required": [
+          "dataset",
+          "aggregates",
+          "time"
+        ],
+        "type": "object"
+      },
+      "QueryAggregate": {
+        "oneOf": [
+          {
+            "properties": {
+              "filter": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/QueryFilter",
+                    "description": "Restricts this fold to the rows one filter selects."
+                  }
+                ]
+              },
+              "fn": {
+                "enum": [
+                  "count"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "What the answer column is called.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "fn"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "filter": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/QueryFilter",
+                    "description": "Restricts this fold to the rows one filter selects."
+                  }
+                ]
+              },
+              "fn": {
+                "enum": [
+                  "sum"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "What the answer column is called.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "field",
+              "fn"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "filter": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/QueryFilter",
+                    "description": "Restricts this fold to the rows one filter selects."
+                  }
+                ]
+              },
+              "fn": {
+                "enum": [
+                  "avg"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "What the answer column is called.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "field",
+              "fn"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "filter": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/QueryFilter",
+                    "description": "Restricts this fold to the rows one filter selects."
+                  }
+                ]
+              },
+              "fn": {
+                "enum": [
+                  "min"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "What the answer column is called.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "field",
+              "fn"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "filter": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/QueryFilter",
+                    "description": "Restricts this fold to the rows one filter selects."
+                  }
+                ]
+              },
+              "fn": {
+                "enum": [
+                  "max"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "What the answer column is called.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "field",
+              "fn"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "QueryAnswer": {
+        "properties": {
+          "columns": {
+            "items": {
+              "$ref": "#/components/schemas/QueryAnswerColumn"
+            },
+            "type": "array"
+          },
+          "flags": {
+            "$ref": "#/components/schemas/QueryAnswerFlags"
+          },
+          "rows": {
+            "items": {
+              "items": {},
+              "type": "array"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "columns",
+          "rows",
+          "flags"
+        ],
+        "type": "object"
+      },
+      "QueryAnswerColumn": {
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/QueryColumnKind"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/QueryColumnType"
+          }
+        },
+        "required": [
+          "name",
+          "kind",
+          "type"
+        ],
+        "type": "object"
+      },
+      "QueryAnswerFlags": {
+        "properties": {
+          "truncated": {
+            "description": "More groups matched than the limit admits; the rows are the first\n`limit` of them in the answer's order.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "truncated"
+        ],
+        "type": "object"
+      },
+      "QueryColumnKind": {
+        "enum": [
+          "dimension",
+          "label",
+          "bucket",
+          "aggregate"
+        ],
+        "type": "string"
+      },
+      "QueryColumnType": {
+        "enum": [
+          "text",
+          "number",
+          "date"
+        ],
+        "type": "string"
+      },
       "QueryDataset": {
         "properties": {
           "dimensions": {
@@ -2376,6 +2676,10 @@
           },
           "key": {
             "type": "string"
+          },
+          "limits": {
+            "$ref": "#/components/schemas/QueryLimits",
+            "description": "The bounds a request against this dataset must stay inside."
           },
           "measurables": {
             "description": "The columns an aggregate may fold.",
@@ -2396,7 +2700,8 @@
           "key",
           "time_fields",
           "dimensions",
-          "measurables"
+          "measurables",
+          "limits"
         ],
         "type": "object"
       },
@@ -2463,6 +2768,427 @@
         "required": [
           "field",
           "default"
+        ],
+        "type": "object"
+      },
+      "QueryDirection": {
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "QueryFilter": {
+        "oneOf": [
+          {
+            "properties": {
+              "field": {
+                "description": "A declared dimension or measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "eq"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/QueryFilterValue"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared dimension or measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "in"
+                ],
+                "type": "string"
+              },
+              "values": {
+                "description": "At least one value, and at most the contract's cap.",
+                "items": {
+                  "$ref": "#/components/schemas/QueryFilterValue"
+                },
+                "maxItems": 256,
+                "minItems": 1,
+                "type": "array"
+              }
+            },
+            "required": [
+              "field",
+              "values",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "gt"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/QueryFilterValue"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "gte"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/QueryFilterValue"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "lt"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/QueryFilterValue"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "lte"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "$ref": "#/components/schemas/QueryFilterValue"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared measurable of the dataset.",
+                "type": "string"
+              },
+              "high": {
+                "$ref": "#/components/schemas/QueryFilterValue",
+                "description": "Inclusive upper bound."
+              },
+              "low": {
+                "$ref": "#/components/schemas/QueryFilterValue",
+                "description": "Inclusive lower bound."
+              },
+              "op": {
+                "enum": [
+                  "between"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "field",
+              "low",
+              "high",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
+              "field": {
+                "description": "A declared dimension or measurable of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "not_null"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "field",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "SQL `LIKE`: `%` matches any run, `_` one character.",
+            "properties": {
+              "field": {
+                "description": "A declared dimension of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "like"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "maxLength": 256,
+                "type": "string"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "An RE2 regular expression, unanchored.",
+            "properties": {
+              "field": {
+                "description": "A declared dimension of the dataset.",
+                "type": "string"
+              },
+              "op": {
+                "enum": [
+                  "match"
+                ],
+                "type": "string"
+              },
+              "value": {
+                "maxLength": 256,
+                "type": "string"
+              }
+            },
+            "required": [
+              "field",
+              "value",
+              "op"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "QueryFilterValue": {
+        "description": "A filter value: text, a number, or a boolean",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "format": "double",
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "QueryGrain": {
+        "enum": [
+          "day",
+          "week",
+          "month"
+        ],
+        "type": "string"
+      },
+      "QueryGroupAxis": {
+        "oneOf": [
+          {
+            "properties": {
+              "axis": {
+                "enum": [
+                  "dimension"
+                ],
+                "type": "string"
+              },
+              "field": {
+                "description": "A declared dimension of the dataset.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "field",
+              "axis"
+            ],
+            "type": "object"
+          },
+          {
+            "description": "The time bucket as a group axis; its width is `time.grain`.",
+            "properties": {
+              "axis": {
+                "enum": [
+                  "time"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "axis"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "QueryLimits": {
+        "description": "The contract's request bounds, identical for every dataset.",
+        "properties": {
+          "default_limit": {
+            "description": "Rows a query gets when it sets no ceiling of its own.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_aggregates": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_filter_values": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_filters": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_group_axes": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_limit": {
+            "description": "Rows a query may ask for at most; over it the query is refused, not clipped.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_name_chars": {
+            "description": "Longest an aggregate's name may be, in characters.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_order_terms": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "max_filters",
+          "max_filter_values",
+          "max_aggregates",
+          "max_group_axes",
+          "max_order_terms",
+          "max_name_chars",
+          "default_limit",
+          "max_limit"
+        ],
+        "type": "object"
+      },
+      "QueryOrder": {
+        "additionalProperties": false,
+        "properties": {
+          "by": {
+            "description": "A column the answer reports: a grouped dimension, `time`, or an aggregate name.",
+            "type": "string"
+          },
+          "dir": {
+            "$ref": "#/components/schemas/QueryDirection"
+          }
+        },
+        "required": [
+          "by"
+        ],
+        "type": "object"
+      },
+      "QueryTime": {
+        "additionalProperties": false,
+        "properties": {
+          "field": {
+            "description": "A declared time field; the dataset's default when omitted.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "from": {
+            "description": "Inclusive first day, UTC.",
+            "format": "date",
+            "type": "string"
+          },
+          "grain": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/QueryGrain",
+                "description": "Bucket width. Required with an `{\"axis\": \"time\"}` axis, refused without one."
+              }
+            ]
+          },
+          "to": {
+            "description": "Inclusive last day, UTC.",
+            "format": "date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "from",
+          "to"
         ],
         "type": "object"
       },
@@ -6755,6 +7481,100 @@
           }
         ],
         "summary": "Run a saved query"
+      }
+    },
+    "/v1/query": {
+      "post": {
+        "operationId": "analytics_api.query.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Query"
+              }
+            }
+          },
+          "description": "The question to answer",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryAnswer"
+                }
+              }
+            },
+            "description": "A typed table"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "415": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unsupported Media Type"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Answer a query over a declared dataset"
       }
     },
     "/v1/reports/export": {

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -2365,6 +2365,107 @@
         ],
         "type": "object"
       },
+      "QueryDataset": {
+        "properties": {
+          "dimensions": {
+            "description": "The axes a query may group by, and filter on beside the measurables.",
+            "items": {
+              "$ref": "#/components/schemas/QueryDatasetDimension"
+            },
+            "type": "array"
+          },
+          "key": {
+            "type": "string"
+          },
+          "measurables": {
+            "description": "The columns an aggregate may fold.",
+            "items": {
+              "$ref": "#/components/schemas/QueryDatasetMeasurable"
+            },
+            "type": "array"
+          },
+          "time_fields": {
+            "description": "The columns a query may bound its window by, and bucket on.",
+            "items": {
+              "$ref": "#/components/schemas/QueryDatasetTimeField"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "key",
+          "time_fields",
+          "dimensions",
+          "measurables"
+        ],
+        "type": "object"
+      },
+      "QueryDatasetDimension": {
+        "properties": {
+          "absent_value": {
+            "description": "The value absent rows group under, and a filter matches them by.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "field": {
+            "type": "string"
+          },
+          "label": {
+            "description": "The answer column carrying this dimension's display label when it is\na group axis; absent when the dataset declares none.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "field"
+        ],
+        "type": "object"
+      },
+      "QueryDatasetList": {
+        "properties": {
+          "datasets": {
+            "items": {
+              "$ref": "#/components/schemas/QueryDataset"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "datasets"
+        ],
+        "type": "object"
+      },
+      "QueryDatasetMeasurable": {
+        "properties": {
+          "field": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "field"
+        ],
+        "type": "object"
+      },
+      "QueryDatasetTimeField": {
+        "properties": {
+          "default": {
+            "description": "The field a query's window binds to when it names none.",
+            "type": "boolean"
+          },
+          "field": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "field",
+          "default"
+        ],
+        "type": "object"
+      },
       "ReportCell": {
         "oneOf": [
           {
@@ -4641,6 +4742,133 @@
           }
         ],
         "summary": "Recent syncs of one connector, newest first"
+      }
+    },
+    "/v1/datasets": {
+      "get": {
+        "operationId": "analytics_api.datasets.list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryDatasetList"
+                }
+              }
+            },
+            "description": "The declared datasets"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List the datasets a query may be built over"
+      }
+    },
+    "/v1/datasets/{key}": {
+      "get": {
+        "operationId": "analytics_api.datasets.get",
+        "parameters": [
+          {
+            "description": "The dataset key, as a query names it",
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryDataset"
+                }
+              }
+            },
+            "description": "The declared dataset"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Describe one dataset a query may be built over"
       }
     },
     "/v1/feedback": {

--- a/docs/domain/datasets/DESIGN.md
+++ b/docs/domain/datasets/DESIGN.md
@@ -1,10 +1,10 @@
 ---
-version: 1.0
+version: 1.1
 status: proposed
 date: 2026-09-08
 ---
 
-# Technical Design — Data Sets
+# Technical Design — Datasets
 
 - [ ] `p1` - **ID**: `cpt-insightspec-ds-design-datasets`
 
@@ -27,15 +27,10 @@ date: 2026-09-08
   - [3.7 Database schemas & tables](#37-database-schemas--tables)
   - [3.8 Deployment Topology](#38-deployment-topology)
 - [4. Additional context](#4-additional-context)
-  - [The declaration](#the-declaration)
-  - [Rules a declaration must satisfy](#rules-a-declaration-must-satisfy)
-  - [Anatomy of a dataset folder](#anatomy-of-a-dataset-folder)
-  - [Adding a dataset](#adding-a-dataset)
-  - [Lifecycle](#lifecycle)
-  - [Kinds of dataset](#kinds-of-dataset)
-  - [Tenant-defined datasets](#tenant-defined-datasets)
-  - [Access rules](#access-rules)
-  - [Not a dataset](#not-a-dataset)
+  - [Dataset authoring and lifecycle](#dataset-authoring-and-lifecycle)
+  - [Tenant-defined datasets (planned)](#tenant-defined-datasets-planned)
+  - [Access policies (planned)](#access-policies-planned)
+  - [Validation limits and open semantics](#validation-limits-and-open-semantics)
 - [5. Traceability](#5-traceability)
 
 <!-- /toc -->
@@ -44,25 +39,24 @@ date: 2026-09-08
 
 ### 1.1 Architectural Vision
 
-A dataset is a declaration bound to one prepared relation. The declaration says what the
-relation is for: its grain, the columns that may be grouped or filtered, the columns that may
-be folded, the columns that carry event time, the labels that travel with values, and how the
-relation must be read to be duplicate-free. Everything downstream — discovery, planning,
-compilation, access rules — reads that declaration and nothing else about storage.
+A dataset declaration binds one prepared relation to its queryable fields and row identity.
+The analytics service embeds shipped declarations, validates them against a column snapshot,
+and exposes their query metadata through an in-memory registry and discovery API.
 
-The declaration lives beside the model that materializes it, one folder per dataset, so a
-dataset is reviewed, shipped and reasoned about as one unit. The service embeds the shipped
-declarations at build time and merges them with tenant-defined ones into a single in-memory
-registry. One loader, one validator, one list.
+Dataset models apply deduplication, attribution, and exclusion rules before queries run.
+The [query engine](https://github.com/constructorfabric/insight/blob/d912c610da33259475d817fc009d34de35b8fe10/docs/domain/query-engine/DESIGN.md) consumes declarations for query execution;
+this module owns definitions and discovery.
 
-Correctness is a property of the relation, not of the question: dedup, attribution and
-exclusion are applied once by the model. The declaration then states the grain that results,
-and a data test enforces it. Realises [PRD.md](PRD.md); the consumer is the
-[query engine](../query-engine/DESIGN.md).
+**Implemented**: shipped declarations, offline schema validation, registry lookup, admin-only
+discovery, and the commits and file changes relations.
+
+**Planned**: tenant-defined datasets, approval and versioning, live-catalog validation, richer
+field metadata, value suggestions, and access policies. Proposed extensions appear in
+Section 4; they are not part of the current runtime.
 
 ### 1.2 Architecture Drivers
 
-**ADRs**: none yet; the first is expected with tenant-defined datasets.
+**ADRs**: none. Tenant-defined dataset storage and composition remain design proposals.
 
 #### Functional Drivers
 
@@ -73,147 +67,162 @@ and a data test enforces it. Realises [PRD.md](PRD.md); the consumer is the
 | `cpt-insightspec-ds-fr-fields` | dimensions with `label_field`, measurables, time fields with one default; every stable column declared |
 | `cpt-insightspec-ds-fr-absent-values` | `absent_value` required on a nullable dimension, refused on a non-nullable one |
 | `cpt-insightspec-ds-fr-correctness-baked` | dedup, attribution and supersede rules live in the model; the shared dedup is its own relation |
-| `cpt-insightspec-ds-fr-registry` | one in-memory registry: shipped from the binary, tenant-defined from the service store |
-| `cpt-insightspec-ds-fr-validated` | one validator against the field catalog: the embedded snapshot in CI, the live catalog at load |
+| `cpt-insightspec-ds-fr-registry` | embedded shipped declarations; tenant-store integration planned |
+| `cpt-insightspec-ds-fr-validated` | validation against the embedded snapshot; live-catalog validation planned |
 | `cpt-insightspec-ds-fr-discovery` | `GET /v1/datasets` and `GET /v1/datasets/{key}` describe declarations, never storage |
-| `cpt-insightspec-ds-fr-field-metadata` | declaration gains label, description and unit; a values endpoint reads distinct values |
+| `cpt-insightspec-ds-fr-field-metadata` | planned: field labels, descriptions, units, and value suggestions |
 | `cpt-insightspec-ds-fr-first-two` | `git_commits` and `git_file_changes`, over the shared authored-change relation |
-| `cpt-insightspec-ds-fr-own-datasets` | three runtime forms over the same declaration shape |
-| `cpt-insightspec-ds-fr-own-validated` | runtime declarations take the same validator and the same violations |
-| `cpt-insightspec-ds-fr-approval` | state on the stored declaration; the registry exposes drafts to their author alone |
-| `cpt-insightspec-ds-fr-versioning` | a new row per edit, keyed by dataset and version, with author and approver |
-| `cpt-insightspec-ds-fr-access-rules` | policies declared beside the fields they bind; the engine enforces them at plan time |
+| `cpt-insightspec-ds-fr-own-datasets` | planned: derived, saved-query, and imported datasets |
+| `cpt-insightspec-ds-fr-own-validated` | planned: shared validation rules and errors |
+| `cpt-insightspec-ds-fr-approval` | planned: author-only drafts and administrator approval |
+| `cpt-insightspec-ds-fr-versioning` | proposed: version records with author and approver |
+| `cpt-insightspec-ds-fr-access-rules` | planned: declared policies, enforced by the query engine |
 
 #### NFR Allocation
 
 | NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
 |--------|-------------|--------------|-----------------|----------------------|
-| `cpt-insightspec-ds-nfr-additive` | a new dataset costs no engine change | declaration format | the engine reads declarations; adding one is a folder plus a build-script pickup | a dataset added with no diff under the engine modules |
-| `cpt-insightspec-ds-nfr-fail-early` | broken definitions never reach people | validator | shipped declarations validated in unit tests against the embedded snapshot; runtime ones validated on save | tests over deliberately broken declarations |
-| `cpt-insightspec-ds-nfr-cheap-discovery` | discovery costs no warehouse read | registry | declarations are resident; describe reads memory | discovery handler holds no ClickHouse call |
+| `cpt-insightspec-ds-nfr-additive` | dataset extensibility | declaration format | the engine reads declarations; adding one is a folder plus a build-script pickup | a dataset added with no diff under the engine modules |
+| `cpt-insightspec-ds-nfr-fail-early` | validation before use | validator | shipped declarations validated in unit tests against the embedded snapshot; runtime validation on save is planned | tests over deliberately broken declarations |
+| `cpt-insightspec-ds-nfr-cheap-discovery` | discovery makes no warehouse queries | registry | declarations are resident; describe reads memory | discovery handler holds no ClickHouse call |
 
 ### 1.3 Architecture Layers
 
 ```text
-src/ingestion/datasets/<key>/          dbt model · properties · declaration · README
-        │ dbt build                            │ build script (named build context)
-        ▼                                      ▼
-ClickHouse relation  ◀── validated against ── analytics service
-                                               ├─ domain::datasets   registry · validator · describe
-                                               └─ api::datasets      GET /v1/datasets[/{key}]
-                                                       │
-                                                 query engine, constructor
+dataset folder
+  model + schema.yml -- dbt build --> prepared relation
+  dataset.yaml ------ build.rs ---> embedded declarations
+                                         |
+column snapshot --------------------> validator
+                                         |
+                                      registry
+                                         |
+                                  discovery API
 ```
 
 - [ ] `p3` - **ID**: `cpt-insightspec-ds-tech-layers`
 
 | Layer | Responsibility | Technology |
-|-------|---------------|------------|
-| Presentation | lists what can be asked about | React constructor page |
-| Application | admin gate, describe, respond | Rust, axum |
-| Domain | declaration model, validation, registry, describe | Rust, serde_yaml |
-| Data definition | model, dbt properties, declaration, README per dataset | dbt, YAML |
-| Infrastructure | prepared relations | ClickHouse MergeTree |
+|---|---|---|
+| Consumer | Dataset selection and query construction | Constructor page, query engine |
+| API | Administrator check and discovery responses | Rust, axum |
+| Domain | Declaration types, validation, registry, descriptions | Rust, serde_yaml |
+| Data preparation | Dataset relations and grain tests | dbt, ClickHouse |
 
 ## 2. Principles & Constraints
 
 ### 2.1 Design Principles
 
-#### A dataset is a declaration, not a table
+#### Declared query surface
 
 - [ ] `p1` - **ID**: `cpt-insightspec-ds-principle-declaration`
 
-The relation is an implementation detail of the dataset. Consumers see the declaration:
-grain, fields, labels, time, policies. Nothing downstream may reach past it to a column the
-declaration does not name.
+Consumers may reference only declared fields. Storage metadata remains internal to the
+query engine and registry.
 
-#### Everything about one dataset in one folder
+#### Dataset colocation
 
 - [ ] `p1` - **ID**: `cpt-insightspec-ds-principle-colocation`
 
-Model, properties, declaration and README live together, outside the medallion layout, so a
-dataset is added, reviewed and deleted as one unit and its parts cannot drift.
+Keep the model, dbt properties, declaration, and README together so changes can be reviewed
+as one unit. Shared preparation models remain outside individual dataset folders.
 
-#### Correctness belongs to the relation
+#### Prepared-data correctness
 
 - [ ] `p1` - **ID**: `cpt-insightspec-ds-principle-correct-relation`
 
-Dedup, attribution and exclusion are applied once where the data is built. A dataset's grain
-is then a fact a test can enforce, not a rule each question must remember.
+Apply counting and attribution rules in data preparation. Verify the resulting row identity
+with dbt uniqueness tests.
 
-#### One registry, whoever wrote the declaration
+#### Shared registry contract
 
 - [ ] `p1` - **ID**: `cpt-insightspec-ds-principle-one-registry`
 
-Shipped and tenant-defined declarations share one shape, one validator and one list. The only
-differences are where the declaration is stored and who may see it.
+The planned tenant-defined extension uses the same declaration contract and validator as
+shipped datasets, with additional persistence and visibility controls.
 
 ### 2.2 Constraints
 
-#### Shipped declarations ship with the binary
+#### Embedded shipped declarations
 
 - [ ] `p1` - **ID**: `cpt-insightspec-ds-constraint-embedded`
 
-The datasets folder is outside the service's build context, so it arrives as a named
-additional build context and the build script embeds every `dataset.yaml`. A shipped
-declaration is never written to any database and never edited in a running installation.
+Shipped declarations are embedded at build time and change only with a product release.
+They are not stored in a runtime database.
 
-#### dbt must not read declarations
+#### dbt declaration exclusion
 
 - [ ] `p1` - **ID**: `cpt-insightspec-ds-constraint-dbt-ignores-declarations`
 
-The datasets folder is a dbt model path, so dbt would otherwise try to parse `dataset.yaml`
-as its own properties. `.dbtignore` excludes it by name.
+The datasets directory is a dbt model path. `.dbtignore` excludes `dataset.yaml` so dbt does
+not parse declarations as model properties.
 
-#### Every named column must exist
+#### Catalog validation
 
 - [ ] `p1` - **ID**: `cpt-insightspec-ds-constraint-catalog-checked`
 
-A declaration is only admissible if the catalog carries every column it names with a
-compatible type, its read discipline matches the relation's engine family, and it declares
-exactly one default time field and a non-empty row identity.
+Declarations must satisfy the validator's field, type, read-discipline, time-field, and
+row-identity checks against the supplied catalog.
 
-#### Prepared relations only
+#### Prepared relations
 
 - [ ] `p1` - **ID**: `cpt-insightspec-ds-constraint-prepared-only`
 
-A dataset binds one relation in the serving database. No raw or intermediate layer, no
-query-time joins beyond a declared lookup, no writes.
+A dataset binds one prepared serving relation. Raw and intermediate relations, writes, and
+query-time joins beyond declared lookups are outside this contract.
 
 ## 3. Technical Architecture
 
 ### 3.1 Domain Model
 
-**Technology**: YAML declarations, Rust types, a JSON snapshot of the warehouse columns.
+**Technology**: YAML declarations, Rust domain types, JSON column snapshot.
 
-**Location**: `src/ingestion/datasets/`, `src/backend/services/analytics/src/domain/datasets/`
+**Location**: `src/ingestion/datasets/` and
+`src/backend/services/analytics/src/domain/datasets/`.
 
-**Core Entities**:
+| Entity | Responsibility | Source |
+|---|---|---|
+| Dataset | Relation binding, queryable fields, and row identity | `datasets/declaration.rs` |
+| Dimension | Grouping/filtering field, optional label field, null representation | `datasets/declaration.rs` |
+| Measurable | Numeric field available for aggregation | `datasets/declaration.rs` |
+| TimeField | Query time field with a default marker | `datasets/declaration.rs` |
+| FieldCatalog | Relations, engine families, and typed columns | `field_catalog/columns.snapshot.json` |
+| DeclarationError | Validation failure with dataset and field context | `datasets/validate.rs` |
+| DatasetDescription | Public query metadata | `datasets/describe.rs` |
 
-| Entity | Description | Schema |
-|--------|-------------|--------|
-| Dataset | key, database, relation, read discipline, tenant field, time fields, dimensions, measurables, row identity | `datasets/declaration.rs` |
-| Dimension | field, optional label field, absent value when nullable | `datasets/declaration.rs` |
-| Measurable | a numeric column an aggregate may fold | `datasets/declaration.rs` |
-| TimeField | an event-time column; exactly one is the default | `datasets/declaration.rs` |
-| FieldCatalog | the relations, engines and columns declarations are checked against | `field_catalog/columns.snapshot.json` |
-| DeclarationError | why a declaration is inadmissible, naming the dataset and field | `datasets/validate.rs` |
-| DatasetDescription | the queryable surface, without storage | `datasets/describe.rs` |
+#### Declaration fields
 
-**Relationships**:
-- Dataset → FieldCatalog: every named column is checked; a mismatch is a `DeclarationError`.
-- Dataset → relation: one dataset binds exactly one prepared relation.
-- Dataset → DatasetDescription: describe drops database, relation, read discipline, tenant
-  field and row identity.
+| Field | Meaning |
+|---|---|
+| `key` | Unique dataset identifier |
+| `database`, `relation` | Prepared relation backing the dataset |
+| `read_discipline` | `plain` or `final`, compatible with the relation's engine family |
+| `tenant_field` | Column used for tenant scoping by the query engine |
+| `time_fields` | Event-time fields, exactly one marked as default |
+| `dimensions` | Grouping/filtering fields, optional `label_field` and `absent_value` |
+| `measurables` | Numeric fields available for aggregation |
+| `row_identity` | Non-empty list of fields defining row uniqueness |
+
+For a complete example, see
+[the file changes declaration](../../../src/ingestion/datasets/git_file_changes/dataset.yaml).
+It binds `git_file_changes`, defaults to `authored_at`, associates `author_email` with
+`author_name`, and declares `__unknown__` for null `source_id` values.
+
+`row_identity` declares grain; it does not enforce database uniqueness. The dataset's dbt
+test verifies uniqueness against materialized rows.
+
+A `DatasetDescription` exposes query metadata and omits the database, relation, read
+discipline, tenant field, and row identity. A dimension's public `label` names its result
+column, such as `author_email_label`, rather than the backing label field `author_name`.
 
 ### 3.2 Component Model
 
 ```text
-datasets folder ──build script──▶ registry ──▶ describe ──▶ discovery API
-                                     ▲
-                    tenant store ────┘ (later)
-                                     │
-                                validator ──▶ field catalog
+embedded declarations + column snapshot
+                   |
+                validator
+                   |
+                registry --> describe --> discovery API
 ```
 
 #### Dataset declarations
@@ -222,22 +231,29 @@ datasets folder ──build script──▶ registry ──▶ describe ──�
 
 ##### Why this component exists
 
-Something must state what a relation is for, in a form both a person and the engine can read.
+Defines a relation's query contract independently of query execution.
 
 ##### Responsibility scope
 
-The declaration format and its parsed types; one folder per dataset holding model, dbt
-properties, `dataset.yaml` and README; the build script that gathers shipped declarations
-through the `DATASETS_DIR` path.
+Owns declaration types and build-time collection through `DATASETS_DIR`. The analytics image
+receives the datasets directory as a named additional build context. Each directory
+under `src/ingestion/datasets/<key>/` contains:
+
+| File | Purpose |
+|---|---|
+| `<key>.sql` | dbt model |
+| `schema.yml` | Column documentation and row-identity test |
+| `dataset.yaml` | Query declaration |
+| `README.md` | Grain, provenance, and semantic caveats |
 
 ##### Responsibility boundaries
 
-Knows nothing about questions, HTTP or tenants. Does not build the relation; dbt does.
+dbt builds the relation. The declaration does not execute queries or handle HTTP requests.
 
 ##### Related components (by ID)
 
-- `cpt-insightspec-ds-component-validator` — checked by
-- `cpt-insightspec-ds-component-registry` — held by
+- `cpt-insightspec-ds-component-validator` — validates declarations
+- `cpt-insightspec-ds-component-registry` — loads declarations
 
 #### Validator
 
@@ -245,25 +261,32 @@ Knows nothing about questions, HTTP or tenants. Does not build the relation; dbt
 
 ##### Why this component exists
 
-A declaration that outgrew its relation must fail loudly and early, in the same words
-wherever it came from.
+Rejects declarations incompatible with their schema catalog.
 
 ##### Responsibility scope
 
-Checks key shape, relation presence, column presence and type class per role, nullability
-against `absent_value`, label fields, read discipline against the engine family, exactly one
-default time field, a non-empty row identity, no duplicate keys, and that a declared sentinel
-carries no parameter placeholder.
+- Require a lowercase snake_case key and an existing relation.
+- Check every referenced column and its role-compatible type: text, UUID, boolean, or
+  numeric dimensions; numeric measurables; date or datetime time fields.
+- Require `absent_value` for nullable dimensions and reject it for non-nullable dimensions.
+- Require a text or UUID tenant field; label fields must exist and have printable types.
+- Reject duplicate fields within the time-field, dimension, and measurable lists.
+- Match `read_discipline` to the engine family; merge-dependent engines require `final`.
+- Require exactly one default time field and a non-empty row identity.
+- Reject sentinels containing parameter placeholders.
+
+The registry additionally rejects duplicate dataset keys. Null representation does not
+define normalization of empty strings or source-specific missing-value sentinels.
 
 ##### Responsibility boundaries
 
-One implementation for shipped and tenant-defined declarations. Does not read the warehouse
-itself; it is given a catalog.
+Receives a catalog; performs no warehouse reads. It checks schema compatibility, not row
+uniqueness or the correctness of deduplication and attribution.
 
 ##### Related components (by ID)
 
-- `cpt-insightspec-ds-component-field-catalog` — reads
-- `cpt-insightspec-ds-component-registry` — used by
+- `cpt-insightspec-ds-component-field-catalog` — supplies schema metadata
+- `cpt-insightspec-ds-component-registry` — invokes validation
 
 #### Field catalog
 
@@ -271,21 +294,21 @@ itself; it is given a catalog.
 
 ##### Why this component exists
 
-Validation needs to know what the warehouse actually holds.
+Provides schema metadata for offline validation.
 
 ##### Responsibility scope
 
-The relations, engine families and typed columns available; loaded from the snapshot
-committed in the repository, which the DDL dump regenerates.
+Loads the committed column snapshot regenerated by the bootstrap DDL dump. The snapshot
+contains relation names, engine families, and column types.
 
 ##### Responsibility boundaries
 
-A snapshot, not a live connection; the live-catalog read that tenant-defined datasets need
-arrives with them.
+The snapshot describes the generated schema, not a running warehouse. Live-catalog loading
+and invalidation for tenant-defined datasets remain planned.
 
 ##### Related components (by ID)
 
-- `cpt-insightspec-ds-component-validator` — read by
+- `cpt-insightspec-ds-component-validator` — consumes the catalog
 
 #### Registry
 
@@ -293,23 +316,23 @@ arrives with them.
 
 ##### Why this component exists
 
-Every consumer must see one list, whoever wrote each entry.
+Provides shared declaration lookup and enumeration.
 
 ##### Responsibility scope
 
-Parses and validates the embedded declarations once, exposes lookup by key and the list in
-declaration order, and will merge tenant-defined declarations from the service store under
-the same types.
+Parses and validates embedded declarations on first use, caching the result in memory.
+Exposes key lookup and enumeration in declaration order. Unit tests invoke the same loading
+path, so invalid shipped declarations fail that test run.
 
 ##### Responsibility boundaries
 
-Serves declarations; never answers a question about the data. Unusable declarations make
-every read a server error, never a refusal of the caller's request.
+No query execution or tenant-defined loading. Test-time validation checks the snapshot,
+not a running warehouse. API error behavior is specified in Section 3.3.
 
 ##### Related components (by ID)
 
-- `cpt-insightspec-ds-component-validator` — depends on
-- `cpt-insightspec-ds-component-discovery-api` — read by
+- `cpt-insightspec-ds-component-validator` — validates loaded declarations
+- `cpt-insightspec-ds-component-discovery-api` — consumes the registry
 
 #### Discovery API
 
@@ -317,46 +340,44 @@ every read a server error, never a refusal of the caller's request.
 
 ##### Why this component exists
 
-Pages and people need the list without reading the repository.
+Makes query metadata available to clients without repository or warehouse access.
 
 ##### Responsibility scope
 
-`GET /v1/datasets` and `GET /v1/datasets/{key}`, admin-gated; describe maps a declaration to
-its queryable surface; an unknown key is a not-found naming it.
+Checks administrator permission and returns dataset descriptions. Unknown keys produce a
+not-found response identifying the requested key.
 
 ##### Responsibility boundaries
 
-No storage detail leaves: database, relation, read discipline, tenant field and row identity
-are dropped. Reads no warehouse.
+Returns no storage metadata and performs no warehouse queries. Broader visibility depends
+on the planned access-policy design.
 
 ##### Related components (by ID)
 
-- `cpt-insightspec-ds-component-registry` — reads
-- `cpt-insightspec-ds-component-tenant-registry` — will read
+- `cpt-insightspec-ds-component-registry` — supplies declarations
+- `cpt-insightspec-ds-component-tenant-registry` — planned source of tenant-defined declarations
 
-#### Tenant registry
+#### Tenant registry (planned)
 
 - [ ] `p2` - **ID**: `cpt-insightspec-ds-component-tenant-registry`
 
 ##### Why this component exists
 
-Datasets people add are mutable, versioned and approved — none of which a shipped
-declaration is.
+Tenant-defined datasets need persistence, versioning, and approval controls.
 
 ##### Responsibility scope
 
-Stores tenant-defined declarations in the service's own relational store with tenant, version,
-author, approver and state; serves drafts to their author and approved ones to the tenant;
-re-validates on read. *Needs design* below.
+Proposed storage for dataset versions and approval state, exposing author-only drafts and
+approved tenant datasets through the shared registry. Section 4 records unresolved design.
 
 ##### Responsibility boundaries
 
-Never holds shipped declarations; never edits one.
+Does not store or modify shipped declarations. Not implemented.
 
 ##### Related components (by ID)
 
-- `cpt-insightspec-ds-component-registry` — merges into
-- `cpt-insightspec-ds-component-validator` — uses
+- `cpt-insightspec-ds-component-registry` — planned integration
+- `cpt-insightspec-ds-component-validator` — shared validation contract
 
 ### 3.3 API Contracts
 
@@ -371,27 +392,24 @@ Never holds shipped declarations; never edits one.
 
 | Method | Path | Description | Stability |
 |--------|------|-------------|-----------|
-| `GET` | `/v1/datasets` | describe every available dataset | unstable (admin-only) |
-| `GET` | `/v1/datasets/{key}` | describe one dataset | unstable (admin-only) |
+| `GET` | `/v1/datasets` | List dataset descriptions | unstable (admin-only) |
+| `GET` | `/v1/datasets/{key}` | Describe a dataset | unstable (admin-only) |
 
-A description carries the key, the time fields with their default, the dimensions with their
-absent value and label column, and the measurables. The request bounds a question must stay
-inside belong to the query engine and are added by it.
+Descriptions contain the dataset key, time fields and default, dimensions with optional
+null representation and result-label column, and measurables. Query limits belong to the
+query engine.
+
+Discovery reads the registry after the administrator check. Listing returns a server error
+if registry validation fails. Detail lookup returns not-found for an unknown key; its current
+lookup also maps registry validation failure to not-found.
 
 ### 3.4 Internal Dependencies
 
 | Dependency Module | Interface Used | Purpose |
 |-------------------|----------------|----------|
-| identity client | admin check over the forwarded session | gates discovery until access rules land |
+| identity client | admin check over the forwarded session | restricts discovery to administrators |
 | toolkit canonical errors | resource-scoped builders | not-found and permission envelopes |
 | dbt project | model paths and `.dbtignore` | builds the relations, ignores declarations |
-
-**Dependency Rules** (per project conventions):
-- No circular dependencies
-- Always use SDK modules for inter-module communication
-- No cross-category sideways deps except through contracts
-- Only integration/adapter modules talk to external systems
-- `SecurityContext` must be propagated across all in-process calls
 
 ### 3.5 External Dependencies
 
@@ -402,16 +420,9 @@ inside belong to the query engine and are added by it.
 | dbt | model materialization | builds each dataset's relation |
 | field catalog | column snapshot dumped from a bootstrap warehouse | validates declarations offline |
 
-**Dependency Rules** (per project conventions):
-- No circular dependencies
-- Always use SDK modules for inter-module communication
-- No cross-category sideways deps except through contracts
-- Only integration/adapter modules talk to external systems
-- `SecurityContext` must be propagated across all in-process calls
-
 ### 3.6 Interactions & Sequences
 
-#### Ship a dataset
+#### Validate shipped datasets
 
 **ID**: `cpt-insightspec-ds-seq-ship`
 
@@ -421,17 +432,19 @@ inside belong to the query engine and are added by it.
 
 ```mermaid
 sequenceDiagram
-    Engineer ->> Repository: dataset folder (model, properties, declaration, README)
-    Repository ->> dbt: build the relation
-    Repository ->> BuildScript: gather dataset.yaml files
-    BuildScript ->> Service: embed declarations
-    Service ->> Validator: check against the column snapshot
-    Validator -->> Service: admissible | DeclarationError
+    Engineer ->> Repository: Dataset model, properties, declaration, README
+    Repository ->> dbt: Build relation and test row identity
+    Repository ->> BuildScript: Collect dataset.yaml files
+    BuildScript ->> Service: Embed declarations
+    Tests ->> Service: Load registry
+    Service ->> Validator: Validate against embedded column snapshot
+    Validator -->> Service: Valid declarations or DeclarationError
 ```
 
-**Description**: a mismatch fails the test run; nothing reaches a caller.
+**Description**: dbt verifies row uniqueness; registry tests verify declaration compatibility
+with the snapshot. Neither is a live-schema check.
 
-#### Describe what is available
+#### Discover datasets
 
 **ID**: `cpt-insightspec-ds-seq-describe`
 
@@ -449,16 +462,18 @@ sequenceDiagram
     API -->> Constructor: descriptions without storage detail
 ```
 
-**Description**: served from memory; no warehouse read.
+**Description**: authorized requests return metadata from memory without warehouse queries.
 
 ### 3.7 Database schemas & tables
 
 - [ ] `p2` - **ID**: `cpt-insightspec-ds-db-relations`
 
-One relation per dataset, plus the shared authored-change relation both git datasets stand
-on. Column documentation lives with each dataset's dbt properties.
+One relation per dataset plus shared `git_authored_file_changes` preparation. Full column
+definitions live in each model's `schema.yml`; the tables below summarize their roles.
 
-#### Table: git_commits
+#### Table: commits
+
+Relation: `git_commits`.
 
 - [ ] `p2` - **ID**: `cpt-insightspec-ds-dbtable-git-commits`
 
@@ -470,17 +485,19 @@ on. Column documentation lives with each dataset's dbt properties.
 | commit_hash | String | the commit |
 | author_email, author_name | String | author and label |
 | authored_at, authored_date | DateTime, Date | event time and its day |
-| branch_scope, repository, project, source (+ `_label`) | String | inherited dimensions |
+| branch_scope, repository, project, source (+ `_label`) | String | dimensions inherited from the commit |
 | message | String | commit message |
-| lines_added, lines_removed | Nullable(Int64) | own contribution after the content dedup |
+| lines_added, lines_removed | Nullable(Int64) | attributed line counts after content deduplication |
 
-**PK**: (tenant_id, author_email, authored_at)
+**Sort key**: (tenant_id, author_email, authored_at)
 
-**Constraints**: one row per (tenant, source, commit_hash), dbt-tested
+**Constraints**: one row per (tenant_id, source, commit_hash), dbt-tested
 
 **Additional info**: partitioned by month of authored_date
 
-#### Table: git_file_changes
+#### Table: file changes
+
+Relation: `git_file_changes`.
 
 - [ ] `p2` - **ID**: `cpt-insightspec-ds-dbtable-git-file-changes`
 
@@ -491,16 +508,18 @@ on. Column documentation lives with each dataset's dbt properties.
 | tenant_id, commit_hash, file_path | Nullable(String), String, String | identity with change_type |
 | author_email, author_name, authored_at, authored_date | String, String, DateTime, Date | inherited from the commit |
 | category, file_extension, change_type (+ `_label`) | String | file dimensions |
-| branch_scope, repository, project, source (+ `_label`) | String | inherited dimensions |
-| lines_added, lines_removed | Nullable(Int64) | summed over folded content identities |
+| branch_scope, repository, project, source (+ `_label`) | String | dimensions inherited from the commit |
+| lines_added, lines_removed | Nullable(Int64) | sum over retained content identities |
 
-**PK**: (tenant_id, author_email, authored_at)
+**Sort key**: (tenant_id, author_email, authored_at)
 
-**Constraints**: one row per (tenant, source, commit_hash, file_path, change_type), dbt-tested
+**Constraints**: one row per (tenant_id, source, commit_hash, file_path, change_type), dbt-tested
 
 **Additional info**: built from the authored-change relation below
 
-#### Table: git_authored_file_changes
+#### Table: authored file changes
+
+Relation: `git_authored_file_changes`.
 
 - [ ] `p2` - **ID**: `cpt-insightspec-ds-dbtable-git-authored-file-changes`
 
@@ -509,16 +528,16 @@ on. Column documentation lives with each dataset's dbt properties.
 | Column | Type | Description |
 |--------|------|-------------|
 | tenant_id, data_source, commit_hash, file_path | Nullable(String), String, String, String | attach key and path |
-| source_id, project_key, repo_slug | Nullable(String), String, String | surviving commit's coordinates |
+| source_id, project_key, repo_slug | Nullable(String), String, String | retained commit's source, project, and repository |
 | file_extension, change_type | String | as collected |
 | lines_added, lines_removed | Nullable(Int64) | as collected |
 
-**PK**: (tenant_id, data_source, commit_hash)
+**Sort key**: (tenant_id, data_source, commit_hash)
 
 **Constraints**: one row per change content, earliest commit wins; superseded changes excluded
 
-**Additional info**: not a dataset — the shared dedup the file-change dataset and the metric
-evidence both read, so its sort runs once per build
+**Additional info**: shared deduplicated input for the git datasets and metric evidence;
+not registered as a dataset.
 
 ### 3.8 Deployment Topology
 
@@ -527,119 +546,56 @@ declarations travel inside the analytics image.
 
 ## 4. Additional context
 
-### The declaration
+### Dataset authoring and lifecycle
 
-```yaml
-key: git_file_changes          # how a question names it
-database: insight              # where the relation lives — never described to callers
-relation: git_file_changes
-read_discipline: plain         # plain | final, matched against the engine family
+A shipped dataset addition includes its model, column documentation, row-identity test,
+declaration, README, and regenerated column snapshot. The registry discovers embedded
+declarations automatically; no query-engine changes are required.
 
-tenant_field: tenant_id        # the column every scan is scoped by
+Shipped definitions evolve with product releases. Removing a declaration removes it from
+discovery; deletion and compatibility with saved queries must be considered together.
 
-time_fields:                   # exactly one default
-  - field: authored_at
-    default: true
+### Tenant-defined datasets (planned)
 
-dimensions:                    # what may be grouped and filtered
-  - field: author_email
-    label_field: author_name   # the readable name travelling beside the value
-  - field: source_id
-    absent_value: __unknown__  # required when the column is nullable
+| Kind | Definition |
+|---|---|
+| Derived | Filtered or relabelled parent dataset with custom categories |
+| Saved query | Query result exposed as a reusable dataset |
+| Imported | Uploaded data or a referenced tenant relation |
 
-measurables:                   # what may be folded
-  - field: lines_added
+The proposed design stores tenant-defined metadata in the analytics service's relational
+store: dataset key, tenant, version, declaration, state, author, approver, and timestamps.
+Edits create new versions. Drafts are author-only; approved versions are available within
+the tenant according to access policies. Validation occurs on save and read, with
+revalidation after schema changes.
 
-row_identity:                  # what makes one row one fact
-  - tenant_id
-  - source
-  - commit_hash
-  - file_path
-  - change_type
-```
+This storage design is not implemented. Open decisions:
 
-### Rules a declaration must satisfy
+- Composition with parent datasets and permitted nesting depth.
+- Whether saved queries retain their requests or freeze their results.
+- Tenant quotas and administrator review workflow.
+- Live-catalog loading, schema-change detection, and cache invalidation.
 
-- Every named column exists in the catalog with a type its role admits: text, uuid, boolean
-  or number for a dimension; number for a measurable; date or datetime for a time field.
-- A nullable dimension declares `absent_value`; a non-nullable one must not.
-- A label field exists and is printable.
-- `read_discipline` matches the relation's engine family: a folding engine (Replacing,
-  Collapsing, Summing, Aggregating, replicated or versioned) must be read collapsed.
-- Exactly one time field is the default; the row identity is non-empty; the key is lowercase
-  snake_case; no two datasets share a key.
-- No declared sentinel contains a parameter placeholder.
+### Access policies (planned)
 
-### Anatomy of a dataset folder
+Declarations would carry dataset access, row visibility, column visibility or masking, and
+personal-data classification. The query engine would enforce these policies during planning.
+Policy representation and enforcement integration remain undesigned; current discovery is
+administrator-only.
 
-```text
-src/ingestion/datasets/git_file_changes/
-  git_file_changes.sql   the model that materializes the relation
-  schema.yml             dbt column docs and the grain test
-  dataset.yaml           the declaration
-  README.md              what one row is, where it comes from, what to watch for
-```
+### Validation limits and open semantics
 
-The folder is a dbt model path, so `dbt build` finds the model and its properties;
-`.dbtignore` keeps `dataset.yaml` out of dbt's hands. The analytics build script reads the
-same folder through a named build context and embeds every declaration.
-
-### Adding a dataset
-
-1. Create the folder and the model; apply the counting rules in the model, not downstream.
-2. Write `schema.yml`: a description per column, and a test that the row identity is unique.
-3. Write `dataset.yaml`: grain, dimensions with labels, measurables, time fields.
-4. Regenerate the column snapshot from a bootstrap warehouse so validation sees the new
-   relation.
-5. Write the README: what one row is, provenance, caveats.
-
-No engine change is required at any step.
-
-### Lifecycle
-
-A shipped dataset is declared, validated at build, served and described, evolved by shipping
-a new version of the product, and retired by deleting its folder. A tenant-defined one is
-drafted, validated on save, usable by its author, approved by an administrator with its
-access rules set, versioned on every edit, and retired by its owner.
-
-### Kinds of dataset
-
-| Kind | Where its declaration lives | Who may add one |
-|---|---|---|
-| Shipped | the product's repository, embedded in the image | product engineers |
-| Derived | the tenant store, over a shipped or approved parent | anyone who may add datasets |
-| Promoted saved question | the tenant store, over a saved question | anyone who may add datasets |
-| Bring-your-own | the tenant store, over an uploaded or pointed-at relation | anyone who may add datasets |
-
-### Tenant-defined datasets
-
-*Needs design.* Stored in the analytics service's relational store — small, mutable,
-versioned, approval-gated metadata, which the warehouse is the wrong shape for. One row per
-dataset version: key, tenant, body, state, author, approver, timestamps. Editing writes a new
-version; approval flips state; the registry merges approved rows for the tenant plus the
-author's own drafts.
-
-Open: how a derived dataset's plan composes with its parent's; whether a promoted saved
-question is stored as its request or frozen; how deep composition may nest; per-tenant
-quotas; the live-catalog read and its invalidation, since the embedded snapshot only covers
-shipped datasets.
-
-### Access rules
-
-*Needs design.* Declared beside the fields they bind, enforced by the query engine at plan
-time: dataset access (who may ask at all), row policy (a dimension bound to a caller
-attribute), column policy (dropped or masked). The declaration also marks which columns
-describe named people. See the engine's design for enforcement.
-
-### Not a dataset
-
-- **A metric.** A metric is one question with one answer; a dataset is what many questions
-  are asked of.
-- **A raw table.** Tables carry storage detail, no grain statement and no labels.
-- **A chart.** Charts are what a question's answer is drawn as.
+- Catalog validation checks field references and types, not deployed-schema compatibility.
+- Row-identity tests check uniqueness, not attribution or deduplication correctness.
+- Null dimensions require `absent_value`. Empty-string and source-sentinel normalization
+  are not established by this contract.
+- The PRD requires stable dimensions to be exposed, but field-selection criteria remain open.
 
 ## 5. Traceability
 
 - **PRD**: [PRD.md](PRD.md)
-- **Consumer**: [query engine design](../query-engine/DESIGN.md)
+- **Consumer**: [query engine design](https://github.com/constructorfabric/insight/blob/d912c610da33259475d817fc009d34de35b8fe10/docs/domain/query-engine/DESIGN.md)
 - **Contract**: [openapi.json](../../components/backend/analytics/openapi.json)
+
+**Revision 1.1**: consolidated declaration and validation contracts, clarified runtime and
+snapshot boundaries, and separated implemented behavior from proposed extensions.

--- a/docs/domain/datasets/DESIGN.md
+++ b/docs/domain/datasets/DESIGN.md
@@ -1,0 +1,645 @@
+---
+version: 1.0
+status: proposed
+date: 2026-09-08
+---
+
+# Technical Design — Data Sets
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-design-datasets`
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+  - [3.8 Deployment Topology](#38-deployment-topology)
+- [4. Additional context](#4-additional-context)
+  - [The declaration](#the-declaration)
+  - [Rules a declaration must satisfy](#rules-a-declaration-must-satisfy)
+  - [Anatomy of a dataset folder](#anatomy-of-a-dataset-folder)
+  - [Adding a dataset](#adding-a-dataset)
+  - [Lifecycle](#lifecycle)
+  - [Kinds of dataset](#kinds-of-dataset)
+  - [Tenant-defined datasets](#tenant-defined-datasets)
+  - [Access rules](#access-rules)
+  - [Not a dataset](#not-a-dataset)
+- [5. Traceability](#5-traceability)
+
+<!-- /toc -->
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+A dataset is a declaration bound to one prepared relation. The declaration says what the
+relation is for: its grain, the columns that may be grouped or filtered, the columns that may
+be folded, the columns that carry event time, the labels that travel with values, and how the
+relation must be read to be duplicate-free. Everything downstream — discovery, planning,
+compilation, access rules — reads that declaration and nothing else about storage.
+
+The declaration lives beside the model that materializes it, one folder per dataset, so a
+dataset is reviewed, shipped and reasoned about as one unit. The service embeds the shipped
+declarations at build time and merges them with tenant-defined ones into a single in-memory
+registry. One loader, one validator, one list.
+
+Correctness is a property of the relation, not of the question: dedup, attribution and
+exclusion are applied once by the model. The declaration then states the grain that results,
+and a data test enforces it. Realises [PRD.md](PRD.md); the consumer is the
+[query engine](../query-engine/DESIGN.md).
+
+### 1.2 Architecture Drivers
+
+**ADRs**: none yet; the first is expected with tenant-defined datasets.
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+|-------------|------------------|
+| `cpt-insightspec-ds-fr-single-home` | `src/ingestion/datasets/<key>/` holds model, dbt properties, declaration and README |
+| `cpt-insightspec-ds-fr-grain` | `row_identity` in the declaration; a dbt uniqueness test over the same columns |
+| `cpt-insightspec-ds-fr-fields` | dimensions with `label_field`, measurables, time fields with one default; every stable column declared |
+| `cpt-insightspec-ds-fr-absent-values` | `absent_value` required on a nullable dimension, refused on a non-nullable one |
+| `cpt-insightspec-ds-fr-correctness-baked` | dedup, attribution and supersede rules live in the model; the shared dedup is its own relation |
+| `cpt-insightspec-ds-fr-registry` | one in-memory registry: shipped from the binary, tenant-defined from the service store |
+| `cpt-insightspec-ds-fr-validated` | one validator against the field catalog: the embedded snapshot in CI, the live catalog at load |
+| `cpt-insightspec-ds-fr-discovery` | `GET /v1/datasets` and `GET /v1/datasets/{key}` describe declarations, never storage |
+| `cpt-insightspec-ds-fr-field-metadata` | declaration gains label, description and unit; a values endpoint reads distinct values |
+| `cpt-insightspec-ds-fr-first-two` | `git_commits` and `git_file_changes`, over the shared authored-change relation |
+| `cpt-insightspec-ds-fr-own-datasets` | three runtime forms over the same declaration shape |
+| `cpt-insightspec-ds-fr-own-validated` | runtime declarations take the same validator and the same violations |
+| `cpt-insightspec-ds-fr-approval` | state on the stored declaration; the registry exposes drafts to their author alone |
+| `cpt-insightspec-ds-fr-versioning` | a new row per edit, keyed by dataset and version, with author and approver |
+| `cpt-insightspec-ds-fr-access-rules` | policies declared beside the fields they bind; the engine enforces them at plan time |
+
+#### NFR Allocation
+
+| NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
+|--------|-------------|--------------|-----------------|----------------------|
+| `cpt-insightspec-ds-nfr-additive` | a new dataset costs no engine change | declaration format | the engine reads declarations; adding one is a folder plus a build-script pickup | a dataset added with no diff under the engine modules |
+| `cpt-insightspec-ds-nfr-fail-early` | broken definitions never reach people | validator | shipped declarations validated in unit tests against the embedded snapshot; runtime ones validated on save | tests over deliberately broken declarations |
+| `cpt-insightspec-ds-nfr-cheap-discovery` | discovery costs no warehouse read | registry | declarations are resident; describe reads memory | discovery handler holds no ClickHouse call |
+
+### 1.3 Architecture Layers
+
+```text
+src/ingestion/datasets/<key>/          dbt model · properties · declaration · README
+        │ dbt build                            │ build script (named build context)
+        ▼                                      ▼
+ClickHouse relation  ◀── validated against ── analytics service
+                                               ├─ domain::datasets   registry · validator · describe
+                                               └─ api::datasets      GET /v1/datasets[/{key}]
+                                                       │
+                                                 query engine, constructor
+```
+
+- [ ] `p3` - **ID**: `cpt-insightspec-ds-tech-layers`
+
+| Layer | Responsibility | Technology |
+|-------|---------------|------------|
+| Presentation | lists what can be asked about | React constructor page |
+| Application | admin gate, describe, respond | Rust, axum |
+| Domain | declaration model, validation, registry, describe | Rust, serde_yaml |
+| Data definition | model, dbt properties, declaration, README per dataset | dbt, YAML |
+| Infrastructure | prepared relations | ClickHouse MergeTree |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### A dataset is a declaration, not a table
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-principle-declaration`
+
+The relation is an implementation detail of the dataset. Consumers see the declaration:
+grain, fields, labels, time, policies. Nothing downstream may reach past it to a column the
+declaration does not name.
+
+#### Everything about one dataset in one folder
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-principle-colocation`
+
+Model, properties, declaration and README live together, outside the medallion layout, so a
+dataset is added, reviewed and deleted as one unit and its parts cannot drift.
+
+#### Correctness belongs to the relation
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-principle-correct-relation`
+
+Dedup, attribution and exclusion are applied once where the data is built. A dataset's grain
+is then a fact a test can enforce, not a rule each question must remember.
+
+#### One registry, whoever wrote the declaration
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-principle-one-registry`
+
+Shipped and tenant-defined declarations share one shape, one validator and one list. The only
+differences are where the declaration is stored and who may see it.
+
+### 2.2 Constraints
+
+#### Shipped declarations ship with the binary
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-constraint-embedded`
+
+The datasets folder is outside the service's build context, so it arrives as a named
+additional build context and the build script embeds every `dataset.yaml`. A shipped
+declaration is never written to any database and never edited in a running installation.
+
+#### dbt must not read declarations
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-constraint-dbt-ignores-declarations`
+
+The datasets folder is a dbt model path, so dbt would otherwise try to parse `dataset.yaml`
+as its own properties. `.dbtignore` excludes it by name.
+
+#### Every named column must exist
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-constraint-catalog-checked`
+
+A declaration is only admissible if the catalog carries every column it names with a
+compatible type, its read discipline matches the relation's engine family, and it declares
+exactly one default time field and a non-empty row identity.
+
+#### Prepared relations only
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-constraint-prepared-only`
+
+A dataset binds one relation in the serving database. No raw or intermediate layer, no
+query-time joins beyond a declared lookup, no writes.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: YAML declarations, Rust types, a JSON snapshot of the warehouse columns.
+
+**Location**: `src/ingestion/datasets/`, `src/backend/services/analytics/src/domain/datasets/`
+
+**Core Entities**:
+
+| Entity | Description | Schema |
+|--------|-------------|--------|
+| Dataset | key, database, relation, read discipline, tenant field, time fields, dimensions, measurables, row identity | `datasets/declaration.rs` |
+| Dimension | field, optional label field, absent value when nullable | `datasets/declaration.rs` |
+| Measurable | a numeric column an aggregate may fold | `datasets/declaration.rs` |
+| TimeField | an event-time column; exactly one is the default | `datasets/declaration.rs` |
+| FieldCatalog | the relations, engines and columns declarations are checked against | `field_catalog/columns.snapshot.json` |
+| DeclarationError | why a declaration is inadmissible, naming the dataset and field | `datasets/validate.rs` |
+| DatasetDescription | the queryable surface, without storage | `datasets/describe.rs` |
+
+**Relationships**:
+- Dataset → FieldCatalog: every named column is checked; a mismatch is a `DeclarationError`.
+- Dataset → relation: one dataset binds exactly one prepared relation.
+- Dataset → DatasetDescription: describe drops database, relation, read discipline, tenant
+  field and row identity.
+
+### 3.2 Component Model
+
+```text
+datasets folder ──build script──▶ registry ──▶ describe ──▶ discovery API
+                                     ▲
+                    tenant store ────┘ (later)
+                                     │
+                                validator ──▶ field catalog
+```
+
+#### Dataset declarations
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-component-declarations`
+
+##### Why this component exists
+
+Something must state what a relation is for, in a form both a person and the engine can read.
+
+##### Responsibility scope
+
+The declaration format and its parsed types; one folder per dataset holding model, dbt
+properties, `dataset.yaml` and README; the build script that gathers shipped declarations
+through the `DATASETS_DIR` path.
+
+##### Responsibility boundaries
+
+Knows nothing about questions, HTTP or tenants. Does not build the relation; dbt does.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-ds-component-validator` — checked by
+- `cpt-insightspec-ds-component-registry` — held by
+
+#### Validator
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-component-validator`
+
+##### Why this component exists
+
+A declaration that outgrew its relation must fail loudly and early, in the same words
+wherever it came from.
+
+##### Responsibility scope
+
+Checks key shape, relation presence, column presence and type class per role, nullability
+against `absent_value`, label fields, read discipline against the engine family, exactly one
+default time field, a non-empty row identity, no duplicate keys, and that a declared sentinel
+carries no parameter placeholder.
+
+##### Responsibility boundaries
+
+One implementation for shipped and tenant-defined declarations. Does not read the warehouse
+itself; it is given a catalog.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-ds-component-field-catalog` — reads
+- `cpt-insightspec-ds-component-registry` — used by
+
+#### Field catalog
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-component-field-catalog`
+
+##### Why this component exists
+
+Validation needs to know what the warehouse actually holds.
+
+##### Responsibility scope
+
+The relations, engine families and typed columns available; loaded from the snapshot
+committed in the repository, which the DDL dump regenerates.
+
+##### Responsibility boundaries
+
+A snapshot, not a live connection; the live-catalog read that tenant-defined datasets need
+arrives with them.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-ds-component-validator` — read by
+
+#### Registry
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-component-registry`
+
+##### Why this component exists
+
+Every consumer must see one list, whoever wrote each entry.
+
+##### Responsibility scope
+
+Parses and validates the embedded declarations once, exposes lookup by key and the list in
+declaration order, and will merge tenant-defined declarations from the service store under
+the same types.
+
+##### Responsibility boundaries
+
+Serves declarations; never answers a question about the data. Unusable declarations make
+every read a server error, never a refusal of the caller's request.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-ds-component-validator` — depends on
+- `cpt-insightspec-ds-component-discovery-api` — read by
+
+#### Discovery API
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-component-discovery-api`
+
+##### Why this component exists
+
+Pages and people need the list without reading the repository.
+
+##### Responsibility scope
+
+`GET /v1/datasets` and `GET /v1/datasets/{key}`, admin-gated; describe maps a declaration to
+its queryable surface; an unknown key is a not-found naming it.
+
+##### Responsibility boundaries
+
+No storage detail leaves: database, relation, read discipline, tenant field and row identity
+are dropped. Reads no warehouse.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-ds-component-registry` — reads
+- `cpt-insightspec-ds-component-tenant-registry` — will read
+
+#### Tenant registry
+
+- [ ] `p2` - **ID**: `cpt-insightspec-ds-component-tenant-registry`
+
+##### Why this component exists
+
+Datasets people add are mutable, versioned and approved — none of which a shipped
+declaration is.
+
+##### Responsibility scope
+
+Stores tenant-defined declarations in the service's own relational store with tenant, version,
+author, approver and state; serves drafts to their author and approved ones to the tenant;
+re-validates on read. *Needs design* below.
+
+##### Responsibility boundaries
+
+Never holds shipped declarations; never edits one.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-ds-component-registry` — merges into
+- `cpt-insightspec-ds-component-validator` — uses
+
+### 3.3 API Contracts
+
+- [ ] `p1` - **ID**: `cpt-insightspec-ds-interface-discovery-api`
+
+- **Contracts**: `cpt-insightspec-ds-contract-prepared-data`
+- **PRD interface**: `cpt-insightspec-ds-interface-discovery`
+- **Technology**: REST/OpenAPI, JSON, RFC 9457 problem envelopes
+- **Location**: [openapi.json](../../components/backend/analytics/openapi.json)
+
+**Endpoints Overview**:
+
+| Method | Path | Description | Stability |
+|--------|------|-------------|-----------|
+| `GET` | `/v1/datasets` | describe every available dataset | unstable (admin-only) |
+| `GET` | `/v1/datasets/{key}` | describe one dataset | unstable (admin-only) |
+
+A description carries the key, the time fields with their default, the dimensions with their
+absent value and label column, and the measurables. The request bounds a question must stay
+inside belong to the query engine and are added by it.
+
+### 3.4 Internal Dependencies
+
+| Dependency Module | Interface Used | Purpose |
+|-------------------|----------------|----------|
+| identity client | admin check over the forwarded session | gates discovery until access rules land |
+| toolkit canonical errors | resource-scoped builders | not-found and permission envelopes |
+| dbt project | model paths and `.dbtignore` | builds the relations, ignores declarations |
+
+**Dependency Rules** (per project conventions):
+- No circular dependencies
+- Always use SDK modules for inter-module communication
+- No cross-category sideways deps except through contracts
+- Only integration/adapter modules talk to external systems
+- `SecurityContext` must be propagated across all in-process calls
+
+### 3.5 External Dependencies
+
+#### ClickHouse
+
+| Dependency Module | Interface Used | Purpose |
+|-------------------|---------------|---------|
+| dbt | model materialization | builds each dataset's relation |
+| field catalog | column snapshot dumped from a bootstrap warehouse | validates declarations offline |
+
+**Dependency Rules** (per project conventions):
+- No circular dependencies
+- Always use SDK modules for inter-module communication
+- No cross-category sideways deps except through contracts
+- Only integration/adapter modules talk to external systems
+- `SecurityContext` must be propagated across all in-process calls
+
+### 3.6 Interactions & Sequences
+
+#### Ship a dataset
+
+**ID**: `cpt-insightspec-ds-seq-ship`
+
+**Use cases**: `cpt-insightspec-ds-usecase-ship-one`
+
+**Actors**: `cpt-insightspec-ds-actor-engineer`
+
+```mermaid
+sequenceDiagram
+    Engineer ->> Repository: dataset folder (model, properties, declaration, README)
+    Repository ->> dbt: build the relation
+    Repository ->> BuildScript: gather dataset.yaml files
+    BuildScript ->> Service: embed declarations
+    Service ->> Validator: check against the column snapshot
+    Validator -->> Service: admissible | DeclarationError
+```
+
+**Description**: a mismatch fails the test run; nothing reaches a caller.
+
+#### Describe what is available
+
+**ID**: `cpt-insightspec-ds-seq-describe`
+
+**Use cases**: `cpt-insightspec-ds-usecase-discover`
+
+**Actors**: `cpt-insightspec-ds-actor-constructor`, `cpt-insightspec-ds-actor-author`
+
+```mermaid
+sequenceDiagram
+    Constructor ->> API: GET /v1/datasets
+    API ->> Identity: is admin?
+    Identity -->> API: yes
+    API ->> Registry: available datasets
+    Registry -->> API: declarations
+    API -->> Constructor: descriptions without storage detail
+```
+
+**Description**: served from memory; no warehouse read.
+
+### 3.7 Database schemas & tables
+
+- [ ] `p2` - **ID**: `cpt-insightspec-ds-db-relations`
+
+One relation per dataset, plus the shared authored-change relation both git datasets stand
+on. Column documentation lives with each dataset's dbt properties.
+
+#### Table: git_commits
+
+- [ ] `p2` - **ID**: `cpt-insightspec-ds-dbtable-git-commits`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| tenant_id | Nullable(String) | tenant |
+| commit_hash | String | the commit |
+| author_email, author_name | String | author and label |
+| authored_at, authored_date | DateTime, Date | event time and its day |
+| branch_scope, repository, project, source (+ `_label`) | String | inherited dimensions |
+| message | String | commit message |
+| lines_added, lines_removed | Nullable(Int64) | own contribution after the content dedup |
+
+**PK**: (tenant_id, author_email, authored_at)
+
+**Constraints**: one row per (tenant, source, commit_hash), dbt-tested
+
+**Additional info**: partitioned by month of authored_date
+
+#### Table: git_file_changes
+
+- [ ] `p2` - **ID**: `cpt-insightspec-ds-dbtable-git-file-changes`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| tenant_id, commit_hash, file_path | Nullable(String), String, String | identity with change_type |
+| author_email, author_name, authored_at, authored_date | String, String, DateTime, Date | inherited from the commit |
+| category, file_extension, change_type (+ `_label`) | String | file dimensions |
+| branch_scope, repository, project, source (+ `_label`) | String | inherited dimensions |
+| lines_added, lines_removed | Nullable(Int64) | summed over folded content identities |
+
+**PK**: (tenant_id, author_email, authored_at)
+
+**Constraints**: one row per (tenant, source, commit_hash, file_path, change_type), dbt-tested
+
+**Additional info**: built from the authored-change relation below
+
+#### Table: git_authored_file_changes
+
+- [ ] `p2` - **ID**: `cpt-insightspec-ds-dbtable-git-authored-file-changes`
+
+**Schema**:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| tenant_id, data_source, commit_hash, file_path | Nullable(String), String, String, String | attach key and path |
+| source_id, project_key, repo_slug | Nullable(String), String, String | surviving commit's coordinates |
+| file_extension, change_type | String | as collected |
+| lines_added, lines_removed | Nullable(Int64) | as collected |
+
+**PK**: (tenant_id, data_source, commit_hash)
+
+**Constraints**: one row per change content, earliest commit wins; superseded changes excluded
+
+**Additional info**: not a dataset — the shared dedup the file-change dataset and the metric
+evidence both read, so its sort runs once per build
+
+### 3.8 Deployment Topology
+
+No deployable of its own. Relations are built by the deploy hook's dbt run; shipped
+declarations travel inside the analytics image.
+
+## 4. Additional context
+
+### The declaration
+
+```yaml
+key: git_file_changes          # how a question names it
+database: insight              # where the relation lives — never described to callers
+relation: git_file_changes
+read_discipline: plain         # plain | final, matched against the engine family
+
+tenant_field: tenant_id        # the column every scan is scoped by
+
+time_fields:                   # exactly one default
+  - field: authored_at
+    default: true
+
+dimensions:                    # what may be grouped and filtered
+  - field: author_email
+    label_field: author_name   # the readable name travelling beside the value
+  - field: source_id
+    absent_value: __unknown__  # required when the column is nullable
+
+measurables:                   # what may be folded
+  - field: lines_added
+
+row_identity:                  # what makes one row one fact
+  - tenant_id
+  - source
+  - commit_hash
+  - file_path
+  - change_type
+```
+
+### Rules a declaration must satisfy
+
+- Every named column exists in the catalog with a type its role admits: text, uuid, boolean
+  or number for a dimension; number for a measurable; date or datetime for a time field.
+- A nullable dimension declares `absent_value`; a non-nullable one must not.
+- A label field exists and is printable.
+- `read_discipline` matches the relation's engine family: a folding engine (Replacing,
+  Collapsing, Summing, Aggregating, replicated or versioned) must be read collapsed.
+- Exactly one time field is the default; the row identity is non-empty; the key is lowercase
+  snake_case; no two datasets share a key.
+- No declared sentinel contains a parameter placeholder.
+
+### Anatomy of a dataset folder
+
+```text
+src/ingestion/datasets/git_file_changes/
+  git_file_changes.sql   the model that materializes the relation
+  schema.yml             dbt column docs and the grain test
+  dataset.yaml           the declaration
+  README.md              what one row is, where it comes from, what to watch for
+```
+
+The folder is a dbt model path, so `dbt build` finds the model and its properties;
+`.dbtignore` keeps `dataset.yaml` out of dbt's hands. The analytics build script reads the
+same folder through a named build context and embeds every declaration.
+
+### Adding a dataset
+
+1. Create the folder and the model; apply the counting rules in the model, not downstream.
+2. Write `schema.yml`: a description per column, and a test that the row identity is unique.
+3. Write `dataset.yaml`: grain, dimensions with labels, measurables, time fields.
+4. Regenerate the column snapshot from a bootstrap warehouse so validation sees the new
+   relation.
+5. Write the README: what one row is, provenance, caveats.
+
+No engine change is required at any step.
+
+### Lifecycle
+
+A shipped dataset is declared, validated at build, served and described, evolved by shipping
+a new version of the product, and retired by deleting its folder. A tenant-defined one is
+drafted, validated on save, usable by its author, approved by an administrator with its
+access rules set, versioned on every edit, and retired by its owner.
+
+### Kinds of dataset
+
+| Kind | Where its declaration lives | Who may add one |
+|---|---|---|
+| Shipped | the product's repository, embedded in the image | product engineers |
+| Derived | the tenant store, over a shipped or approved parent | anyone who may add datasets |
+| Promoted saved question | the tenant store, over a saved question | anyone who may add datasets |
+| Bring-your-own | the tenant store, over an uploaded or pointed-at relation | anyone who may add datasets |
+
+### Tenant-defined datasets
+
+*Needs design.* Stored in the analytics service's relational store — small, mutable,
+versioned, approval-gated metadata, which the warehouse is the wrong shape for. One row per
+dataset version: key, tenant, body, state, author, approver, timestamps. Editing writes a new
+version; approval flips state; the registry merges approved rows for the tenant plus the
+author's own drafts.
+
+Open: how a derived dataset's plan composes with its parent's; whether a promoted saved
+question is stored as its request or frozen; how deep composition may nest; per-tenant
+quotas; the live-catalog read and its invalidation, since the embedded snapshot only covers
+shipped datasets.
+
+### Access rules
+
+*Needs design.* Declared beside the fields they bind, enforced by the query engine at plan
+time: dataset access (who may ask at all), row policy (a dimension bound to a caller
+attribute), column policy (dropped or masked). The declaration also marks which columns
+describe named people. See the engine's design for enforcement.
+
+### Not a dataset
+
+- **A metric.** A metric is one question with one answer; a dataset is what many questions
+  are asked of.
+- **A raw table.** Tables carry storage detail, no grain statement and no labels.
+- **A chart.** Charts are what a question's answer is drawn as.
+
+## 5. Traceability
+
+- **PRD**: [PRD.md](PRD.md)
+- **Consumer**: [query engine design](../query-engine/DESIGN.md)
+- **Contract**: [openapi.json](../../components/backend/analytics/openapi.json)

--- a/docs/domain/datasets/PRD.md
+++ b/docs/domain/datasets/PRD.md
@@ -1,0 +1,558 @@
+---
+version: 1.0
+status: proposed
+date: 2026-09-08
+---
+
+# PRD — Data Sets
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Module-Specific Environment Constraints](#31-module-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 Defining a data set](#51-defining-a-data-set)
+  - [5.2 Offering data sets](#52-offering-data-sets)
+  - [5.3 The first data sets](#53-the-first-data-sets)
+  - [5.4 Data sets people add](#54-data-sets-people-add)
+  - [5.5 Who may see what](#55-who-may-see-what)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 NFR Inclusions](#61-nfr-inclusions)
+  - [6.2 NFR Exclusions](#62-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+
+<!-- /toc -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+A data set is one kind of thing people can ask about — commits, file changes, later
+deployments or tickets. It names what can be broken down, what can be counted, and over
+which dates, in words a person recognises. Everything the product can answer, and everything
+a chart can offer, comes from this list.
+
+Built by [DESIGN.md](DESIGN.md). Asking questions of these data sets is the
+[query engine](../query-engine/PRD.md).
+
+### 1.2 Background / Problem Statement
+
+The product's numbers are pre-built metrics. Each one hard-codes which table it reads, what
+it counts and how it may be split. Nothing describes the underlying data itself, so there is
+no list a person or a page can choose from, and every new question means a developer reading
+warehouse tables to work out where the answer lives.
+
+The tables themselves are not a substitute. They carry columns nobody should have to reason
+about, they need rules applied to avoid double counting, and they say nothing about which
+column is a name for which other column. A person cannot tell from a table what one row
+means.
+
+Customers also have facts we do not: which repositories belong to which product line, which
+people belong to which cost centre. Today those cannot enter the product at all.
+
+### 1.3 Goals (Business Outcomes)
+
+- Anyone building a chart can see what is available to ask about, in readable words, without
+  reading a table or asking a developer.
+- One row of a data set means one thing, and that meaning is written down where the data set
+  is defined.
+- Adding a data set is a self-contained piece of work: define it, describe it, ship it — no
+  change to the code that answers questions.
+- People and their assistants add data sets of their own, and what they add is checked the
+  same way as what we ship.
+- The rules about who may see which rows are attached to the data set, so every question
+  inherits them.
+
+### 1.4 Glossary
+
+| Term | Meaning |
+|---|---|
+| **Data set** | one kind of thing to ask about, with everything needed to ask: what one row is, what it can be split by, what can be counted, which dates apply |
+| **Grain** | what one row of a data set represents, exactly: one commit, one file in one commit |
+| **Breakdown** | a column an answer can be split by, with a readable name |
+| **Measure** | a number that can be counted or added up |
+| **Declaration** | the file or record that states all of the above |
+| **Shipped data set** | one the product provides and maintains |
+| **Own data set** | one a person or their assistant adds to their own installation |
+| **Registry** | the single list of every data set available right now, shipped and added |
+| **Access rule** | a condition attached to a data set that decides who may ask about it and which rows count |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Dashboard author
+
+**ID**: `cpt-insightspec-ds-actor-author`
+
+**Role**: builds charts and questions for other people.
+**Needs**: to see what exists and what each thing means before building anything.
+
+#### Instance administrator
+
+**ID**: `cpt-insightspec-ds-actor-admin`
+
+**Role**: runs the installation; approves data sets people add before others rely on them.
+**Needs**: to see what was added, by whom, and over what data, before approving.
+
+#### Product engineer
+
+**ID**: `cpt-insightspec-ds-actor-engineer`
+
+**Role**: adds and maintains the data sets the product ships.
+**Needs**: to add one in a single place, with checks that catch a mistake before release.
+
+### 2.2 System Actors
+
+#### Query engine
+
+**ID**: `cpt-insightspec-ds-actor-engine`
+
+**Role**: the only reader of the registry; turns a question about a data set into an answer.
+
+#### Constructor page
+
+**ID**: `cpt-insightspec-ds-actor-constructor`
+
+**Role**: shows people what is available and builds a question from it.
+
+#### Warehouse
+
+**ID**: `cpt-insightspec-ds-actor-warehouse`
+
+**Role**: holds the prepared tables behind the data sets.
+
+## 3. Operational Concept & Environment
+
+### 3.1 Module-Specific Environment Constraints
+
+- A data set stands on prepared data that the pipeline already builds; defining one never
+  changes how data is collected.
+- What the product ships is fixed in a release: a shipped data set changes by shipping a new
+  version, never by editing it in a running installation.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- What a data set is: its grain, its breakdowns and their readable names, its measures, its
+  dates, and how its rows must be read to avoid double counting.
+- Where a data set is defined: one place, next to the thing that builds its data.
+- The registry that holds every available data set and hands it to whoever asks.
+- Describing the available data sets to people and pages.
+- Checking a data set against the data that actually exists, before it is offered.
+- The first two: commits and file changes.
+- Data sets people add themselves, and the approval step before others use them.
+- Access rules as something a data set declares.
+
+### 4.2 Out of Scope
+
+- Asking questions: filters, breakdowns, counting, charts — the [query
+  engine](../query-engine/PRD.md).
+- Collecting data and building the tables underneath.
+- Enforcing access rules at answer time; that is the engine applying what is declared here.
+- Deciding which data sets to build next.
+
+## 5. Functional Requirements
+
+### 5.1 Defining a data set
+
+#### One definition, in one place
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-fr-single-home`
+
+A data set **MUST** be defined in one place that holds everything about it: how its data is
+built, what one row means, what can be asked of it, and its own page of notes.
+
+**Rationale**: split across the codebase, the parts drift and nobody can review a data set
+as one thing.
+
+**Actors**: `cpt-insightspec-ds-actor-engineer`
+
+#### Say what one row is
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-fr-grain`
+
+Every data set **MUST** state what makes one row unique, and that statement **MUST** be
+enforced by an automatic check against the built data.
+
+**Rationale**: every number is a count or a sum of rows; if one row is not one thing, every
+number is wrong.
+
+**Actors**: `cpt-insightspec-ds-actor-engineer`
+
+#### Offer every stable column
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-fr-fields`
+
+A data set **MUST** offer, as things to break down or filter by, every column whose value is
+stable enough to mean something, and **MUST** name which other column carries the readable
+label for each. It **MUST** state which columns hold numbers that can be counted or added up,
+and which hold the dates a question can range over.
+
+**Rationale**: an axis that exists in the data but not in the list is a question nobody can
+ask; a value without its label is a chart nobody can read.
+
+**Actors**: `cpt-insightspec-ds-actor-author`
+
+#### Name the rows with nothing there
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-fr-absent-values`
+
+Where a column may hold nothing, the data set **MUST** give those rows a name people can see
+and filter by, and the product **MUST** refuse a data set that leaves them unnamed.
+
+**Rationale**: rows that vanish from a breakdown make totals that do not add up.
+
+**Actors**: `cpt-insightspec-ds-actor-author`
+
+#### Carry the counting rules
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-fr-correctness-baked`
+
+A data set **MUST** carry the rules that make its numbers right — the same work counted once
+however many sources reported it, the right person credited, superseded records excluded —
+applied once where its data is built, not by whoever asks.
+
+**Rationale**: rules that live in the asker's head produce a different number for every
+asker.
+
+**Actors**: `cpt-insightspec-ds-actor-engineer`
+
+### 5.2 Offering data sets
+
+#### Keep one list
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-fr-registry`
+
+The product **MUST** keep a single list of the data sets available right now, holding both
+the ones it ships and the ones people added, and everything that reads data sets **MUST**
+read that list.
+
+**Rationale**: two lists become two answers to "what can I ask about".
+
+**Actors**: `cpt-insightspec-ds-actor-engine`
+
+#### Check against the data that exists
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-fr-validated`
+
+Before a data set is offered, the product **MUST** check every column it names against the
+data that actually exists, and refuse it — saying which part is wrong — if anything is
+missing or of the wrong kind. For shipped data sets this check **MUST** also run before
+release.
+
+**Rationale**: a promise the data cannot keep is an error in front of a person instead of a
+failed build.
+
+**Actors**: `cpt-insightspec-ds-actor-engineer`, `cpt-insightspec-ds-actor-admin`
+
+#### Describe what is available
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-fr-discovery`
+
+The product **MUST** describe every available data set — its breakdowns with their labels,
+its measures, its dates — to people and pages that may see it, and **MUST NOT** reveal where
+or how the data is stored.
+
+**Rationale**: a page builds a question from this description; storage details help nobody
+and expose the warehouse.
+
+**Actors**: `cpt-insightspec-ds-actor-constructor`
+
+#### Readable names and value suggestions
+
+- [ ] `p2` - **ID**: `cpt-insightspec-ds-fr-field-metadata`
+
+Each column a data set offers **MUST** carry a readable name, a short description and, for
+numbers, a unit; and the product **MUST** be able to suggest the values a column actually
+holds.
+
+**Rationale**: wording is the product's job, not each page's, and nobody should type a
+repository name from memory.
+
+**Actors**: `cpt-insightspec-ds-actor-constructor`
+
+### 5.3 The first data sets
+
+#### Commits and file changes
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-fr-first-two`
+
+The product **MUST** ship a commits data set — one row per commit somebody wrote — and a file
+changes data set — one row per file a commit touched — each with the person, the repository,
+the project, the source, the branch scope, the dates and the lines involved.
+
+**Rationale**: they answer most questions asked of engineering data today and prove the shape
+works for two different grains.
+
+**Actors**: `cpt-insightspec-ds-actor-author`
+
+### 5.4 Data sets people add
+
+#### Add your own
+
+- [ ] `p3` - **ID**: `cpt-insightspec-ds-fr-own-datasets`
+
+The product **MUST** let someone add a data set at runtime in three forms: a narrowed or
+relabelled version of an existing one, with their own categories added; a saved question
+other people can break down further; and their own table or uploaded list. An assistant may
+write any of these on someone's behalf.
+
+**Rationale**: the questions worth asking outgrow any list we ship.
+
+**Actors**: `cpt-insightspec-ds-actor-author`, `cpt-insightspec-ds-actor-admin`
+
+#### Same checks, whoever wrote it
+
+- [ ] `p3` - **ID**: `cpt-insightspec-ds-fr-own-validated`
+
+A data set someone adds **MUST** be checked exactly like a shipped one, refused in the same
+words, kept inside the organisation that added it, and re-checked whenever the data beneath
+it changes shape.
+
+**Rationale**: an added data set is used for the same decisions as a shipped one.
+
+**Actors**: `cpt-insightspec-ds-actor-author`
+
+#### Yours immediately, shared after approval
+
+- [ ] `p3` - **ID**: `cpt-insightspec-ds-fr-approval`
+
+A newly added data set **MUST** be usable straight away by whoever added it, and **MUST NOT**
+be available to anyone else until an administrator approves it and its access rules are set.
+
+**Rationale**: exploring should be instant; sharing a number other people act on should not
+be.
+
+**Actors**: `cpt-insightspec-ds-actor-admin`
+
+#### Keep the versions
+
+- [ ] `p3` - **ID**: `cpt-insightspec-ds-fr-versioning`
+
+Editing an added data set **MUST** create a new version rather than overwrite the old one,
+and the product **MUST** record who wrote and who approved each version.
+
+**Rationale**: a chart that changed needs an answer to "what changed, and who agreed to it".
+
+**Actors**: `cpt-insightspec-ds-actor-admin`
+
+### 5.5 Who may see what
+
+#### Declare the access rules
+
+- [ ] `p2` - **ID**: `cpt-insightspec-ds-fr-access-rules`
+
+A data set **MUST** be able to declare who may ask about it at all, which rows count towards
+a given person's answers, and which columns they may see — including the fact that some of
+its columns describe named people.
+
+**Rationale**: visibility is a property of the data, not of each question asked about it.
+
+**Actors**: `cpt-insightspec-ds-actor-admin`, `cpt-insightspec-ds-actor-engine`
+
+## 6. Non-Functional Requirements
+
+### 6.1 NFR Inclusions
+
+#### Adding one is a contained change
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-nfr-additive`
+
+Adding a shipped data set **MUST** require no change to the code that answers questions.
+
+**Threshold**: a new data set is a new folder plus its declaration; nothing in the query
+engine is edited.
+
+**Rationale**: if every data set costs engine work, the list stops growing.
+
+#### Broken definitions never reach people
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-nfr-fail-early`
+
+A shipped data set that does not match the data **MUST** stop the build; one added at runtime
+**MUST** be refused when it is saved.
+
+**Threshold**: no path where a mismatch first appears as a failed question.
+
+**Rationale**: the person asking cannot fix a broken definition.
+
+#### Descriptions cost nothing to read
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-nfr-cheap-discovery`
+
+Describing the available data sets **MUST NOT** touch the warehouse.
+
+**Threshold**: descriptions served from the list already in memory.
+
+**Rationale**: a page asks on every load; the warehouse is for answering questions.
+
+### 6.2 NFR Exclusions
+
+- **Storing anything**: shipped data sets ship with the product; added ones live in the
+  product's own store. This part writes nothing to the warehouse.
+- **Signing in**: handled before any request reaches this.
+- **Uptime and recovery**: inherited from the service the registry lives in.
+- **Accessibility and translation**: no interface of its own; the pages that read it follow
+  the product's standards.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### The description of what is available
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-interface-discovery`
+
+**Type**: published read-only description of every available data set
+
+**Stability**: still changing while administrator-only
+
+**Description**: the list a page or a person uses to find out what can be asked about.
+
+**Breaking Change Policy**: a field already described keeps its meaning; new detail is added,
+never substituted.
+
+### 7.2 External Integration Contracts
+
+#### The prepared data underneath
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-contract-prepared-data`
+
+**Direction**: required from the data pipeline
+
+**Protocol/Format**: one prepared table per data set, at the stated grain, with the counting
+rules already applied
+
+**Compatibility**: a column a data set names must exist; if it stops existing, the check
+fails rather than the answer being wrong.
+
+## 8. Use Cases
+
+#### Find out what can be asked about
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-usecase-discover`
+
+**Actor**: `cpt-insightspec-ds-actor-author`
+
+**Preconditions**:
+- At least one data set is available to this person.
+
+**Main Flow**:
+1. The author opens the page that builds questions.
+2. The product lists the available data sets and, for the chosen one, what can be broken
+   down, what can be counted, and which dates apply.
+3. The author builds a question from that list alone.
+
+**Postconditions**:
+- A question was built without anyone reading a table.
+
+**Alternative Flows**:
+- **Nothing is available to this person**: the page says so rather than showing an empty
+  list of fields.
+
+#### Add a data set to the product
+
+- [x] `p1` - **ID**: `cpt-insightspec-ds-usecase-ship-one`
+
+**Actor**: `cpt-insightspec-ds-actor-engineer`
+
+**Preconditions**:
+- The data behind it exists or is built as part of the same change.
+
+**Main Flow**:
+1. The engineer creates the data set's folder: how its data is built, what one row is, what
+   can be asked, and a page of notes.
+2. The checks confirm every named column exists and that one row is one thing.
+3. The data set ships and appears in the list.
+
+**Postconditions**:
+- A new data set is available and nothing in the query engine changed.
+
+**Alternative Flows**:
+- **A named column does not exist**: the build fails, naming the column.
+
+#### Add one of your own
+
+- [ ] `p3` - **ID**: `cpt-insightspec-ds-usecase-own-dataset`
+
+**Actor**: `cpt-insightspec-ds-actor-author`
+
+**Preconditions**:
+- The person may add data sets in their organisation.
+
+**Main Flow**:
+1. The author narrows an existing data set, adds their own categories, and saves it.
+2. The product checks it as it would a shipped one and makes it available to the author.
+3. An administrator reviews it, sets its access rules, and approves it.
+
+**Postconditions**:
+- Other people can build charts on it.
+
+**Alternative Flows**:
+- **It does not match the data**: refused when saved, naming what is wrong.
+- **Not approved**: it stays visible to its author alone.
+
+## 9. Acceptance Criteria
+
+- [x] The commits and file changes data sets are available, and each states what one row is.
+- [x] Each one's grain is enforced by a check against the built data.
+- [x] The description of a data set names its breakdowns, labels, measures and dates, and no
+  storage detail.
+- [x] A data set naming a column the data does not have fails before release.
+- [ ] A data set added at runtime is refused on the same grounds a shipped one would be.
+- [ ] An added data set is invisible to everyone but its author until approved.
+
+## 10. Dependencies
+
+| Dependency | Description | Criticality |
+|------------|-------------|-------------|
+| Data pipeline | builds the prepared table behind each data set | p1 |
+| Record of what the warehouse holds | what declarations are checked against before release | p1 |
+| Query engine | the reader of the registry; turns data sets into answers | p1 |
+| Identity service | who is asking, for approval and access rules | p2 |
+
+## 11. Assumptions
+
+- Most questions are answered by a handful of well-shaped data sets rather than many narrow
+  ones.
+- A data set's prepared table is small enough to be queried directly within the engine's
+  limits.
+- People adding their own will mostly narrow and relabel what exists rather than bring
+  entirely new data.
+
+**Open questions**
+
+| Question | Owner | Resolve by |
+|---|---|---|
+| Which data sets come after commits and file changes, in what order? | product | after the first charts are built |
+| How does an administrator review an added data set — what do they see? | product | when own data sets start |
+| Where do team-to-resource facts live, for the access rules that need them? | product + backend | before the first access rule |
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| A data set's grain is wrong | every number built on it is wrong, quietly | the grain is stated and checked automatically against the built data |
+| The list grows faster than the checks | broken definitions reach people | one validation path for shipped and added alike, run before release and on save |
+| People add near-duplicate data sets | nobody knows which to use | approval before sharing; each one carries a page saying what it is for |
+| A prepared table changes shape underneath | questions fail or answer differently | declarations are re-checked against the data; a mismatch is refused, not guessed |

--- a/docs/domain/datasets/PRD.md
+++ b/docs/domain/datasets/PRD.md
@@ -1,10 +1,10 @@
 ---
-version: 1.0
+version: 1.1
 status: proposed
 date: 2026-09-08
 ---
 
-# PRD — Data Sets
+# PRD — Datasets
 
 <!-- toc -->
 
@@ -22,11 +22,11 @@ date: 2026-09-08
   - [4.1 In Scope](#41-in-scope)
   - [4.2 Out of Scope](#42-out-of-scope)
 - [5. Functional Requirements](#5-functional-requirements)
-  - [5.1 Defining a data set](#51-defining-a-data-set)
-  - [5.2 Offering data sets](#52-offering-data-sets)
-  - [5.3 The first data sets](#53-the-first-data-sets)
-  - [5.4 Data sets people add](#54-data-sets-people-add)
-  - [5.5 Who may see what](#55-who-may-see-what)
+  - [5.1 Dataset definitions](#51-dataset-definitions)
+  - [5.2 Registry and discovery](#52-registry-and-discovery)
+  - [5.3 Initial datasets](#53-initial-datasets)
+  - [5.4 Tenant-defined datasets (planned)](#54-tenant-defined-datasets-planned)
+  - [5.5 Access policies (planned)](#55-access-policies-planned)
 - [6. Non-Functional Requirements](#6-non-functional-requirements)
   - [6.1 NFR Inclusions](#61-nfr-inclusions)
   - [6.2 NFR Exclusions](#62-nfr-exclusions)
@@ -45,55 +45,48 @@ date: 2026-09-08
 
 ### 1.1 Purpose
 
-A data set is one kind of thing people can ask about — commits, file changes, later
-deployments or tickets. It names what can be broken down, what can be counted, and over
-which dates, in words a person recognises. Everything the product can answer, and everything
-a chart can offer, comes from this list.
+A dataset defines queryable data at a documented row grain. It specifies dimensions for
+grouping and filtering, numeric fields for aggregation, and supported time fields. Chart
+builders discover these capabilities without inspecting warehouse schemas.
 
-Built by [DESIGN.md](DESIGN.md). Asking questions of these data sets is the
-[query engine](../query-engine/PRD.md).
+This PRD covers shipped datasets and planned extensions for tenant-defined datasets and
+access policies. [DESIGN.md](DESIGN.md) describes the implementation and its limits. Query
+execution belongs to the [query engine](https://github.com/constructorfabric/insight/blob/d912c610da33259475d817fc009d34de35b8fe10/docs/domain/query-engine/PRD.md).
 
 ### 1.2 Background / Problem Statement
 
-The product's numbers are pre-built metrics. Each one hard-codes which table it reads, what
-it counts and how it may be split. Nothing describes the underlying data itself, so there is
-no list a person or a page can choose from, and every new question means a developer reading
-warehouse tables to work out where the answer lives.
+Pre-built metrics encode their source data, aggregation, and supported dimensions separately.
+They do not provide a reusable description of the underlying data for chart builders.
 
-The tables themselves are not a substitute. They carry columns nobody should have to reason
-about, they need rules applied to avoid double counting, and they say nothing about which
-column is a name for which other column. A person cannot tell from a table what one row
-means.
+Warehouse tables alone do not supply that contract. Consumers need an explicit row grain,
+queryable fields, display labels, and consistent deduplication and attribution rules.
 
-Customers also have facts we do not: which repositories belong to which product line, which
-people belong to which cost centre. Today those cannot enter the product at all.
+Tenant-defined datasets would extend this catalog with custom classifications, derived data,
+and imported tables.
 
 ### 1.3 Goals (Business Outcomes)
 
-- Anyone building a chart can see what is available to ask about, in readable words, without
-  reading a table or asking a developer.
-- One row of a data set means one thing, and that meaning is written down where the data set
-  is defined.
-- Adding a data set is a self-contained piece of work: define it, describe it, ship it — no
-  change to the code that answers questions.
-- People and their assistants add data sets of their own, and what they add is checked the
-  same way as what we ship.
-- The rules about who may see which rows are attached to the data set, so every question
-  inherits them.
+- Build queries from discoverable dataset metadata.
+- Define and verify each dataset's row grain.
+- Add shipped datasets without changing query-engine code.
+- Apply the same validation requirements to shipped and tenant-defined datasets.
+- Declare access policies once per dataset for enforcement on every query.
 
 ### 1.4 Glossary
 
 | Term | Meaning |
 |---|---|
-| **Data set** | one kind of thing to ask about, with everything needed to ask: what one row is, what it can be split by, what can be counted, which dates apply |
-| **Grain** | what one row of a data set represents, exactly: one commit, one file in one commit |
-| **Breakdown** | a column an answer can be split by, with a readable name |
-| **Measure** | a number that can be counted or added up |
-| **Declaration** | the file or record that states all of the above |
-| **Shipped data set** | one the product provides and maintains |
-| **Own data set** | one a person or their assistant adds to their own installation |
-| **Registry** | the single list of every data set available right now, shipped and added |
-| **Access rule** | a condition attached to a data set that decides who may ask about it and which rows count |
+| Dataset | Queryable data with a declared grain, dimensions, measurables, and time fields |
+| Grain | What one row represents |
+| Row identity | Fields that uniquely identify a row at the declared grain |
+| Dimension | Field available for grouping and filtering |
+| Breakdown | Query results grouped by one or more dimensions |
+| Measurable | Numeric field available for aggregation; distinct from a pre-built metric |
+| Declaration | Dataset metadata stored as a file or record |
+| Shipped dataset | Dataset maintained and released with the product |
+| Tenant-defined dataset | Dataset created within a tenant at runtime |
+| Registry | Catalog of available dataset declarations |
+| Access policy | Dataset, row, or column visibility rules |
 
 ## 2. Actors
 
@@ -103,22 +96,22 @@ people belong to which cost centre. Today those cannot enter the product at all.
 
 **ID**: `cpt-insightspec-ds-actor-author`
 
-**Role**: builds charts and questions for other people.
-**Needs**: to see what exists and what each thing means before building anything.
+**Role**: builds charts and queries.
+**Needs**: discoverable fields and documented dataset semantics.
 
 #### Instance administrator
 
 **ID**: `cpt-insightspec-ds-actor-admin`
 
-**Role**: runs the installation; approves data sets people add before others rely on them.
-**Needs**: to see what was added, by whom, and over what data, before approving.
+**Role**: accesses initial discovery; approves tenant-defined datasets in the planned extension.
+**Needs**: dataset provenance, authorship, and access policies for review.
 
 #### Product engineer
 
 **ID**: `cpt-insightspec-ds-actor-engineer`
 
-**Role**: adds and maintains the data sets the product ships.
-**Needs**: to add one in a single place, with checks that catch a mistake before release.
+**Role**: maintains shipped datasets.
+**Needs**: self-contained definitions and validation before release.
 
 ### 2.2 System Actors
 
@@ -126,247 +119,228 @@ people belong to which cost centre. Today those cannot enter the product at all.
 
 **ID**: `cpt-insightspec-ds-actor-engine`
 
-**Role**: the only reader of the registry; turns a question about a data set into an answer.
+**Role**: consumes declarations to plan and execute queries.
 
 #### Constructor page
 
 **ID**: `cpt-insightspec-ds-actor-constructor`
 
-**Role**: shows people what is available and builds a question from it.
+**Role**: uses discovery metadata to present dataset fields and construct queries.
 
 #### Warehouse
 
 **ID**: `cpt-insightspec-ds-actor-warehouse`
 
-**Role**: holds the prepared tables behind the data sets.
+**Role**: stores the prepared data backing datasets.
 
 ## 3. Operational Concept & Environment
 
 ### 3.1 Module-Specific Environment Constraints
 
-- A data set stands on prepared data that the pipeline already builds; defining one never
-  changes how data is collected.
-- What the product ships is fixed in a release: a shipped data set changes by shipping a new
-  version, never by editing it in a running installation.
+- Datasets use prepared pipeline data; declarations do not change data collection.
+- Shipped definitions change through product releases, not runtime edits.
 
 ## 4. Scope
 
 ### 4.1 In Scope
 
-- What a data set is: its grain, its breakdowns and their readable names, its measures, its
-  dates, and how its rows must be read to avoid double counting.
-- Where a data set is defined: one place, next to the thing that builds its data.
-- The registry that holds every available data set and hands it to whoever asks.
-- Describing the available data sets to people and pages.
-- Checking a data set against the data that actually exists, before it is offered.
-- The first two: commits and file changes.
-- Data sets people add themselves, and the approval step before others use them.
-- Access rules as something a data set declares.
+**Initial implementation**: shipped declarations, row identity and validation, a registry,
+admin-only discovery, and the commits and file changes datasets.
+
+**Planned extensions**: field descriptions, units, value suggestions, tenant-defined datasets,
+approval and versioning, and declared access policies. These remain product requirements;
+they are not implemented by the initial release.
 
 ### 4.2 Out of Scope
 
-- Asking questions: filters, breakdowns, counting, charts — the [query
-  engine](../query-engine/PRD.md).
-- Collecting data and building the tables underneath.
-- Enforcing access rules at answer time; that is the engine applying what is declared here.
-- Deciding which data sets to build next.
+- Query execution, aggregation, and chart rendering.
+- Data collection and pipeline implementation.
+- Access-policy enforcement, owned by the query engine.
+- Selection of subsequent shipped datasets.
 
 ## 5. Functional Requirements
 
-### 5.1 Defining a data set
+### 5.1 Dataset definitions
 
-#### One definition, in one place
+#### Dataset definition
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-fr-single-home`
 
-A data set **MUST** be defined in one place that holds everything about it: how its data is
-built, what one row means, what can be asked of it, and its own page of notes.
+A dataset **MUST** have one definition that groups its data preparation, grain,
+queryable fields, and documentation.
 
-**Rationale**: split across the codebase, the parts drift and nobody can review a data set
-as one thing.
+**Rationale**: Reviewing these together reduces inconsistent changes.
 
 **Actors**: `cpt-insightspec-ds-actor-engineer`
 
-#### Say what one row is
+#### Row grain
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-fr-grain`
 
-Every data set **MUST** state what makes one row unique, and that statement **MUST** be
-enforced by an automatic check against the built data.
+Every dataset **MUST** declare its row identity and verify its uniqueness against the
+prepared data.
 
-**Rationale**: every number is a count or a sum of rows; if one row is not one thing, every
-number is wrong.
+**Rationale**: Duplicate rows can inflate counts and sums.
 
 **Actors**: `cpt-insightspec-ds-actor-engineer`
 
-#### Offer every stable column
+#### Queryable fields
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-fr-fields`
 
-A data set **MUST** offer, as things to break down or filter by, every column whose value is
-stable enough to mean something, and **MUST** name which other column carries the readable
-label for each. It **MUST** state which columns hold numbers that can be counted or added up,
-and which hold the dates a question can range over.
+A dataset **MUST** expose all stable dimensions for grouping and filtering, identify their
+display-label fields, and declare its measurables and time fields.
 
-**Rationale**: an axis that exists in the data but not in the list is a question nobody can
-ask; a value without its label is a chart nobody can read.
+**Rationale**: A missing dimension prevents queries that the underlying data could support.
+The criteria for including a field as a stable dimension remain open in Section 11.
 
 **Actors**: `cpt-insightspec-ds-actor-author`
 
-#### Name the rows with nothing there
+#### Missing dimension values
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-fr-absent-values`
 
-Where a column may hold nothing, the data set **MUST** give those rows a name people can see
-and filter by, and the product **MUST** refuse a data set that leaves them unnamed.
+A dataset **MUST** declare a visible, filterable representation for missing dimension
+values. A declaration without a required representation **MUST** be rejected.
 
-**Rationale**: rows that vanish from a breakdown make totals that do not add up.
+**Rationale**: Missing values must remain identifiable in grouped results. The current
+null-handling contract is documented in DESIGN; broader missing-value semantics remain open.
 
 **Actors**: `cpt-insightspec-ds-actor-author`
 
-#### Carry the counting rules
+#### Consistent data preparation
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-fr-correctness-baked`
 
-A data set **MUST** carry the rules that make its numbers right — the same work counted once
-however many sources reported it, the right person credited, superseded records excluded —
-applied once where its data is built, not by whoever asks.
+Dataset preparation **MUST** apply deduplication, attribution, and superseded-record
+exclusion rules before queries use the data.
 
-**Rationale**: rules that live in the asker's head produce a different number for every
-asker.
+**Rationale**: Queries over the same dataset must use the same counting and attribution rules.
 
 **Actors**: `cpt-insightspec-ds-actor-engineer`
 
-### 5.2 Offering data sets
+### 5.2 Registry and discovery
 
-#### Keep one list
+#### Dataset registry
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-fr-registry`
 
-The product **MUST** keep a single list of the data sets available right now, holding both
-the ones it ships and the ones people added, and everything that reads data sets **MUST**
-read that list.
+All dataset consumers **MUST** use one registry of available declarations. The registry
+**MUST** support shipped and, in the planned extension, tenant-defined datasets.
 
-**Rationale**: two lists become two answers to "what can I ask about".
+**Rationale**: Discovery and query execution must agree on available datasets.
 
 **Actors**: `cpt-insightspec-ds-actor-engine`
 
-#### Check against the data that exists
+#### Declaration validation
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-fr-validated`
 
-Before a data set is offered, the product **MUST** check every column it names against the
-data that actually exists, and refuse it — saying which part is wrong — if anything is
-missing or of the wrong kind. For shipped data sets this check **MUST** also run before
-release.
+Before exposing a dataset, the product **MUST** validate its referenced fields and their
+types, rejecting invalid declarations with an error identifying the dataset and field.
+Shipped declarations **MUST** also be validated before release.
 
-**Rationale**: a promise the data cannot keep is an error in front of a person instead of a
-failed build.
+**Rationale**: Invalid definitions should fail before users depend on them. DESIGN states the
+current validation source and its limits.
 
 **Actors**: `cpt-insightspec-ds-actor-engineer`, `cpt-insightspec-ds-actor-admin`
 
-#### Describe what is available
+#### Dataset discovery
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-fr-discovery`
 
-The product **MUST** describe every available data set — its breakdowns with their labels,
-its measures, its dates — to people and pages that may see it, and **MUST NOT** reveal where
-or how the data is stored.
+The product **MUST** describe available datasets, dimensions, labels, measurables, and time
+fields without exposing storage details. Initial discovery **MUST** be restricted to instance
+administrators; broader visibility depends on the planned access policies.
 
-**Rationale**: a page builds a question from this description; storage details help nobody
-and expose the warehouse.
+**Rationale**: Consumers need query capabilities without warehouse access.
 
 **Actors**: `cpt-insightspec-ds-actor-constructor`
 
-#### Readable names and value suggestions
+#### Field metadata and value suggestions
 
 - [ ] `p2` - **ID**: `cpt-insightspec-ds-fr-field-metadata`
 
-Each column a data set offers **MUST** carry a readable name, a short description and, for
-numbers, a unit; and the product **MUST** be able to suggest the values a column actually
-holds.
+Each exposed field **MUST** have a display name and short description; numeric fields
+**MUST** include units. The product **MUST** suggest values present in a field.
 
-**Rationale**: wording is the product's job, not each page's, and nobody should type a
-repository name from memory.
+**Rationale**: Shared metadata keeps field presentation consistent across clients.
 
 **Actors**: `cpt-insightspec-ds-actor-constructor`
 
-### 5.3 The first data sets
+### 5.3 Initial datasets
 
 #### Commits and file changes
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-fr-first-two`
 
-The product **MUST** ship a commits data set — one row per commit somebody wrote — and a file
-changes data set — one row per file a commit touched — each with the person, the repository,
-the project, the source, the branch scope, the dates and the lines involved.
+The product **MUST** provide commits and file changes datasets. Commits represent authored
+commits; file changes represent changes to paths within commits. Both **MUST** expose author,
+repository, project, source, branch scope, event time, and line counts.
 
-**Rationale**: they answer most questions asked of engineering data today and prove the shape
-works for two different grains.
+**Rationale**: These datasets establish the contract at two related grains. DESIGN specifies
+their exact row identities and preparation rules.
 
 **Actors**: `cpt-insightspec-ds-actor-author`
 
-### 5.4 Data sets people add
+### 5.4 Tenant-defined datasets (planned)
 
-#### Add your own
+#### Tenant-defined datasets
 
 - [ ] `p3` - **ID**: `cpt-insightspec-ds-fr-own-datasets`
 
-The product **MUST** let someone add a data set at runtime in three forms: a narrowed or
-relabelled version of an existing one, with their own categories added; a saved question
-other people can break down further; and their own table or uploaded list. An assistant may
-write any of these on someone's behalf.
+Authorized authors **MUST** be able to create datasets at runtime as derived datasets with
+filters, labels, and custom categories; reusable saved queries; or imported tables and lists.
+An assistant may create these on the author's behalf.
 
-**Rationale**: the questions worth asking outgrow any list we ship.
+**Rationale**: Tenant-specific data and classifications extend shipped datasets.
 
 **Actors**: `cpt-insightspec-ds-actor-author`, `cpt-insightspec-ds-actor-admin`
 
-#### Same checks, whoever wrote it
+#### Tenant-defined dataset validation
 
 - [ ] `p3` - **ID**: `cpt-insightspec-ds-fr-own-validated`
 
-A data set someone adds **MUST** be checked exactly like a shipped one, refused in the same
-words, kept inside the organisation that added it, and re-checked whenever the data beneath
-it changes shape.
+Tenant-defined datasets **MUST** use the same validation rules and errors as shipped
+datasets, remain tenant-scoped, and be revalidated after underlying schema changes.
 
-**Rationale**: an added data set is used for the same decisions as a shipped one.
+**Rationale**: Dataset origin must not weaken validation or tenant isolation.
 
 **Actors**: `cpt-insightspec-ds-actor-author`
 
-#### Yours immediately, shared after approval
+#### Approval before sharing
 
 - [ ] `p3` - **ID**: `cpt-insightspec-ds-fr-approval`
 
-A newly added data set **MUST** be usable straight away by whoever added it, and **MUST NOT**
-be available to anyone else until an administrator approves it and its access rules are set.
+A newly created tenant-defined dataset **MUST** be available immediately to its author and
+**MUST NOT** be available to others until an administrator approves it and sets its access
+policies.
 
-**Rationale**: exploring should be instant; sharing a number other people act on should not
-be.
+**Rationale**: Authors can explore privately before publishing shared data.
 
 **Actors**: `cpt-insightspec-ds-actor-admin`
 
-#### Keep the versions
+#### Dataset version history
 
 - [ ] `p3` - **ID**: `cpt-insightspec-ds-fr-versioning`
 
-Editing an added data set **MUST** create a new version rather than overwrite the old one,
-and the product **MUST** record who wrote and who approved each version.
+Editing a tenant-defined dataset **MUST** create a new version and preserve earlier
+versions. The product **MUST** record each version's author and approver.
 
-**Rationale**: a chart that changed needs an answer to "what changed, and who agreed to it".
+**Rationale**: Version history supports investigation of changed query results.
 
 **Actors**: `cpt-insightspec-ds-actor-admin`
 
-### 5.5 Who may see what
+### 5.5 Access policies (planned)
 
-#### Declare the access rules
+#### Declared access policies
 
 - [ ] `p2` - **ID**: `cpt-insightspec-ds-fr-access-rules`
 
-A data set **MUST** be able to declare who may ask about it at all, which rows count towards
-a given person's answers, and which columns they may see — including the fact that some of
-its columns describe named people.
+A dataset **MUST** support declarations for dataset access, row visibility, and column
+visibility. It **MUST** identify fields containing personal data.
 
-**Rationale**: visibility is a property of the data, not of each question asked about it.
+**Rationale**: The query engine needs dataset-level policies to enforce consistent access.
 
 **Actors**: `cpt-insightspec-ds-actor-admin`, `cpt-insightspec-ds-actor-engine`
 
@@ -374,185 +348,177 @@ its columns describe named people.
 
 ### 6.1 NFR Inclusions
 
-#### Adding one is a contained change
+#### Dataset extensibility
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-nfr-additive`
 
-Adding a shipped data set **MUST** require no change to the code that answers questions.
+Adding a shipped dataset **MUST NOT** require query-engine changes.
 
-**Threshold**: a new data set is a new folder plus its declaration; nothing in the query
-engine is edited.
+**Threshold**: zero changes to query-engine code when adding a supported dataset definition.
 
-**Rationale**: if every data set costs engine work, the list stops growing.
+**Rationale**: dataset additions should not require engine development.
 
-#### Broken definitions never reach people
+#### Validation before use
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-nfr-fail-early`
 
-A shipped data set that does not match the data **MUST** stop the build; one added at runtime
-**MUST** be refused when it is saved.
+Invalid shipped declarations **MUST** block release. Invalid runtime declarations **MUST**
+be rejected on save.
 
-**Threshold**: no path where a mismatch first appears as a failed question.
+**Threshold**: all declaration mismatches detectable by the validator are rejected before use.
 
-**Rationale**: the person asking cannot fix a broken definition.
+**Rationale**: query authors cannot repair dataset definitions. The initial implementation
+validates shipped declarations; runtime validation is planned.
 
-#### Descriptions cost nothing to read
+#### Discovery without warehouse queries
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-nfr-cheap-discovery`
 
-Describing the available data sets **MUST NOT** touch the warehouse.
+Dataset discovery **MUST NOT** query the warehouse.
 
-**Threshold**: descriptions served from the list already in memory.
+**Threshold**: zero warehouse queries per discovery request.
 
-**Rationale**: a page asks on every load; the warehouse is for answering questions.
+**Rationale**: loading dataset metadata must not add warehouse query load.
 
 ### 6.2 NFR Exclusions
 
-- **Storing anything**: shipped data sets ship with the product; added ones live in the
-  product's own store. This part writes nothing to the warehouse.
-- **Signing in**: handled before any request reaches this.
-- **Uptime and recovery**: inherited from the service the registry lives in.
-- **Accessibility and translation**: no interface of its own; the pages that read it follow
-  the product's standards.
+- **Warehouse writes**: declarations describe prepared data; this module does not write it.
+- **Authentication**: supplied by the hosting service; dataset permissions remain in scope.
+- **Availability and recovery**: inherit the hosting service's requirements.
+- **Accessibility and translation**: apply to consuming interfaces; this module has no UI.
 
 ## 7. Public Library Interfaces
 
 ### 7.1 Public API Surface
 
-#### The description of what is available
+#### Dataset discovery
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-interface-discovery`
 
-**Type**: published read-only description of every available data set
+**Type**: read-only dataset metadata.
 
-**Stability**: still changing while administrator-only
+**Stability**: experimental while administrator-only.
 
-**Description**: the list a page or a person uses to find out what can be asked about.
+**Description**: available datasets and their queryable fields.
 
-**Breaking Change Policy**: a field already described keeps its meaning; new detail is added,
-never substituted.
+**Breaking Change Policy**: existing fields retain their meaning; metadata additions are
+additive. DESIGN defines the interface contract.
 
 ### 7.2 External Integration Contracts
 
-#### The prepared data underneath
+#### Prepared data
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-contract-prepared-data`
 
-**Direction**: required from the data pipeline
+**Direction**: required from the data pipeline.
 
-**Protocol/Format**: one prepared table per data set, at the stated grain, with the counting
-rules already applied
+**Protocol/Format**: one prepared relation per dataset at its declared grain, with
+counting and attribution rules applied.
 
-**Compatibility**: a column a data set names must exist; if it stops existing, the check
-fails rather than the answer being wrong.
+**Compatibility**: referenced fields must exist with compatible types; detected mismatches
+invalidate the declaration.
 
 ## 8. Use Cases
 
-#### Find out what can be asked about
+#### Discover dataset fields
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-usecase-discover`
 
 **Actor**: `cpt-insightspec-ds-actor-author`
 
-**Preconditions**:
-- At least one data set is available to this person.
+**Preconditions**: the author has discovery permission; initially this requires administrator access.
 
 **Main Flow**:
-1. The author opens the page that builds questions.
-2. The product lists the available data sets and, for the chosen one, what can be broken
-   down, what can be counted, and which dates apply.
-3. The author builds a question from that list alone.
 
-**Postconditions**:
-- A question was built without anyone reading a table.
+1. The author selects an available dataset.
+2. The client presents its dimensions, measurables, and time fields.
+3. The author builds a query using those fields.
 
-**Alternative Flows**:
-- **Nothing is available to this person**: the page says so rather than showing an empty
-  list of fields.
+**Postconditions**: the query uses discoverable metadata without warehouse inspection.
 
-#### Add a data set to the product
+**Alternative Flows**: if no datasets are available, the client reports that state.
+
+#### Add a shipped dataset
 
 - [x] `p1` - **ID**: `cpt-insightspec-ds-usecase-ship-one`
 
 **Actor**: `cpt-insightspec-ds-actor-engineer`
 
-**Preconditions**:
-- The data behind it exists or is built as part of the same change.
+**Preconditions**: prepared data exists or is supplied with the dataset.
 
 **Main Flow**:
-1. The engineer creates the data set's folder: how its data is built, what one row is, what
-   can be asked, and a page of notes.
-2. The checks confirm every named column exists and that one row is one thing.
-3. The data set ships and appears in the list.
 
-**Postconditions**:
-- A new data set is available and nothing in the query engine changed.
+1. The engineer defines the dataset's grain, fields, preparation, and documentation.
+2. Validation checks the declaration and row uniqueness.
+3. The dataset becomes discoverable in a product release.
 
-**Alternative Flows**:
-- **A named column does not exist**: the build fails, naming the column.
+**Postconditions**: a dataset is available without query-engine changes.
 
-#### Add one of your own
+**Alternative Flows**: invalid definitions block release with a validation error.
+
+#### Create and share a tenant-defined dataset (planned)
 
 - [ ] `p3` - **ID**: `cpt-insightspec-ds-usecase-own-dataset`
 
 **Actor**: `cpt-insightspec-ds-actor-author`
 
-**Preconditions**:
-- The person may add data sets in their organisation.
+**Preconditions**: the author may create datasets within the tenant.
 
 **Main Flow**:
-1. The author narrows an existing data set, adds their own categories, and saves it.
-2. The product checks it as it would a shipped one and makes it available to the author.
-3. An administrator reviews it, sets its access rules, and approves it.
 
-**Postconditions**:
-- Other people can build charts on it.
+1. The author derives and saves a dataset.
+2. Validation succeeds; the dataset becomes available to its author.
+3. An administrator sets access policies and approves sharing.
 
-**Alternative Flows**:
-- **It does not match the data**: refused when saved, naming what is wrong.
-- **Not approved**: it stays visible to its author alone.
+**Postconditions**: authorized users can query the approved dataset.
+
+**Alternative Flows**: invalid definitions are rejected; unapproved datasets remain private.
 
 ## 9. Acceptance Criteria
 
-- [x] The commits and file changes data sets are available, and each states what one row is.
-- [x] Each one's grain is enforced by a check against the built data.
-- [x] The description of a data set names its breakdowns, labels, measures and dates, and no
-  storage detail.
-- [x] A data set naming a column the data does not have fails before release.
-- [ ] A data set added at runtime is refused on the same grounds a shipped one would be.
-- [ ] An added data set is invisible to everyone but its author until approved.
+- [x] Commits and file changes datasets declare their row identities.
+- [x] Automated checks verify row uniqueness against prepared data.
+- [x] Discovery describes queryable fields without exposing storage details.
+- [x] Invalid field references fail shipped-declaration validation before release.
+- [ ] Runtime declarations receive equivalent validation.
+- [ ] Tenant-defined datasets remain author-only until approved for sharing.
+
+These markers distinguish delivered requirements from planned ones. They are not evidence
+that every deployment or end-to-end workflow has been validated.
 
 ## 10. Dependencies
 
-| Dependency | Description | Criticality |
-|------------|-------------|-------------|
-| Data pipeline | builds the prepared table behind each data set | p1 |
-| Record of what the warehouse holds | what declarations are checked against before release | p1 |
-| Query engine | the reader of the registry; turns data sets into answers | p1 |
-| Identity service | who is asking, for approval and access rules | p2 |
+| Dependency | Purpose | Criticality |
+|---|---|---|
+| Data pipeline | Prepared relations and grain checks | p1 |
+| Schema catalog | Field and type information for validation | p1 |
+| Query engine | Query planning and execution from declarations | p1 |
+| Identity service | Administrator checks; future approval and access policies | p1 |
 
 ## 11. Assumptions
 
-- Most questions are answered by a handful of well-shaped data sets rather than many narrow
-  ones.
-- A data set's prepared table is small enough to be queried directly within the engine's
-  limits.
-- People adding their own will mostly narrow and relabel what exists rather than bring
-  entirely new data.
+- Prepared relations can be queried within the query engine's limits.
+- Shared dataset definitions can serve multiple query and chart configurations.
+- Derived datasets are expected to cover common customization needs; this is unverified.
 
 **Open questions**
 
 | Question | Owner | Resolve by |
 |---|---|---|
-| Which data sets come after commits and file changes, in what order? | product | after the first charts are built |
-| How does an administrator review an added data set — what do they see? | product | when own data sets start |
-| Where do team-to-resource facts live, for the access rules that need them? | product + backend | before the first access rule |
+| What qualifies a dimension as stable and eligible for exposure? | product + backend | before extending field selection rules |
+| Does missing-value handling cover empty strings or source sentinels as well as nulls? | product + backend | before extending missing-value semantics |
+| Which datasets follow commits and file changes? | product | after initial chart workflows |
+| What must administrators review before approving a dataset? | product | before tenant-defined datasets |
+| Where are team-to-resource mappings defined for access policies? | product + backend | before access-policy implementation |
 
 ## 12. Risks
 
 | Risk | Impact | Mitigation |
-|------|--------|------------|
-| A data set's grain is wrong | every number built on it is wrong, quietly | the grain is stated and checked automatically against the built data |
-| The list grows faster than the checks | broken definitions reach people | one validation path for shipped and added alike, run before release and on save |
-| People add near-duplicate data sets | nobody knows which to use | approval before sharing; each one carries a page saying what it is for |
-| A prepared table changes shape underneath | questions fail or answer differently | declarations are re-checked against the data; a mismatch is refused, not guessed |
+|---|---|---|
+| Incorrect grain | Inflated counts or sums | Declare row identity and test uniqueness |
+| Invalid declarations | Failed queries | Shared validation before release or save |
+| Duplicate tenant-defined datasets | Unclear dataset selection | Approval and purpose documentation |
+| Schema drift | Invalid references or changed results | Revalidation; explicit snapshot limits in DESIGN |
+
+**Revision 1.1**: clarified terminology, implementation scope, and validation limits; recorded
+unresolved field-selection and missing-value semantics.

--- a/docs/domain/query-engine/DESIGN.md
+++ b/docs/domain/query-engine/DESIGN.md
@@ -1,0 +1,723 @@
+---
+version: 2.2
+status: proposed
+date: 2026-09-08
+---
+
+# Technical Design — Query Engine
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-design-query-engine`
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+  - [3.8 Deployment Topology](#38-deployment-topology)
+- [4. Additional context](#4-additional-context)
+  - [Capability status and proposed semantics](#capability-status-and-proposed-semantics)
+  - [Saved queries (specified, not implemented)](#saved-queries-specified-not-implemented)
+  - [Non-goals](#non-goals)
+- [5. Traceability](#5-traceability)
+
+<!-- /toc -->
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+The engine validates a structured request against a dataset declaration, compiles one
+parameterized ClickHouse query, and returns a typed table. The compiler applies session
+tenancy, dataset read discipline, null-preserving aggregation, UTC boundaries, ordering,
+and row limits. The executor bounds fetched bytes, timeout, and concurrent scans.
+
+Validation, compilation, and answer assembly are pure domain operations. The API handles
+authorization and orchestration; infrastructure executes the query. Dataset declarations
+and their snapshot validation belong to the [dataset registry](../datasets/DESIGN.md).
+
+**Implemented**: single-dataset queries, basic and pattern filters, dimension and time
+grouping, conditional count/sum/avg/min/max, ordering, truncation, and administrator access.
+
+**Planned**: constructor UI, advanced query operations, saved queries, and access policies.
+Section 3 defines the supported contract; Section 4 preserves proposed extension semantics.
+See [PRD.md](PRD.md) for requirements and [MIGRATION.md](MIGRATION.md) for migration.
+
+### 1.2 Architecture Drivers
+
+**ADRs**: none. Access-policy design remains open.
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+|-------------|------------------|
+| `cpt-insightspec-qe-fr-ask` | request → plan → compile → one scan; no metric definition in the path |
+| `cpt-insightspec-qe-fr-group` | a labelled dimension answers `<field>_label` beside its value; grouping restricted to declared dimensions |
+| `cpt-insightspec-qe-fr-filter` | tagged filter variants; patterns bound as parameters, `match` compiled at validation; operator/target mismatch refused |
+| `cpt-insightspec-qe-fr-fold` | `OrNull` aggregates; `count` alone reports 0 |
+| `cpt-insightspec-qe-fr-bounds` | window cap; `LIMIT limit + 1` with `flags.truncated`; chunked byte ceiling; semaphore |
+| `cpt-insightspec-qe-fr-refusal` | semantic violations collected after dataset resolution; deserialization fails separately |
+| `cpt-insightspec-qe-fr-boolean` | planned: `any`/`all`/`not` variants → parenthesised predicates |
+| `cpt-insightspec-qe-fr-relative-window` | planned: resolved at plan time; answer reports `resolved_window` |
+| `cpt-insightspec-qe-fr-derived` | planned: `classify` → one `multiIf`; `time_part` → date-part function in the query zone |
+| `cpt-insightspec-qe-fr-richer-folds` | planned: advanced aggregates and window operations over the same plan (§4) |
+| `cpt-insightspec-qe-fr-time-intelligence` | planned: zone, week start, fiscal start as compiler inputs to every boundary |
+| `cpt-insightspec-qe-fr-rows` | planned: row-level results keyed on `row_identity`; route remains undecided |
+| `cpt-insightspec-qe-fr-saved` | planned: stored request re-planned on every read |
+| `cpt-insightspec-qe-fr-cross-dataset` | planned: one scan per dataset aligned on conformed dimensions; lookups joined on a unique key |
+| `cpt-insightspec-qe-fr-funnels` | planned: aggregate families over ClickHouse `windowFunnel`, `retention` |
+| `cpt-insightspec-qe-fr-admin-gate` | `require_admin` before every query and discovery handler |
+| `cpt-insightspec-qe-fr-access-policies` | planned: policy predicates bound from the caller context at plan time, before any capability |
+
+#### NFR Allocation
+
+| NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
+|--------|-------------|--------------|-----------------|----------------------|
+| `cpt-insightspec-qe-nfr-correctness` | consistent query semantics | compiler | tenancy predicate first; `FINAL` per read discipline; `OrNull` aggregates; `toDate(x, 'UTC')` | rendered-SQL goldens; stand reconciliations |
+| `cpt-insightspec-qe-nfr-bounded` | bounded cost | validation, executor, handler | 731-day window; 10 000 rows; 16 MiB chunked ceiling; 8-permit semaphore → 429 | unit tests per cap; stand 400/429 cases |
+| `cpt-insightspec-qe-nfr-latency` | interactive latency | gold datasets, compiler | flat pre-joined relations; one scan; partitioned by month, sorted by tenant | planned benchmark; reference workload not yet defined |
+| `cpt-insightspec-qe-nfr-contract` | stable contract | contract DTOs | tagged unions with `deny_unknown_fields`; OpenAPI generated from types; CI drift gate | drift check; stand schema generation |
+| `cpt-insightspec-qe-nfr-person-data` | personal-data handling | declarations, executor | admin gate and no result store; classification and policies planned | authorization tests; inspect persistence boundaries |
+
+### 1.3 Architecture Layers
+
+```text
+constructor ──HTTP──▶ gateway ──▶ analytics service
+                                   ├─ api     gate · extract · respond
+                                   ├─ domain  declarations · validation · compile · answer
+                                   └─ infra   bounded fetch · metrics ──▶ ClickHouse gold
+ingestion (dbt) ─────────────────────────────────────────────────────▶ ClickHouse gold
+```
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-tech-layers`
+
+| Layer | Responsibility | Technology |
+|-------|---------------|------------|
+| Presentation | constructor: form → request; answer → table and chart | React, TanStack Query |
+| Application | handlers: admin gate, extraction, error envelopes | Rust, axum, canonical errors |
+| Domain | declarations, validation, compilation, answer assembly | Rust, pure functions |
+| Infrastructure | bounded ClickHouse fetch, metrics, identity client | Rust, clickhouse client |
+| Data | gold datasets from silver class relations | dbt, ClickHouse MergeTree |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Structured query contract
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-contract`
+
+Callers select typed operations over declared fields. SQL identifiers are resolved from the
+plan; caller values are bound as parameters. Requests cannot override tenant scoping or
+read discipline.
+
+#### Declared fields
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-declarations`
+
+Requests may reference only fields exposed by the selected dataset. Shipped declarations
+are validated against an embedded column snapshot; this is not a live-schema check.
+
+#### Structured validation errors
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-refusals`
+
+After deserialization and dataset resolution, validation collects independent semantic
+violations with field paths, reason codes, and available choices. Malformed requests and
+unknown datasets fail earlier. Unusable declarations and warehouse failures are server errors.
+
+#### Shared compiler rules
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-principle-correctness`
+
+Compiler tests verify tenant predicates, read discipline, aggregate null behavior, and
+time boundaries. Prepared-data deduplication and attribution remain dataset responsibilities.
+
+### 2.2 Constraints
+
+#### Session tenant
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-tenancy`
+
+First predicate of every scan is the tenant from the security context. No request member
+names a tenant; unknown members are refused.
+
+#### Initial administrator restriction
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-admin-gate`
+
+Datasets carry person columns and declare no access policy yet: `POST /v1/query` and both
+`GET /v1/datasets` routes refuse non-administrators. The change declaring the first policy
+must specify what replaces the minimum-peer suppression of the metric surfaces.
+
+#### Execution limits
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-bounds`
+
+| Limit | Value |
+|---|---|
+| Inclusive time window | 731 days, within the supported `Date` range |
+| Result rows | Default 1,000; maximum 10,000; fetch one extra to detect truncation |
+| Fetched response bytes | 16 MiB, checked while receiving chunks |
+| Concurrent scans | Eight per process |
+| Permit acquisition | Two seconds, then a retryable capacity error |
+| Top-level filters / values per membership filter | 32 / 256 |
+| Aggregates / grouping axes / ordering terms | 16 / 4 / 4 |
+| Aggregate-name / pattern length | 64 / 256 characters |
+
+Constants live in `contract/dto.rs`, `api/query.rs`, and `infra/query.rs`. The byte cap applies
+to fetched warehouse data, not the size of the final serialized HTTP response.
+
+#### Gold relations only
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-constraint-gold-only`
+
+A declaration binds an `insight.*` relation whose columns exist in the embedded snapshot. No
+bronze, no silver, no query-time joins beyond a future declared lookup, no writes.
+
+#### Security and operations dispositions
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-constraint-inherited-platform`
+
+- **Authentication**: gateway and identity establish the session; the engine trusts the
+  `SecurityContext` it receives and never authenticates.
+- **Data protection**: TLS and tenant isolation inherited from the platform; personal-field
+  classification and column masking are planned with access policies.
+- **Threats**: injection via operands — mitigated by binding every caller value; over-broad
+  exposure before policies — mitigated by the admin gate; resource exhaustion — mitigated by
+  the caps above; malformed regex — compiled at validation.
+- **Audit**: latency and error class recorded per query; caller/query audit remains open
+  and tracked under access policies.
+- **Capacity and recovery**: no durable query state. In-process concurrency is bounded;
+  warehouse capacity and query shape still affect latency. Recovery follows the service.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: Rust types, YAML dataset declarations, JSON column snapshot.
+
+**Location**: `src/backend/services/analytics/src/domain/query/`
+
+**Core Entities**:
+
+| Entity | Description | Schema |
+|--------|-------------|--------|
+| Dataset | a declaration read from the registry: grain, dimensions with labels, measurables, time fields, read discipline — see the [dataset design](../datasets/DESIGN.md) | `domain/datasets/declaration.rs` |
+| QueryRequest | tagged request document | `contract/dto.rs` |
+| QueryPlan | request bound to its dataset; answer columns with sources | `plan.rs` |
+| CompiledQuery | statement text and positional bindings | `compile/mod.rs` |
+| QueryAnswer | typed columns, rows, flags | `contract/dto.rs`, `answer.rs` |
+| Violation | field, machine reason, sentence | `violation.rs` |
+
+**Relationships**:
+- Dataset: owned by the registry; the engine only reads it.
+- QueryRequest → QueryPlan: `validation::plan` binds or refuses.
+- QueryPlan → CompiledQuery: `compile` renders.
+- CompiledQuery → QueryAnswer: executor returns rows; `answer::assemble` maps aliases.
+
+### 3.2 Component Model
+
+```text
+request ─▶ api (gate) ─▶ validation ─▶ compile ─▶ executor ─▶ ClickHouse
+                            │                        │
+                    dataset registry               answer ─▶ response
+                     (its own design)
+```
+
+#### Validation
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-validation`
+
+##### Why this component exists
+
+Resolves field references and checks operations before SQL compilation.
+
+##### Responsibility scope
+
+Bind filters, axes, aggregates, order, window to the declaration; check operand types and
+operator/target pairs; compile `match` patterns; enforce caps; build answer columns (value,
+label, bucket, aggregate) with sources; return a `QueryPlan` or collected `Violation` values.
+
+##### Responsibility boundaries
+
+No SQL, no connection. `PlanError` separates a refused request from unusable declarations.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-ds-component-registry` — reads declarations from
+- `cpt-insightspec-qe-component-compiler` — hands the plan to
+
+#### Compiler
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-compiler`
+
+##### Why this component exists
+
+Compiles validated plans with consistent query semantics.
+
+##### Responsibility scope
+
+Render one statement: positional aliases; `FINAL` per read discipline; `OrNull` aggregates;
+`toDate(x, 'UTC')`; dimension values via `toString` and the absent sentinel; every caller
+value as `?`; tenancy, window, filters in that order; `GROUP BY` group columns;
+deterministic `ORDER BY`; `LIMIT limit + 1`.
+
+##### Responsibility boundaries
+
+Never sees a raw request or a connection; no authorization logic.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-validation` — consumes its plan
+- `cpt-insightspec-qe-component-executor` — hands the statement to
+
+#### Executor and answer
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-executor`
+
+##### Why this component exists
+
+Centralizes warehouse execution and bounded response collection.
+
+##### Responsibility scope
+
+Bind parameters; run under a fetch timeout; collect chunks against the byte ceiling; decode
+off the async runtime; record latency and error class. `answer::assemble` maps aliases to
+columns, drops the extra row, sets `flags.truncated`.
+
+##### Responsibility boundaries
+
+Does not interpret the request; a ceiling breach is a typed error the handler maps.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-compiler` — depends on
+- `cpt-insightspec-qe-component-api` — called by
+
+#### API
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-component-api`
+
+##### Why this component exists
+
+Exposes query execution through the analytics API.
+
+##### Responsibility scope
+
+`POST /v1/query`: authorize, plan, compile, acquire a permit, fetch, release the permit,
+and assemble the result. Section 3.3 defines errors. Dataset discovery is owned by the
+datasets API; the query contract supplies its limits metadata.
+
+##### Responsibility boundaries
+
+No business logic, no SQL.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-validation` — calls
+- `cpt-insightspec-qe-component-executor` — calls
+- `cpt-insightspec-qe-component-constructor` — serves
+
+#### Constructor page (planned)
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-component-constructor`
+
+##### Why this component exists
+
+Provides query composition and result rendering for administrators.
+
+##### Responsibility scope
+
+Read descriptions; keep a form draft; build the request (measurable operands as numbers,
+dimension operands and patterns as text); run; render table and chart; show each violation
+beside its input and the truncation flag.
+
+##### Responsibility boundaries
+
+Uses dataset metadata and query errors; owns no metric semantics or persistence.
+Not implemented in this change.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-api` — calls
+
+#### Access policies (needs design)
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-component-access-policies`
+
+##### Why this component exists
+
+Extends administrator-only access with dataset, row, and column policies.
+
+##### Responsibility scope
+
+Per dataset: dataset access (roles or allow list); row policies (dimension bound to a caller
+attribute: visible people, team repositories); column policies (dropped or masked per role).
+Proposed enforcement occurs at plan time. Section 4 records unresolved decisions.
+
+##### Responsibility boundaries
+
+Never decides who the caller is; refuses when a needed fact is missing.
+
+##### Related components (by ID)
+
+- `cpt-insightspec-qe-component-validation` — extends the plan
+- `cpt-insightspec-ds-component-declarations` — policies are declared beside the dataset
+
+### 3.3 API Contracts
+
+- [ ] `p1` - **ID**: `cpt-insightspec-qe-interface-query-api`
+
+- **Contracts**: `cpt-insightspec-qe-contract-caller-context`
+- **PRD interface**: `cpt-insightspec-qe-interface-query`
+- **Technology**: REST/OpenAPI, JSON, RFC 9457 problem envelopes
+- **Location**: [openapi.json](../../components/backend/analytics/openapi.json) — the
+  authority for the supported wire schema
+
+**Endpoints Overview**:
+
+| Method | Path | Description | Stability |
+|--------|------|-------------|-----------|
+| `POST` | `/v1/query` | Execute a query over one dataset | unstable (admin-only) |
+
+Discovery — `GET /v1/datasets` — belongs to the [dataset registry](../datasets/DESIGN.md);
+the engine contributes only the request bounds each description carries.
+
+#### Supported request
+
+| Member | Contract |
+|---|---|
+| `dataset` | One registered dataset key |
+| `filters` | Optional list, combined with AND |
+| `group_by` | Optional dimension or time axes |
+| `aggregates` | One or more named count, sum, avg, min, or max operations; each may have one filter |
+| `time` | Required inclusive `from` and `to`; optional declared `field` and day/week/month `grain` |
+| `order` | Optional result-column names with ascending or descending direction |
+| `limit` | Optional row limit, subject to declared bounds |
+
+`op`, `axis`, and `fn` select tagged variants. Unknown members and operands belonging to
+another variant are rejected during deserialization. The OpenAPI document is the complete
+wire schema; semantic validation additionally checks dataset fields, types, and limits.
+
+#### Supported operations
+
+- Filters: `eq`, `in`, `gt`, `gte`, `lt`, `lte`, `between`, `not_null`, `like`, `match`.
+- Dimensions compare as their string result values. Ordered comparisons require measurables;
+  pattern filters require dimensions. Membership lists must be non-empty.
+- `like` uses `%` and `_`; `match` uses unanchored RE2 patterns validated before execution.
+  Both are case-sensitive; a case-insensitive request option is planned.
+- `count` counts rows without a field. Other aggregates require a measurable and preserve null
+  for no observations. Conditional aggregates treat an unknown predicate as a non-match.
+- Time windows use UTC dates and inclusive endpoints. The time field defaults to the dataset
+  default. `time.grain` is required with a time axis and rejected without one. Buckets are
+  day, Monday-start week, or month. No dense fill is implemented.
+- Grouped dimensions with declared labels return a separate `<field>_label` column.
+- Ordering defaults to ascending and includes grouping tie-breakers. Fetching `limit + 1`
+  detects truncation.
+
+#### Result and errors
+
+Results contain `columns`, positional `rows`, and `flags.truncated`. Current column kinds are
+dimension, label, bucket, and aggregate; column types are text, number, and date.
+Cursors, freshness metadata, resolved relative
+windows, expression columns, and window columns are planned extensions.
+
+| Condition | Response |
+|---|---|
+| Semantic validation failure | 400 with field paths, reason codes, and explanations |
+| Non-administrator | Permission denial |
+| Fetched response exceeds byte cap | 400 with an `OUT_OF_RANGE` violation on `limit` |
+| Permit acquisition times out | 429 with retry metadata |
+| Unusable declarations, fetch failure, or assembly failure | 500 |
+
+Deserialization failures occur before semantic planning and do not use its collected
+violation list. A rejected plan performs no warehouse query.
+
+### 3.4 Internal Dependencies
+
+| Dependency Module | Interface Used | Purpose |
+|-------------------|----------------|----------|
+| identity client | `is_admin` over the forwarded session | admin gate; later the caller context |
+| insight-clickhouse | bound query, bytes cursor | executor fetch |
+| toolkit canonical errors | resource-scoped builders | violation, permission, quota envelopes |
+| toolkit security | `SecurityContext` | the tenant every scan binds |
+
+### 3.5 External Dependencies
+
+#### ClickHouse
+
+| Dependency Module | Interface Used | Purpose |
+|-------------------|---------------|---------|
+| executor | HTTP query, positional bindings, `JSONEachRow` | runs the scan |
+| declarations | embedded column snapshot | validates datasets offline |
+
+### 3.6 Interactions & Sequences
+
+#### Execute a query
+
+**ID**: `cpt-insightspec-qe-seq-answer`
+
+**Use cases**: `cpt-insightspec-qe-usecase-build-chart`, `cpt-insightspec-qe-usecase-own-category`
+
+**Actors**: `cpt-insightspec-qe-actor-admin`, `cpt-insightspec-qe-actor-constructor`
+
+```mermaid
+sequenceDiagram
+    Constructor ->> API: POST /v1/query
+    API ->> Identity: is admin?
+    Identity -->> API: yes
+    API ->> Validation: plan(request)
+    Validation ->> Declarations: dataset(key)
+    Validation -->> API: QueryPlan | violations
+    API ->> Compiler: compile(plan, tenant)
+    API ->> API: Acquire scan permit
+    API ->> Executor: Fetch under byte ceiling
+    Executor ->> ClickHouse: statement
+    ClickHouse -->> Executor: rows
+    API ->> API: Release scan permit
+    API ->> Answer: assemble
+    API -->> Constructor: QueryAnswer | problem+json
+```
+
+**Description**: semantic validation completes before warehouse execution. The permit covers
+fetching and decoding, and is released before answer assembly.
+
+### 3.7 Database schemas & tables
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-db-relations`
+
+The engine owns no relation. It scans the one each dataset declares; their schemas, grains
+and provenance are in the [dataset design](../datasets/DESIGN.md).
+
+### 3.8 Deployment Topology
+
+Part of the analytics service; no extra deployable. Gold relations are built by the deploy
+hook's `dbt run --select tag:gold`.
+
+## 4. Additional context
+
+### Capability status and proposed semantics
+
+**Implemented** capabilities are accepted by the current API. **Specified, not implemented**
+capabilities retain their proposed semantics below. **Needs design** identifies unresolved
+architecture. Proposed request members are rejected until implemented.
+
+| Capability | Status |
+|---|---|
+| Filters: `eq`, `in`, comparisons, `between`, `not_null` | implemented |
+| Pattern filters: `like`, `match` | implemented |
+| Boolean filter groups: `any`, `all`, `not` | specified, not implemented |
+| Case-insensitive patterns | specified, not implemented |
+| Dimension and time group axes | implemented |
+| Date-part axes | specified, not implemented |
+| Bins as dimensions | specified, not implemented |
+| Derived dimensions (`classify`) | specified, not implemented |
+| `count`, `sum`, `avg`, `min`, `max` with a conditional filter | implemented |
+| `count_distinct` (exact and approximate), `median`, `quantile`, `stddev` | specified, not implemented |
+| Expressions over aggregate names | specified, not implemented |
+| Windows: running sum, moving average, rank, delta, percent change | specified, not implemented |
+| Share of total | specified, not implemented |
+| `having` | specified, not implemented |
+| Top groups with remainder | specified, not implemented |
+| Dense fill | specified, not implemented |
+| Fixed window, UTC, day/week/month grain | implemented |
+| Relative windows | specified, not implemented |
+| Timezone, week start, to-date, compare windows | specified, not implemented |
+| Fiscal calendars | specified, not implemented |
+| Grouping sets and totals | specified, not implemented |
+| Semi-additive aggregates | specified, not implemented |
+| Truncation flag | implemented |
+| Cursors | specified, not implemented |
+| Rows behind a cell (drilldown shape) | needs design |
+| Multiple datasets in one query over conformed dimensions | needs design |
+| Runtime-defined datasets | [datasets](../datasets/DESIGN.md) |
+| Discovery of what can be asked | [datasets](../datasets/DESIGN.md) |
+| Freshness (`data_through`) | specified, not implemented |
+| Saved queries | specified, not implemented |
+| Access policies: dataset, row, column | needs design |
+| Enrichment lookups (customer-declared dimensions) | needs design |
+| Funnels and retention | needs design |
+
+#### Post-aggregation filters (specified)
+
+`having` filters groups by aggregate or expression names after aggregation. Unknown targets
+produce violations listing available names. Operands remain bound parameters.
+
+#### Boolean filter logic (specified)
+
+Top-level `filters` is an implicit `all`. `any`, `all`, `not` are filter variants: nest
+anywhere a filter may appear. Compile to parenthesised predicates, never reordered. Caps:
+total filters and nesting depth. Empty groups refused. `case_insensitive` → `ILIKE` or a
+case-insensitive regex; default case-sensitive.
+
+#### Aggregate naming and cross-dataset alignment
+
+`count` counts rows without a field; numeric aggregates read a measurable. Names are unique, snake_case,
+and also unique against group columns. Cross-dataset alignment is not implemented; proposed
+behavior and open decisions appear under *Multiple datasets in one query*.
+
+#### Expressions
+
+Arithmetic over aggregate names: four operations, parentheses, numeric literals, `nullif`.
+Parsed to an AST, rendered from the AST; a non-round-tripping string is refused. NULL
+propagates; division by zero is NULL via `nullif`.
+
+#### Windows
+
+Over the answer's buckets after aggregation, partitioned by named dimensions: running sum,
+moving average with a bounded frame, rank, delta, percent change. Refused over a sparse axis
+unless fill is dense. The first bucket's delta is null. Proposed variants are `running_sum`,
+`moving_avg`, `rank`, `delta`, and `pct_change`, with `name`, `of`, and partition dimensions
+in `over`. Only `moving_avg` accepts a bounded `frame`.
+
+#### Top groups and the remainder
+
+`top` ranks groups by an aggregate within each `per` partition, keeps `n`, and with
+`remainder` folds the rest into one row with a declared label. Ties break on the group value.
+The remainder's aggregates are computed over the underlying rows or merged states, never
+from finalized scalars. `n` is capped.
+
+#### Fill and dense axes
+
+`time.fill: dense` materialises every bucket in the window; each aggregate's `fill` (zero or
+null) says what an empty bucket reports. Sparse is the default.
+
+#### Time intelligence
+
+Boundaries in the query's timezone with its week start. `to_date` clips every bucket at the
+point the last one reached. `compare.aligned` shifts by whole periods keeping the day count.
+`flags.incomplete_period` identifies an incomplete final bucket. Proposed time grains add
+quarter and year; `compare.offset` selects period, month, quarter, or year.
+
+Windows are fixed (`from`/`to`) or relative: last N units (optionally including the current
+one) or a calendar period (`this`/`previous` unit, `to_date`). Resolved at plan time in the
+query zone; the answer reports `resolved_window`. Same span cap. `fiscal_year_start` shifts
+quarter and year buckets and periods; tenant settings supply defaults. Proposed members
+include `relative.last`, `unit`, `include_current`, or `period` with `to_date`; fixed and
+relative windows are mutually exclusive. The proposed timezone default is UTC.
+
+#### Grouping sets and totals
+
+`totals` lists grouping sets; `[]` is the grand total. Total rows carry a marker column and
+sort after detail rows, using the proposed `total_marker` column kind.
+
+#### Bins as dimensions
+
+Numeric or temporal field binned by fixed `width`, explicit `edges`, or a `count` of equal
+buckets, using `bin_width`, `bin_edges`, or `bin_count` axis variants. A bin is a group axis;
+a distribution combines a bin axis with a count.
+
+#### Date parts as axes
+
+`time_part`: hour, day of week, day of month, week of year, month of year, quarter of year,
+in the query zone with its week and fiscal start. Ordinary dimension; may sit beside `time`.
+Numeric column with a declared label form.
+
+#### Derived dimensions
+
+`classify`: ordered cases (label + filter over one field) plus `else`; first match wins.
+One `multiIf`; behaves as a group axis in filters, `top`, totals. Caps: case count, pattern
+length. Same `name` twice is a duplicate.
+
+#### Distinct counts
+
+`count_distinct` over a dimension; exact by default, `approx: true` uses HyperLogLog and the
+column type says so. Empty group → 0. `median`, `quantile`, `stddev` fold measurables and
+return null over no observations; `quantile` takes a `q` parameter.
+
+#### Share of total
+
+`share` window: `of` divided by the partition's sum, 0..1; empty `over` = whole answer. Zero
+total → NULL. Composes with `top` (remainder's share is the rest) and grouping sets.
+
+#### Semi-additive aggregates
+
+`per_period` (last, first, min, max) folds inside each period first, then across; seat-day
+and headcount shapes.
+
+#### Cursors over grouped answers
+
+An answer past `limit` returns a keyset cursor over its own order, made total with the group
+columns. The request carries `cursor`; the response returns `next_cursor`. Cursors are bound
+to the query fingerprint; reuse with a different query is rejected.
+
+#### Freshness (specified)
+
+`flags.data_through`: newest event time the scanned relation holds for the tenant.
+
+#### Access policies (needs design)
+
+**Needs design.** Identity supplies the caller context (subject, roles, visible people, team
+memberships, tenant settings); the engine enforces declared policies at plan time. Three
+kinds: dataset access (roles or allow list); row policy (dimension ← caller attribute, e.g.
+`author_email ← visible_people`, `repository ← team_repositories`), applied to every scan
+whatever the query selects, refused when the attribute is missing; column policy (dropped or
+masked per role). Open: where team-to-resource facts live; replacement for minimum-peer
+suppression; how a saved question records the policy it was validated under. Admin-only
+until the first policy lands.
+
+#### Enrichment lookups
+
+**Needs design.** Customer relation keyed on a conformed dimension (repository → product,
+person → cost centre), declared as a lookup, joined at plan time; its columns become
+dimensions on every dataset sharing the key. Non-unique key refused (fan-out); unmatched key
+→ absent sentinel. Open: upload/sync path; tenant- vs per-user scope.
+
+#### Funnels and retention
+
+**Needs design.** Aggregate families over datasets declaring an actor key and event time,
+backed by `windowFunnel`, `retention`, `sequenceMatch`. Funnel: ordered step filters plus a
+window → actors reaching each step. Retention: entry filter, return filter, period. Group by
+any dimension. Open: strict vs any-order steps; exposing a step's actor set for drilldown.
+
+#### Rows behind a cell
+
+**Needs design.** Row-level shape over the same dataset, filters and window: declared columns
+instead of groups and aggregates, `row_identity` as page key, cursors, sort by any reported
+column. Open: mode of `POST /v1/query` or sibling route (preference: sibling); how a cell's
+group values become filters.
+
+#### Multiple datasets in one query
+
+**Needs design.** Several datasets with conformed dimensions; one scan each, aligned on shared
+axes. Open: declaring conformance; refusing mismatched grains; making fan-out impossible.
+Row-level joins stay out.
+
+### Saved queries (specified, not implemented)
+
+A saved query is a named request with a dataset and a version, selected through the proposed
+`saved` request member instead of `dataset`. Read re-runs validation; a
+dataset change that invalidates it is a refusal naming the field, never a reinterpretation.
+On run, a request may *replace* `time`, `order`, `limit`, `cursor`, `top`, `totals`,
+`fill`, `compare`; may *append* `filters` (AND-ed); may not touch `dataset`, `group_by`,
+`aggregates`, `expressions`, `windows`, `having`. Versioned; the metric library becomes the
+shipped set of saved queries.
+
+### Non-goals
+
+- Undeclared joins in the query; joins live in the modeled relation or a declared lookup.
+- Pivot, layout, conditional formatting.
+- OData or GraphQL as the native contract.
+- Chart-type-specific endpoints; a chart the contract cannot feed is a contract gap.
+- Path analysis and sessionization.
+
+## 5. Traceability
+
+- **PRD**: [PRD.md](PRD.md)
+- **Migration map**: [MIGRATION.md](MIGRATION.md)
+- **Contract**: [openapi.json](../../components/backend/analytics/openapi.json)
+
+**Revision 2.2**: separated the supported API from proposed extensions, consolidated query
+semantics and limits, and clarified validation, execution, and authorization boundaries.

--- a/docs/domain/query-engine/MIGRATION.md
+++ b/docs/domain/query-engine/MIGRATION.md
@@ -1,0 +1,57 @@
+# Migration: current serving surface to the query engine
+
+Companion to [DESIGN.md](DESIGN.md). The design reads timeless; this file
+carries the mapping from what serves today to what the engine becomes, and is
+deleted when the migration completes.
+
+## What generalizes (machinery kept, renamed under the contract)
+
+| Today | Becomes | Notes |
+|---|---|---|
+| Values total / timeseries / rollup grains | one `query` with `group_by` + optional `{time: true}` axis | grain enum dissolves into group-axis composition |
+| Distributions endpoint (histogram, quantiles) | `bin` group axis + `quantile` aggregates | no separate surface |
+| Compare windows (previous period / month / quarter / year) | `compare.aligned` | the equal-day-count rule is already implemented and tested |
+| Group-cap "Other" folding | `top` with `remainder` | the ranking CTE, deterministic ties, and remainder fold survive as-is |
+| Rows evidence pages (keyset + server sort) | unchanged | already generic |
+| Ratio / derived metric computations | `expressions` over aggregate names | AST-rendered instead of two computation kinds |
+| Percentile / stddev metrics | `quantile` / `stddev` aggregates | per-event row discipline unchanged |
+| Seat-month/seat-day style period folds | `per_period` semi-additive aggregates | the hand-built shape becomes a contract feature |
+| Measure cache (deferred PR) | refresh engine behind saved queries | its four review findings get fixed in that role |
+| Metric definitions + seeds | saved queries + the OTB library | definitions store and versioning survive; the metric key stops being the API's spine |
+| Dry-run validation endpoint | saved-query validation | same violation-list loop |
+| Discovery catalog | dataset + saved-query catalog | advertises declarations, not metric capabilities |
+
+## What dies
+
+- **Peer comparison views and endpoint** — cohort spreads, target-vs-peers,
+  the minimum-peer floor. A dashboard wanting a spread composes queries.
+- **Capped-timeseries as a bespoke view kind** — subsumed by `top`.
+- **Person-entity machinery as the API spine** — identity resolution and
+  visibility become the declared entity policy of person-shaped datasets;
+  datasets without the declaration carry none of it.
+- **Metric-centric query shape** — requests name datasets (or saved queries), not
+  metric keys; direction/format/labels move wholly into rendering metadata.
+- **Grain/fold advertisement per metric** — the catalog describes datasets
+  and saved queries; admissibility falls out of the contract, not per-key
+  capability lists.
+
+## What stays out of scope for this rebuild
+
+- Ingestion layout and the field-catalog snapshot gate stay exactly as they
+  are; the engine consumes the same catalog the current compiler does.
+- Dataset authoring remains repository-owned (declarations in the seeds and
+  roles files); no runtime authoring surface is part of this migration.
+
+## Sequencing
+
+1. Land the current stack (store, compiler, query surface, discovery catalog,
+   families) — it is the kernel: the compiler's tenancy, null, identity, and
+   read-discipline rules transfer verbatim.
+2. Introduce `/v1/query` beside the existing surface, implementing the
+   contract capability by capability; the existing endpoints keep serving
+   until their consumers move.
+3. Re-express the OTB metrics as saved queries; the transcription corpus (105
+   metrics with exact legacy reconciliation) becomes the regression suite for
+   the new contract.
+4. Retire the metric-centric endpoints and the dead view kinds; the deferred
+   cache PR lands re-aimed at saved-query refresh.

--- a/docs/domain/query-engine/PRD.md
+++ b/docs/domain/query-engine/PRD.md
@@ -1,0 +1,574 @@
+---
+version: 1.3
+status: proposed
+date: 2026-09-08
+---
+
+# PRD — Query Engine
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Module-Specific Environment Constraints](#31-module-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 Query execution](#51-query-execution)
+  - [5.2 Validation](#52-validation)
+  - [5.3 Planned capabilities](#53-planned-capabilities)
+  - [5.4 Authorization](#54-authorization)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 NFR Inclusions](#61-nfr-inclusions)
+  - [6.2 NFR Exclusions](#62-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+
+<!-- /toc -->
+
+## 1. Overview
+
+### 1.1 Purpose
+
+The query engine executes structured queries over declared datasets and returns typed tables
+for charts and analysis. Callers select filters, grouping, aggregates, ordering, and a time
+window without defining a new server-side metric.
+
+[Datasets](../datasets/PRD.md) define the available data and fields. [DESIGN.md](DESIGN.md)
+defines query semantics and implementation. [MIGRATION.md](MIGRATION.md) covers the transition
+from existing metric APIs.
+
+### 1.2 Background / Problem Statement
+
+Pre-built metrics couple each supported calculation to server code. Queries outside those
+combinations require development and a release.
+
+A chart builder needs a discoverable query contract: available fields, supported operations,
+limits, and structured errors. An administrator SQL console does not provide that contract
+or automatically apply the dataset semantics required by chart consumers.
+
+### 1.3 Goals (Business Outcomes)
+
+- Build a supported query and chart within one working session, without a release.
+- Apply tenant isolation, dataset read rules, null semantics, and time boundaries consistently.
+- Return actionable validation errors identifying invalid inputs.
+- Preserve saved-query meaning or reject incompatible definitions.
+- Extend access to team leads after dataset access policies are enforced.
+- Query newly declared datasets without engine changes.
+
+### 1.4 Glossary
+
+| Term | Meaning |
+|---|---|
+| Dataset | Declared queryable data with a row grain and field metadata |
+| Dimension | Declared field available for grouping and filtering |
+| Measurable | Declared numeric field available for aggregation |
+| Aggregate | Computation over rows, such as count, sum, or average |
+| Filter | Predicate selecting rows |
+| Grouping | Partitioning results by dimensions or time buckets |
+| Time window | Required inclusive start and end dates |
+| Time grain | Bucket size: initially day, week, or month |
+| Violation | Validation error with a field path, reason code, and explanation |
+| Access policy | Dataset, row, or column visibility rule |
+| Constructor | Client for composing queries and rendering results |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Instance administrator
+
+**ID**: `cpt-insightspec-qe-actor-admin`
+
+**Role**: executes queries under the initial administrator-only access model.
+**Needs**: query composition and actionable errors without warehouse expertise.
+
+#### Team lead
+
+**ID**: `cpt-insightspec-qe-actor-lead`
+
+**Role**: planned query consumer restricted to authorized people and resources.
+**Needs**: visibility policies applied independently of grouping.
+
+#### Dashboard author
+
+**ID**: `cpt-insightspec-qe-actor-author`
+
+**Role**: builds charts and, in the planned extension, saved queries.
+**Needs**: discoverable fields, operations, and limits.
+
+### 2.2 System Actors
+
+#### Constructor page
+
+**ID**: `cpt-insightspec-qe-actor-constructor`
+
+**Role**: composes requests, renders results, and displays validation errors.
+
+#### Identity service
+
+**ID**: `cpt-insightspec-qe-actor-identity`
+
+**Role**: supplies administrator checks and, later, caller attributes for access policies.
+
+#### Warehouse
+
+**ID**: `cpt-insightspec-qe-actor-warehouse`
+
+**Role**: stores prepared datasets and executes compiled queries.
+
+## 3. Operational Concept & Environment
+
+### 3.1 Module-Specific Environment Constraints
+
+- Queries read prepared datasets and do not modify data.
+- Dataset declarations must pass validation before use. The dataset design documents the
+  limits of snapshot-based validation.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+**Initial implementation**: single-dataset queries with filters, dimension and time grouping,
+conditional aggregates, ordering, row limits, a required time window, structured errors,
+typed results, and truncation reporting. Discovery includes query limits.
+
+**Planned product scope**: a constructor UI, Boolean filter groups, relative windows, derived
+dimensions, richer aggregates, expressions, windows, totals, pagination, saved queries,
+cross-dataset analysis, and access-policy enforcement. DESIGN records each capability's status.
+
+### 4.2 Out of Scope
+
+- Dataset definition and registration, owned by the datasets module.
+- User-authored SQL; the administrator SQL console remains separate.
+- Chart layout and formatting.
+- Event-path analysis and sessionization beyond the planned funnel and retention operations.
+- Alerts and notifications.
+- Replacing existing chart APIs before capability and migration requirements are met.
+
+## 5. Functional Requirements
+
+### 5.1 Query execution
+
+#### Structured queries
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-ask`
+
+The system **MUST** execute a query naming a dataset, time window, and at least one
+aggregate, with optional filters, grouping, ordering, and row limit.
+
+**Rationale**: Supported queries must not require pre-built metrics.
+
+**Actors**: `cpt-insightspec-qe-actor-admin`, `cpt-insightspec-qe-actor-constructor`
+
+#### Dimension and time grouping
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-group`
+
+The system **MUST** group by declared dimensions and by day, week, or month. For dimensions
+with a declared label, results **MUST** include the label beside the stable value.
+
+**Rationale**: Clients need stable identifiers and readable labels.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Row filters
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-filter`
+
+The system **MUST** support equality, membership, ordered comparisons, inclusive ranges,
+non-null checks, wildcard patterns, and regular expressions. It **MUST** reject operations
+incompatible with the target field, including ordered text comparisons and numeric patterns.
+
+**Rationale**: Field-aware validation prevents misleading comparisons.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Conditional aggregates
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-fold`
+
+The system **MUST** support count, sum, average, minimum, and maximum, each with an optional
+filter. An aggregate over no observations **MUST** return null, except count, which returns
+zero.
+
+**Rationale**: Null distinguishes missing observations from measured zero.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Query limits
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-bounds`
+
+The system **MUST** require a time window of at most 731 days and bound result rows,
+response size, and concurrent execution. Results **MUST** indicate row-limit truncation.
+
+**Rationale**: Resource limits protect shared capacity; truncation must remain visible.
+
+**Actors**: `cpt-insightspec-qe-actor-admin`
+
+### 5.2 Validation
+
+#### Validation errors
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-refusal`
+
+The system **MUST** validate requests before execution and report violations with field
+paths, machine-readable reasons, and valid choices where available. It **MUST** report
+independent semantic violations together when the request can be resolved.
+
+**Rationale**: Clients can identify invalid inputs without repeated trial-and-error requests.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+### 5.3 Planned capabilities
+
+#### Boolean filter groups
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-boolean`
+
+The system **MUST** support nested AND, OR, and NOT conditions.
+
+**Rationale**: Compound selection requires more than the initial implicit AND. Nesting limits
+remain a design parameter.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Relative time windows
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-relative-window`
+
+The system **MUST** support relative and calendar windows, including recent weeks, the
+current month, the previous quarter, and year-to-date. Results **MUST** report resolved dates.
+
+**Rationale**: Saved charts need windows that advance over time.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Derived dimensions
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-derived`
+
+The system **MUST** group by caller-defined categories and date parts such as weekday or hour.
+
+**Rationale**: Authors need classifications beyond shipped dimensions.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Advanced aggregation
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-richer-folds`
+
+The system **MUST** support exact and approximate distinct counts, medians, percentiles,
+dispersion, computed-column arithmetic, running and moving calculations, share of total,
+top-N with an Other group, empty-period fill, subtotals, grand totals, and per-period
+aggregation for quantities such as headcount.
+
+**Rationale**: These operations expand chart coverage beyond basic aggregates.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Calendars and period comparison
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-time-intelligence`
+
+The system **MUST** support a chosen timezone, week start, and fiscal-year start, and
+compare equivalent portions of successive periods.
+
+**Rationale**: Calendar settings determine comparable reporting periods.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Pagination and drilldown
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-rows`
+
+The system **MUST** support pagination beyond the result row limit and retrieval of records
+contributing to a result cell.
+
+**Rationale**: Users need complete result traversal and supporting records.
+
+**Actors**: `cpt-insightspec-qe-actor-lead`
+
+#### Saved queries
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-saved`
+
+The system **MUST** save named queries and revalidate them on each use. Callers may change
+time windows, ordering, and limits, and add filters; changes to the query definition
+**MUST** be rejected. DESIGN specifies the proposed override contract.
+
+**Rationale**: Revalidation and restricted overrides preserve query meaning.
+
+**Actors**: `cpt-insightspec-qe-actor-author`, `cpt-insightspec-qe-actor-lead`
+
+#### Cross-dataset queries and enrichment
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-cross-dataset`
+
+The system **MUST** combine datasets sharing dimensions without aggregate inflation and
+support tenant reference data as additional dimensions wherever the keys are compatible.
+
+**Rationale**: Shared dimensions enable analysis across sources and tenant classifications.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+#### Funnels and retention
+
+- [ ] `p3` - **ID**: `cpt-insightspec-qe-fr-funnels`
+
+The system **MUST** count entities reaching ordered steps within a period and entities
+returning after an initial event.
+
+**Rationale**: Sequence and return-rate analysis require operations beyond independent counts.
+
+**Actors**: `cpt-insightspec-qe-actor-author`
+
+### 5.4 Authorization
+
+#### Initial administrator restriction
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-fr-admin-gate`
+
+The system **MUST** reject query execution and discovery for non-administrators until
+access policies protect datasets containing personal data.
+
+**Rationale**: The initial engine has no row- or column-level access-policy enforcement.
+
+**Actors**: `cpt-insightspec-qe-actor-admin`, `cpt-insightspec-qe-actor-lead`
+
+#### Dataset access policies
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-fr-access-policies`
+
+The system **MUST** enforce dataset access, row visibility based on caller attributes, and
+column visibility for every query, regardless of its grouping.
+
+**Rationale**: Grouping by a resource must not bypass restrictions on the underlying people.
+
+**Actors**: `cpt-insightspec-qe-actor-lead`, `cpt-insightspec-qe-actor-identity`
+
+## 6. Non-Functional Requirements
+
+### 6.1 NFR Inclusions
+
+#### Consistent result semantics
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-correctness`
+
+Queries **MUST** enforce tenant isolation, dataset read rules, null-preserving aggregates
+with the count exception, and consistent UTC day boundaries. Callers **MUST NOT** override
+these rules.
+
+**Threshold**: equivalence checks for regrouping and filtering must agree within their
+applicable aggregate semantics.
+
+**Rationale**: query configuration must not bypass shared data rules.
+
+#### Bounded execution
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-bounded`
+
+The system **MUST** reject requests exceeding declared input limits and stop execution when
+runtime limits are reached.
+
+**Threshold**: at most 731 days, 10,000 result rows, 16 MiB per answer, and eight concurrent
+scans per process; excess demand receives a retryable rejection.
+
+**Rationale**: time and row limits alone do not bound query cost or result size.
+
+#### Interactive latency
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-nfr-latency`
+
+Queries with up to four grouping axes over one year **SHOULD** complete within two seconds
+at the 95th percentile on a reference environment.
+
+**Threshold**: p95 ≤ 2 seconds. Reference data volume and workload remain to be defined;
+this is a target, not a measured guarantee.
+
+**Rationale**: query composition requires responsive feedback.
+
+#### Published contract
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-contract`
+
+Request and response formats **MUST** have a machine-readable contract. Unknown request
+members **MUST** be rejected rather than ignored.
+
+**Threshold**: contract drift checks fail on divergence between published and generated schemas.
+
+**Rationale**: clients need a consistent request and response structure. Semantic constraints
+remain subject to runtime validation.
+
+#### Personal-data handling
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-nfr-person-data`
+
+Personal fields **MUST** be restricted to authorized callers. The engine **MUST NOT** persist
+query result data; retention and deletion remain with the source systems.
+
+**Threshold**: no engine-owned result store. Dataset personal-field classification and
+fine-grained policies are planned; the initial implementation uses the administrator gate.
+
+**Rationale**: query execution must not create an independently retained copy of activity data.
+
+### 6.2 NFR Exclusions
+
+- **Offline operation**: queries require warehouse access.
+- **Durable engine storage**: absent until saved queries are implemented.
+- **Authentication, availability, and recovery**: inherited from the hosting service.
+- **Accessibility, localization, and device support**: owned by consuming clients under product standards.
+- **Additional certifications**: no module-specific requirements.
+- **Monitoring**: uses service query-latency and error metrics.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### Query contract
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-interface-query`
+
+**Type**: published analytics request and response format.
+
+**Stability**: experimental while administrator-only.
+
+**Description**: structured queries and typed tabular results; discovery reports query limits.
+
+**Breaking Change Policy**: accepted operations retain their meaning; extensions are additive.
+
+### 7.2 External Integration Contracts
+
+#### Caller context (planned)
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-contract-caller-context`
+
+**Direction**: required from identity.
+
+**Protocol/Format**: caller permissions, visible people, and team membership resolved per query.
+
+**Compatibility**: missing attributes required by a policy cause rejection, not broader access.
+
+## 8. Use Cases
+
+#### Build a query-backed chart
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-usecase-build-chart`
+
+**Actor**: `cpt-insightspec-qe-actor-admin`
+
+**Preconditions**: administrator access and an available dataset.
+
+**Main Flow**:
+
+1. The client presents dataset fields and query limits.
+2. The administrator selects a time window, grouping, aggregates, and filters.
+3. The engine returns a typed result or validation errors.
+4. The client renders the result and its truncation status.
+
+**Postconditions**: a chart uses a query without a pre-built metric.
+
+**Alternative Flows**: invalid inputs are identified; truncated results are labelled.
+
+#### Conditional aggregation
+
+- [x] `p1` - **ID**: `cpt-insightspec-qe-usecase-own-category`
+
+**Actor**: `cpt-insightspec-qe-actor-author`
+
+**Preconditions**: administrator access and a dataset with a path dimension and line measurable.
+
+**Main Flow**:
+
+1. The author requests total lines and lines matching a path pattern, grouped by file type.
+2. The engine validates the pattern and computes both aggregates.
+
+**Postconditions**: results compare a caller-defined category with the total.
+
+**Alternative Flows**: invalid patterns produce a field violation.
+
+#### Team-scoped query (planned)
+
+- [ ] `p2` - **ID**: `cpt-insightspec-qe-usecase-lead-visibility`
+
+**Actor**: `cpt-insightspec-qe-actor-lead`
+
+**Preconditions**: an enforced dataset policy identifies the caller's visible people.
+
+**Main Flow**:
+
+1. The lead opens a saved query grouped by repository.
+2. The engine restricts rows to authorized people before aggregation.
+
+**Postconditions**: results respect the caller's visibility regardless of grouping.
+
+**Alternative Flows**: missing visibility context causes rejection.
+
+## 9. Acceptance Criteria
+
+- [x] Administrators can query declared datasets without pre-built metrics.
+- [x] Automated reconciliation cases cover equivalent grouping and filtering operations.
+- [x] Non-administrators are denied query execution and discovery.
+- [x] Semantic validation errors identify invalid request fields.
+- [ ] Saved queries reject incompatible dataset changes.
+- [ ] Team-lead queries enforce row visibility independently of grouping.
+
+The initial delivery provides the API. The chart-builder workflow also requires the planned
+constructor client; completed API requirements do not establish end-to-end UI delivery.
+
+## 10. Dependencies
+
+| Dependency | Purpose | Criticality |
+|---|---|---|
+| Dataset registry | Validated declarations and prepared-data semantics | p1 |
+| Schema catalog | Snapshot metadata used by dataset validation | p1 |
+| Identity service | Administrator checks; planned visibility context | p1 |
+| Published API contract | Client integration and schema drift checks | p1 |
+
+## 11. Assumptions
+
+- Shipped datasets provide prepared data; tenant-defined datasets are a later extension.
+- Administrators may query their session's tenant under the initial access model.
+- Reconciliation fixtures cover each supported dataset and the semantics being compared.
+- Query cost depends on data volume, selectivity, and grouping cardinality as well as dates
+  and result limits. Limits alone do not establish latency guarantees.
+
+**Open questions**
+
+| Question | Owner | Resolve by |
+|---|---|---|
+| Where are team-to-resource mappings defined? | product + backend | before access policies |
+| What replaces minimum-peer suppression for broader access? | product | before team-lead access |
+| What reference volume and workload define the latency target? | backend | before latency acceptance |
+| What nesting limit applies to Boolean groups? | backend | before Boolean filters |
+| Which datasets follow commits and file changes? | product | after constructor workflows |
+| Who may create datasets, and what must approvers review? | product | before tenant-defined datasets |
+| Is drilldown a query mode or a separate operation? | backend | before drilldown |
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Unsupported query operations | Continued dependence on pre-built metrics or SQL | Explicit capability roadmap; retain existing APIs |
+| Delayed access policies | Team leads cannot use the engine | Keep administrator restriction until enforcement is available |
+| Broad or high-cardinality queries | Slow execution or resource exhaustion | Input, byte, timeout, and concurrency limits |
+| Dataset schema changes | Invalid saved queries | Planned revalidation; document snapshot limits |
+| Invalid tenant-defined datasets | Incorrect results or unintended access | Shared validation and limits; planned approval and policies |
+
+**Revision 1.3**: clarified query terminology, initial delivery, planned capabilities,
+validation boundaries, and unresolved requirements.

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "opentelemetry",
  "p256 0.14.0",
  "redis",
+ "regex-lite",
  "reqwest 0.12.28",
  "rmcp",
  "rust_xlsxwriter",

--- a/src/backend/services/analytics/Cargo.toml
+++ b/src/backend/services/analytics/Cargo.toml
@@ -56,6 +56,7 @@ redis = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
+regex-lite = { workspace = true }
 serde_yaml = { workspace = true }
 schemars = { workspace = true }
 url = { workspace = true }

--- a/src/backend/services/analytics/Dockerfile
+++ b/src/backend/services/analytics/Dockerfile
@@ -26,6 +26,7 @@ COPY libs/insight-log-context/Cargo.toml ./libs/insight-log-context/Cargo.toml
 COPY libs/authenticator-sdk/Cargo.toml ./libs/authenticator-sdk/Cargo.toml
 COPY libs/insight-migration/Cargo.toml ./libs/insight-migration/Cargo.toml
 COPY services/analytics/Cargo.toml ./services/analytics/Cargo.toml
+COPY services/analytics/build.rs ./services/analytics/build.rs
 COPY services/authenticator/Cargo.toml ./services/authenticator/Cargo.toml
 # identity-resolution is a workspace member; cargo must load its manifest to
 # resolve the workspace even though this image never builds or ships it.
@@ -35,6 +36,12 @@ COPY services/previews/Cargo.toml ./services/previews/Cargo.toml
 # routegen is a workspace member (build-time CLI); cargo must load its manifest
 # to resolve the workspace even though this image never builds it.
 COPY tools/routegen/Cargo.toml ./tools/routegen/Cargo.toml
+
+# The datasets folder lives outside this build context: it arrives as a named
+# additional context so the analytics build script can embed every shipped
+# dataset declaration.
+COPY --from=datasets . /datasets
+ENV DATASETS_DIR=/datasets
 
 RUN mkdir -p libs/insight-clickhouse/src && echo "" > libs/insight-clickhouse/src/lib.rs && \
     mkdir -p libs/insight-http-metrics/src && echo "" > libs/insight-http-metrics/src/lib.rs && \

--- a/src/backend/services/analytics/build.rs
+++ b/src/backend/services/analytics/build.rs
@@ -1,0 +1,64 @@
+//! Gathers the shipped dataset declarations so the service carries them.
+//!
+//! A dataset declares itself beside the model that materializes it, under the
+//! datasets folder — outside this crate. `DATASETS_DIR` points at that folder:
+//! the image sets it to the copy taken from a named build context, and a local
+//! build finds it in the repository.
+
+use std::env;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_DIR: &str = "../../../ingestion/datasets";
+
+fn main() {
+    let dir = datasets_dir();
+    println!("cargo:rerun-if-env-changed=DATASETS_DIR");
+    println!("cargo:rerun-if-changed={}", dir.display());
+
+    let mut declarations: Vec<PathBuf> = read_dir(&dir)
+        .map(|entry| entry.path().join("dataset.yaml"))
+        .filter(|path| path.is_file())
+        .collect();
+    declarations.sort();
+    assert!(
+        !declarations.is_empty(),
+        "no dataset declarations under {}",
+        dir.display()
+    );
+
+    let mut generated = String::from("[\n");
+    for path in &declarations {
+        println!("cargo:rerun-if-changed={}", path.display());
+        let _ = writeln!(generated, "    include_str!(r\"{}\"),", path.display());
+    }
+    generated.push(']');
+
+    let out = Path::new(&var("OUT_DIR")).join("shipped_datasets.rs");
+    fs::write(&out, generated).unwrap_or_else(|error| {
+        panic!(
+            "the generated declaration list is not writable at {}: {error}",
+            out.display()
+        )
+    });
+}
+
+fn read_dir(dir: &Path) -> impl Iterator<Item = fs::DirEntry> {
+    fs::read_dir(dir)
+        .unwrap_or_else(|error| panic!("datasets folder {} is unreadable: {error}", dir.display()))
+        .filter_map(Result::ok)
+}
+
+fn datasets_dir() -> PathBuf {
+    let raw = env::var("DATASETS_DIR").unwrap_or_else(|_| DEFAULT_DIR.to_owned());
+    let path = PathBuf::from(&raw);
+    if path.is_absolute() {
+        return path;
+    }
+    PathBuf::from(var("CARGO_MANIFEST_DIR")).join(path)
+}
+
+fn var(name: &str) -> String {
+    env::var(name).unwrap_or_else(|_| panic!("cargo sets {name}"))
+}

--- a/src/backend/services/analytics/src/api/datasets.rs
+++ b/src/backend/services/analytics/src/api/datasets.rs
@@ -1,0 +1,99 @@
+//! `GET /v1/datasets` and `GET /v1/datasets/{key}` — what a query may be built over.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Extension, Path};
+use axum::http::HeaderMap;
+use toolkit_canonical_errors::CanonicalError;
+
+use super::error::DatasetError;
+use super::{ADMIN_ONLY, AppState, require_admin};
+use crate::domain::datasets;
+use crate::domain::datasets::describe::{
+    DatasetDescription, DatasetListDescription, describe, describe_all,
+};
+
+// INVARIANT: declarations are installation-wide, so neither handler reads the
+// session's tenant. Both are gated like `POST /v1/query`: a description of a
+// surface a caller cannot query is nothing to build from.
+pub async fn list_datasets(
+    Extension(state): Extension<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<Json<DatasetListDescription>, CanonicalError> {
+    require_admin(&state, &headers, admin_only).await?;
+
+    listing()
+}
+
+pub async fn get_dataset(
+    Extension(state): Extension<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(key): Path<String>,
+) -> Result<Json<DatasetDescription>, CanonicalError> {
+    require_admin(&state, &headers, admin_only).await?;
+
+    description(&key)
+}
+
+fn listing() -> Result<Json<DatasetListDescription>, CanonicalError> {
+    let declared = datasets::product_datasets().map_err(|error| {
+        tracing::error!(error = %error, "the shipped dataset declarations are unusable");
+        CanonicalError::internal("failed to list the datasets").create()
+    })?;
+
+    Ok(Json(describe_all(declared)))
+}
+
+fn description(key: &str) -> Result<Json<DatasetDescription>, CanonicalError> {
+    let declared = datasets::dataset(key).ok_or_else(|| {
+        DatasetError::not_found("no such dataset")
+            .with_resource(key)
+            .create()
+    })?;
+
+    Ok(Json(describe(declared)))
+}
+
+fn admin_only() -> CanonicalError {
+    DatasetError::permission_denied()
+        .with_reason(ADMIN_ONLY)
+        .create()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use toolkit_canonical_errors::Problem;
+
+    use super::*;
+
+    #[test]
+    fn a_key_this_build_declares_no_dataset_for_is_a_not_found_naming_it() {
+        let refusal = description("git_tags").expect_err("an undeclared key is refused");
+        let problem =
+            serde_json::to_value(Problem::from(refusal)).expect("the envelope serializes");
+
+        assert_eq!(problem["status"], 404);
+        assert_eq!(
+            problem["context"]["resource_type"],
+            "gts.cf.insight.analytics_api.dataset.v1~"
+        );
+        assert_eq!(problem["context"]["resource_name"], "git_tags");
+    }
+
+    #[test]
+    fn a_declared_key_answers_the_description_the_listing_carries() {
+        let Json(listing) = listing().expect("the declarations load");
+        let Json(one) = description("git_commits").expect("git_commits is declared");
+
+        assert_eq!(
+            listing
+                .datasets
+                .iter()
+                .find(|dataset| dataset.key == "git_commits"),
+            Some(&one),
+            "the listing and the detail describe the dataset differently"
+        );
+    }
+}

--- a/src/backend/services/analytics/src/api/error.rs
+++ b/src/backend/services/analytics/src/api/error.rs
@@ -14,6 +14,11 @@ use toolkit_canonical_errors::resource_error;
 #[resource_error("gts.cf.insight.analytics_api.metric.v1~")]
 pub struct MetricError;
 
+/// Resource namespace for `/v1/query` (the query contract over declared
+/// datasets). Every refusal is an `invalid_argument` naming the request field.
+#[resource_error("gts.cf.insight.analytics_api.query.v1~")]
+pub struct QueryError;
+
 /// Resource namespace for `/v1/datasets*` (what a query may be built over). A
 /// key this build declares no dataset for is a `not_found`, not a refused
 /// request.

--- a/src/backend/services/analytics/src/api/error.rs
+++ b/src/backend/services/analytics/src/api/error.rs
@@ -14,6 +14,12 @@ use toolkit_canonical_errors::resource_error;
 #[resource_error("gts.cf.insight.analytics_api.metric.v1~")]
 pub struct MetricError;
 
+/// Resource namespace for `/v1/datasets*` (what a query may be built over). A
+/// key this build declares no dataset for is a `not_found`, not a refused
+/// request.
+#[resource_error("gts.cf.insight.analytics_api.dataset.v1~")]
+pub struct DatasetError;
+
 /// Resource namespace for `/v1/reports*`.
 #[resource_error("gts.cf.insight.analytics_api.report.v1~")]
 pub struct ReportError;

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -11,6 +11,7 @@ mod metric_drilldown;
 mod metric_results;
 mod metrics;
 mod person_names;
+mod query;
 mod reports;
 mod saved_queries;
 pub(crate) mod usage;
@@ -488,6 +489,33 @@ pub(crate) fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) ->
         )
         .standard_errors(openapi)
         .handler(ai::explain::explain_metric)
+        .register(router, openapi);
+
+    // The query surface: one query contract over the declared datasets. Tenancy
+    // binds from the session, so the body names no tenant and every refusal is
+    // a field-named `invalid_argument`. Admin-only until the datasets declare
+    // an entity policy: they carry person columns.
+    router = OperationBuilder::post("/v1/query")
+        .operation_id("analytics_api.query.create")
+        .summary("Answer a query over a declared dataset")
+        .authenticated()
+        .no_license_required()
+        .json_request::<crate::domain::query::contract::dto::QueryRequest>(
+            openapi,
+            "The question to answer",
+        )
+        .json_response_with_schema::<crate::domain::query::contract::dto::QueryAnswer>(
+            openapi,
+            StatusCode::OK,
+            "A typed table",
+        )
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_415(openapi)
+        .error_429(openapi)
+        .error_500(openapi)
+        .handler(query::query)
         .register(router, openapi);
 
     // What a query may be built over. Read-only over the declarations loaded at

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod ai;
 mod connector_health;
+mod datasets;
 pub(crate) mod error;
 mod feedback;
 mod ingestion;
@@ -40,6 +41,7 @@ use tokio::sync::Semaphore;
 use crate::config::GearConfig;
 use crate::domain::ai::dto as ai_dto;
 use crate::domain::connector_health as connector_health_domain;
+use crate::domain::datasets::describe as dataset_describe;
 use crate::domain::external_links::ExternalSourceRegistry;
 use crate::domain::metric_crud;
 use crate::domain::metric_definitions::listing as metric_definitions_listing;
@@ -486,6 +488,43 @@ pub(crate) fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) ->
         )
         .standard_errors(openapi)
         .handler(ai::explain::explain_metric)
+        .register(router, openapi);
+
+    // What a query may be built over. Read-only over the declarations loaded at
+    // boot, so both operations answer the same object and neither touches the
+    // warehouse. Gated with the query surface they describe.
+    router = OperationBuilder::get("/v1/datasets")
+        .operation_id("analytics_api.datasets.list")
+        .summary("List the datasets a query may be built over")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<dataset_describe::DatasetListDescription>(
+            openapi,
+            StatusCode::OK,
+            "The declared datasets",
+        )
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_500(openapi)
+        .handler(datasets::list_datasets)
+        .register(router, openapi);
+
+    router = OperationBuilder::get("/v1/datasets/{key}")
+        .operation_id("analytics_api.datasets.get")
+        .summary("Describe one dataset a query may be built over")
+        .path_param("key", "The dataset key, as a query names it")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<dataset_describe::DatasetDescription>(
+            openapi,
+            StatusCode::OK,
+            "The declared dataset",
+        )
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .handler(datasets::get_dataset)
         .register(router, openapi);
 
     router = OperationBuilder::post("/v1/metric-results")

--- a/src/backend/services/analytics/src/api/openapi_tests.rs
+++ b/src/backend/services/analytics/src/api/openapi_tests.rs
@@ -35,6 +35,8 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
         "/v1/ai/settings",
         "/v1/connector-health",
         "/v1/connector-health/{connector}/syncs",
+        "/v1/datasets",
+        "/v1/datasets/{key}",
         "/v1/feedback",
         "/v1/ingestion/intensity",
         "/v1/metric-definitions",
@@ -58,7 +60,7 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
     }
     assert_eq!(
         paths.len(),
-        26,
+        28,
         "the contract must carry exactly the surviving paths, got {:?}",
         paths.keys().collect::<Vec<_>>()
     );

--- a/src/backend/services/analytics/src/api/openapi_tests.rs
+++ b/src/backend/services/analytics/src/api/openapi_tests.rs
@@ -52,6 +52,7 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
         "/v1/queries",
         "/v1/queries/{id}",
         "/v1/queries/{id}/run",
+        "/v1/query",
         "/v1/usage/config",
         "/v1/usage/events",
         "/v1/usage/summary",
@@ -60,7 +61,7 @@ fn openapi_document_covers_the_route_table() -> anyhow::Result<()> {
     }
     assert_eq!(
         paths.len(),
-        28,
+        29,
         "the contract must carry exactly the surviving paths, got {:?}",
         paths.keys().collect::<Vec<_>>()
     );

--- a/src/backend/services/analytics/src/api/query.rs
+++ b/src/backend/services/analytics/src/api/query.rs
@@ -1,0 +1,176 @@
+//! `POST /v1/query` — one query contract over the declared datasets.
+
+use std::sync::{Arc, LazyLock};
+use std::time::Duration;
+
+use axum::Json;
+use axum::extract::Extension;
+use axum::http::HeaderMap;
+use tokio::sync::{Semaphore, SemaphorePermit};
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::SecurityContext;
+
+use super::error::QueryError;
+use super::{ADMIN_ONLY, AppState, require_admin};
+use crate::domain::query::compile::params::QueryParam;
+use crate::domain::query::compile::{self, CompiledQuery};
+use crate::domain::query::contract::dto::{QueryAnswer, QueryRequest};
+use crate::domain::query::validation::PlanError;
+use crate::domain::query::violation::Violation;
+use crate::domain::query::{answer, validation};
+use crate::infra::metrics::QueryKind;
+use crate::infra::query::{BoundedFetchError, MAX_ANSWER_BYTES, fetch_bound_rows};
+
+const MAX_CONCURRENT_QUERIES: usize = 8;
+const ACQUIRE_TIMEOUT: Duration = Duration::from_secs(2);
+static QUERY_SEMAPHORE: LazyLock<Semaphore> =
+    LazyLock::new(|| Semaphore::new(MAX_CONCURRENT_QUERIES));
+
+// SAFETY: the datasets carry person columns and declare no entity policy yet,
+// so the whole surface is administrative until one does.
+pub async fn query(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    headers: HeaderMap,
+    Json(request): Json<QueryRequest>,
+) -> Result<Json<QueryAnswer>, CanonicalError> {
+    require_admin(&state, &headers, admin_only).await?;
+
+    let plan = validation::plan(&request).map_err(no_plan)?;
+
+    // INVARIANT: the scan's tenancy binds from the session, never from the query.
+    let tenant_id = ctx.subject_tenant_id().to_string();
+    let CompiledQuery { sql, params } = compile::compile(&plan, &tenant_id);
+    let bindings: Vec<serde_json::Value> = params.iter().map(QueryParam::binding).collect();
+    let comment = format!("query:{}", plan.dataset.key);
+
+    // INVARIANT: the permit is held across the fetch on purpose — it is the
+    // per-process cap on scans in flight — and released before assembly,
+    // which touches no connection.
+    let permit = acquire_permit().await?;
+    let returned = fetch_bound_rows(&state.ch, &sql, &bindings, QueryKind::Query, &comment)
+        .await
+        .map_err(|error| unanswered(&error, &comment))?;
+    drop(permit);
+
+    let answer = answer::assemble(&plan, returned).map_err(|error| {
+        tracing::error!(error = %error, comment, "query answer assembly failed");
+        CanonicalError::internal("failed to answer the query").create()
+    })?;
+
+    Ok(Json(answer))
+}
+
+fn unanswered(error: &BoundedFetchError, comment: &str) -> CanonicalError {
+    match error {
+        BoundedFetchError::TooLarge => QueryError::invalid_argument()
+            .with_field_violation(
+                "limit",
+                format!(
+                    "the answer exceeded {MAX_ANSWER_BYTES} bytes; lower the limit or narrow the query"
+                ),
+                "OUT_OF_RANGE",
+            )
+            .create(),
+        BoundedFetchError::Fetch(error) => {
+            tracing::error!(error = %error, comment, "query failed");
+            CanonicalError::internal("failed to answer the query").create()
+        }
+    }
+}
+
+async fn acquire_permit() -> Result<SemaphorePermit<'static>, CanonicalError> {
+    tokio::time::timeout(ACQUIRE_TIMEOUT, QUERY_SEMAPHORE.acquire())
+        .await
+        .map_err(|_| {
+            tracing::warn!(
+                capacity = MAX_CONCURRENT_QUERIES,
+                available = QUERY_SEMAPHORE.available_permits(),
+                "query capacity exhausted"
+            );
+            busy()
+        })?
+        .map_err(|_| busy())
+}
+
+fn busy() -> CanonicalError {
+    QueryError::resource_exhausted("query capacity is busy")
+        .with_quota_violation("queries", "concurrency limit reached")
+        .with_quota_violation_retry_after_seconds(ACQUIRE_TIMEOUT.as_secs())
+        .create()
+}
+
+fn admin_only() -> CanonicalError {
+    QueryError::permission_denied()
+        .with_reason(ADMIN_ONLY)
+        .create()
+}
+
+fn no_plan(error: PlanError) -> CanonicalError {
+    match error {
+        PlanError::Refused(violations) => refused(&violations),
+        PlanError::DeclarationsUnusable(error) => {
+            tracing::error!(error = %error, "the shipped dataset declarations are unusable");
+            CanonicalError::internal("failed to answer the query").create()
+        }
+    }
+}
+
+// INVARIANT: the refusal path is reached only with at least one violation, which
+// the builder needs to open a field-violation envelope.
+fn refused(violations: &[Violation]) -> CanonicalError {
+    let Some((first, rest)) = violations.split_first() else {
+        return CanonicalError::internal("a query was refused without a reason").create();
+    };
+
+    let mut refusal = QueryError::invalid_argument().with_field_violation(
+        &first.field,
+        &first.detail,
+        first.reason.as_code(),
+    );
+    for violation in rest {
+        refusal = refusal.with_field_violation(
+            &violation.field,
+            &violation.detail,
+            violation.reason.as_code(),
+        );
+    }
+
+    refusal.create()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use toolkit_canonical_errors::Problem;
+
+    use super::*;
+    use crate::domain::query::violation::Reason;
+
+    #[test]
+    fn a_refusal_reports_every_violation_with_its_field_and_machine_code() {
+        let problem = Problem::from(refused(&[
+            Violation::new(
+                "limit",
+                Reason::OutOfRange,
+                "an answer carries at most 10000 rows",
+            ),
+            Violation::unknown("group_by[0].field", "branch", &["repository"]),
+        ]));
+        let problem = serde_json::to_value(problem).expect("the envelope serializes");
+
+        assert_eq!(problem["status"], 400);
+        assert_eq!(
+            problem["context"]["resource_type"],
+            "gts.cf.insight.analytics_api.query.v1~"
+        );
+        let violations = problem["context"]["field_violations"]
+            .as_array()
+            .expect("field_violations is an array");
+        assert_eq!(violations.len(), 2);
+        assert_eq!(violations[0]["field"], "limit");
+        assert_eq!(violations[0]["reason"], "OUT_OF_RANGE");
+        assert_eq!(violations[1]["field"], "group_by[0].field");
+        assert_eq!(violations[1]["reason"], "UNKNOWN");
+    }
+}

--- a/src/backend/services/analytics/src/domain/datasets/declaration.rs
+++ b/src/backend/services/analytics/src/domain/datasets/declaration.rs
@@ -1,0 +1,175 @@
+//! What a dataset declaration says, before and after the field catalog checks it.
+//!
+//! INVARIANT: a [`Dataset`] has every column resolved, so no layer above re-asks
+//! whether one exists.
+
+use serde::Deserialize;
+
+use crate::domain::field_catalog::model::ReadDiscipline;
+
+/// How a query names a dataset, parsed so no raw string reaches a lookup.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DatasetKey(String);
+
+impl DatasetKey {
+    pub fn parse(raw: &str) -> Option<Self> {
+        let mut characters = raw.chars();
+        match characters.next() {
+            Some(first) if first.is_ascii_lowercase() => {}
+            Some(_) | None => return None,
+        }
+        characters
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+            .then(|| Self(raw.to_owned()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for DatasetKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DatasetDocument {
+    pub key: String,
+    pub database: String,
+    pub relation: String,
+    pub read_discipline: ReadDiscipline,
+    pub tenant_field: String,
+    pub time_fields: Vec<TimeFieldDocument>,
+    #[serde(default)]
+    pub dimensions: Vec<DimensionDocument>,
+    #[serde(default)]
+    pub measurables: Vec<MeasurableDocument>,
+    pub row_identity: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TimeFieldDocument {
+    pub field: String,
+    #[serde(default)]
+    pub default: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DimensionDocument {
+    pub field: String,
+    #[serde(default)]
+    pub label_field: Option<String>,
+    /// Required of a nullable column and refused of any other.
+    #[serde(default)]
+    pub absent_value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MeasurableDocument {
+    pub field: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dataset {
+    pub key: DatasetKey,
+    pub database: String,
+    pub relation: String,
+    pub read_discipline: ReadDiscipline,
+    pub tenant_field: String,
+    pub time_fields: Vec<TimeField>,
+    pub dimensions: Vec<Dimension>,
+    pub measurables: Vec<Measurable>,
+    pub row_identity: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimeField {
+    pub field: String,
+    pub nullable: bool,
+    pub default: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Dimension {
+    pub field: String,
+    pub label_field: Option<String>,
+    /// Present exactly when the column is nullable.
+    pub absent_value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Measurable {
+    pub field: String,
+}
+
+#[expect(
+    dead_code,
+    reason = "the query engine reads the registry through these; this crate only declares them until it lands"
+)]
+impl Dataset {
+    pub fn dimension(&self, field: &str) -> Option<&Dimension> {
+        self.dimensions
+            .iter()
+            .find(|dimension| dimension.field == field)
+    }
+
+    pub fn measurable(&self, field: &str) -> Option<&Measurable> {
+        self.measurables
+            .iter()
+            .find(|measurable| measurable.field == field)
+    }
+
+    pub fn time_field(&self, field: &str) -> Option<&TimeField> {
+        self.time_fields
+            .iter()
+            .find(|candidate| candidate.field == field)
+    }
+
+    /// INVARIANT: validation admits exactly one default, so this never fails on
+    /// a declaration the loader accepted.
+    pub fn default_time_field(&self) -> Option<&TimeField> {
+        self.time_fields.iter().find(|field| field.default)
+    }
+
+    pub fn dimension_names(&self) -> Vec<&str> {
+        self.dimensions
+            .iter()
+            .map(|dimension| dimension.field.as_str())
+            .collect()
+    }
+
+    pub fn measurable_names(&self) -> Vec<&str> {
+        self.measurables
+            .iter()
+            .map(|measurable| measurable.field.as_str())
+            .collect()
+    }
+
+    pub fn time_field_names(&self) -> Vec<&str> {
+        self.time_fields
+            .iter()
+            .map(|field| field.field.as_str())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_dataset_key_is_lowercase_snake_case() {
+        assert!(DatasetKey::parse("git_commits").is_some());
+        assert!(DatasetKey::parse("git2").is_some());
+        for rejected in ["Git", "_git", "2git", "git-commits", "git.commits", ""] {
+            assert!(DatasetKey::parse(rejected).is_none(), "{rejected}");
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/datasets/declaration.rs
+++ b/src/backend/services/analytics/src/domain/datasets/declaration.rs
@@ -108,10 +108,6 @@ pub struct Measurable {
     pub field: String,
 }
 
-#[expect(
-    dead_code,
-    reason = "the query engine reads the registry through these; this crate only declares them until it lands"
-)]
 impl Dataset {
     pub fn dimension(&self, field: &str) -> Option<&Dimension> {
         self.dimensions

--- a/src/backend/services/analytics/src/domain/datasets/describe.rs
+++ b/src/backend/services/analytics/src/domain/datasets/describe.rs
@@ -1,0 +1,220 @@
+//! The queryable surface of a dataset, which is less than its declaration says.
+//!
+//! INVARIANT: where the rows live — database, relation, read discipline, tenancy
+//! column, row identity — is never served here.
+
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use super::declaration::{Dataset, Dimension, Measurable, TimeField};
+use crate::domain::datasets::label_column_name;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[schema(as = QueryDatasetList)]
+pub struct DatasetListDescription {
+    pub datasets: Vec<DatasetDescription>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[schema(as = QueryDataset)]
+pub struct DatasetDescription {
+    pub key: String,
+    /// The columns a query may bound its window by, and bucket on.
+    pub time_fields: Vec<TimeFieldDescription>,
+    /// The axes a query may group by, and filter on beside the measurables.
+    pub dimensions: Vec<DimensionDescription>,
+    /// The columns an aggregate may fold.
+    pub measurables: Vec<MeasurableDescription>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[schema(as = QueryDatasetTimeField)]
+pub struct TimeFieldDescription {
+    pub field: String,
+    /// The field a query's window binds to when it names none.
+    pub default: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[schema(as = QueryDatasetDimension)]
+pub struct DimensionDescription {
+    pub field: String,
+    /// The value absent rows group under, and a filter matches them by.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub absent_value: Option<String>,
+    /// The answer column carrying this dimension's display label when it is
+    /// a group axis; absent when the dataset declares none.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[schema(as = QueryDatasetMeasurable)]
+pub struct MeasurableDescription {
+    pub field: String,
+}
+
+pub fn describe(dataset: &Dataset) -> DatasetDescription {
+    DatasetDescription {
+        key: dataset.key.to_string(),
+        time_fields: dataset.time_fields.iter().map(time_field).collect(),
+        dimensions: dataset.dimensions.iter().map(dimension).collect(),
+        measurables: dataset.measurables.iter().map(measurable).collect(),
+    }
+}
+
+pub fn describe_all(datasets: &[Dataset]) -> DatasetListDescription {
+    DatasetListDescription {
+        datasets: datasets.iter().map(describe).collect(),
+    }
+}
+
+fn time_field(field: &TimeField) -> TimeFieldDescription {
+    TimeFieldDescription {
+        field: field.field.clone(),
+        default: field.default,
+    }
+}
+
+fn dimension(dimension: &Dimension) -> DimensionDescription {
+    DimensionDescription {
+        field: dimension.field.clone(),
+        absent_value: dimension.absent_value.clone(),
+        label: dimension
+            .label_field
+            .as_ref()
+            .map(|_| label_column_name(dimension)),
+    }
+}
+
+fn measurable(measurable: &Measurable) -> MeasurableDescription {
+    MeasurableDescription {
+        field: measurable.field.clone(),
+    }
+}
+
+impl toolkit::api::api_dto::ResponseApiDto for DatasetListDescription {}
+impl toolkit::api::api_dto::ResponseApiDto for DatasetDescription {}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::super::{dataset, product_datasets};
+    use super::*;
+
+    fn description(key: &str) -> DatasetDescription {
+        describe(dataset(key).unwrap_or_else(|| panic!("{key} is declared")))
+    }
+
+    #[test]
+    fn a_description_reports_every_field_its_declaration_admits_and_no_other() {
+        for key in ["git_commits", "git_file_changes"] {
+            let declared = dataset(key).unwrap_or_else(|| panic!("{key} is declared"));
+            let described = description(key);
+
+            assert_eq!(described.key, key);
+            assert_eq!(
+                described
+                    .time_fields
+                    .iter()
+                    .map(|field| field.field.as_str())
+                    .collect::<Vec<_>>(),
+                declared.time_field_names(),
+                "{key}: time fields"
+            );
+            assert_eq!(
+                described
+                    .dimensions
+                    .iter()
+                    .map(|dimension| dimension.field.as_str())
+                    .collect::<Vec<_>>(),
+                declared.dimension_names(),
+                "{key}: dimensions"
+            );
+            assert_eq!(
+                described
+                    .measurables
+                    .iter()
+                    .map(|measurable| measurable.field.as_str())
+                    .collect::<Vec<_>>(),
+                declared.measurable_names(),
+                "{key}: measurables"
+            );
+        }
+    }
+
+    #[test]
+    fn a_described_dimension_names_absent_rows_exactly_as_its_declaration_does() {
+        for key in ["git_commits", "git_file_changes"] {
+            let declared = dataset(key).unwrap_or_else(|| panic!("{key} is declared"));
+            for described in description(key).dimensions {
+                let source = declared
+                    .dimension(&described.field)
+                    .unwrap_or_else(|| panic!("{key}: {} is declared", described.field));
+
+                assert_eq!(
+                    described.absent_value, source.absent_value,
+                    "{key}: {} absent value",
+                    described.field
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_time_field_a_window_binds_to_by_default_is_the_one_flagged_default() {
+        for key in ["git_commits", "git_file_changes"] {
+            let declared = dataset(key).unwrap_or_else(|| panic!("{key} is declared"));
+            let described = description(key);
+
+            let defaults: Vec<&str> = described
+                .time_fields
+                .iter()
+                .filter(|field| field.default)
+                .map(|field| field.field.as_str())
+                .collect();
+
+            assert_eq!(
+                defaults,
+                [declared
+                    .default_time_field()
+                    .map(|field| field.field.as_str())
+                    .expect("a declaration carries one default time field")],
+                "{key}: default time field"
+            );
+        }
+    }
+
+    #[test]
+    fn a_description_carries_nothing_about_where_the_rows_live() {
+        let json = serde_json::to_value(description("git_commits"))
+            .expect("a description serializes")
+            .to_string();
+
+        for internal in [
+            "\"database\"",
+            "\"relation\"",
+            "tenant_id",
+            "row_identity",
+            "plain",
+        ] {
+            assert!(
+                !json.contains(internal),
+                "the description leaks `{internal}`: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_declared_dataset_is_listed_once_in_declaration_order() {
+        let datasets = product_datasets().expect("the shipped declarations are admissible");
+        let described = describe_all(datasets);
+        let listed: Vec<&str> = described
+            .datasets
+            .iter()
+            .map(|entry| entry.key.as_str())
+            .collect();
+
+        assert_eq!(listed, ["git_commits", "git_file_changes"]);
+    }
+}

--- a/src/backend/services/analytics/src/domain/datasets/describe.rs
+++ b/src/backend/services/analytics/src/domain/datasets/describe.rs
@@ -6,6 +6,11 @@
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use crate::domain::query::contract::dto::{
+    DEFAULT_ROW_LIMIT, MAX_AGGREGATES, MAX_FILTER_VALUES, MAX_FILTERS, MAX_GROUP_AXES,
+    MAX_NAME_CHARS, MAX_ORDER_TERMS, MAX_ROW_LIMIT,
+};
+
 use super::declaration::{Dataset, Dimension, Measurable, TimeField};
 use crate::domain::datasets::label_column_name;
 
@@ -25,6 +30,8 @@ pub struct DatasetDescription {
     pub dimensions: Vec<DimensionDescription>,
     /// The columns an aggregate may fold.
     pub measurables: Vec<MeasurableDescription>,
+    /// The bounds a request against this dataset must stay inside.
+    pub limits: QueryLimits,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
@@ -54,12 +61,45 @@ pub struct MeasurableDescription {
     pub field: String,
 }
 
+/// The contract's request bounds, identical for every dataset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[schema(as = QueryLimits)]
+pub struct QueryLimits {
+    pub max_filters: usize,
+    pub max_filter_values: usize,
+    pub max_aggregates: usize,
+    pub max_group_axes: usize,
+    pub max_order_terms: usize,
+    /// Longest an aggregate's name may be, in characters.
+    pub max_name_chars: usize,
+    /// Rows a query gets when it sets no ceiling of its own.
+    pub default_limit: u32,
+    /// Rows a query may ask for at most; over it the query is refused, not clipped.
+    pub max_limit: u32,
+}
+
+impl QueryLimits {
+    const fn contract() -> Self {
+        Self {
+            max_filters: MAX_FILTERS,
+            max_filter_values: MAX_FILTER_VALUES,
+            max_aggregates: MAX_AGGREGATES,
+            max_group_axes: MAX_GROUP_AXES,
+            max_order_terms: MAX_ORDER_TERMS,
+            max_name_chars: MAX_NAME_CHARS,
+            default_limit: DEFAULT_ROW_LIMIT,
+            max_limit: MAX_ROW_LIMIT,
+        }
+    }
+}
+
 pub fn describe(dataset: &Dataset) -> DatasetDescription {
     DatasetDescription {
         key: dataset.key.to_string(),
         time_fields: dataset.time_fields.iter().map(time_field).collect(),
         dimensions: dataset.dimensions.iter().map(dimension).collect(),
         measurables: dataset.measurables.iter().map(measurable).collect(),
+        limits: QueryLimits::contract(),
     }
 }
 
@@ -203,6 +243,20 @@ mod tests {
                 "the description leaks `{internal}`: {json}"
             );
         }
+    }
+
+    #[test]
+    fn the_limits_a_dataset_reports_are_the_ones_validation_enforces() {
+        let limits = description("git_commits").limits;
+
+        assert_eq!(limits.max_filters, MAX_FILTERS);
+        assert_eq!(limits.max_filter_values, MAX_FILTER_VALUES);
+        assert_eq!(limits.max_aggregates, MAX_AGGREGATES);
+        assert_eq!(limits.max_group_axes, MAX_GROUP_AXES);
+        assert_eq!(limits.max_order_terms, MAX_ORDER_TERMS);
+        assert_eq!(limits.max_name_chars, MAX_NAME_CHARS);
+        assert_eq!(limits.default_limit, DEFAULT_ROW_LIMIT);
+        assert_eq!(limits.max_limit, MAX_ROW_LIMIT);
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/datasets/mod.rs
+++ b/src/backend/services/analytics/src/domain/datasets/mod.rs
@@ -1,0 +1,172 @@
+//! The datasets this build ships.
+//!
+//! Every dataset declares itself beside the model that materializes it, under
+//! `src/ingestion/datasets/<key>/dataset.yaml`. The build script gathers those
+//! files so the service carries them; a tenant's own datasets will join this
+//! registry from the identity-side store, validated by the same code.
+//!
+//! INVARIANT: shipped declarations are validated once at first use, so one that
+//! has outgrown the warehouse fails a test run rather than a request.
+
+pub mod declaration;
+pub mod describe;
+pub mod validate;
+
+use std::sync::OnceLock;
+
+use crate::domain::field_catalog::product_catalog;
+
+use declaration::{Dataset, DatasetDocument};
+use validate::DeclarationError;
+
+/// The shipped declarations, gathered by `build.rs` from the datasets folder.
+const DECLARATIONS: &[&str] = &include!(concat!(env!("OUT_DIR"), "/shipped_datasets.rs"));
+
+/// The answer column a dimension's declared label travels under.
+pub fn label_column_name(dimension: &declaration::Dimension) -> String {
+    format!("{}_label", dimension.field)
+}
+
+pub fn product_datasets() -> Result<&'static [Dataset], &'static DeclarationError> {
+    static DATASETS: OnceLock<Result<Vec<Dataset>, DeclarationError>> = OnceLock::new();
+    DATASETS
+        .get_or_init(|| load(DECLARATIONS))
+        .as_ref()
+        .map(Vec::as_slice)
+}
+
+pub fn dataset(key: &str) -> Option<&'static Dataset> {
+    product_datasets()
+        .ok()?
+        .iter()
+        .find(|dataset| dataset.key.as_str() == key)
+}
+
+/// Every key a query may name, in declaration order.
+fn load(documents: &[&str]) -> Result<Vec<Dataset>, DeclarationError> {
+    let catalog =
+        product_catalog().map_err(|error| DeclarationError::Document(error.to_string()))?;
+
+    let mut datasets: Vec<Dataset> = Vec::with_capacity(documents.len());
+    for raw in documents {
+        let document: DatasetDocument = serde_yaml::from_str(raw)
+            .map_err(|error| DeclarationError::Document(error.to_string()))?;
+        let dataset = validate::validate(document, catalog)?;
+
+        if datasets.iter().any(|seen| seen.key == dataset.key) {
+            return Err(DeclarationError::DuplicateDataset(dataset.key.to_string()));
+        }
+        datasets.push(dataset);
+    }
+
+    Ok(datasets)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_shipped_declaration_agrees_with_the_field_catalog() {
+        let datasets = product_datasets().expect("the shipped declarations are admissible");
+        assert!(!datasets.is_empty());
+    }
+
+    #[test]
+    fn the_commits_dataset_declares_what_a_query_over_it_needs() {
+        let commits = dataset("git_commits").expect("git_commits is declared");
+
+        assert_eq!(commits.database, "insight");
+        assert_eq!(commits.relation, "git_commits");
+        assert_eq!(commits.tenant_field, "tenant_id");
+        assert_eq!(
+            commits
+                .default_time_field()
+                .map(|field| field.field.as_str()),
+            Some("authored_at")
+        );
+        for field in ["author_email", "commit_hash", "message", "repository"] {
+            assert!(
+                commits.dimension(field).is_some(),
+                "{field} must be a dimension"
+            );
+        }
+        assert!(commits.measurable("lines_added").is_some());
+        assert_eq!(commits.row_identity, ["tenant_id", "source", "commit_hash"]);
+    }
+
+    #[test]
+    fn the_file_change_dataset_declares_the_grain_below_a_commit() {
+        let changes = dataset("git_file_changes").expect("git_file_changes is declared");
+
+        assert_eq!(changes.database, "insight");
+        assert_eq!(changes.relation, "git_file_changes");
+        assert_eq!(changes.tenant_field, "tenant_id");
+        assert_eq!(
+            changes
+                .default_time_field()
+                .map(|field| field.field.as_str()),
+            Some("authored_at")
+        );
+        for field in [
+            "file_extension",
+            "change_type",
+            "category",
+            "file_path",
+            "commit_hash",
+        ] {
+            assert!(
+                changes.dimension(field).is_some(),
+                "{field} must be groupable"
+            );
+        }
+        assert_eq!(
+            changes.row_identity,
+            [
+                "tenant_id",
+                "source",
+                "commit_hash",
+                "file_path",
+                "change_type"
+            ]
+        );
+    }
+
+    #[test]
+    fn a_column_one_dataset_groups_by_is_not_thereby_groupable_on_another() {
+        let commits = dataset("git_commits").expect("git_commits is declared");
+        let changes = dataset("git_file_changes").expect("git_file_changes is declared");
+
+        assert!(changes.dimension("file_extension").is_some());
+        assert!(
+            commits.dimension("file_extension").is_none(),
+            "a commit has no one file extension"
+        );
+        assert!(changes.dimension("file_path").is_some());
+        assert!(
+            commits.dimension("file_path").is_none(),
+            "a commit has no one path"
+        );
+    }
+
+    #[test]
+    fn a_key_no_declaration_carries_resolves_to_nothing() {
+        assert!(dataset("git_tags").is_none());
+        let keys: Vec<&str> = product_datasets()
+            .expect("the shipped declarations are admissible")
+            .iter()
+            .map(|dataset| dataset.key.as_str())
+            .collect();
+        assert_eq!(keys, ["git_commits", "git_file_changes"]);
+    }
+
+    #[test]
+    fn a_repeated_declaration_key_is_refused() {
+        let one = DECLARATIONS[0];
+        assert_eq!(
+            load(&[one, one]),
+            Err(DeclarationError::DuplicateDataset("git_commits".to_owned()))
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/datasets/mod.rs
+++ b/src/backend/services/analytics/src/domain/datasets/mod.rs
@@ -43,6 +43,18 @@ pub fn dataset(key: &str) -> Option<&'static Dataset> {
 }
 
 /// Every key a query may name, in declaration order.
+/// Every key a query may name, in declaration order.
+pub fn declared_keys() -> Vec<&'static str> {
+    product_datasets()
+        .map(|datasets| {
+            datasets
+                .iter()
+                .map(|dataset| dataset.key.as_str())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 fn load(documents: &[&str]) -> Result<Vec<Dataset>, DeclarationError> {
     let catalog =
         product_catalog().map_err(|error| DeclarationError::Document(error.to_string()))?;

--- a/src/backend/services/analytics/src/domain/datasets/validate.rs
+++ b/src/backend/services/analytics/src/domain/datasets/validate.rs
@@ -1,0 +1,600 @@
+//! Checks a dataset declaration against the field catalog.
+//!
+//! INVARIANT: a declaration that passes here can never fail a compile for a
+//! missing column.
+
+use std::collections::HashSet;
+
+use crate::domain::field_catalog::model::{
+    CatalogColumn, CatalogRelation, FieldCatalog, ReadDiscipline, TypeClass,
+};
+
+use super::declaration::{Dataset, DatasetDocument, DatasetKey, Dimension, Measurable, TimeField};
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DeclarationError {
+    #[error("dataset declaration does not parse: {0}")]
+    Document(String),
+    #[error("`{0}` is not a dataset key: lowercase snake_case starting with [a-z]")]
+    BadKey(String),
+    #[error("dataset `{0}` is declared twice")]
+    DuplicateDataset(String),
+    #[error("dataset `{dataset}` names relation `{database}.{relation}`, absent from the catalog")]
+    RelationNotFound {
+        dataset: String,
+        database: String,
+        relation: String,
+    },
+    #[error(
+        "dataset `{dataset}` declares a `{declared}` read of `{relation}`, whose engine needs `{required}`"
+    )]
+    ReadDisciplineMismatch {
+        dataset: String,
+        relation: String,
+        declared: &'static str,
+        required: &'static str,
+    },
+    #[error(
+        "dataset `{dataset}` names `{field}` as its {role}, and the relation has no such column"
+    )]
+    ColumnNotFound {
+        dataset: String,
+        field: String,
+        role: &'static str,
+    },
+    #[error(
+        "dataset `{dataset}` names `{field}` as its {role}, and a {found} column cannot be one"
+    )]
+    ColumnTypeRejected {
+        dataset: String,
+        field: String,
+        role: &'static str,
+        found: &'static str,
+    },
+    #[error("dataset `{dataset}` declares `{field}` as a {role} twice")]
+    DuplicateField {
+        dataset: String,
+        field: String,
+        role: &'static str,
+    },
+    #[error("dataset `{dataset}` declares {count} default time fields, and a scan buckets by one")]
+    DefaultTimeFields { dataset: String, count: usize },
+    #[error(
+        "dataset `{dataset}` groups nullable dimension `{field}` without an absent_value, so its absent rows have no name"
+    )]
+    DimensionWithoutAbsentValue { dataset: String, field: String },
+    #[error(
+        "dataset `{dataset}` gives non-nullable dimension `{field}` an absent_value, which no row can take"
+    )]
+    DimensionWithUnreachableAbsentValue { dataset: String, field: String },
+    #[error("dataset `{dataset}` declares an empty row identity, so no row is one fact")]
+    EmptyRowIdentity { dataset: String },
+    #[error(
+        "dataset `{dataset}` gives dimension `{field}` an absent_value containing `?`, which the driver would read as a binding"
+    )]
+    AbsentValueWithPlaceholder { dataset: String, field: String },
+}
+
+pub fn validate(
+    document: DatasetDocument,
+    catalog: &FieldCatalog,
+) -> Result<Dataset, DeclarationError> {
+    let dataset = document.key.clone();
+    let key = DatasetKey::parse(&document.key)
+        .ok_or_else(|| DeclarationError::BadKey(document.key.clone()))?;
+
+    let relation = catalog
+        .relation(&document.database, &document.relation)
+        .ok_or_else(|| DeclarationError::RelationNotFound {
+            dataset: dataset.clone(),
+            database: document.database.clone(),
+            relation: document.relation.clone(),
+        })?;
+
+    check_read_discipline(&dataset, &document, relation)?;
+
+    let tenant = column(&dataset, relation, &document.tenant_field, "tenant field")?;
+    admit(
+        &dataset,
+        tenant,
+        "tenant field",
+        &[TypeClass::Text, TypeClass::Uuid],
+    )?;
+
+    let time_fields = validate_time_fields(&dataset, &document, relation)?;
+    let dimensions = validate_dimensions(&dataset, &document, relation)?;
+    let measurables = validate_measurables(&dataset, &document, relation)?;
+
+    if document.row_identity.is_empty() {
+        return Err(DeclarationError::EmptyRowIdentity { dataset });
+    }
+    for field in &document.row_identity {
+        column(&dataset, relation, field, "row identity")?;
+    }
+
+    Ok(Dataset {
+        key,
+        database: document.database,
+        relation: document.relation,
+        read_discipline: document.read_discipline,
+        tenant_field: document.tenant_field,
+        time_fields,
+        dimensions,
+        measurables,
+        row_identity: document.row_identity,
+    })
+}
+
+fn check_read_discipline(
+    dataset: &str,
+    document: &DatasetDocument,
+    relation: &CatalogRelation,
+) -> Result<(), DeclarationError> {
+    if document.read_discipline == relation.read_discipline {
+        return Ok(());
+    }
+
+    Err(DeclarationError::ReadDisciplineMismatch {
+        dataset: dataset.to_owned(),
+        relation: format!("{}.{}", document.database, document.relation),
+        declared: discipline_name(document.read_discipline),
+        required: discipline_name(relation.read_discipline),
+    })
+}
+
+fn validate_time_fields(
+    dataset: &str,
+    document: &DatasetDocument,
+    relation: &CatalogRelation,
+) -> Result<Vec<TimeField>, DeclarationError> {
+    let mut seen = HashSet::new();
+    let mut time_fields = Vec::with_capacity(document.time_fields.len());
+    for declared in &document.time_fields {
+        if !seen.insert(declared.field.as_str()) {
+            return Err(DeclarationError::DuplicateField {
+                dataset: dataset.to_owned(),
+                field: declared.field.clone(),
+                role: "time field",
+            });
+        }
+
+        let found = column(dataset, relation, &declared.field, "time field")?;
+        admit(
+            dataset,
+            found,
+            "time field",
+            &[TypeClass::Date, TypeClass::Timestamp],
+        )?;
+
+        time_fields.push(TimeField {
+            field: declared.field.clone(),
+            nullable: found.field_type.nullable,
+            default: declared.default,
+        });
+    }
+
+    let defaults = time_fields.iter().filter(|field| field.default).count();
+    if defaults != 1 {
+        return Err(DeclarationError::DefaultTimeFields {
+            dataset: dataset.to_owned(),
+            count: defaults,
+        });
+    }
+
+    Ok(time_fields)
+}
+
+fn validate_dimensions(
+    dataset: &str,
+    document: &DatasetDocument,
+    relation: &CatalogRelation,
+) -> Result<Vec<Dimension>, DeclarationError> {
+    let mut seen = HashSet::new();
+    let mut dimensions = Vec::with_capacity(document.dimensions.len());
+    for declared in &document.dimensions {
+        if !seen.insert(declared.field.as_str()) {
+            return Err(DeclarationError::DuplicateField {
+                dataset: dataset.to_owned(),
+                field: declared.field.clone(),
+                role: "dimension",
+            });
+        }
+
+        let found = column(dataset, relation, &declared.field, "dimension")?;
+        admit(
+            dataset,
+            found,
+            "dimension",
+            &[
+                TypeClass::Text,
+                TypeClass::Uuid,
+                TypeClass::Boolean,
+                TypeClass::Number,
+            ],
+        )?;
+
+        match (found.field_type.nullable, &declared.absent_value) {
+            (true, None) => {
+                return Err(DeclarationError::DimensionWithoutAbsentValue {
+                    dataset: dataset.to_owned(),
+                    field: declared.field.clone(),
+                });
+            }
+            (false, Some(_)) => {
+                return Err(DeclarationError::DimensionWithUnreachableAbsentValue {
+                    dataset: dataset.to_owned(),
+                    field: declared.field.clone(),
+                });
+            }
+            // SAFETY: the sentinel is written into the statement text as a
+            // literal, and the driver binds every `?` it sees by position.
+            (true, Some(absent)) if absent.contains('?') => {
+                return Err(DeclarationError::AbsentValueWithPlaceholder {
+                    dataset: dataset.to_owned(),
+                    field: declared.field.clone(),
+                });
+            }
+            (true, Some(_)) | (false, None) => {}
+        }
+
+        if let Some(label) = &declared.label_field {
+            let label_column = column(dataset, relation, label, "dimension label")?;
+            admit(
+                dataset,
+                label_column,
+                "dimension label",
+                &[TypeClass::Text, TypeClass::Uuid, TypeClass::Number],
+            )?;
+        }
+
+        dimensions.push(Dimension {
+            field: declared.field.clone(),
+            label_field: declared.label_field.clone(),
+            absent_value: declared.absent_value.clone(),
+        });
+    }
+
+    Ok(dimensions)
+}
+
+fn validate_measurables(
+    dataset: &str,
+    document: &DatasetDocument,
+    relation: &CatalogRelation,
+) -> Result<Vec<Measurable>, DeclarationError> {
+    let mut seen = HashSet::new();
+    let mut measurables = Vec::with_capacity(document.measurables.len());
+    for declared in &document.measurables {
+        if !seen.insert(declared.field.as_str()) {
+            return Err(DeclarationError::DuplicateField {
+                dataset: dataset.to_owned(),
+                field: declared.field.clone(),
+                role: "measurable",
+            });
+        }
+
+        let found = column(dataset, relation, &declared.field, "measurable")?;
+        admit(dataset, found, "measurable", &[TypeClass::Number])?;
+
+        measurables.push(Measurable {
+            field: declared.field.clone(),
+        });
+    }
+
+    Ok(measurables)
+}
+
+fn column<'a>(
+    dataset: &str,
+    relation: &'a CatalogRelation,
+    field: &str,
+    role: &'static str,
+) -> Result<&'a CatalogColumn, DeclarationError> {
+    relation
+        .column(field)
+        .ok_or_else(|| DeclarationError::ColumnNotFound {
+            dataset: dataset.to_owned(),
+            field: field.to_owned(),
+            role,
+        })
+}
+
+fn admit(
+    dataset: &str,
+    found: &CatalogColumn,
+    role: &'static str,
+    admissible: &[TypeClass],
+) -> Result<(), DeclarationError> {
+    if admissible.contains(&found.field_type.class) {
+        return Ok(());
+    }
+
+    Err(DeclarationError::ColumnTypeRejected {
+        dataset: dataset.to_owned(),
+        field: found.name.clone(),
+        role,
+        found: class_name(found.field_type.class),
+    })
+}
+
+fn class_name(class: TypeClass) -> &'static str {
+    match class {
+        TypeClass::Text => "text",
+        TypeClass::Number => "numeric",
+        TypeClass::Boolean => "boolean",
+        TypeClass::Date => "date",
+        TypeClass::Timestamp => "timestamp",
+        TypeClass::Uuid => "uuid",
+        TypeClass::Composite => "composite",
+    }
+}
+
+fn discipline_name(discipline: ReadDiscipline) -> &'static str {
+    match discipline {
+        ReadDiscipline::Plain => "plain",
+        ReadDiscipline::Final => "final",
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::field_catalog::loader;
+
+    const SNAPSHOT: &str = r#"[
+      {
+        "database": "insight",
+        "relation": "git_commits",
+        "engine": "MergeTree",
+        "sorting_key": "tenant_id",
+        "columns": [
+          {"name": "tenant_id", "type": "Nullable(String)"},
+          {"name": "authored_at", "type": "DateTime"},
+          {"name": "commit_hash", "type": "String"},
+          {"name": "message", "type": "String"},
+          {"name": "repository", "type": "String"},
+          {"name": "repository_label", "type": "String"},
+          {"name": "source_id", "type": "Nullable(String)"},
+          {"name": "lines_added", "type": "Nullable(Int64)"},
+          {"name": "payload", "type": "Map(String, String)"}
+        ]
+      },
+      {
+        "database": "silver",
+        "relation": "class_git_commits",
+        "engine": "ReplacingMergeTree",
+        "sorting_key": "unique_key",
+        "columns": [
+          {"name": "insight_tenant_id", "type": "String"},
+          {"name": "authored_at", "type": "DateTime"}
+        ]
+      }
+    ]"#;
+
+    const MINIMAL: &str = "
+key: git_commits
+database: insight
+relation: git_commits
+read_discipline: plain
+tenant_field: tenant_id
+time_fields:
+  - field: authored_at
+    default: true
+row_identity: [commit_hash]
+";
+
+    fn catalog() -> FieldCatalog {
+        loader::load(SNAPSHOT).expect("the fixture snapshot parses")
+    }
+
+    fn declare(yaml: &str) -> Result<Dataset, DeclarationError> {
+        let document: DatasetDocument =
+            serde_yaml::from_str(yaml).expect("the fixture document parses");
+        validate(document, &catalog())
+    }
+
+    fn with(extra: &str) -> String {
+        format!("{MINIMAL}{extra}")
+    }
+
+    #[test]
+    fn a_declaration_the_catalog_agrees_with_resolves() {
+        let dataset = declare(&with(
+            "dimensions:
+  - field: repository
+    label_field: repository_label
+  - field: source_id
+    absent_value: __unknown__
+measurables:
+  - field: lines_added
+",
+        ))
+        .expect("the declaration is admissible");
+
+        assert_eq!(dataset.key.as_str(), "git_commits");
+        assert_eq!(dataset.read_discipline, ReadDiscipline::Plain);
+        assert_eq!(
+            dataset
+                .default_time_field()
+                .map(|field| field.field.as_str()),
+            Some("authored_at")
+        );
+        assert_eq!(
+            dataset
+                .dimension("source_id")
+                .and_then(|d| d.absent_value.as_deref()),
+            Some("__unknown__")
+        );
+        assert_eq!(
+            dataset
+                .dimension("repository")
+                .and_then(|d| d.label_field.as_deref()),
+            Some("repository_label")
+        );
+    }
+
+    #[test]
+    fn a_column_the_warehouse_lacks_is_refused() {
+        let error = declare(&with("dimensions:\n  - field: branch\n")).expect_err("no such column");
+        assert_eq!(
+            error,
+            DeclarationError::ColumnNotFound {
+                dataset: "git_commits".to_owned(),
+                field: "branch".to_owned(),
+                role: "dimension",
+            }
+        );
+    }
+
+    #[test]
+    fn a_column_whose_type_cannot_hold_its_role_is_refused() {
+        let cases = [
+            ("measurables:\n  - field: message\n", "measurable"),
+            ("dimensions:\n  - field: payload\n", "dimension"),
+        ];
+        for (extra, role) in cases {
+            let error = declare(&with(extra)).expect_err("the type cannot hold the role");
+            assert!(
+                matches!(&error, DeclarationError::ColumnTypeRejected { role: found, .. } if *found == role),
+                "{extra}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_nullable_dimension_without_a_name_for_its_absent_rows_is_refused() {
+        let error =
+            declare(&with("dimensions:\n  - field: source_id\n")).expect_err("no absent_value");
+        assert_eq!(
+            error,
+            DeclarationError::DimensionWithoutAbsentValue {
+                dataset: "git_commits".to_owned(),
+                field: "source_id".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn an_absent_value_the_driver_would_read_as_a_binding_is_refused() {
+        let error = declare(&with(
+            "dimensions:\n  - field: source_id\n    absent_value: 'unknown?'\n",
+        ))
+        .expect_err("a `?` in the statement text shifts every binding after it");
+        assert_eq!(
+            error,
+            DeclarationError::AbsentValueWithPlaceholder {
+                dataset: "git_commits".to_owned(),
+                field: "source_id".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_non_nullable_dimension_naming_absent_rows_is_refused() {
+        let error = declare(&with(
+            "dimensions:\n  - field: repository\n    absent_value: __unknown__\n",
+        ))
+        .expect_err("no row can be absent");
+        assert_eq!(
+            error,
+            DeclarationError::DimensionWithUnreachableAbsentValue {
+                dataset: "git_commits".to_owned(),
+                field: "repository".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_declaration_must_name_exactly_one_default_time_field() {
+        let none = declare(
+            "
+key: git_commits
+database: insight
+relation: git_commits
+read_discipline: plain
+tenant_field: tenant_id
+time_fields:
+  - field: authored_at
+row_identity: [commit_hash]
+",
+        )
+        .expect_err("no default");
+        assert_eq!(
+            none,
+            DeclarationError::DefaultTimeFields {
+                dataset: "git_commits".to_owned(),
+                count: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn a_plain_read_of_a_replacing_relation_is_refused() {
+        let error = declare(
+            "
+key: git_commits
+database: silver
+relation: class_git_commits
+read_discipline: plain
+tenant_field: insight_tenant_id
+time_fields:
+  - field: authored_at
+    default: true
+row_identity: [insight_tenant_id]
+",
+        )
+        .expect_err("a replacing engine must be read collapsed");
+        assert!(matches!(
+            error,
+            DeclarationError::ReadDisciplineMismatch {
+                declared: "plain",
+                required: "final",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn a_relation_the_catalog_lacks_is_refused() {
+        let error = declare(&MINIMAL.replace("relation: git_commits", "relation: git_tags"))
+            .expect_err("no such relation");
+        assert!(matches!(error, DeclarationError::RelationNotFound { .. }));
+    }
+
+    #[test]
+    fn a_repeated_field_in_one_role_is_refused() {
+        let error = declare(&with(
+            "dimensions:\n  - field: repository\n  - field: repository\n",
+        ))
+        .expect_err("declared twice");
+        assert_eq!(
+            error,
+            DeclarationError::DuplicateField {
+                dataset: "git_commits".to_owned(),
+                field: "repository".to_owned(),
+                role: "dimension",
+            }
+        );
+    }
+
+    #[test]
+    fn a_declaration_without_a_row_identity_is_refused() {
+        let error = declare(&MINIMAL.replace("row_identity: [commit_hash]", "row_identity: []"))
+            .expect_err("no fact grain");
+        assert_eq!(
+            error,
+            DeclarationError::EmptyRowIdentity {
+                dataset: "git_commits".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn an_unknown_key_in_a_declaration_is_refused() {
+        let document: Result<DatasetDocument, _> = serde_yaml::from_str(&with(
+            "dimensions:\n  - field: repository\n    labelfield: x\n",
+        ));
+        assert!(document.is_err());
+    }
+}

--- a/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
+++ b/src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json
@@ -1,0 +1,6094 @@
+[
+  {
+    "columns": [
+      {
+        "name": "insight_tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "insight_source_type",
+        "type": "String"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "String"
+      },
+      {
+        "name": "source_account_id",
+        "type": "String"
+      },
+      {
+        "name": "field_id",
+        "type": "String"
+      },
+      {
+        "name": "value_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "value_label",
+        "type": "String"
+      },
+      {
+        "name": "valid_from",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "valid_to",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "ingested_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "account_attribute_values",
+    "sorting_key": "insight_tenant_id, insight_source_type, insight_source_id, source_account_id, field_id, valid_from"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "record_id",
+        "type": "String"
+      },
+      {
+        "name": "record_kind",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "record_label",
+        "type": "String"
+      },
+      {
+        "name": "contribution",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      },
+      {
+        "name": "details",
+        "type": "Map(String, String)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ai_cost_metric_evidence",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date, record_id"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "value",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ai_cost_metric_observations",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "record_id",
+        "type": "String"
+      },
+      {
+        "name": "record_kind",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "record_label",
+        "type": "String"
+      },
+      {
+        "name": "contribution",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      },
+      {
+        "name": "details",
+        "type": "Map(String, String)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ai_metric_evidence",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date, record_id"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "value",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ai_metric_observations",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "source_database",
+        "type": "LowCardinality(String)"
+      },
+      {
+        "name": "connector",
+        "type": "LowCardinality(String)"
+      },
+      {
+        "name": "stream",
+        "type": "LowCardinality(String)"
+      },
+      {
+        "name": "extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "insight",
+    "engine": "View",
+    "relation": "bronze_insert_events",
+    "sorting_key": ""
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "source_entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "record_id",
+        "type": "String"
+      },
+      {
+        "name": "record_kind",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "record_label",
+        "type": "String"
+      },
+      {
+        "name": "contribution",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      },
+      {
+        "name": "details",
+        "type": "Map(String, Nullable(String))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ci_metric_evidence",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date, record_id"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "value",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "ci_metric_observations",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "record_id",
+        "type": "String"
+      },
+      {
+        "name": "record_kind",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "record_label",
+        "type": "String"
+      },
+      {
+        "name": "contribution",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      },
+      {
+        "name": "details",
+        "type": "Map(String, String)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "collab_metric_evidence",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date, record_id"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "value",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "collab_metric_observations",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "committer_date",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "branch_scope_value",
+        "type": "String"
+      },
+      {
+        "name": "branch_scope_label",
+        "type": "String"
+      },
+      {
+        "name": "project_value",
+        "type": "String"
+      },
+      {
+        "name": "project_label",
+        "type": "String"
+      },
+      {
+        "name": "repository_value",
+        "type": "String"
+      },
+      {
+        "name": "repository_label",
+        "type": "String"
+      },
+      {
+        "name": "source_value",
+        "type": "String"
+      },
+      {
+        "name": "source_label",
+        "type": "String"
+      },
+      {
+        "name": "source_dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_authored_commits",
+    "sorting_key": "tenant_id, data_source, commit_hash"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "file_path",
+        "type": "String"
+      },
+      {
+        "name": "file_extension",
+        "type": "String"
+      },
+      {
+        "name": "change_type",
+        "type": "String"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_authored_file_changes",
+    "sorting_key": "tenant_id, data_source, commit_hash"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "committer_date",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "file_path",
+        "type": "String"
+      },
+      {
+        "name": "file_extension",
+        "type": "String"
+      },
+      {
+        "name": "change_type",
+        "type": "String"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "pre_image_oid",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "post_image_oid",
+        "type": "Nullable(String)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_commit_file_changes",
+    "sorting_key": "tenant_id, data_source, commit_hash"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "file_change_rows",
+        "type": "UInt64"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_commit_file_line_totals",
+    "sorting_key": "tenant_id, data_source, commit_hash"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "author_email",
+        "type": "String"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "authored_at",
+        "type": "DateTime"
+      },
+      {
+        "name": "authored_date",
+        "type": "Date"
+      },
+      {
+        "name": "branch_scope",
+        "type": "String"
+      },
+      {
+        "name": "branch_scope_label",
+        "type": "String"
+      },
+      {
+        "name": "repository",
+        "type": "String"
+      },
+      {
+        "name": "repository_label",
+        "type": "String"
+      },
+      {
+        "name": "project",
+        "type": "String"
+      },
+      {
+        "name": "project_label",
+        "type": "String"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "source_label",
+        "type": "String"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_commits",
+    "sorting_key": "tenant_id, author_email, authored_at"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_default_branch_commits",
+    "sorting_key": "tenant_id, source_id, project_key, repo_slug, commit_hash"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "reason",
+        "type": "String"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_derived_commits",
+    "sorting_key": "tenant_id, data_source, commit_hash"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "commits",
+        "type": "UInt64"
+      },
+      {
+        "name": "commits_requiring_file_changes",
+        "type": "UInt64"
+      },
+      {
+        "name": "known_zero_size_commits",
+        "type": "UInt64"
+      },
+      {
+        "name": "unknown_size_commits",
+        "type": "UInt64"
+      },
+      {
+        "name": "commits_with_file_changes",
+        "type": "UInt64"
+      },
+      {
+        "name": "collected_pct",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "recent_commits_requiring_file_changes",
+        "type": "UInt64"
+      },
+      {
+        "name": "recent_collected_pct",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "uncollected_lines",
+        "type": "Int64"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_file_change_coverage",
+    "sorting_key": "tenant_id, data_source, source_id"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "file_path",
+        "type": "String"
+      },
+      {
+        "name": "author_email",
+        "type": "String"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "authored_at",
+        "type": "DateTime"
+      },
+      {
+        "name": "authored_date",
+        "type": "Date"
+      },
+      {
+        "name": "category",
+        "type": "String"
+      },
+      {
+        "name": "category_label",
+        "type": "String"
+      },
+      {
+        "name": "file_extension",
+        "type": "String"
+      },
+      {
+        "name": "file_extension_label",
+        "type": "String"
+      },
+      {
+        "name": "change_type",
+        "type": "String"
+      },
+      {
+        "name": "change_type_label",
+        "type": "String"
+      },
+      {
+        "name": "branch_scope",
+        "type": "String"
+      },
+      {
+        "name": "branch_scope_label",
+        "type": "String"
+      },
+      {
+        "name": "repository",
+        "type": "String"
+      },
+      {
+        "name": "repository_label",
+        "type": "String"
+      },
+      {
+        "name": "project",
+        "type": "String"
+      },
+      {
+        "name": "project_label",
+        "type": "String"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "source_label",
+        "type": "String"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_file_changes",
+    "sorting_key": "tenant_id, author_email, authored_at"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "record_id",
+        "type": "String"
+      },
+      {
+        "name": "record_kind",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "record_label",
+        "type": "String"
+      },
+      {
+        "name": "contribution",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      },
+      {
+        "name": "details",
+        "type": "Map(String, String)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_metric_evidence",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date, record_id"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "value",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_metric_observations",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "event_kind",
+        "type": "String"
+      },
+      {
+        "name": "event_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "pr_id",
+        "type": "Int64"
+      },
+      {
+        "name": "pr_number",
+        "type": "Int64"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "title",
+        "type": "String"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "author_email",
+        "type": "String"
+      },
+      {
+        "name": "actor_person_id",
+        "type": "String"
+      },
+      {
+        "name": "author_person_id",
+        "type": "String"
+      },
+      {
+        "name": "comment_target_value",
+        "type": "String"
+      },
+      {
+        "name": "comment_target_label",
+        "type": "String"
+      },
+      {
+        "name": "project_value",
+        "type": "String"
+      },
+      {
+        "name": "project_label",
+        "type": "String"
+      },
+      {
+        "name": "repository_value",
+        "type": "String"
+      },
+      {
+        "name": "repository_label",
+        "type": "String"
+      },
+      {
+        "name": "destination_branch_value",
+        "type": "String"
+      },
+      {
+        "name": "destination_branch_label",
+        "type": "String"
+      },
+      {
+        "name": "source_value",
+        "type": "String"
+      },
+      {
+        "name": "source_label",
+        "type": "String"
+      },
+      {
+        "name": "source_dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_review_events",
+    "sorting_key": "tenant_id, entity_id, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "file_path",
+        "type": "String"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "git_superseded_file_changes",
+    "sorting_key": "tenant_id, data_source, commit_hash"
+  },
+  {
+    "columns": [
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "observation_rows",
+        "type": "UInt64"
+      },
+      {
+        "name": "unresolved_rows",
+        "type": "UInt64"
+      },
+      {
+        "name": "unresolved_people",
+        "type": "UInt64"
+      },
+      {
+        "name": "match_rate_pct",
+        "type": "Float64"
+      }
+    ],
+    "database": "insight",
+    "engine": "View",
+    "relation": "identity_resolution_coverage",
+    "sorting_key": ""
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "cohort_key",
+        "type": "String"
+      },
+      {
+        "name": "cohort_id",
+        "type": "Nullable(String)"
+      }
+    ],
+    "database": "insight",
+    "engine": "View",
+    "relation": "metric_entity_cohorts_current",
+    "sorting_key": ""
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "entity_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "issue_id",
+        "type": "String"
+      },
+      {
+        "name": "id_readable",
+        "type": "String"
+      },
+      {
+        "name": "title",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "status_category",
+        "type": "String"
+      },
+      {
+        "name": "issue_type",
+        "type": "String"
+      },
+      {
+        "name": "issue_kind",
+        "type": "String"
+      },
+      {
+        "name": "issue_type_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "issue_type_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "due_date",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "time_estimate_seconds",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "time_spent_seconds",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "created_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "final_close_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "last_status_event_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "task_issue_state",
+    "sorting_key": "insight_source_id, issue_id"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "record_id",
+        "type": "String"
+      },
+      {
+        "name": "record_kind",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "record_label",
+        "type": "String"
+      },
+      {
+        "name": "contribution",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      },
+      {
+        "name": "details",
+        "type": "Map(String, String)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "task_metric_evidence",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date, record_id"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "value",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "task_metric_observations",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "insight_source_id",
+        "type": "String"
+      },
+      {
+        "name": "issue_id",
+        "type": "String"
+      },
+      {
+        "name": "interval_start",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "interval_end",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "status_category",
+        "type": "String"
+      },
+      {
+        "name": "duration_seconds",
+        "type": "Float64"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "task_status_spans",
+    "sorting_key": "insight_source_id, issue_id, interval_start"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "in_progress_seconds",
+        "type": "Float64"
+      },
+      {
+        "name": "worklog_seconds",
+        "type": "Float64"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "task_worklog_flow",
+    "sorting_key": "tenant_id, entity_id, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "record_id",
+        "type": "String"
+      },
+      {
+        "name": "record_kind",
+        "type": "String"
+      },
+      {
+        "name": "granularity",
+        "type": "String"
+      },
+      {
+        "name": "record_label",
+        "type": "String"
+      },
+      {
+        "name": "contribution",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      },
+      {
+        "name": "details",
+        "type": "Map(String, String)"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "wiki_metric_evidence",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date, record_id"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "source_key",
+        "type": "String"
+      },
+      {
+        "name": "entity_type",
+        "type": "String"
+      },
+      {
+        "name": "entity_id",
+        "type": "String"
+      },
+      {
+        "name": "account_source_type",
+        "type": "String"
+      },
+      {
+        "name": "account_source_id",
+        "type": "String"
+      },
+      {
+        "name": "account_id",
+        "type": "String"
+      },
+      {
+        "name": "metric_date",
+        "type": "Date"
+      },
+      {
+        "name": "observed_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "measure_key",
+        "type": "String"
+      },
+      {
+        "name": "value",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "subject_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "dimensions",
+        "type": "Array(Tuple(key String, value String, label Nullable(String)))"
+      }
+    ],
+    "database": "insight",
+    "engine": "MergeTree",
+    "relation": "wiki_metric_observations",
+    "sorting_key": "tenant_id, source_key, entity_type, entity_id, measure_key, metric_date"
+  },
+  {
+    "columns": [
+      {
+        "name": "insight_tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "String"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "day",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "tool",
+        "type": "String"
+      },
+      {
+        "name": "surface",
+        "type": "String"
+      },
+      {
+        "name": "session_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "conversation_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "message_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "action_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "files_uploaded_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "artifacts_created_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "projects_created_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "projects_used_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "skills_used_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "connectors_used_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "thinking_message_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "dispatch_turn_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "search_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "cost_cents",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "surface_metrics_json",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "collected_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_ai_assistant_usage",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "insight_tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "String"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "api_key_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "day",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "tool",
+        "type": "String"
+      },
+      {
+        "name": "session_count",
+        "type": "UInt32"
+      },
+      {
+        "name": "conversation_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "lines_added",
+        "type": "UInt32"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "total_lines_added",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "total_lines_removed",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "tool_use_offered",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "tool_use_accepted",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "agent_sessions",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "chat_requests",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "cost_cents",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "commits_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "pull_requests_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "prs_with_cc_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "prs_total_count",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "tool_action_breakdown_json",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "collected_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "seat_status",
+        "type": "Nullable(String)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_ai_dev_usage",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "insight_tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "invoice_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "line_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "tool",
+        "type": "String"
+      },
+      {
+        "name": "invoice_status",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "chain_status",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "category",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "tier_label",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "tier_ref",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "is_proration",
+        "type": "UInt8"
+      },
+      {
+        "name": "currency",
+        "type": "String"
+      },
+      {
+        "name": "period_month",
+        "type": "Date"
+      },
+      {
+        "name": "amount_cents",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "seat_unit_cents",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "seat_quantity",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "invoice_net_cents",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "invoice_metrics_json",
+        "type": "String"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "collected_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_ai_invoice",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "insight_tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "String"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "account_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "period_month",
+        "type": "Date"
+      },
+      {
+        "name": "tool",
+        "type": "String"
+      },
+      {
+        "name": "seat_tier",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "currency",
+        "type": "String"
+      },
+      {
+        "name": "credit_limit_cents",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "used_amount_cents",
+        "type": "UInt32"
+      },
+      {
+        "name": "overage_cents",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "is_over_limit",
+        "type": "Nullable(UInt8)"
+      },
+      {
+        "name": "is_enabled",
+        "type": "Nullable(UInt8)"
+      },
+      {
+        "name": "overage_metrics_json",
+        "type": "String"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "collected_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_ai_overage",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "insight_tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "String"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "account_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "snapshot_date",
+        "type": "Date"
+      },
+      {
+        "name": "period_month",
+        "type": "Date"
+      },
+      {
+        "name": "tool",
+        "type": "String"
+      },
+      {
+        "name": "seat_tier",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "currency",
+        "type": "String"
+      },
+      {
+        "name": "credit_limit_cents",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "used_amount_cents",
+        "type": "UInt32"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "collected_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_ai_overage_daily",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(FixedString(16))"
+      },
+      {
+        "name": "user_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "user_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "person_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "date",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "direct_messages",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "group_chat_messages",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "direct_and_group_messages",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "total_chat_messages",
+        "type": "Int64"
+      },
+      {
+        "name": "channel_posts",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "channel_replies",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "urgent_messages",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "report_period",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_collab_chat_activity",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(FixedString(16))"
+      },
+      {
+        "name": "user_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "user_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "person_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "date",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "product",
+        "type": "String"
+      },
+      {
+        "name": "viewed_or_edited_count",
+        "type": "Nullable(Decimal(38, 9))"
+      },
+      {
+        "name": "synced_count",
+        "type": "Nullable(Decimal(38, 9))"
+      },
+      {
+        "name": "shared_internally_count",
+        "type": "Nullable(Decimal(38, 9))"
+      },
+      {
+        "name": "shared_externally_count",
+        "type": "Nullable(Decimal(38, 9))"
+      },
+      {
+        "name": "visited_page_count",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "report_period",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_collab_document_activity",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(FixedString(16))"
+      },
+      {
+        "name": "user_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "user_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "person_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "date",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "sent_count",
+        "type": "Nullable(Decimal(38, 9))"
+      },
+      {
+        "name": "received_count",
+        "type": "Nullable(Decimal(38, 9))"
+      },
+      {
+        "name": "read_count",
+        "type": "Nullable(Decimal(38, 9))"
+      },
+      {
+        "name": "meetings_created",
+        "type": "Nullable(Decimal(38, 9))"
+      },
+      {
+        "name": "meetings_interacted",
+        "type": "Nullable(Decimal(38, 9))"
+      },
+      {
+        "name": "report_period",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_collab_email_activity",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(FixedString(16))"
+      },
+      {
+        "name": "user_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "user_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "person_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "date",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "calls_count",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "meetings_organized",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "meetings_attended",
+        "type": "Int64"
+      },
+      {
+        "name": "adhoc_meetings_organized",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "adhoc_meetings_attended",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "scheduled_meetings_organized",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "scheduled_meetings_attended",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "audio_duration_seconds",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "video_duration_seconds",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "screen_share_duration_seconds",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "report_period",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_collab_meeting_activity",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "account_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "domain",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "industry",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "owner_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "parent_account_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "metadata",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "updated_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "data_source",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_crm_accounts",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "activity_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "activity_type",
+        "type": "String"
+      },
+      {
+        "name": "owner_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "created_by_user_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "contact_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "deal_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "account_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "timestamp",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "duration_seconds",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "outcome",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "metadata",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "data_source",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_crm_activities",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "contact_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "first_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "last_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "owner_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "account_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "lifecycle_stage",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "metadata",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "updated_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "data_source",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_crm_contacts",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "deal_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "forecast_category",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "stage",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "amount",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "amount_home",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "acv",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "tcv",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "arr",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "close_date",
+        "type": "Nullable(Date32)"
+      },
+      {
+        "name": "owner_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "created_by_user_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "account_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "is_closed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "is_won",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lead_source",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "probability",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "deal_type",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "lost_reason",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "pipeline_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "metadata",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "updated_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "data_source",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_crm_deals",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "user_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "hs_user_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "first_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "last_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "title",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "department",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "is_active",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "metadata",
+        "type": "String"
+      },
+      {
+        "name": "collected_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "data_source",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_crm_users",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "insight_tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "day",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "meetings_count",
+        "type": "Int64"
+      },
+      {
+        "name": "meeting_hours",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "working_hours_per_day",
+        "type": "Float64"
+      },
+      {
+        "name": "focus_time_pct",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "dev_time_h",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_focus_metrics",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "repo_full_name",
+        "type": "String"
+      },
+      {
+        "name": "pipeline_key",
+        "type": "String"
+      },
+      {
+        "name": "pipeline_name",
+        "type": "String"
+      },
+      {
+        "name": "run_id",
+        "type": "Int64"
+      },
+      {
+        "name": "run_number",
+        "type": "Int64"
+      },
+      {
+        "name": "attempt",
+        "type": "Int64"
+      },
+      {
+        "name": "is_retry",
+        "type": "UInt8"
+      },
+      {
+        "name": "trigger_category",
+        "type": "String"
+      },
+      {
+        "name": "trigger_raw",
+        "type": "String"
+      },
+      {
+        "name": "outcome",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "is_gate",
+        "type": "UInt8"
+      },
+      {
+        "name": "branch",
+        "type": "String"
+      },
+      {
+        "name": "commit_sha",
+        "type": "String"
+      },
+      {
+        "name": "actor_login",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "started_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "finished_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "duration_s",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_ci_runs",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "branch",
+        "type": "String"
+      },
+      {
+        "name": "is_default_branch",
+        "type": "Nullable(UInt8)"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "author_email",
+        "type": "String"
+      },
+      {
+        "name": "committer_name",
+        "type": "String"
+      },
+      {
+        "name": "committer_email",
+        "type": "String"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "date",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "files_changed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "is_merge_commit",
+        "type": "UInt8"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "patch_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "committer_date",
+        "type": "Nullable(DateTime)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_commits",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "repo_full_name",
+        "type": "String"
+      },
+      {
+        "name": "deployment_id",
+        "type": "String"
+      },
+      {
+        "name": "event_id",
+        "type": "Int64"
+      },
+      {
+        "name": "state",
+        "type": "String"
+      },
+      {
+        "name": "environment",
+        "type": "String"
+      },
+      {
+        "name": "creator_login",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_deployment_events",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "repo_full_name",
+        "type": "String"
+      },
+      {
+        "name": "deployment_id",
+        "type": "String"
+      },
+      {
+        "name": "environment",
+        "type": "String"
+      },
+      {
+        "name": "is_production",
+        "type": "UInt8"
+      },
+      {
+        "name": "is_transient",
+        "type": "UInt8"
+      },
+      {
+        "name": "ref",
+        "type": "String"
+      },
+      {
+        "name": "commit_sha",
+        "type": "String"
+      },
+      {
+        "name": "task",
+        "type": "String"
+      },
+      {
+        "name": "creator_login",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_deployments",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "file_path",
+        "type": "String"
+      },
+      {
+        "name": "file_extension",
+        "type": "String"
+      },
+      {
+        "name": "change_type",
+        "type": "String"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "source_type",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "pre_image_oid",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "post_image_oid",
+        "type": "Nullable(String)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_file_changes",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "item_type",
+        "type": "String"
+      },
+      {
+        "name": "item_number",
+        "type": "Int64"
+      },
+      {
+        "name": "event_id",
+        "type": "String"
+      },
+      {
+        "name": "event_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "actor_name",
+        "type": "String"
+      },
+      {
+        "name": "field_id",
+        "type": "String"
+      },
+      {
+        "name": "delta_action",
+        "type": "String"
+      },
+      {
+        "name": "delta_value_id",
+        "type": "String"
+      },
+      {
+        "name": "delta_value_display",
+        "type": "String"
+      },
+      {
+        "name": "prev_value_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "prev_value_display",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_item_events",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "pr_id",
+        "type": "Int64"
+      },
+      {
+        "name": "pr_number",
+        "type": "Int64"
+      },
+      {
+        "name": "event_kind",
+        "type": "String"
+      },
+      {
+        "name": "review_state",
+        "type": "String"
+      },
+      {
+        "name": "actor_login",
+        "type": "String"
+      },
+      {
+        "name": "actor_name",
+        "type": "String"
+      },
+      {
+        "name": "actor_account_id",
+        "type": "String"
+      },
+      {
+        "name": "actor_email",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_pr_review_events",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "pr_id",
+        "type": "Int64"
+      },
+      {
+        "name": "pr_number",
+        "type": "Int64"
+      },
+      {
+        "name": "title",
+        "type": "String"
+      },
+      {
+        "name": "description",
+        "type": "String"
+      },
+      {
+        "name": "state",
+        "type": "String"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "author_email",
+        "type": "String"
+      },
+      {
+        "name": "author_account_id",
+        "type": "String"
+      },
+      {
+        "name": "source_branch",
+        "type": "String"
+      },
+      {
+        "name": "destination_branch",
+        "type": "String"
+      },
+      {
+        "name": "created_on",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "updated_on",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "closed_on",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "merge_commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "files_changed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_pull_requests",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "pr_id",
+        "type": "Int64"
+      },
+      {
+        "name": "comment_id",
+        "type": "Int64"
+      },
+      {
+        "name": "content",
+        "type": "String"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "author_uuid",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "updated_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "is_inline",
+        "type": "UInt8"
+      },
+      {
+        "name": "file_path",
+        "type": "String"
+      },
+      {
+        "name": "line_number",
+        "type": "Int64"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_pull_requests_comments",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "pr_id",
+        "type": "Int64"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "commit_order",
+        "type": "Int64"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_pull_requests_commits",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "pr_id",
+        "type": "Int64"
+      },
+      {
+        "name": "reviewer_name",
+        "type": "String"
+      },
+      {
+        "name": "reviewer_uuid",
+        "type": "String"
+      },
+      {
+        "name": "status",
+        "type": "String"
+      },
+      {
+        "name": "approved",
+        "type": "UInt8"
+      },
+      {
+        "name": "reviewed_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_pull_requests_reviewers",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "repo_uuid",
+        "type": "String"
+      },
+      {
+        "name": "name",
+        "type": "String"
+      },
+      {
+        "name": "full_name",
+        "type": "String"
+      },
+      {
+        "name": "description",
+        "type": "String"
+      },
+      {
+        "name": "is_private",
+        "type": "UInt8"
+      },
+      {
+        "name": "created_on",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "updated_on",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "size",
+        "type": "Int64"
+      },
+      {
+        "name": "language",
+        "type": "String"
+      },
+      {
+        "name": "has_issues",
+        "type": "UInt8"
+      },
+      {
+        "name": "has_wiki",
+        "type": "UInt8"
+      },
+      {
+        "name": "metadata",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "default_branch",
+        "type": "Nullable(String)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_repositories",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "branch_name",
+        "type": "String"
+      },
+      {
+        "name": "is_default",
+        "type": "UInt8"
+      },
+      {
+        "name": "last_commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "last_commit_date",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_git_repository_branches",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "insight_tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_person_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "event_type",
+        "type": "String"
+      },
+      {
+        "name": "event_subtype",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "start_date",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "end_date",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "duration_amount",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "duration_unit",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "request_status",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "ingested_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_hr_events",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "insight_tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_person_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "display_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "employment_type",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "working_hours_per_day",
+        "type": "Float64"
+      },
+      {
+        "name": "working_hours_per_week",
+        "type": "Float64"
+      },
+      {
+        "name": "ingested_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_hr_working_hours",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "String"
+      },
+      {
+        "name": "workspace_id",
+        "type": "String"
+      },
+      {
+        "name": "person_id",
+        "type": "Nullable(UUID)"
+      },
+      {
+        "name": "valid_from",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "source_person_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "employee_number",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "display_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "first_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "last_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "job_title",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "department_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "manager_person_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "status",
+        "type": "String"
+      },
+      {
+        "name": "employment_type",
+        "type": "String"
+      },
+      {
+        "name": "hire_date",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "termination_date",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "location",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "country",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "fte",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "custom_str_attrs",
+        "type": "Map(String, String)"
+      },
+      {
+        "name": "custom_num_attrs",
+        "type": "Map(String, Float64)"
+      },
+      {
+        "name": "ingested_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_people",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "unique_key",
+        "type": "String"
+      },
+      {
+        "name": "insight_tenant_id",
+        "type": "String"
+      },
+      {
+        "name": "insight_source_type",
+        "type": "String"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "String"
+      },
+      {
+        "name": "source_account_id",
+        "type": "String"
+      },
+      {
+        "name": "field_id",
+        "type": "String"
+      },
+      {
+        "name": "value_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "value_label",
+        "type": "String"
+      },
+      {
+        "name": "claim_action",
+        "type": "Enum8('set' = 1, 'clear' = 2)"
+      },
+      {
+        "name": "observed_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "ingested_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_person_attribute_claims",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(FixedString(16))"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "person_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "date",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "updates",
+        "type": "UInt64"
+      },
+      {
+        "name": "public_comments",
+        "type": "UInt64"
+      },
+      {
+        "name": "private_comments",
+        "type": "UInt64"
+      },
+      {
+        "name": "solved",
+        "type": "UInt64"
+      },
+      {
+        "name": "kb_articles_created",
+        "type": "Nullable(UInt32)"
+      },
+      {
+        "name": "csat_good",
+        "type": "UInt64"
+      },
+      {
+        "name": "csat_total",
+        "type": "UInt64"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_support_activity",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "comment_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "id_readable",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "author_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "updated_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "body",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "is_deleted",
+        "type": "Nullable(UInt8)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_task_comments",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "unique_key",
+        "type": "String"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "issue_id",
+        "type": "String"
+      },
+      {
+        "name": "id_readable",
+        "type": "String"
+      },
+      {
+        "name": "title",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "event_id",
+        "type": "String"
+      },
+      {
+        "name": "event_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "event_kind",
+        "type": "Enum8('changelog' = 1, 'synthetic_initial' = 2, 'availability' = 3, 'lifecycle' = 4)"
+      },
+      {
+        "name": "_seq",
+        "type": "UInt32"
+      },
+      {
+        "name": "author_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "field_id",
+        "type": "String"
+      },
+      {
+        "name": "field_name",
+        "type": "String"
+      },
+      {
+        "name": "field_cardinality",
+        "type": "Enum8('single' = 1, 'multi' = 2)"
+      },
+      {
+        "name": "delta_action",
+        "type": "Enum8('set' = 1, 'add' = 2, 'remove' = 3)"
+      },
+      {
+        "name": "value_ids",
+        "type": "Array(String)"
+      },
+      {
+        "name": "value_displays",
+        "type": "Array(String)"
+      },
+      {
+        "name": "value_id_type",
+        "type": "Enum8('opaque_id' = 1, 'account_id' = 2, 'string_literal' = 3, 'path' = 4, 'none' = 5)"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "_version",
+        "type": "UInt64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_task_field_history",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "project_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "field_id",
+        "type": "String"
+      },
+      {
+        "name": "field_name",
+        "type": "String"
+      },
+      {
+        "name": "is_multi",
+        "type": "UInt8"
+      },
+      {
+        "name": "field_type",
+        "type": "String"
+      },
+      {
+        "name": "has_id",
+        "type": "UInt8"
+      },
+      {
+        "name": "observed_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_task_field_metadata",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "issue_type_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "issue_type_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "untranslated_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "issue_kind",
+        "type": "String"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_task_issuetypes",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "unique_key",
+        "type": "String"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "id_readable",
+        "type": "String"
+      },
+      {
+        "name": "link_type",
+        "type": "String"
+      },
+      {
+        "name": "target_type",
+        "type": "Enum8('issue' = 1, 'pull_request' = 2)"
+      },
+      {
+        "name": "target_readable",
+        "type": "String"
+      },
+      {
+        "name": "is_cross_repository",
+        "type": "Bool"
+      },
+      {
+        "name": "valid_from",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "valid_from_known",
+        "type": "UInt8"
+      },
+      {
+        "name": "valid_to",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "added_by",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "removed_by",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "evidence",
+        "type": "Enum8('event' = 1, 'observation' = 2)"
+      },
+      {
+        "name": "origin_event_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "_version",
+        "type": "UInt64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_task_links",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "project_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "lead_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_type",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_style",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "archived",
+        "type": "Nullable(UInt8)"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_task_projects",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "sprint_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "board_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "board_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "sprint_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "state",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "start_date",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "end_date",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "complete_date",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_task_sprints",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "status_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "status_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "category_id",
+        "type": "Nullable(Int32)"
+      },
+      {
+        "name": "category_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "status_category",
+        "type": "String"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_task_statuses",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "user_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "display_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "username",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "account_type",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "is_active",
+        "type": "Nullable(UInt8)"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime64(3)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_task_users",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "worklog_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "id_readable",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "author_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "work_date",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "duration_seconds",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "description",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "collected_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "is_deleted",
+        "type": "Nullable(UInt8)"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_task_worklogs",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "String"
+      },
+      {
+        "name": "author_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "author_email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "day",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "pages_edited",
+        "type": "UInt32"
+      },
+      {
+        "name": "total_edits",
+        "type": "UInt32"
+      },
+      {
+        "name": "pages_created",
+        "type": "UInt32"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "collected_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_wiki_activity",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "String"
+      },
+      {
+        "name": "page_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "day",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "total_comments",
+        "type": "UInt32"
+      },
+      {
+        "name": "footer_comments",
+        "type": "UInt32"
+      },
+      {
+        "name": "inline_comments",
+        "type": "UInt32"
+      },
+      {
+        "name": "replies",
+        "type": "UInt32"
+      },
+      {
+        "name": "unique_commenters",
+        "type": "UInt32"
+      },
+      {
+        "name": "unresolved_inline_count",
+        "type": "UInt32"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "collected_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_wiki_engagement",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "page_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "space_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "space_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "title",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "status",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "author_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "author_email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "last_editor_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "last_editor_email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "parent_page_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "version_count",
+        "type": "UInt32"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "updated_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "space_url",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source",
+        "type": "String"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "collected_at",
+        "type": "Nullable(DateTime64(3))"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "class_wiki_pages",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "version",
+        "type": "UInt32"
+      }
+    ],
+    "database": "silver",
+    "engine": "View",
+    "relation": "contract_version",
+    "sorting_key": ""
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(FixedString(16))"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "source_agent_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "person_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "email",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "display_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "role_canonical",
+        "type": "String"
+      },
+      {
+        "name": "group_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "group_name",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "is_active",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "dim_support_agent",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(FixedString(16))"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "source_ticket_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "subject",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "status_canonical",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "priority_canonical",
+        "type": "String"
+      },
+      {
+        "name": "type_canonical",
+        "type": "String"
+      },
+      {
+        "name": "assignee_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "assignee_person_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "group_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "requester_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "org_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "created_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "updated_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "solved_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "dim_support_ticket",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "branch",
+        "type": "String"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "author_email",
+        "type": "String"
+      },
+      {
+        "name": "person_key",
+        "type": "String"
+      },
+      {
+        "name": "committer_name",
+        "type": "String"
+      },
+      {
+        "name": "committer_email",
+        "type": "String"
+      },
+      {
+        "name": "message",
+        "type": "String"
+      },
+      {
+        "name": "date",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "week",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "files_changed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "is_merge_commit",
+        "type": "UInt8"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "fct_git_commit",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "file_path",
+        "type": "String"
+      },
+      {
+        "name": "file_extension",
+        "type": "String"
+      },
+      {
+        "name": "change_type",
+        "type": "String"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "file_category",
+        "type": "String"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "author_email",
+        "type": "String"
+      },
+      {
+        "name": "person_key",
+        "type": "String"
+      },
+      {
+        "name": "committed_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "week",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "is_merge_commit",
+        "type": "UInt8"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "fct_git_file_change",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "pr_id",
+        "type": "Int64"
+      },
+      {
+        "name": "pr_number",
+        "type": "Int64"
+      },
+      {
+        "name": "title",
+        "type": "String"
+      },
+      {
+        "name": "state",
+        "type": "String"
+      },
+      {
+        "name": "state_norm",
+        "type": "String"
+      },
+      {
+        "name": "author_name",
+        "type": "String"
+      },
+      {
+        "name": "author_email",
+        "type": "String"
+      },
+      {
+        "name": "person_key",
+        "type": "String"
+      },
+      {
+        "name": "source_branch",
+        "type": "String"
+      },
+      {
+        "name": "destination_branch",
+        "type": "String"
+      },
+      {
+        "name": "created_on",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "updated_on",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "closed_on",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "merge_commit_hash",
+        "type": "String"
+      },
+      {
+        "name": "files_changed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_added",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "lines_removed",
+        "type": "Nullable(Int64)"
+      },
+      {
+        "name": "cycle_time_h",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "fct_git_pr",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "project_key",
+        "type": "String"
+      },
+      {
+        "name": "repo_slug",
+        "type": "String"
+      },
+      {
+        "name": "pr_id",
+        "type": "Int64"
+      },
+      {
+        "name": "reviewer_name",
+        "type": "String"
+      },
+      {
+        "name": "reviewer_uuid",
+        "type": "String"
+      },
+      {
+        "name": "person_key",
+        "type": "String"
+      },
+      {
+        "name": "status",
+        "type": "String"
+      },
+      {
+        "name": "approved",
+        "type": "UInt8"
+      },
+      {
+        "name": "reviewed_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      },
+      {
+        "name": "_airbyte_extracted_at",
+        "type": "DateTime64(3)"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "fct_git_review",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "person_key",
+        "type": "String"
+      },
+      {
+        "name": "unique_key",
+        "type": "String"
+      },
+      {
+        "name": "prs_created",
+        "type": "UInt64"
+      },
+      {
+        "name": "prs_merged",
+        "type": "UInt64"
+      },
+      {
+        "name": "avg_pr_cycle_time_h",
+        "type": "Nullable(Float64)"
+      },
+      {
+        "name": "commits",
+        "type": "UInt64"
+      },
+      {
+        "name": "loc",
+        "type": "Int64"
+      },
+      {
+        "name": "clean_loc",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "mtr_git_person_totals",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "person_key",
+        "type": "String"
+      },
+      {
+        "name": "week",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "commits",
+        "type": "UInt64"
+      },
+      {
+        "name": "prs_merged",
+        "type": "UInt64"
+      },
+      {
+        "name": "code_loc",
+        "type": "Int64"
+      },
+      {
+        "name": "spec_lines",
+        "type": "Int64"
+      },
+      {
+        "name": "config_loc",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "mtr_git_person_weekly",
+    "sorting_key": "unique_key"
+  },
+  {
+    "columns": [
+      {
+        "name": "tenant_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "insight_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "unique_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "data_source",
+        "type": "String"
+      },
+      {
+        "name": "ticket_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "source_ticket_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "actor_person_key",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "actor_source_id",
+        "type": "Nullable(String)"
+      },
+      {
+        "name": "event_type",
+        "type": "String"
+      },
+      {
+        "name": "is_public",
+        "type": "Nullable(UInt8)"
+      },
+      {
+        "name": "occurred_at",
+        "type": "Nullable(DateTime)"
+      },
+      {
+        "name": "metric_date",
+        "type": "Nullable(Date)"
+      },
+      {
+        "name": "collected_at",
+        "type": "DateTime"
+      },
+      {
+        "name": "_version",
+        "type": "Int64"
+      }
+    ],
+    "database": "silver",
+    "engine": "ReplacingMergeTree",
+    "relation": "zendesk__support_event",
+    "sorting_key": "unique_key"
+  }
+]

--- a/src/backend/services/analytics/src/domain/field_catalog/loader.rs
+++ b/src/backend/services/analytics/src/domain/field_catalog/loader.rs
@@ -1,0 +1,128 @@
+//! Parses the schema snapshot into the catalog.
+
+use serde::Deserialize;
+
+use super::model::{CatalogColumn, CatalogRelation, FieldCatalog, FieldType, ReadDiscipline};
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CatalogError {
+    #[error("schema snapshot does not parse: {0}")]
+    Snapshot(String),
+    #[error("schema snapshot carries `{database}.{relation}` twice")]
+    DuplicateRelation { database: String, relation: String },
+}
+
+#[derive(Debug, Deserialize)]
+struct SnapshotRelation {
+    database: String,
+    relation: String,
+    engine: String,
+    columns: Vec<SnapshotColumn>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SnapshotColumn {
+    name: String,
+    #[serde(rename = "type")]
+    column_type: String,
+}
+
+pub fn load(snapshot_json: &str) -> Result<FieldCatalog, CatalogError> {
+    let snapshot: Vec<SnapshotRelation> = serde_json::from_str(snapshot_json)
+        .map_err(|error| CatalogError::Snapshot(error.to_string()))?;
+
+    let mut relations: Vec<CatalogRelation> = Vec::with_capacity(snapshot.len());
+    for raw in snapshot {
+        if relations
+            .iter()
+            .any(|seen| seen.database == raw.database && seen.relation == raw.relation)
+        {
+            return Err(CatalogError::DuplicateRelation {
+                database: raw.database,
+                relation: raw.relation,
+            });
+        }
+
+        relations.push(CatalogRelation {
+            read_discipline: ReadDiscipline::for_engine(&raw.engine),
+            columns: raw
+                .columns
+                .into_iter()
+                .map(|column| CatalogColumn {
+                    name: column.name,
+                    field_type: FieldType::parse(&column.column_type),
+                })
+                .collect(),
+            database: raw.database,
+            relation: raw.relation,
+        });
+    }
+
+    Ok(FieldCatalog { relations })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::field_catalog::model::TypeClass;
+
+    const SNAPSHOT: &str = r#"[
+      {
+        "database": "insight",
+        "relation": "git_commits",
+        "engine": "MergeTree",
+        "sorting_key": "tenant_id, author_email, authored_at",
+        "columns": [
+          {"name": "tenant_id", "type": "Nullable(String)"},
+          {"name": "authored_at", "type": "DateTime"},
+          {"name": "lines_added", "type": "Nullable(Int64)"},
+          {"name": "payload", "type": "Map(String, String)"}
+        ]
+      }
+    ]"#;
+
+    #[test]
+    fn a_snapshot_relation_becomes_typed_columns_with_a_read_discipline() {
+        let catalog = load(SNAPSHOT).expect("the snapshot parses");
+        let relation = catalog
+            .relation("insight", "git_commits")
+            .expect("the relation is catalogued");
+
+        assert_eq!(relation.read_discipline, ReadDiscipline::Plain);
+
+        let tenant = relation.column("tenant_id").expect("column is present");
+        assert_eq!(tenant.field_type.class, TypeClass::Text);
+        assert!(tenant.field_type.nullable);
+
+        let composite = relation.column("payload").expect("column is present");
+        assert_eq!(composite.field_type.class, TypeClass::Composite);
+    }
+
+    #[test]
+    fn a_relation_the_snapshot_lacks_is_absent_rather_than_invented() {
+        let catalog = load(SNAPSHOT).expect("the snapshot parses");
+        assert!(catalog.relation("insight", "git_tags").is_none());
+        assert!(catalog.relation("silver", "git_commits").is_none());
+    }
+
+    #[test]
+    fn a_snapshot_repeating_a_relation_is_rejected() {
+        let doubled = format!("[{0},{0}]", &SNAPSHOT[1..SNAPSHOT.len() - 1]);
+        assert_eq!(
+            load(&doubled),
+            Err(CatalogError::DuplicateRelation {
+                database: "insight".to_owned(),
+                relation: "git_commits".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_snapshot_that_is_not_the_expected_shape_is_rejected() {
+        assert!(matches!(
+            load("{\"relations\": []}"),
+            Err(CatalogError::Snapshot(_))
+        ));
+    }
+}

--- a/src/backend/services/analytics/src/domain/field_catalog/mod.rs
+++ b/src/backend/services/analytics/src/domain/field_catalog/mod.rs
@@ -1,0 +1,46 @@
+//! Every warehouse relation the service may read, with the type of every column.
+//!
+//! INVARIANT: `columns.snapshot.json` is compiled in, so a declaration naming a
+//! column the warehouse does not carry fails a test run rather than a request.
+
+pub mod loader;
+pub mod model;
+
+use std::sync::OnceLock;
+
+use loader::CatalogError;
+use model::FieldCatalog;
+
+const COLUMN_SNAPSHOT: &str = include_str!("columns.snapshot.json");
+
+pub fn product_catalog() -> Result<&'static FieldCatalog, &'static CatalogError> {
+    static CATALOG: OnceLock<Result<FieldCatalog, CatalogError>> = OnceLock::new();
+    CATALOG
+        .get_or_init(|| loader::load(COLUMN_SNAPSHOT))
+        .as_ref()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_shipped_snapshot_loads() {
+        let catalog = product_catalog().expect("the shipped snapshot parses");
+        assert!(!catalog.relations.is_empty());
+    }
+
+    #[test]
+    fn every_catalogued_relation_names_at_least_one_column() {
+        let catalog = product_catalog().expect("the shipped snapshot parses");
+        for relation in &catalog.relations {
+            assert!(
+                !relation.columns.is_empty(),
+                "{}.{} carries no columns",
+                relation.database,
+                relation.relation
+            );
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/field_catalog/model.rs
+++ b/src/backend/services/analytics/src/domain/field_catalog/model.rs
@@ -1,0 +1,195 @@
+//! The relations the warehouse carries and the type of every column in them.
+
+/// A column's type, normalized from the warehouse's spelling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FieldType {
+    pub class: TypeClass,
+    pub nullable: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeClass {
+    Text,
+    Number,
+    Boolean,
+    Date,
+    Timestamp,
+    Uuid,
+    /// INVARIANT: never groupable or measurable.
+    Composite,
+}
+
+/// How a relation must be scanned for its rows to be the deduplicated truth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadDiscipline {
+    Plain,
+    /// A replacing engine: every read must collapse superseded rows.
+    Final,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogColumn {
+    pub name: String,
+    pub field_type: FieldType,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogRelation {
+    pub database: String,
+    pub relation: String,
+    pub read_discipline: ReadDiscipline,
+    pub columns: Vec<CatalogColumn>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldCatalog {
+    pub relations: Vec<CatalogRelation>,
+}
+
+impl FieldType {
+    // SAFETY: an unknown type name is admitted as composite, so a declaration
+    // naming the column is refused rather than the column silently invented.
+    pub fn parse(raw: &str) -> Self {
+        let trimmed = raw.trim();
+        if let Some(inner) = strip_wrapper(trimmed, "Nullable") {
+            return Self {
+                class: Self::parse(inner).class,
+                nullable: true,
+            };
+        }
+        if let Some(inner) = strip_wrapper(trimmed, "LowCardinality") {
+            return Self::parse(inner);
+        }
+
+        let head = trimmed
+            .split_once('(')
+            .map_or(trimmed, |(head, _)| head)
+            .trim();
+        let class = match head {
+            "String" | "FixedString" | "IPv4" | "IPv6" => TypeClass::Text,
+            _ if head.starts_with("Enum") => TypeClass::Text,
+            "Bool" => TypeClass::Boolean,
+            "Date" | "Date32" => TypeClass::Date,
+            "DateTime" | "DateTime64" => TypeClass::Timestamp,
+            "UUID" => TypeClass::Uuid,
+            "Float32" | "Float64" | "Decimal" => TypeClass::Number,
+            _ if head.starts_with("Int") || head.starts_with("UInt") => TypeClass::Number,
+            _ => TypeClass::Composite,
+        };
+
+        Self {
+            class,
+            nullable: false,
+        }
+    }
+}
+
+impl ReadDiscipline {
+    // INVARIANT: an engine that folds rows at merge time keeps the unfolded rows
+    // until a merge that may never come, so every read of one must collapse
+    // them. The family name is matched anywhere in the engine name, so the
+    // Replicated and Versioned forms fold the same way.
+    pub fn for_engine(engine: &str) -> Self {
+        const FOLDING_FAMILIES: [&str; 4] = ["Replacing", "Collapsing", "Summing", "Aggregating"];
+        if FOLDING_FAMILIES
+            .iter()
+            .any(|family| engine.contains(family))
+        {
+            Self::Final
+        } else {
+            Self::Plain
+        }
+    }
+}
+
+impl CatalogRelation {
+    pub fn column(&self, name: &str) -> Option<&CatalogColumn> {
+        self.columns.iter().find(|column| column.name == name)
+    }
+}
+
+impl FieldCatalog {
+    pub fn relation(&self, database: &str, relation: &str) -> Option<&CatalogRelation> {
+        self.relations
+            .iter()
+            .find(|candidate| candidate.database == database && candidate.relation == relation)
+    }
+}
+
+fn strip_wrapper<'a>(raw: &'a str, wrapper: &str) -> Option<&'a str> {
+    raw.strip_prefix(wrapper)
+        .and_then(|rest| rest.strip_prefix('('))
+        .and_then(|rest| rest.strip_suffix(')'))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clickhouse_types_map_to_classes() {
+        let cases = [
+            ("String", TypeClass::Text, false),
+            ("Nullable(String)", TypeClass::Text, true),
+            ("Enum8('set' = 1, 'add' = 2)", TypeClass::Text, false),
+            ("LowCardinality(String)", TypeClass::Text, false),
+            ("Nullable(LowCardinality(String))", TypeClass::Text, true),
+            ("Int64", TypeClass::Number, false),
+            ("Nullable(UInt8)", TypeClass::Number, true),
+            ("Nullable(Decimal(38, 9))", TypeClass::Number, true),
+            ("Float64", TypeClass::Number, false),
+            ("Date", TypeClass::Date, false),
+            ("Nullable(Date32)", TypeClass::Date, true),
+            ("DateTime64(3)", TypeClass::Timestamp, false),
+            ("Nullable(DateTime)", TypeClass::Timestamp, true),
+            ("Nullable(UUID)", TypeClass::Uuid, true),
+            ("Map(String, String)", TypeClass::Composite, false),
+            ("Array(String)", TypeClass::Composite, false),
+        ];
+
+        for (raw, class, nullable) in cases {
+            let parsed = FieldType::parse(raw);
+            assert_eq!(parsed.class, class, "{raw}");
+            assert_eq!(parsed.nullable, nullable, "{raw}");
+        }
+    }
+
+    #[test]
+    fn an_unknown_type_stays_composite_rather_than_being_guessed() {
+        assert_eq!(
+            FieldType::parse("Variant(String, Int64)").class,
+            TypeClass::Composite
+        );
+    }
+
+    #[test]
+    fn every_engine_that_folds_rows_at_merge_time_must_be_read_collapsed() {
+        let folding = [
+            "ReplacingMergeTree",
+            "ReplicatedReplacingMergeTree",
+            "CollapsingMergeTree",
+            "VersionedCollapsingMergeTree",
+            "ReplicatedVersionedCollapsingMergeTree",
+            "SummingMergeTree",
+            "AggregatingMergeTree",
+            "ReplicatedAggregatingMergeTree",
+        ];
+        for engine in folding {
+            assert_eq!(
+                ReadDiscipline::for_engine(engine),
+                ReadDiscipline::Final,
+                "{engine}"
+            );
+        }
+
+        for engine in ["MergeTree", "ReplicatedMergeTree", "View", "Memory"] {
+            assert_eq!(
+                ReadDiscipline::for_engine(engine),
+                ReadDiscipline::Plain,
+                "{engine}"
+            );
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/mod.rs
+++ b/src/backend/services/analytics/src/domain/mod.rs
@@ -12,6 +12,7 @@ pub mod metric_drilldown;
 pub mod metric_key;
 pub mod metric_results;
 pub(crate) mod person_visibility;
+pub mod query;
 pub mod query_gate;
 pub mod reports;
 pub mod saved_query;

--- a/src/backend/services/analytics/src/domain/mod.rs
+++ b/src/backend/services/analytics/src/domain/mod.rs
@@ -1,8 +1,10 @@
 pub mod ai;
 pub(crate) mod connector_health;
 pub mod contract_version;
+pub mod datasets;
 pub(crate) mod date_window;
 pub mod external_links;
+pub mod field_catalog;
 pub(crate) mod metric_access;
 pub mod metric_crud;
 pub mod metric_definitions;

--- a/src/backend/services/analytics/src/domain/query/answer.rs
+++ b/src/backend/services/analytics/src/domain/query/answer.rs
@@ -1,0 +1,210 @@
+//! Turns what the warehouse returned into the answer's typed table.
+//!
+//! INVARIANT: the statement aliases every column by position, so the decode is
+//! a lookup by alias and never a guess.
+
+use serde_json::{Map, Value};
+
+use super::contract::dto::{AnswerFlags, QueryAnswer};
+use super::plan::{QueryPlan, column_alias};
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AnswerError {
+    #[error("a returned row is not an object")]
+    RowShape,
+    #[error("a returned row reports no `{alias}` for column `{column}`")]
+    ColumnMissing { alias: String, column: String },
+}
+
+// INVARIANT: the statement asked for one row over the limit; a returned set
+// larger than the limit is the truncation signal, and the extra row is dropped.
+pub fn assemble(plan: &QueryPlan<'_>, returned: Vec<Value>) -> Result<QueryAnswer, AnswerError> {
+    let aliases: Vec<String> = (0..plan.columns.len()).map(column_alias).collect();
+    let limit = plan.limit as usize;
+    let truncated = returned.len() > limit;
+
+    let mut rows = Vec::with_capacity(returned.len().min(limit));
+    for row in returned.into_iter().take(limit) {
+        let Value::Object(row) = row else {
+            return Err(AnswerError::RowShape);
+        };
+        rows.push(decode_row(plan, &aliases, &row)?);
+    }
+
+    Ok(QueryAnswer {
+        columns: plan
+            .columns
+            .iter()
+            .map(|column| column.answer.clone())
+            .collect(),
+        rows,
+        flags: AnswerFlags { truncated },
+    })
+}
+
+fn decode_row(
+    plan: &QueryPlan<'_>,
+    aliases: &[String],
+    row: &Map<String, Value>,
+) -> Result<Vec<Value>, AnswerError> {
+    let mut values = Vec::with_capacity(aliases.len());
+    for (alias, column) in aliases.iter().zip(&plan.columns) {
+        let value = row
+            .get(alias)
+            .ok_or_else(|| AnswerError::ColumnMissing {
+                alias: alias.clone(),
+                column: column.answer.name.clone(),
+            })?
+            .clone();
+
+        // INVARIANT: a grouped column is never NULL; an aggregate may be, and
+        // NULL is the answer rather than a zero to fill in.
+        values.push(value);
+    }
+
+    Ok(values)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::query::contract::dto::{ColumnKind, ColumnType};
+    use crate::domain::query::fixtures;
+    use crate::domain::query::validation::plan_against;
+
+    const GROUPED: &str = r#"{
+      "dataset": "git_commits",
+      "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+      "aggregates": [{"name": "commits", "fn": "count"},
+                     {"name": "added", "fn": "sum", "field": "lines_added"}],
+      "time": {"from": "2026-01-01", "to": "2026-01-31", "grain": "week"},
+      "limit": 2
+    }"#;
+
+    fn returned(rows: &str) -> Vec<Value> {
+        serde_json::from_str(rows).expect("the fixture rows parse")
+    }
+
+    #[test]
+    fn an_answer_reports_its_columns_in_the_order_a_row_carries_them() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        let answer = assemble(
+            &plan,
+            returned(
+                r#"[{"c0": "example/app", "c1": "App", "c2": "2026-01-05", "c3": 12, "c4": 340},
+                    {"c0": "example/lib", "c1": "Lib", "c2": "2026-01-05", "c3": 3, "c4": null}]"#,
+            ),
+        )
+        .expect("the rows decode");
+
+        assert_eq!(
+            answer
+                .columns
+                .iter()
+                .map(|column| (column.name.as_str(), column.kind, column.value_type))
+                .collect::<Vec<_>>(),
+            vec![
+                ("repository", ColumnKind::Dimension, ColumnType::Text),
+                ("repository_label", ColumnKind::Label, ColumnType::Text),
+                ("time", ColumnKind::Bucket, ColumnType::Date),
+                ("commits", ColumnKind::Aggregate, ColumnType::Number),
+                ("added", ColumnKind::Aggregate, ColumnType::Number),
+            ]
+        );
+        assert_eq!(
+            answer.rows,
+            vec![
+                returned(r#"["example/app", "App", "2026-01-05", 12, 340]"#),
+                returned(r#"["example/lib", "Lib", "2026-01-05", 3, null]"#),
+            ]
+        );
+        assert!(!answer.flags.truncated);
+    }
+
+    #[test]
+    fn a_result_one_row_over_the_limit_is_reported_truncated_and_clipped_to_the_limit() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        let answer = assemble(
+            &plan,
+            returned(
+                r#"[{"c0": "a", "c1": "A", "c2": "2026-01-05", "c3": 1, "c4": 1},
+                    {"c0": "b", "c1": "B", "c2": "2026-01-05", "c3": 1, "c4": 1},
+                    {"c0": "c", "c1": "C", "c2": "2026-01-05", "c3": 1, "c4": 1}]"#,
+            ),
+        )
+        .expect("the rows decode");
+
+        assert!(answer.flags.truncated);
+        assert_eq!(answer.rows.len(), 2);
+    }
+
+    #[test]
+    fn a_fold_over_nothing_observed_stays_null_rather_than_becoming_zero() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        let answer = assemble(
+            &plan,
+            returned(
+                r#"[{"c0": "example/app", "c1": "App", "c2": "2026-01-05", "c3": 0, "c4": null}]"#,
+            ),
+        )
+        .expect("the rows decode");
+
+        assert_eq!(answer.rows[0][4], Value::Null);
+    }
+
+    #[test]
+    fn an_answer_over_no_rows_still_reports_its_columns() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        let answer = assemble(&plan, Vec::new()).expect("an empty result decodes");
+
+        assert_eq!(answer.columns.len(), 5);
+        assert!(answer.rows.is_empty());
+        assert!(!answer.flags.truncated);
+    }
+
+    #[test]
+    fn a_row_missing_a_column_the_statement_asked_for_is_an_error_not_a_hole() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        let error = assemble(
+            &plan,
+            returned(r#"[{"c0": "example/app", "c1": "App", "c2": "2026-01-05", "c3": 12}]"#),
+        )
+        .expect_err("the row is short");
+
+        assert_eq!(
+            error,
+            AnswerError::ColumnMissing {
+                alias: "c4".to_owned(),
+                column: "added".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_returned_value_that_is_not_a_row_is_an_error() {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(GROUPED);
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        assert_eq!(
+            assemble(&plan, returned("[42]")).expect_err("not a row"),
+            AnswerError::RowShape
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/aggregates.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/aggregates.rs
@@ -1,0 +1,143 @@
+//! The folds a query computes over each group.
+//!
+//! INVARIANT: a fold over nothing observed reports NULL, and `count` — the one
+//! fold whose zero is a real observation — reports 0.
+
+use crate::domain::query::plan::{FoldFn, PlannedAggregate, PlannedFold};
+
+use super::filters;
+use super::params::QueryParam;
+
+pub fn fold_expr(aggregate: &PlannedAggregate<'_>, params: &mut Vec<QueryParam>) -> String {
+    let (function, operand) = match &aggregate.fold {
+        PlannedFold::Rows => ("count", None),
+        PlannedFold::Values {
+            function,
+            measurable,
+        } => (function_name(*function), Some(measurable.field.as_str())),
+    };
+    // A count's zero is a real observation; every other fold saw nothing.
+    let empty = if operand.is_none() { "" } else { "OrNull" };
+
+    let Some(filter) = &aggregate.filter else {
+        return match operand {
+            None => format!("{function}{empty}()"),
+            Some(column) => format!("{function}{empty}({column})"),
+        };
+    };
+
+    // SAFETY: the collapse makes a row the filter is unknown of a definite
+    // non-match rather than a row that silently leaves the fold.
+    let condition = format!("coalesce({}, 0)", filters::render(filter, params));
+    match operand {
+        None => format!("{function}If{empty}({condition})"),
+        Some(column) => format!("{function}If{empty}({column}, {condition})"),
+    }
+}
+
+fn function_name(function: FoldFn) -> &'static str {
+    match function {
+        FoldFn::Sum => "sum",
+        FoldFn::Avg => "avg",
+        FoldFn::Min => "min",
+        FoldFn::Max => "max",
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::datasets::declaration::{Dimension, Measurable};
+    use crate::domain::query::contract::dto::ScalarDto;
+    use crate::domain::query::plan::{FilterTarget, PlannedFilter, PlannedTest};
+
+    fn measurable() -> Measurable {
+        Measurable {
+            field: "lines_added".to_owned(),
+        }
+    }
+
+    fn dimension() -> Dimension {
+        Dimension {
+            field: "source".to_owned(),
+            label_field: None,
+            absent_value: None,
+        }
+    }
+
+    fn on_github(dimension: &Dimension) -> PlannedFilter<'_> {
+        PlannedFilter {
+            target: FilterTarget::Dimension(dimension),
+            test: PlannedTest::Eq(ScalarDto::Text("github".to_owned())),
+        }
+    }
+
+    fn rendered(aggregate: &PlannedAggregate<'_>) -> (String, Vec<QueryParam>) {
+        let mut params = Vec::new();
+        let sql = fold_expr(aggregate, &mut params);
+        (sql, params)
+    }
+
+    fn fold<'d>(fold: PlannedFold<'d>, filter: Option<PlannedFilter<'d>>) -> PlannedAggregate<'d> {
+        PlannedAggregate {
+            index: 0,
+            name: "value".to_owned(),
+            fold,
+            filter,
+        }
+    }
+
+    fn values(function: FoldFn, measurable: &Measurable) -> PlannedFold<'_> {
+        PlannedFold::Values {
+            function,
+            measurable,
+        }
+    }
+
+    #[test]
+    fn every_fold_over_no_observation_reports_null_except_a_count() {
+        let measurable = measurable();
+        let cases = [
+            (PlannedFold::Rows, "count()"),
+            (values(FoldFn::Sum, &measurable), "sumOrNull(lines_added)"),
+            (values(FoldFn::Avg, &measurable), "avgOrNull(lines_added)"),
+            (values(FoldFn::Min, &measurable), "minOrNull(lines_added)"),
+            (values(FoldFn::Max, &measurable), "maxOrNull(lines_added)"),
+        ];
+
+        for (planned, expected) in cases {
+            let label = format!("{planned:?}");
+            let (sql, params) = rendered(&fold(planned, None));
+            assert_eq!(sql, expected, "{label}");
+            assert!(params.is_empty(), "{label}");
+        }
+    }
+
+    #[test]
+    fn a_conditional_fold_treats_an_unknown_condition_as_a_non_match() {
+        let dimension = dimension();
+        let measurable = measurable();
+
+        let (sql, params) = rendered(&fold(
+            values(FoldFn::Sum, &measurable),
+            Some(on_github(&dimension)),
+        ));
+
+        assert_eq!(
+            sql,
+            "sumIfOrNull(lines_added, coalesce(toString(source) = ?, 0))"
+        );
+        assert_eq!(params, vec![QueryParam::Text("github".to_owned())]);
+        assert_eq!(sql.matches('?').count(), params.len());
+    }
+
+    #[test]
+    fn a_conditional_count_folds_rows_and_reads_no_column() {
+        let dimension = dimension();
+
+        let (sql, _) = rendered(&fold(PlannedFold::Rows, Some(on_github(&dimension))));
+
+        assert_eq!(sql, "countIf(coalesce(toString(source) = ?, 0))");
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/filters.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/filters.rs
@@ -1,0 +1,224 @@
+//! Renders one filter into a predicate and the values it binds.
+
+use crate::domain::query::contract::dto::ScalarDto;
+use crate::domain::query::plan::{CompareOp, FilterTarget, PlannedFilter, PlannedTest};
+
+use super::group::dimension_expr;
+use super::params::{QueryParam, placeholders};
+
+pub fn render(filter: &PlannedFilter<'_>, params: &mut Vec<QueryParam>) -> String {
+    let mut bind = |scalar: &ScalarDto| params.push(bound(filter, scalar));
+
+    match &filter.test {
+        // SAFETY: reads the raw column — a dimension's sentinel would answer
+        // that the row always has a value.
+        PlannedTest::NotNull => format!("{} IS NOT NULL", raw_column(filter)),
+        PlannedTest::Eq(value) => {
+            bind(value);
+            format!("{} = ?", comparison_expr(filter))
+        }
+        PlannedTest::Compare(op, value) => {
+            bind(value);
+            format!("{} {} ?", comparison_expr(filter), operator(*op))
+        }
+        PlannedTest::In(values) => {
+            for value in values {
+                bind(value);
+            }
+            format!(
+                "{} IN ({})",
+                comparison_expr(filter),
+                placeholders(values.len())
+            )
+        }
+        PlannedTest::Between { low, high } => {
+            bind(low);
+            bind(high);
+            let expr = comparison_expr(filter);
+            format!("({expr} >= ? AND {expr} <= ?)")
+        }
+        PlannedTest::Like(pattern) => {
+            params.push(QueryParam::Text(pattern.clone()));
+            format!("{} LIKE ?", comparison_expr(filter))
+        }
+        PlannedTest::Matches(pattern) => {
+            params.push(QueryParam::Text(pattern.clone()));
+            format!("match({}, ?)", comparison_expr(filter))
+        }
+    }
+}
+
+fn comparison_expr(filter: &PlannedFilter<'_>) -> String {
+    match filter.target {
+        FilterTarget::Dimension(dimension) => dimension_expr(dimension),
+        FilterTarget::Measurable(measurable) => measurable.field.clone(),
+    }
+}
+
+fn raw_column<'f>(filter: &'f PlannedFilter<'_>) -> &'f str {
+    match filter.target {
+        FilterTarget::Dimension(dimension) => &dimension.field,
+        FilterTarget::Measurable(measurable) => &measurable.field,
+    }
+}
+
+fn bound(filter: &PlannedFilter<'_>, scalar: &ScalarDto) -> QueryParam {
+    match filter.target {
+        FilterTarget::Dimension(_) => QueryParam::text_of(scalar),
+        FilterTarget::Measurable(_) => QueryParam::number_of(scalar),
+    }
+}
+
+fn operator(op: CompareOp) -> &'static str {
+    match op {
+        CompareOp::Gt => ">",
+        CompareOp::Gte => ">=",
+        CompareOp::Lt => "<",
+        CompareOp::Lte => "<=",
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::datasets::declaration::{Dimension, Measurable};
+
+    fn dimension() -> Dimension {
+        Dimension {
+            field: "source_id".to_owned(),
+            label_field: None,
+            absent_value: Some("__unknown__".to_owned()),
+        }
+    }
+
+    fn measurable() -> Measurable {
+        Measurable {
+            field: "lines_added".to_owned(),
+        }
+    }
+
+    fn text(value: &str) -> ScalarDto {
+        ScalarDto::Text(value.to_owned())
+    }
+
+    fn number(raw: &str) -> ScalarDto {
+        ScalarDto::Number(raw.parse().expect("a JSON number"))
+    }
+
+    fn render_with(target: FilterTarget<'_>, test: PlannedTest) -> (String, Vec<QueryParam>) {
+        let filter = PlannedFilter { target, test };
+        let mut params = Vec::new();
+        let sql = render(&filter, &mut params);
+        (sql, params)
+    }
+
+    #[test]
+    fn every_test_over_a_measurable_reads_the_numeric_column() {
+        let measurable = measurable();
+        let cases = [
+            (PlannedTest::Eq(number("500")), "lines_added = ?", 1),
+            (
+                PlannedTest::Compare(CompareOp::Gt, number("500")),
+                "lines_added > ?",
+                1,
+            ),
+            (
+                PlannedTest::Compare(CompareOp::Gte, number("500")),
+                "lines_added >= ?",
+                1,
+            ),
+            (
+                PlannedTest::Compare(CompareOp::Lt, number("500")),
+                "lines_added < ?",
+                1,
+            ),
+            (
+                PlannedTest::Compare(CompareOp::Lte, number("500")),
+                "lines_added <= ?",
+                1,
+            ),
+            (
+                PlannedTest::In(vec![number("1"), number("2")]),
+                "lines_added IN (?, ?)",
+                2,
+            ),
+            (
+                PlannedTest::Between {
+                    low: number("1"),
+                    high: number("9"),
+                },
+                "(lines_added >= ? AND lines_added <= ?)",
+                2,
+            ),
+            (PlannedTest::NotNull, "lines_added IS NOT NULL", 0),
+        ];
+
+        for (test, expected, bound) in cases {
+            let label = format!("{test:?}");
+            let (sql, params) = render_with(FilterTarget::Measurable(&measurable), test);
+            assert_eq!(sql, expected, "{label}");
+            assert_eq!(params.len(), bound, "{label}");
+            assert_eq!(sql.matches('?').count(), params.len(), "{label}");
+        }
+    }
+
+    #[test]
+    fn a_dimension_filter_compares_against_the_value_the_answer_reports() {
+        let dimension = dimension();
+        let (sql, params) = render_with(
+            FilterTarget::Dimension(&dimension),
+            PlannedTest::Eq(text("__unknown__")),
+        );
+
+        assert_eq!(sql, "coalesce(toString(source_id), '__unknown__') = ?");
+        assert_eq!(params, vec![QueryParam::Text("__unknown__".to_owned())]);
+    }
+
+    #[test]
+    fn a_pattern_binds_as_text_against_the_value_the_answer_reports() {
+        let dimension = dimension();
+        let (like, like_params) = render_with(
+            FilterTarget::Dimension(&dimension),
+            PlannedTest::Like("src/%".to_owned()),
+        );
+        assert_eq!(like, "coalesce(toString(source_id), '__unknown__') LIKE ?");
+        assert_eq!(like_params, vec![QueryParam::Text("src/%".to_owned())]);
+
+        let (matches, match_params) = render_with(
+            FilterTarget::Dimension(&dimension),
+            PlannedTest::Matches("^a|b$".to_owned()),
+        );
+        assert_eq!(
+            matches,
+            "match(coalesce(toString(source_id), '__unknown__'), ?)"
+        );
+        assert_eq!(match_params, vec![QueryParam::Text("^a|b$".to_owned())]);
+    }
+
+    #[test]
+    fn not_null_over_a_dimension_asks_the_raw_column_the_sentinel_would_hide() {
+        let dimension = dimension();
+        let (sql, params) = render_with(FilterTarget::Dimension(&dimension), PlannedTest::NotNull);
+
+        assert_eq!(sql, "source_id IS NOT NULL");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn a_measurable_value_binds_as_a_number_and_a_dimension_value_as_text() {
+        let measurable = measurable();
+        let (_, numeric) = render_with(
+            FilterTarget::Measurable(&measurable),
+            PlannedTest::Compare(CompareOp::Gte, number("500")),
+        );
+        assert_eq!(numeric, vec![QueryParam::Int(500)]);
+
+        let dimension = dimension();
+        let (_, textual) = render_with(
+            FilterTarget::Dimension(&dimension),
+            PlannedTest::Eq(number("500")),
+        );
+        assert_eq!(textual, vec![QueryParam::Text("500".to_owned())]);
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/group.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/group.rs
@@ -1,0 +1,81 @@
+//! How a group axis becomes a column of the answer.
+//!
+//! INVARIANT: the answer and a filter both read a dimension's rendered value,
+//! never the raw column.
+
+use crate::domain::datasets::declaration::Dimension;
+use crate::domain::query::plan::{QueryPlan, column_alias};
+
+/// What the answer reports for one dimension; a group is never NULL.
+pub fn dimension_expr(dimension: &Dimension) -> String {
+    let value = format!("toString({})", dimension.field);
+    match &dimension.absent_value {
+        // SAFETY: the sentinel comes from the declaration, not from a caller.
+        Some(absent) => format!("coalesce({value}, '{}')", escape_literal(absent)),
+        None => value,
+    }
+}
+
+/// The declared label beside a dimension's value; one per group, so any row's.
+pub fn label_expr(dimension: &Dimension) -> String {
+    let label = dimension.label_field.as_deref().unwrap_or(&dimension.field);
+    format!("any({label})")
+}
+
+pub fn group_aliases(plan: &QueryPlan<'_>) -> Vec<String> {
+    plan.columns
+        .iter()
+        .enumerate()
+        .filter(|(_, column)| column.groups())
+        .map(|(index, _)| column_alias(index))
+        .collect()
+}
+
+fn escape_literal(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn dimension(absent_value: Option<&str>) -> Dimension {
+        Dimension {
+            field: "repository".to_owned(),
+            label_field: None,
+            absent_value: absent_value.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn a_dimension_over_a_non_nullable_column_reports_the_column_as_text() {
+        assert_eq!(dimension_expr(&dimension(None)), "toString(repository)");
+    }
+
+    #[test]
+    fn a_nullable_dimension_reports_its_absent_rows_under_the_declared_value() {
+        assert_eq!(
+            dimension_expr(&dimension(Some("__unknown__"))),
+            "coalesce(toString(repository), '__unknown__')"
+        );
+    }
+
+    #[test]
+    fn a_label_column_reads_the_declared_label_field() {
+        let dimension = Dimension {
+            field: "repository".to_owned(),
+            label_field: Some("repository_label".to_owned()),
+            absent_value: None,
+        };
+        assert_eq!(label_expr(&dimension), "any(repository_label)");
+    }
+
+    #[test]
+    fn a_quote_in_a_declared_value_cannot_end_the_literal() {
+        assert_eq!(
+            dimension_expr(&dimension(Some("it's"))),
+            r"coalesce(toString(repository), 'it\'s')"
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/mod.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/mod.rs
@@ -1,0 +1,493 @@
+//! Turns a plan into one bounded ClickHouse statement and the values to bind
+//! against it. Nothing here touches a connection.
+//!
+//! SAFETY: only engine-owned strings reach the statement text; every
+//! caller-supplied value binds.
+
+pub mod aggregates;
+pub mod filters;
+pub mod group;
+pub mod order;
+pub mod params;
+pub mod scan;
+pub mod time;
+
+use std::fmt::Write;
+
+use super::plan::{ColumnSource, QueryPlan, column_alias};
+
+use params::QueryParam;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompiledQuery {
+    pub sql: String,
+    pub params: Vec<QueryParam>,
+}
+
+// INVARIANT: placeholders bind by position — folds, then scope predicates,
+// then the row ceiling. The ceiling is one over the limit: the extra row is
+// how the answer knows it was truncated, and assembly drops it.
+pub fn compile(plan: &QueryPlan<'_>, tenant_id: &str) -> CompiledQuery {
+    let mut params = Vec::new();
+
+    let selects = select_terms(plan, &mut params);
+    let predicates = scan::predicates(plan, tenant_id, &mut params);
+    params.push(QueryParam::UInt(u64::from(plan.limit) + 1));
+
+    let mut sql = String::from("SELECT\n");
+    let _ = writeln!(sql, "    {}", selects.join(",\n    "));
+    let _ = writeln!(sql, "FROM {}", scan::from_clause(plan));
+    let _ = writeln!(sql, "WHERE {}", predicates.join("\n  AND "));
+
+    let group_aliases = group::group_aliases(plan);
+    if !group_aliases.is_empty() {
+        let _ = writeln!(sql, "GROUP BY {}", group_aliases.join(", "));
+    }
+
+    let order_terms = order::terms(plan);
+    if !order_terms.is_empty() {
+        let _ = writeln!(sql, "ORDER BY {}", order_terms.join(", "));
+    }
+    let _ = write!(sql, "LIMIT ?");
+
+    CompiledQuery { sql, params }
+}
+
+fn select_terms(plan: &QueryPlan<'_>, params: &mut Vec<QueryParam>) -> Vec<String> {
+    plan.columns
+        .iter()
+        .enumerate()
+        .map(|(index, column)| {
+            let expr = match column.source {
+                ColumnSource::Dimension(dimension) => group::dimension_expr(dimension),
+                ColumnSource::Label(dimension) => group::label_expr(dimension),
+                // INVARIANT: validation admits a time axis only beside a grain.
+                ColumnSource::Bucket => plan
+                    .time
+                    .grain
+                    .map(|grain| time::bucket_expr(plan.time.field, grain))
+                    .unwrap_or_default(),
+                ColumnSource::Aggregate(position) => {
+                    aggregates::fold_expr(&plan.aggregates[position], params)
+                }
+            };
+            format!("{expr} AS {}", column_alias(index))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::datasets::declaration::Dataset;
+    use crate::domain::query::contract::dto::MAX_ROW_LIMIT;
+    use crate::domain::query::fixtures;
+    use crate::domain::query::validation::plan_against;
+
+    const TENANT: &str = "acme-tenant";
+
+    fn compiled(dataset: &Dataset, json: &str) -> CompiledQuery {
+        let request = fixtures::query(json);
+        let plan = plan_against(&request, dataset).expect("the query is admissible");
+        compile(&plan, TENANT)
+    }
+
+    fn text(value: &str) -> QueryParam {
+        QueryParam::Text(value.to_owned())
+    }
+
+    fn lines(expected: &[&str]) -> String {
+        expected.join("\n")
+    }
+
+    #[test]
+    fn a_grouped_bucketed_filtered_query_renders_one_bounded_scan() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            r#"{
+              "dataset": "git_commits",
+              "filters": [
+                {"field": "source", "op": "in", "values": ["github", "gitlab"]},
+                {"field": "lines_added", "op": "gte", "value": 500}
+              ],
+              "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+              "aggregates": [
+                {"name": "commits", "fn": "count"},
+                {"name": "added_on_default", "fn": "sum", "field": "lines_added",
+                 "filter": {"field": "branch_scope", "op": "eq", "value": "default"}}
+              ],
+              "time": {"from": "2026-01-01", "to": "2026-03-31", "grain": "week"},
+              "order": [{"by": "commits", "dir": "desc"}],
+              "limit": 100
+            }"#,
+        );
+
+        assert_eq!(
+            compiled.sql,
+            lines(&[
+                "SELECT",
+                "    toString(repository) AS c0,",
+                "    any(repository_label) AS c1,",
+                "    toStartOfWeek(toDate(authored_at, 'UTC'), 1) AS c2,",
+                "    count() AS c3,",
+                "    sumIfOrNull(lines_added, coalesce(toString(branch_scope) = ?, 0)) AS c4",
+                "FROM insight.git_commits",
+                "WHERE tenant_id = ?",
+                "  AND toDate(authored_at, 'UTC') >= toDate(?, 'UTC')",
+                "  AND toDate(authored_at, 'UTC') <= toDate(?, 'UTC')",
+                "  AND toString(source) IN (?, ?)",
+                "  AND lines_added >= ?",
+                "GROUP BY c0, c2",
+                "ORDER BY c3 DESC, c0 ASC, c2 ASC",
+                "LIMIT ?",
+            ])
+        );
+        assert_eq!(
+            compiled.params,
+            vec![
+                text("default"),
+                text(TENANT),
+                text("2026-01-01"),
+                text("2026-03-31"),
+                text("github"),
+                text("gitlab"),
+                QueryParam::Int(500),
+                QueryParam::UInt(101),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_query_grouping_by_nothing_folds_the_window_into_one_row() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert_eq!(
+            compiled.sql,
+            lines(&[
+                "SELECT",
+                "    count() AS c0",
+                "FROM insight.git_commits",
+                "WHERE tenant_id = ?",
+                "  AND toDate(authored_at, 'UTC') >= toDate(?, 'UTC')",
+                "  AND toDate(authored_at, 'UTC') <= toDate(?, 'UTC')",
+                "LIMIT ?",
+            ])
+        );
+    }
+
+    #[test]
+    fn every_grain_renders_its_own_bucket() {
+        let dataset = fixtures::commits();
+        let cases = [
+            ("day", "toDate(authored_at, 'UTC') AS c0"),
+            ("week", "toStartOfWeek(toDate(authored_at, 'UTC'), 1) AS c0"),
+            ("month", "toStartOfMonth(toDate(authored_at, 'UTC')) AS c0"),
+        ];
+
+        for (grain, expected) in cases {
+            let compiled = compiled(
+                &dataset,
+                &format!(
+                    r#"{{"dataset": "git_commits",
+                         "group_by": [{{"axis": "time"}}],
+                         "aggregates": [{{"name": "commits", "fn": "count"}}],
+                         "time": {{"from": "2026-01-01", "to": "2026-01-31", "grain": "{grain}"}}}}"#
+                ),
+            );
+            assert!(compiled.sql.contains(expected), "{grain}: {}", compiled.sql);
+        }
+    }
+
+    #[test]
+    fn every_fold_renders_the_function_its_empty_case_needs() {
+        let dataset = fixtures::commits();
+        let cases = [
+            ("count", None, "count() AS c0"),
+            ("sum", Some("lines_added"), "sumOrNull(lines_added) AS c0"),
+            ("avg", Some("lines_added"), "avgOrNull(lines_added) AS c0"),
+            (
+                "min",
+                Some("lines_removed"),
+                "minOrNull(lines_removed) AS c0",
+            ),
+            (
+                "max",
+                Some("lines_removed"),
+                "maxOrNull(lines_removed) AS c0",
+            ),
+        ];
+
+        for (function, field, expected) in cases {
+            let field = field.map_or(String::new(), |name| format!(r#", "field": "{name}""#));
+            let compiled = compiled(
+                &dataset,
+                &format!(
+                    r#"{{"dataset": "git_commits",
+                         "aggregates": [{{"name": "value", "fn": "{function}"{field}}}],
+                         "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+                ),
+            );
+            assert!(
+                compiled.sql.contains(expected),
+                "{function}: {}",
+                compiled.sql
+            );
+        }
+    }
+
+    #[test]
+    fn every_filter_operator_renders_its_own_predicate() {
+        let dataset = fixtures::commits();
+        let cases = [
+            (
+                r#"{"field": "source", "op": "eq", "value": "github"}"#,
+                "toString(source) = ?",
+            ),
+            (
+                r#"{"field": "source", "op": "in", "values": ["github"]}"#,
+                "toString(source) IN (?)",
+            ),
+            (
+                r#"{"field": "lines_added", "op": "gt", "value": 1}"#,
+                "lines_added > ?",
+            ),
+            (
+                r#"{"field": "lines_added", "op": "gte", "value": 1}"#,
+                "lines_added >= ?",
+            ),
+            (
+                r#"{"field": "lines_added", "op": "lt", "value": 1}"#,
+                "lines_added < ?",
+            ),
+            (
+                r#"{"field": "lines_added", "op": "lte", "value": 1}"#,
+                "lines_added <= ?",
+            ),
+            (
+                r#"{"field": "lines_added", "op": "between", "low": 1, "high": 9}"#,
+                "(lines_added >= ? AND lines_added <= ?)",
+            ),
+            (
+                r#"{"field": "source_id", "op": "not_null"}"#,
+                "source_id IS NOT NULL",
+            ),
+            (
+                r#"{"field": "repository", "op": "like", "value": "example/%"}"#,
+                "toString(repository) LIKE ?",
+            ),
+            (
+                r#"{"field": "repository", "op": "match", "value": "^example/"}"#,
+                "match(toString(repository), ?)",
+            ),
+        ];
+
+        for (filter, expected) in cases {
+            let compiled = compiled(
+                &dataset,
+                &format!(
+                    r#"{{"dataset": "git_commits", "filters": [{filter}],
+                         "aggregates": [{{"name": "commits", "fn": "count"}}],
+                         "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+                ),
+            );
+            assert!(
+                compiled.sql.contains(expected),
+                "{filter}: {}",
+                compiled.sql
+            );
+        }
+    }
+
+    #[test]
+    fn a_nullable_dimension_groups_its_absent_rows_under_the_declared_value() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "source_id"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert!(
+            compiled
+                .sql
+                .contains("coalesce(toString(source_id), '__unknown__') AS c0"),
+            "{}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn tenancy_leads_every_scan_and_binds_from_the_session() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            r#"{"dataset": "git_commits",
+                 "filters": [{"field": "source", "op": "eq", "value": "github"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert!(compiled.sql.contains("WHERE tenant_id = ?\n  AND"));
+        assert_eq!(compiled.params[0], text(TENANT));
+    }
+
+    #[test]
+    fn a_query_over_a_relation_that_must_be_read_collapsed_scans_it_final() {
+        let mut dataset = fixtures::commits();
+        dataset.read_discipline = crate::domain::field_catalog::model::ReadDiscipline::Final;
+        let compiled = compiled(
+            &dataset,
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert!(compiled.sql.contains("FROM insight.git_commits FINAL"));
+    }
+
+    #[test]
+    fn the_row_ceiling_binds_last_and_one_over_the_limit() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            &format!(
+                r#"{{"dataset": "git_commits",
+                     "aggregates": [{{"name": "commits", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}},
+                     "limit": {MAX_ROW_LIMIT}}}"#
+            ),
+        );
+
+        assert!(compiled.sql.ends_with("LIMIT ?"));
+        assert_eq!(
+            compiled.params.last(),
+            Some(&QueryParam::UInt(u64::from(MAX_ROW_LIMIT) + 1))
+        );
+    }
+
+    #[test]
+    fn a_grouped_answer_orders_by_every_group_column_the_query_did_not_name() {
+        let dataset = fixtures::commits();
+        let compiled = compiled(
+            &dataset,
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "dimension", "field": "source"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"},
+                 "order": [{"by": "source", "dir": "desc"}]}"#,
+        );
+
+        assert!(
+            compiled.sql.contains("ORDER BY c2 DESC, c0 ASC"),
+            "{}",
+            compiled.sql
+        );
+    }
+
+    #[test]
+    fn every_rendered_statement_binds_one_parameter_per_placeholder() {
+        let dataset = fixtures::commits();
+        let queries = [
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "author_email"}, {"axis": "time"}],
+                 "filters": [{"field": "source_id", "op": "in", "values": ["a", "b", "c"]},
+                             {"field": "lines_removed", "op": "between", "low": 0, "high": 100},
+                             {"field": "repository", "op": "not_null"}],
+                 "aggregates": [{"name": "commits", "fn": "count",
+                                 "filter": {"field": "source", "op": "eq", "value": "github"}},
+                                {"name": "added", "fn": "sum", "field": "lines_added"},
+                                {"name": "biggest", "fn": "max", "field": "lines_added",
+                                 "filter": {"field": "lines_added", "op": "gt", "value": 10}}],
+                 "time": {"field": "authored_date", "from": "2026-01-01", "to": "2026-12-31",
+                          "grain": "month"},
+                 "order": [{"by": "added", "dir": "desc"}],
+                 "limit": 250}"#,
+        ];
+
+        for query in queries {
+            let compiled = compiled(&dataset, query);
+            assert_eq!(
+                compiled.sql.matches('?').count(),
+                compiled.params.len(),
+                "{}",
+                compiled.sql
+            );
+        }
+    }
+
+    #[test]
+    fn a_query_over_the_file_change_dataset_scans_its_own_relation() {
+        let request = fixtures::query(
+            r#"{"dataset": "git_file_changes",
+                 "group_by": [{"axis": "dimension", "field": "file_extension"}, {"axis": "time"}],
+                 "aggregates": [
+                   {"name": "changes", "fn": "count"},
+                   {"name": "added_to_tests", "fn": "sum", "field": "lines_added",
+                    "filter": {"field": "category", "op": "eq", "value": "test"}}
+                 ],
+                 "time": {"from": "2026-01-01", "to": "2026-03-31", "grain": "month"},
+                 "order": [{"by": "changes", "dir": "desc"}],
+                 "limit": 500}"#,
+        );
+        let plan = crate::domain::query::validation::plan(&request).expect("admissible");
+        let compiled = compile(&plan, TENANT);
+
+        assert_eq!(
+            compiled.sql,
+            lines(&[
+                "SELECT",
+                "    toString(file_extension) AS c0,",
+                "    any(file_extension_label) AS c1,",
+                "    toStartOfMonth(toDate(authored_at, 'UTC')) AS c2,",
+                "    count() AS c3,",
+                "    sumIfOrNull(lines_added, coalesce(toString(category) = ?, 0)) AS c4",
+                "FROM insight.git_file_changes",
+                "WHERE tenant_id = ?",
+                "  AND toDate(authored_at, 'UTC') >= toDate(?, 'UTC')",
+                "  AND toDate(authored_at, 'UTC') <= toDate(?, 'UTC')",
+                "GROUP BY c0, c2",
+                "ORDER BY c3 DESC, c0 ASC, c2 ASC",
+                "LIMIT ?",
+            ])
+        );
+        assert_eq!(
+            compiled.params,
+            vec![
+                text("test"),
+                text(TENANT),
+                text("2026-01-01"),
+                text("2026-03-31"),
+                QueryParam::UInt(501),
+            ]
+        );
+        assert_eq!(compiled.sql.matches('?').count(), compiled.params.len());
+    }
+
+    #[test]
+    fn the_shipped_dataset_compiles_the_same_query_the_fixture_does() {
+        let request = fixtures::query(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-03-31", "grain": "week"}}"#,
+        );
+        let plan = crate::domain::query::validation::plan(&request).expect("admissible");
+        let compiled = compile(&plan, TENANT);
+
+        assert!(compiled.sql.contains("FROM insight.git_commits"));
+        assert_eq!(compiled.sql.matches('?').count(), compiled.params.len());
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/order.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/order.rs
@@ -1,0 +1,36 @@
+//! How the answer's rows are ordered and how many of them there are.
+//!
+//! INVARIANT: a grouped query orders by every group column the query did not
+//! name, so a row ceiling truncates the same rows on every run.
+
+use crate::domain::query::contract::dto::Direction;
+use crate::domain::query::plan::{QueryPlan, column_alias};
+
+pub fn terms(plan: &QueryPlan<'_>) -> Vec<String> {
+    let mut ordered: Vec<usize> = Vec::with_capacity(plan.order.len() + plan.group_by.len());
+    let mut terms = Vec::with_capacity(ordered.capacity());
+
+    for term in &plan.order {
+        ordered.push(term.column);
+        terms.push(format!(
+            "{} {}",
+            column_alias(term.column),
+            direction(term.direction)
+        ));
+    }
+
+    for (index, column) in plan.columns.iter().enumerate() {
+        if column.groups() && !ordered.contains(&index) {
+            terms.push(format!("{} ASC", column_alias(index)));
+        }
+    }
+
+    terms
+}
+
+fn direction(direction: Direction) -> &'static str {
+    match direction {
+        Direction::Asc => "ASC",
+        Direction::Desc => "DESC",
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/params.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/params.rs
@@ -1,0 +1,107 @@
+//! Bound values, in the spelling ClickHouse receives them in.
+//!
+//! SAFETY: every caller-supplied value in a compiled statement is one of these.
+//! Nothing here is ever written into the SQL text.
+
+use crate::domain::query::contract::dto::ScalarDto;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryParam {
+    Text(String),
+    Int(i64),
+    UInt(u64),
+    Float(f64),
+}
+
+impl QueryParam {
+    /// A dimension compares as text, whatever the column's own type is.
+    pub fn text_of(scalar: &ScalarDto) -> Self {
+        Self::Text(match scalar {
+            ScalarDto::Bool(value) => value.to_string(),
+            ScalarDto::Number(value) => value.to_string(),
+            ScalarDto::Text(value) => value.clone(),
+        })
+    }
+
+    /// A measurable compares against the numeric column itself.
+    pub fn number_of(scalar: &ScalarDto) -> Self {
+        let ScalarDto::Number(number) = scalar else {
+            return Self::text_of(scalar);
+        };
+        if let Some(value) = number.as_i64() {
+            Self::Int(value)
+        } else if let Some(value) = number.as_u64() {
+            Self::UInt(value)
+        } else if let Some(value) = number.as_f64() {
+            Self::Float(value)
+        } else {
+            Self::Text(number.to_string())
+        }
+    }
+
+    pub fn binding(&self) -> serde_json::Value {
+        match self {
+            Self::Text(value) => serde_json::Value::String(value.clone()),
+            Self::Int(value) => serde_json::Value::from(*value),
+            Self::UInt(value) => serde_json::Value::from(*value),
+            Self::Float(value) => serde_json::Number::from_f64(*value)
+                .map_or_else(serde_json::Value::default, serde_json::Value::Number),
+        }
+    }
+}
+
+pub fn placeholders(count: usize) -> String {
+    vec!["?"; count].join(", ")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn number(raw: &str) -> ScalarDto {
+        ScalarDto::Number(raw.parse().expect("a JSON number"))
+    }
+
+    #[test]
+    fn a_dimension_value_binds_as_the_text_the_answer_reports() {
+        assert_eq!(
+            QueryParam::text_of(&ScalarDto::Text("github".to_owned())),
+            QueryParam::Text("github".to_owned())
+        );
+        assert_eq!(
+            QueryParam::text_of(&number("42")),
+            QueryParam::Text("42".to_owned())
+        );
+        assert_eq!(
+            QueryParam::text_of(&ScalarDto::Bool(true)),
+            QueryParam::Text("true".to_owned())
+        );
+    }
+
+    #[test]
+    fn a_measurable_value_keeps_the_numeric_width_it_was_written_in() {
+        assert_eq!(QueryParam::number_of(&number("500")), QueryParam::Int(500));
+        assert_eq!(QueryParam::number_of(&number("-1")), QueryParam::Int(-1));
+        assert_eq!(
+            QueryParam::number_of(&number("18446744073709551615")),
+            QueryParam::UInt(u64::MAX)
+        );
+        assert_eq!(
+            QueryParam::number_of(&number("1.5")),
+            QueryParam::Float(1.5)
+        );
+    }
+
+    #[test]
+    fn a_bound_value_reaches_the_driver_with_its_own_json_type() {
+        assert!(QueryParam::Int(5).binding().is_number());
+        assert!(QueryParam::Text("5".to_owned()).binding().is_string());
+    }
+
+    #[test]
+    fn placeholders_are_one_per_value() {
+        assert_eq!(placeholders(1), "?");
+        assert_eq!(placeholders(3), "?, ?, ?");
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/compile/scan.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/scan.rs
@@ -1,0 +1,41 @@
+//! What a scan reads and what it is scoped to.
+//!
+//! INVARIANT: tenancy leads every read, bound from the session and never from
+//! the request.
+
+use crate::domain::field_catalog::model::ReadDiscipline;
+use crate::domain::query::plan::QueryPlan;
+
+use super::filters;
+use super::params::QueryParam;
+use super::time::event_day;
+
+pub fn from_clause(plan: &QueryPlan<'_>) -> String {
+    let relation = format!("{}.{}", plan.dataset.database, plan.dataset.relation);
+    match plan.dataset.read_discipline {
+        ReadDiscipline::Plain => relation,
+        ReadDiscipline::Final => format!("{relation} FINAL"),
+    }
+}
+
+/// The `WHERE` predicates, in binding order: tenancy, window, then row filters.
+pub fn predicates(
+    plan: &QueryPlan<'_>,
+    tenant_id: &str,
+    params: &mut Vec<QueryParam>,
+) -> Vec<String> {
+    let mut predicates = vec![format!("{} = ?", plan.dataset.tenant_field)];
+    params.push(QueryParam::Text(tenant_id.to_owned()));
+
+    let day = event_day(plan.time.field);
+    predicates.push(format!("{day} >= toDate(?, 'UTC')"));
+    params.push(QueryParam::Text(plan.time.from.to_string()));
+    predicates.push(format!("{day} <= toDate(?, 'UTC')"));
+    params.push(QueryParam::Text(plan.time.to.to_string()));
+
+    for filter in &plan.filters {
+        predicates.push(filters::render(filter, params));
+    }
+
+    predicates
+}

--- a/src/backend/services/analytics/src/domain/query/compile/time.rs
+++ b/src/backend/services/analytics/src/domain/query/compile/time.rs
@@ -1,0 +1,73 @@
+//! The time bucket and the window every scan is bounded by. UTC only.
+//!
+//! INVARIANT: every day boundary names its zone. A bare `toDate` over a
+//! `DateTime` reads the server's zone, so the same query would bucket rows
+//! differently on two installations.
+
+use crate::domain::datasets::declaration::TimeField;
+use crate::domain::query::contract::dto::Grain;
+
+/// ClickHouse's Monday-first week mode.
+const MONDAY_FIRST: u8 = 1;
+const ZONE: &str = "'UTC'";
+
+// SAFETY: an absent event time compares NULL against both bounds, so the row
+// falls outside every window and the scan never reads it.
+pub fn event_day(field: &TimeField) -> String {
+    format!("toDate({}, {ZONE})", field.field)
+}
+
+// SAFETY: `assumeNotNull` is sound because the window bounds already excluded
+// every row whose event time is absent.
+pub fn bucket_expr(field: &TimeField, grain: Grain) -> String {
+    let day = if field.nullable {
+        format!("toDate(assumeNotNull({}), {ZONE})", field.field)
+    } else {
+        format!("toDate({}, {ZONE})", field.field)
+    };
+
+    match grain {
+        Grain::Day => day,
+        Grain::Week => format!("toStartOfWeek({day}, {MONDAY_FIRST})"),
+        Grain::Month => format!("toStartOfMonth({day})"),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn field(nullable: bool) -> TimeField {
+        TimeField {
+            field: "authored_at".to_owned(),
+            nullable,
+            default: true,
+        }
+    }
+
+    #[test]
+    fn each_grain_renders_its_own_bucket_boundary() {
+        let cases = [
+            (Grain::Day, "toDate(authored_at, 'UTC')"),
+            (Grain::Week, "toStartOfWeek(toDate(authored_at, 'UTC'), 1)"),
+            (Grain::Month, "toStartOfMonth(toDate(authored_at, 'UTC'))"),
+        ];
+        for (grain, expected) in cases {
+            assert_eq!(bucket_expr(&field(false), grain), expected, "{grain:?}");
+        }
+    }
+
+    #[test]
+    fn a_nullable_event_time_buckets_the_value_the_window_already_admitted() {
+        assert_eq!(
+            bucket_expr(&field(true), Grain::Day),
+            "toDate(assumeNotNull(authored_at), 'UTC')"
+        );
+    }
+
+    #[test]
+    fn the_window_bounds_compare_against_the_event_day() {
+        assert_eq!(event_day(&field(true)), "toDate(authored_at, 'UTC')");
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/contract/dto.rs
+++ b/src/backend/services/analytics/src/domain/query/contract/dto.rs
@@ -1,0 +1,631 @@
+//! The wire shape of a query and of the answer it gets.
+
+use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+pub const MAX_FILTERS: usize = 32;
+pub const MAX_FILTER_VALUES: usize = 256;
+pub const MAX_AGGREGATES: usize = 16;
+pub const MAX_GROUP_AXES: usize = 4;
+pub const MAX_ORDER_TERMS: usize = 4;
+pub const MAX_NAME_CHARS: usize = 64;
+pub const MAX_PATTERN_CHARS: usize = 256;
+pub const DEFAULT_ROW_LIMIT: u32 = 1_000;
+pub const MAX_ROW_LIMIT: u32 = 10_000;
+/// Two years inclusive of a leap day, so a year-over-year window fits.
+pub const MAX_WINDOW_DAYS: i64 = 731;
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(as = Query)]
+pub struct QueryRequest {
+    pub dataset: String,
+    /// Row filters, narrowing the scan before aggregation.
+    #[serde(default)]
+    pub filters: Vec<FilterDto>,
+    #[serde(default)]
+    pub group_by: Vec<GroupAxisDto>,
+    pub aggregates: Vec<AggregateDto>,
+    /// The window every scan is bounded by, and the width of its buckets.
+    pub time: TimeDto,
+    #[serde(default)]
+    pub order: Vec<OrderDto>,
+    /// Row ceiling; a query over the cap is refused rather than clipped.
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+// INVARIANT: every tagged request shape is an enum of struct variants with
+// `deny_unknown_fields` on the enum, so an operand of another variant is refused
+// at deserialization and the published schema carries the tag beside the
+// operands of each variant.
+#[derive(Debug, Clone, PartialEq, Deserialize, ToSchema)]
+#[serde(tag = "op", rename_all = "snake_case", deny_unknown_fields)]
+#[schema(as = QueryFilter)]
+pub enum FilterDto {
+    Eq {
+        /// A declared dimension or measurable of the dataset.
+        field: String,
+        value: ScalarDto,
+    },
+    In {
+        /// A declared dimension or measurable of the dataset.
+        field: String,
+        /// At least one value, and at most the contract's cap.
+        // INVARIANT: equals MAX_FILTER_VALUES; the derive takes a literal only,
+        // and a test pins the two together.
+        #[schema(min_items = 1, max_items = 256)]
+        values: Vec<ScalarDto>,
+    },
+    Gt {
+        /// A declared measurable of the dataset.
+        field: String,
+        value: ScalarDto,
+    },
+    Gte {
+        /// A declared measurable of the dataset.
+        field: String,
+        value: ScalarDto,
+    },
+    Lt {
+        /// A declared measurable of the dataset.
+        field: String,
+        value: ScalarDto,
+    },
+    Lte {
+        /// A declared measurable of the dataset.
+        field: String,
+        value: ScalarDto,
+    },
+    Between {
+        /// A declared measurable of the dataset.
+        field: String,
+        /// Inclusive lower bound.
+        low: ScalarDto,
+        /// Inclusive upper bound.
+        high: ScalarDto,
+    },
+    NotNull {
+        /// A declared dimension or measurable of the dataset.
+        field: String,
+    },
+    /// SQL `LIKE`: `%` matches any run, `_` one character.
+    Like {
+        /// A declared dimension of the dataset.
+        field: String,
+        // INVARIANT: equals MAX_PATTERN_CHARS; the derive takes a literal only,
+        // and a test pins the two together.
+        #[schema(max_length = 256)]
+        value: String,
+    },
+    /// An RE2 regular expression, unanchored.
+    #[serde(rename = "match")]
+    Matches {
+        /// A declared dimension of the dataset.
+        field: String,
+        #[schema(max_length = 256)]
+        value: String,
+    },
+}
+
+impl FilterDto {
+    pub fn field(&self) -> &str {
+        match self {
+            Self::Eq { field, .. }
+            | Self::In { field, .. }
+            | Self::Gt { field, .. }
+            | Self::Gte { field, .. }
+            | Self::Lt { field, .. }
+            | Self::Lte { field, .. }
+            | Self::Between { field, .. }
+            | Self::NotNull { field }
+            | Self::Like { field, .. }
+            | Self::Matches { field, .. } => field,
+        }
+    }
+}
+
+/// A filter value, in the JSON type it was written as.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum ScalarDto {
+    Bool(bool),
+    Number(serde_json::Number),
+    Text(String),
+}
+
+// WORKAROUND: the derive cannot annotate a newtype variant's field, and
+// `serde_json::Number` carries no schema of its own.
+impl utoipa::PartialSchema for ScalarDto {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        utoipa::openapi::schema::OneOfBuilder::new()
+            .item(<String as utoipa::PartialSchema>::schema())
+            .item(<f64 as utoipa::PartialSchema>::schema())
+            .item(<bool as utoipa::PartialSchema>::schema())
+            .description(Some("A filter value: text, a number, or a boolean"))
+            .into()
+    }
+}
+
+impl utoipa::ToSchema for ScalarDto {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("QueryFilterValue")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, ToSchema)]
+#[serde(tag = "axis", rename_all = "snake_case", deny_unknown_fields)]
+#[schema(as = QueryGroupAxis)]
+pub enum GroupAxisDto {
+    Dimension {
+        /// A declared dimension of the dataset.
+        field: String,
+    },
+    /// The time bucket as a group axis; its width is `time.grain`.
+    Time {},
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, ToSchema)]
+#[serde(tag = "fn", rename_all = "snake_case", deny_unknown_fields)]
+#[schema(as = QueryAggregate)]
+pub enum AggregateDto {
+    Count {
+        /// What the answer column is called.
+        name: String,
+        /// Restricts this fold to the rows one filter selects.
+        #[serde(default)]
+        filter: Option<FilterDto>,
+    },
+    Sum {
+        /// What the answer column is called.
+        name: String,
+        /// A declared measurable of the dataset.
+        field: String,
+        /// Restricts this fold to the rows one filter selects.
+        #[serde(default)]
+        filter: Option<FilterDto>,
+    },
+    Avg {
+        /// What the answer column is called.
+        name: String,
+        /// A declared measurable of the dataset.
+        field: String,
+        /// Restricts this fold to the rows one filter selects.
+        #[serde(default)]
+        filter: Option<FilterDto>,
+    },
+    Min {
+        /// What the answer column is called.
+        name: String,
+        /// A declared measurable of the dataset.
+        field: String,
+        /// Restricts this fold to the rows one filter selects.
+        #[serde(default)]
+        filter: Option<FilterDto>,
+    },
+    Max {
+        /// What the answer column is called.
+        name: String,
+        /// A declared measurable of the dataset.
+        field: String,
+        /// Restricts this fold to the rows one filter selects.
+        #[serde(default)]
+        filter: Option<FilterDto>,
+    },
+}
+
+impl AggregateDto {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Count { name, .. }
+            | Self::Sum { name, .. }
+            | Self::Avg { name, .. }
+            | Self::Min { name, .. }
+            | Self::Max { name, .. } => name,
+        }
+    }
+
+    pub fn filter(&self) -> Option<&FilterDto> {
+        match self {
+            Self::Count { filter, .. }
+            | Self::Sum { filter, .. }
+            | Self::Avg { filter, .. }
+            | Self::Min { filter, .. }
+            | Self::Max { filter, .. } => filter.as_ref(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(as = QueryTime)]
+pub struct TimeDto {
+    /// A declared time field; the dataset's default when omitted.
+    #[serde(default)]
+    pub field: Option<String>,
+    /// Inclusive first day, UTC.
+    pub from: NaiveDate,
+    /// Inclusive last day, UTC.
+    pub to: NaiveDate,
+    /// Bucket width. Required with an `{"axis": "time"}` axis, refused without one.
+    #[serde(default)]
+    pub grain: Option<Grain>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[schema(as = QueryGrain)]
+pub enum Grain {
+    Day,
+    Week,
+    Month,
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(as = QueryOrder)]
+pub struct OrderDto {
+    /// A column the answer reports: a grouped dimension, `time`, or an aggregate name.
+    pub by: String,
+    #[serde(default)]
+    pub dir: Direction,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[schema(as = QueryDirection)]
+pub enum Direction {
+    #[default]
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct QueryAnswer {
+    pub columns: Vec<AnswerColumn>,
+    /// One cell per column, in column order; a fold that observed nothing is null.
+    #[schema(schema_with = answer_rows_schema)]
+    pub rows: Vec<Vec<serde_json::Value>>,
+    pub flags: AnswerFlags,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[schema(as = QueryAnswerFlags)]
+pub struct AnswerFlags {
+    /// More groups matched than the limit admits; the rows are the first
+    /// `limit` of them in the answer's order.
+    pub truncated: bool,
+}
+
+fn answer_rows_schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+    use utoipa::openapi::schema::{ArrayBuilder, Object, SchemaType};
+
+    let cell = Object::with_type(SchemaType::AnyValue);
+    ArrayBuilder::new()
+        .items(ArrayBuilder::new().items(cell))
+        .into()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
+#[schema(as = QueryAnswerColumn)]
+pub struct AnswerColumn {
+    pub name: String,
+    pub kind: ColumnKind,
+    #[serde(rename = "type")]
+    pub value_type: ColumnType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[schema(as = QueryColumnKind)]
+pub enum ColumnKind {
+    Dimension,
+    /// The declared display label of the dimension column before it, named
+    /// `<field>_label`; null when the dataset carries none for a group.
+    Label,
+    Bucket,
+    Aggregate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+#[schema(as = QueryColumnType)]
+pub enum ColumnType {
+    Text,
+    Number,
+    Date,
+}
+
+impl toolkit::api::api_dto::RequestApiDto for QueryRequest {}
+impl toolkit::api::api_dto::ResponseApiDto for QueryAnswer {}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> Result<QueryRequest, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    const MINIMAL: &str = r#"{
+      "dataset": "git_commits",
+      "aggregates": [{"name": "commits", "fn": "count"}],
+      "time": {"from": "2026-01-01", "to": "2026-01-31"}
+    }"#;
+
+    #[test]
+    fn a_query_naming_only_what_it_needs_deserializes() {
+        let query = parse(MINIMAL).expect("the minimal query is in the contract");
+
+        assert_eq!(query.dataset, "git_commits");
+        assert!(query.filters.is_empty());
+        assert!(query.group_by.is_empty());
+        assert!(query.order.is_empty());
+        assert_eq!(query.limit, None);
+        assert_eq!(query.time.grain, None);
+        assert!(matches!(query.aggregates[0], AggregateDto::Count { .. }));
+    }
+
+    #[test]
+    fn a_key_the_contract_does_not_declare_is_refused_at_deserialization() {
+        let cases = [
+            r#"{"dataset": "d", "aggregates": [], "time": {"from": "2026-01-01", "to": "2026-01-02"}, "having": []}"#,
+            r#"{"dataset": "d", "aggregates": [{"name": "n", "fn": "count", "quantile": 0.9}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "time": {"from": "2026-01-01", "to": "2026-01-02", "timezone": "UTC"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "filters": [{"field": "f", "op": "eq", "values": [1], "extra": 2}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "order": [{"by": "n", "dir": "asc", "nulls": "last"}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+        ];
+        for json in cases {
+            assert!(parse(json).is_err(), "{json}");
+        }
+    }
+
+    #[test]
+    fn an_enumerated_field_refuses_a_value_outside_its_enumeration() {
+        let cases = [
+            r#"{"dataset": "d", "aggregates": [{"name": "n", "fn": "median"}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "filters": [{"field": "f", "op": "regex", "value": "x"}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "time": {"from": "2026-01-01", "to": "2026-01-02", "grain": "quarter"}}"#,
+            r#"{"dataset": "d", "aggregates": [], "order": [{"by": "n", "dir": "sideways"}], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#,
+        ];
+        for json in cases {
+            assert!(parse(json).is_err(), "{json}");
+        }
+    }
+
+    #[test]
+    fn a_group_axis_is_either_a_dimension_or_the_time_bucket() {
+        let query = parse(
+            r#"{
+              "dataset": "git_commits",
+              "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+              "aggregates": [{"name": "commits", "fn": "count"}],
+              "time": {"from": "2026-01-01", "to": "2026-01-31", "grain": "week"}
+            }"#,
+        )
+        .expect("both axis shapes are in the contract");
+
+        assert!(matches!(query.group_by[0], GroupAxisDto::Dimension { .. }));
+        assert!(matches!(query.group_by[1], GroupAxisDto::Time {}));
+
+        assert!(
+            parse(
+                r#"{"dataset": "d", "group_by": [{"bin": {"field": "f", "width": 10}}],
+                    "aggregates": [], "time": {"from": "2026-01-01", "to": "2026-01-02"}}"#
+            )
+            .is_err(),
+            "a bin axis is not a shape this contract carries yet"
+        );
+    }
+
+    #[test]
+    fn a_filter_value_keeps_the_json_type_it_was_written_as() {
+        let query = parse(
+            r#"{
+              "dataset": "git_commits",
+              "filters": [
+                {"field": "source", "op": "eq", "value": "github"},
+                {"field": "lines_added", "op": "gte", "value": 500},
+                {"field": "lines_added", "op": "not_null"}
+              ],
+              "aggregates": [{"name": "commits", "fn": "count"}],
+              "time": {"from": "2026-01-01", "to": "2026-01-31"}
+            }"#,
+        )
+        .expect("the filter shapes are in the contract");
+
+        assert_eq!(
+            query.filters[0],
+            FilterDto::Eq {
+                field: "source".to_owned(),
+                value: ScalarDto::Text("github".to_owned()),
+            }
+        );
+        assert!(matches!(
+            &query.filters[1],
+            FilterDto::Gte {
+                value: ScalarDto::Number(_),
+                ..
+            }
+        ));
+        assert!(matches!(query.filters[2], FilterDto::NotNull { .. }));
+    }
+
+    fn filter(json: &str) -> Result<FilterDto, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    #[test]
+    fn the_published_in_list_bounds_are_the_ones_validation_enforces() {
+        let schema = serde_json::to_value(<FilterDto as utoipa::PartialSchema>::schema())
+            .expect("the filter schema serializes");
+        let values = schema["oneOf"]
+            .as_array()
+            .expect("a tagged union")
+            .iter()
+            .find_map(|variant| variant["properties"].get("values"))
+            .expect("the `in` variant publishes `values`");
+
+        assert_eq!(values["minItems"], 1);
+        assert_eq!(values["maxItems"], MAX_FILTER_VALUES);
+
+        for op in ["like", "match"] {
+            let pattern = schema["oneOf"]
+                .as_array()
+                .expect("a tagged union")
+                .iter()
+                .find(|variant| variant["properties"]["op"]["enum"][0] == op)
+                .map_or_else(
+                    || panic!("the `{op}` variant publishes `value`"),
+                    |variant| &variant["properties"]["value"],
+                );
+            assert_eq!(pattern["maxLength"], MAX_PATTERN_CHARS, "{op}");
+        }
+    }
+
+    #[test]
+    fn every_filter_operator_carries_exactly_the_operands_it_takes() {
+        let cases = [
+            (
+                r#"{"op": "eq", "field": "source", "value": "github"}"#,
+                FilterDto::Eq {
+                    field: "source".to_owned(),
+                    value: ScalarDto::Text("github".to_owned()),
+                },
+            ),
+            (
+                r#"{"op": "in", "field": "source", "values": ["github", "gitlab"]}"#,
+                FilterDto::In {
+                    field: "source".to_owned(),
+                    values: vec![
+                        ScalarDto::Text("github".to_owned()),
+                        ScalarDto::Text("gitlab".to_owned()),
+                    ],
+                },
+            ),
+            (
+                r#"{"op": "lt", "field": "lines_added", "value": 10}"#,
+                FilterDto::Lt {
+                    field: "lines_added".to_owned(),
+                    value: ScalarDto::Number(10.into()),
+                },
+            ),
+            (
+                r#"{"op": "between", "field": "lines_added", "low": 1, "high": 9}"#,
+                FilterDto::Between {
+                    field: "lines_added".to_owned(),
+                    low: ScalarDto::Number(1.into()),
+                    high: ScalarDto::Number(9.into()),
+                },
+            ),
+            (
+                r#"{"op": "not_null", "field": "source_id"}"#,
+                FilterDto::NotNull {
+                    field: "source_id".to_owned(),
+                },
+            ),
+            (
+                r#"{"op": "like", "field": "file_path", "value": "%/tests/%"}"#,
+                FilterDto::Like {
+                    field: "file_path".to_owned(),
+                    value: "%/tests/%".to_owned(),
+                },
+            ),
+            (
+                r#"{"op": "match", "field": "file_path", "value": "\\.(test|spec)\\.ts$"}"#,
+                FilterDto::Matches {
+                    field: "file_path".to_owned(),
+                    value: "\\.(test|spec)\\.ts$".to_owned(),
+                },
+            ),
+        ];
+
+        for (json, expected) in cases {
+            assert_eq!(filter(json).expect(json), expected, "{json}");
+        }
+    }
+
+    #[test]
+    fn an_operand_belonging_to_another_operator_is_refused_at_deserialization() {
+        let cases = [
+            r#"{"op": "eq", "field": "source", "values": ["github"]}"#,
+            r#"{"op": "eq", "field": "source", "value": "a", "high": "b"}"#,
+            r#"{"op": "in", "field": "source", "value": "github"}"#,
+            r#"{"op": "gte", "field": "lines_added", "low": 1, "high": 9}"#,
+            r#"{"op": "between", "field": "lines_added", "value": 1}"#,
+            r#"{"op": "between", "field": "lines_added", "low": 1}"#,
+            r#"{"op": "not_null", "field": "source_id", "value": 1}"#,
+            r#"{"op": "like", "field": "file_path", "value": 1}"#,
+            r#"{"op": "match", "field": "file_path", "values": ["a"]}"#,
+            r#"{"field": "source", "value": "github"}"#,
+        ];
+
+        for json in cases {
+            assert!(filter(json).is_err(), "{json}");
+        }
+    }
+
+    fn aggregate(json: &str) -> Result<AggregateDto, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    #[test]
+    fn every_fold_carries_a_column_exactly_when_it_reads_one() {
+        let count = aggregate(r#"{"fn": "count", "name": "commits"}"#).expect("a count");
+        assert_eq!(
+            count,
+            AggregateDto::Count {
+                name: "commits".to_owned(),
+                filter: None,
+            }
+        );
+
+        for function in ["sum", "avg", "min", "max"] {
+            let json = format!(r#"{{"fn": "{function}", "name": "v", "field": "lines_added"}}"#);
+            let parsed = aggregate(&json).unwrap_or_else(|error| panic!("{json}: {error}"));
+            assert_eq!(parsed.name(), "v", "{json}");
+        }
+    }
+
+    #[test]
+    fn a_fold_that_names_the_wrong_operands_is_refused_at_deserialization() {
+        let cases = [
+            r#"{"fn": "count", "name": "commits", "field": "lines_added"}"#,
+            r#"{"fn": "sum", "name": "added"}"#,
+            r#"{"fn": "median", "name": "v", "field": "lines_added"}"#,
+            r#"{"name": "v", "field": "lines_added"}"#,
+        ];
+
+        for json in cases {
+            assert!(aggregate(json).is_err(), "{json}");
+        }
+    }
+
+    #[test]
+    fn a_group_axis_names_the_axis_it_is() {
+        let cases = [
+            r#"{"axis": "dimension", "field": "repository"}"#,
+            r#"{"axis": "time"}"#,
+        ];
+        for json in cases {
+            serde_json::from_str::<GroupAxisDto>(json).unwrap_or_else(|error| {
+                panic!("{json}: {error}");
+            });
+        }
+
+        let refused = [
+            r#"{"axis": "time", "dimension": "repository"}"#,
+            r#"{"axis": "dimension"}"#,
+            r#"{"dimension": "repository"}"#,
+            r#"{"axis": "bin", "field": "lines_added", "width": 10}"#,
+        ];
+        for json in refused {
+            assert!(
+                serde_json::from_str::<GroupAxisDto>(json).is_err(),
+                "{json}"
+            );
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/contract/mod.rs
+++ b/src/backend/services/analytics/src/domain/query/contract/mod.rs
@@ -1,0 +1,3 @@
+//! The query contract: the request a caller writes and the answer it gets back.
+
+pub mod dto;

--- a/src/backend/services/analytics/src/domain/query/fixtures.rs
+++ b/src/backend/services/analytics/src/domain/query/fixtures.rs
@@ -1,0 +1,74 @@
+//! A dataset for the engine's own tests, validated the way a shipped one is.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use crate::domain::field_catalog::loader;
+
+use super::contract::dto::QueryRequest;
+use crate::domain::datasets::declaration::{Dataset, DatasetDocument};
+use crate::domain::datasets::validate;
+
+const SNAPSHOT: &str = r#"[
+  {
+    "database": "insight",
+    "relation": "git_commits",
+    "engine": "MergeTree",
+    "columns": [
+      {"name": "tenant_id", "type": "Nullable(String)"},
+      {"name": "source_id", "type": "Nullable(String)"},
+      {"name": "commit_hash", "type": "String"},
+      {"name": "author_email", "type": "String"},
+      {"name": "message", "type": "String"},
+      {"name": "authored_at", "type": "DateTime"},
+      {"name": "authored_date", "type": "Date"},
+      {"name": "branch_scope", "type": "String"},
+      {"name": "branch_scope_label", "type": "String"},
+      {"name": "repository", "type": "String"},
+      {"name": "repository_label", "type": "String"},
+      {"name": "source", "type": "String"},
+      {"name": "source_label", "type": "String"},
+      {"name": "lines_added", "type": "Nullable(Int64)"},
+      {"name": "lines_removed", "type": "Nullable(Int64)"}
+    ]
+  }
+]"#;
+
+const DECLARATION: &str = "
+key: git_commits
+database: insight
+relation: git_commits
+read_discipline: plain
+tenant_field: tenant_id
+time_fields:
+  - field: authored_at
+    default: true
+  - field: authored_date
+dimensions:
+  - field: author_email
+  - field: branch_scope
+    label_field: branch_scope_label
+  - field: repository
+    label_field: repository_label
+  - field: source
+    label_field: source_label
+  - field: source_id
+    absent_value: __unknown__
+measurables:
+  - field: lines_added
+  - field: lines_removed
+row_identity:
+  - tenant_id
+  - source
+  - commit_hash
+";
+
+pub fn commits() -> Dataset {
+    let catalog = loader::load(SNAPSHOT).expect("the fixture snapshot parses");
+    let document: DatasetDocument =
+        serde_yaml::from_str(DECLARATION).expect("the fixture declaration parses");
+    validate::validate(document, &catalog).expect("the fixture declaration is admissible")
+}
+
+pub fn query(json: &str) -> QueryRequest {
+    serde_json::from_str(json).expect("the fixture query is in the contract")
+}

--- a/src/backend/services/analytics/src/domain/query/mod.rs
+++ b/src/backend/services/analytics/src/domain/query/mod.rs
@@ -1,0 +1,13 @@
+//! The query engine: one query contract over declared datasets.
+//!
+//! INVARIANT: identity is a dataset's declared policy, and no dataset in this
+//! build declares one.
+
+pub mod answer;
+pub mod compile;
+pub mod contract;
+#[cfg(test)]
+pub mod fixtures;
+pub mod plan;
+pub mod validation;
+pub mod violation;

--- a/src/backend/services/analytics/src/domain/query/plan.rs
+++ b/src/backend/services/analytics/src/domain/query/plan.rs
@@ -1,0 +1,162 @@
+//! A query bound to its dataset, with every field reference already resolved.
+//!
+//! INVARIANT: a plan exists only for a query [`super::validation`] accepted, so
+//! the compiler never re-asks whether anything is declared.
+
+use chrono::NaiveDate;
+
+use super::contract::dto::{AnswerColumn, Direction, Grain, ScalarDto};
+use crate::domain::datasets::declaration::{Dataset, Dimension, Measurable, TimeField};
+pub use crate::domain::datasets::label_column_name;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryPlan<'d> {
+    pub dataset: &'d Dataset,
+    pub filters: Vec<PlannedFilter<'d>>,
+    pub group_by: Vec<PlannedAxis<'d>>,
+    pub aggregates: Vec<PlannedAggregate<'d>>,
+    pub time: PlannedTime<'d>,
+    pub order: Vec<PlannedOrder>,
+    pub limit: u32,
+    pub columns: Vec<PlannedColumn<'d>>,
+}
+
+/// One column of the answer and what the statement selects for it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannedColumn<'d> {
+    pub answer: AnswerColumn,
+    pub source: ColumnSource<'d>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ColumnSource<'d> {
+    Dimension(&'d Dimension),
+    /// The declared label of a dimension the answer also carries the value of.
+    Label(&'d Dimension),
+    Bucket,
+    /// Index into [`QueryPlan::aggregates`].
+    Aggregate(usize),
+}
+
+impl PlannedColumn<'_> {
+    /// Whether the statement groups by this column.
+    pub fn groups(&self) -> bool {
+        match self.source {
+            ColumnSource::Dimension(_) | ColumnSource::Bucket => true,
+            ColumnSource::Label(_) | ColumnSource::Aggregate(_) => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlannedAxis<'d> {
+    Dimension(&'d Dimension),
+    Time,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannedFilter<'d> {
+    pub target: FilterTarget<'d>,
+    pub test: PlannedTest,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PlannedTest {
+    Eq(ScalarDto),
+    /// INVARIANT: validation admits between one value and the contract's cap.
+    In(Vec<ScalarDto>),
+    Compare(CompareOp, ScalarDto),
+    Between {
+        low: ScalarDto,
+        high: ScalarDto,
+    },
+    NotNull,
+    /// INVARIANT: validation admits a pattern only over a dimension and within the length cap.
+    Like(String),
+    /// INVARIANT: validation compiled the expression, so the warehouse will too.
+    Matches(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompareOp {
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+}
+
+impl PlannedTest {
+    pub fn operands(&self) -> Vec<(String, &ScalarDto)> {
+        match self {
+            Self::Eq(value) | Self::Compare(_, value) => vec![("value".to_owned(), value)],
+            Self::In(values) => values
+                .iter()
+                .enumerate()
+                .map(|(index, value)| (format!("values[{index}]"), value))
+                .collect(),
+            Self::Between { low, high } => {
+                vec![("low".to_owned(), low), ("high".to_owned(), high)]
+            }
+            Self::NotNull | Self::Like(_) | Self::Matches(_) => Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilterTarget<'d> {
+    /// Compared against the value the answer reports, never the raw column.
+    Dimension(&'d Dimension),
+    /// Compared against the numeric column itself.
+    Measurable(&'d Measurable),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannedAggregate<'d> {
+    /// Position in the request's `aggregates`, which a refusal names.
+    pub index: usize,
+    pub name: String,
+    pub fold: PlannedFold<'d>,
+    pub filter: Option<PlannedFilter<'d>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlannedFold<'d> {
+    Rows,
+    Values {
+        function: FoldFn,
+        measurable: &'d Measurable,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FoldFn {
+    Sum,
+    Avg,
+    Min,
+    Max,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedTime<'d> {
+    pub field: &'d TimeField,
+    pub from: NaiveDate,
+    pub to: NaiveDate,
+    /// Present exactly when the query carries a time axis.
+    pub grain: Option<Grain>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlannedOrder {
+    /// Index into [`QueryPlan::columns`].
+    pub column: usize,
+    pub direction: Direction,
+}
+
+/// The name the bucket column answers under, and an order term reaches it by.
+pub const BUCKET_COLUMN: &str = "time";
+
+// SAFETY: aliases are positional and engine-owned, so no caller-supplied string
+// reaches the SQL text, and no alias can shadow the column it reads.
+pub fn column_alias(index: usize) -> String {
+    format!("c{index}")
+}

--- a/src/backend/services/analytics/src/domain/query/validation.rs
+++ b/src/backend/services/analytics/src/domain/query/validation.rs
@@ -1,0 +1,1217 @@
+//! Binds a query to its dataset, or refuses it.
+//!
+//! INVARIANT: the whole query is checked before anything is refused, so a caller
+//! sees every problem at once.
+
+use std::collections::HashSet;
+
+use chrono::NaiveDate;
+
+use super::contract::dto::{
+    AggregateDto, AnswerColumn, ColumnKind, ColumnType, DEFAULT_ROW_LIMIT, FilterDto, GroupAxisDto,
+    MAX_AGGREGATES, MAX_FILTER_VALUES, MAX_FILTERS, MAX_GROUP_AXES, MAX_NAME_CHARS,
+    MAX_ORDER_TERMS, MAX_PATTERN_CHARS, MAX_ROW_LIMIT, MAX_WINDOW_DAYS, OrderDto, QueryRequest,
+    ScalarDto,
+};
+use super::plan::{
+    BUCKET_COLUMN, ColumnSource, CompareOp, FilterTarget, FoldFn, PlannedAggregate, PlannedAxis,
+    PlannedColumn, PlannedFilter, PlannedFold, PlannedOrder, PlannedTest, PlannedTime, QueryPlan,
+    label_column_name,
+};
+use super::violation::{Reason, Violation};
+use crate::domain::datasets;
+use crate::domain::datasets::declaration::Dataset;
+use crate::domain::datasets::validate::DeclarationError;
+
+/// Why a request got no plan: the request's fault, or this build's.
+#[derive(Debug)]
+pub enum PlanError {
+    Refused(Vec<Violation>),
+    /// The shipped declarations failed to load, so no query can be answered.
+    DeclarationsUnusable(&'static DeclarationError),
+}
+
+pub fn plan(request: &QueryRequest) -> Result<QueryPlan<'static>, PlanError> {
+    let declared = datasets::product_datasets().map_err(PlanError::DeclarationsUnusable)?;
+
+    let dataset = declared
+        .iter()
+        .find(|dataset| dataset.key.as_str() == request.dataset)
+        .ok_or_else(|| {
+            PlanError::Refused(vec![Violation::unknown(
+                "dataset",
+                &request.dataset,
+                &datasets::declared_keys(),
+            )])
+        })?;
+
+    plan_against(request, dataset).map_err(PlanError::Refused)
+}
+
+pub fn plan_against<'d>(
+    request: &QueryRequest,
+    dataset: &'d Dataset,
+) -> Result<QueryPlan<'d>, Vec<Violation>> {
+    let mut violations = Vec::new();
+
+    let filters = plan_filters(&request.filters, dataset, &mut violations);
+    let group_by = plan_axes(&request.group_by, dataset, &mut violations);
+    let aggregates = plan_aggregates(&request.aggregates, dataset, &mut violations);
+    let time = plan_time(request, &group_by, dataset, &mut violations);
+    let limit = plan_limit(request.limit, &mut violations);
+
+    let columns = answer_columns(&group_by, &aggregates, &mut violations);
+    let order = plan_order(&request.order, &columns, &mut violations);
+
+    let Some(time) = time else {
+        return Err(violations);
+    };
+    if !violations.is_empty() {
+        return Err(violations);
+    }
+
+    Ok(QueryPlan {
+        dataset,
+        filters,
+        group_by,
+        aggregates,
+        time,
+        order,
+        limit,
+        columns,
+    })
+}
+
+fn plan_filters<'d>(
+    filters: &[FilterDto],
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Vec<PlannedFilter<'d>> {
+    if filters.len() > MAX_FILTERS {
+        violations.push(Violation::new(
+            "filters",
+            Reason::OutOfRange,
+            format!("a query carries at most {MAX_FILTERS} filters"),
+        ));
+    }
+
+    filters
+        .iter()
+        .enumerate()
+        .filter_map(|(index, filter)| {
+            plan_filter(filter, &format!("filters[{index}]"), dataset, violations)
+        })
+        .collect()
+}
+
+fn plan_filter<'d>(
+    filter: &FilterDto,
+    path: &str,
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Option<PlannedFilter<'d>> {
+    let target = resolve_filter_target(filter, path, dataset, violations)?;
+    let test = planned_test(filter, path, violations)?;
+    check_operands(&test, &target, path, violations);
+
+    Some(PlannedFilter { target, test })
+}
+
+// INVARIANT: every operator but `in` has its arity fixed by its shape.
+fn planned_test(
+    filter: &FilterDto,
+    path: &str,
+    violations: &mut Vec<Violation>,
+) -> Option<PlannedTest> {
+    let test = match filter {
+        FilterDto::Eq { value, .. } => PlannedTest::Eq(value.clone()),
+        FilterDto::In { values, .. } => {
+            let complaint = match values.len() {
+                0 => Some("takes at least one value".to_owned()),
+                n if n > MAX_FILTER_VALUES => {
+                    Some(format!("takes at most {MAX_FILTER_VALUES} values"))
+                }
+                _ => None,
+            };
+            if let Some(complaint) = complaint {
+                violations.push(Violation::new(
+                    format!("{path}.values"),
+                    Reason::OutOfRange,
+                    format!("`in` {complaint}, and {} were given", values.len()),
+                ));
+                return None;
+            }
+            PlannedTest::In(values.clone())
+        }
+        FilterDto::Gt { value, .. } => PlannedTest::Compare(CompareOp::Gt, value.clone()),
+        FilterDto::Gte { value, .. } => PlannedTest::Compare(CompareOp::Gte, value.clone()),
+        FilterDto::Lt { value, .. } => PlannedTest::Compare(CompareOp::Lt, value.clone()),
+        FilterDto::Lte { value, .. } => PlannedTest::Compare(CompareOp::Lte, value.clone()),
+        FilterDto::Between { low, high, .. } => PlannedTest::Between {
+            low: low.clone(),
+            high: high.clone(),
+        },
+        FilterDto::NotNull { .. } => PlannedTest::NotNull,
+        FilterDto::Like { value, .. } => {
+            check_pattern_length(value, path, violations)?;
+            PlannedTest::Like(value.clone())
+        }
+        FilterDto::Matches { value, .. } => {
+            check_pattern_length(value, path, violations)?;
+            if let Err(error) = regex_lite::Regex::new(value) {
+                violations.push(Violation::new(
+                    format!("{path}.value"),
+                    Reason::Malformed,
+                    format!("the pattern is not a regular expression: {error}"),
+                ));
+                return None;
+            }
+            PlannedTest::Matches(value.clone())
+        }
+    };
+
+    Some(test)
+}
+
+fn check_pattern_length(pattern: &str, path: &str, violations: &mut Vec<Violation>) -> Option<()> {
+    if pattern.chars().count() <= MAX_PATTERN_CHARS {
+        return Some(());
+    }
+    violations.push(Violation::new(
+        format!("{path}.value"),
+        Reason::OutOfRange,
+        format!("a pattern is at most {MAX_PATTERN_CHARS} characters"),
+    ));
+    None
+}
+
+fn resolve_filter_target<'d>(
+    filter: &FilterDto,
+    path: &str,
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Option<FilterTarget<'d>> {
+    if let Some(dimension) = dataset.dimension(filter.field()) {
+        return Some(FilterTarget::Dimension(dimension));
+    }
+    if let Some(measurable) = dataset.measurable(filter.field()) {
+        return Some(FilterTarget::Measurable(measurable));
+    }
+
+    let mut admissible = dataset.dimension_names();
+    admissible.extend(dataset.measurable_names());
+    violations.push(Violation::unknown(
+        format!("{path}.field"),
+        filter.field(),
+        &admissible,
+    ));
+    None
+}
+
+// INVARIANT: a dimension compares as text, so an ordered test over it would
+// order lexicographically; a measurable compares against the numeric column, so
+// a pattern cannot apply and only a number can be on the other side.
+fn check_operands(
+    test: &PlannedTest,
+    target: &FilterTarget<'_>,
+    path: &str,
+    violations: &mut Vec<Violation>,
+) {
+    let measurable = match target {
+        FilterTarget::Dimension(dimension) => {
+            if matches!(test, PlannedTest::Compare(..) | PlannedTest::Between { .. }) {
+                violations.push(Violation::new(
+                    format!("{path}.op"),
+                    Reason::Unexpected,
+                    format!(
+                        "`{}` is a dimension and takes eq, in, not_null, like or match",
+                        dimension.field
+                    ),
+                ));
+            }
+            return;
+        }
+        FilterTarget::Measurable(measurable) => measurable,
+    };
+
+    if matches!(test, PlannedTest::Like(_) | PlannedTest::Matches(_)) {
+        violations.push(Violation::new(
+            format!("{path}.op"),
+            Reason::Unexpected,
+            format!(
+                "`{}` is numeric and takes eq, in, not_null, the comparisons or between",
+                measurable.field
+            ),
+        ));
+        return;
+    }
+
+    for (operand, value) in test.operands() {
+        if matches!(value, ScalarDto::Number(_)) {
+            continue;
+        }
+        violations.push(Violation::new(
+            format!("{path}.{operand}"),
+            Reason::TypeMismatch,
+            format!(
+                "`{}` is numeric and compares against numbers",
+                measurable.field
+            ),
+        ));
+    }
+}
+
+fn plan_axes<'d>(
+    axes: &[GroupAxisDto],
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Vec<PlannedAxis<'d>> {
+    if axes.len() > MAX_GROUP_AXES {
+        violations.push(Violation::new(
+            "group_by",
+            Reason::OutOfRange,
+            format!("a query groups by at most {MAX_GROUP_AXES} axes"),
+        ));
+    }
+
+    let mut seen_dimensions = HashSet::new();
+    let mut seen_time = false;
+    let mut planned = Vec::with_capacity(axes.len());
+
+    for (index, axis) in axes.iter().enumerate() {
+        match axis {
+            GroupAxisDto::Dimension { field: named } => {
+                let Some(dimension) = dataset.dimension(named) else {
+                    violations.push(Violation::unknown(
+                        format!("group_by[{index}].field"),
+                        named,
+                        &dataset.dimension_names(),
+                    ));
+                    continue;
+                };
+                if !seen_dimensions.insert(dimension.field.as_str()) {
+                    violations.push(Violation::new(
+                        format!("group_by[{index}].field"),
+                        Reason::Duplicate,
+                        format!("`{}` is already a group axis", dimension.field),
+                    ));
+                    continue;
+                }
+                planned.push(PlannedAxis::Dimension(dimension));
+            }
+            GroupAxisDto::Time {} => {
+                if seen_time {
+                    violations.push(Violation::new(
+                        format!("group_by[{index}].axis"),
+                        Reason::Duplicate,
+                        "a query carries one time axis",
+                    ));
+                    continue;
+                }
+                seen_time = true;
+                planned.push(PlannedAxis::Time);
+            }
+        }
+    }
+
+    planned
+}
+
+fn plan_aggregates<'d>(
+    aggregates: &[AggregateDto],
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Vec<PlannedAggregate<'d>> {
+    if aggregates.is_empty() {
+        violations.push(Violation::new(
+            "aggregates",
+            Reason::Missing,
+            "a query computes at least one aggregate",
+        ));
+    }
+    if aggregates.len() > MAX_AGGREGATES {
+        violations.push(Violation::new(
+            "aggregates",
+            Reason::OutOfRange,
+            format!("a query carries at most {MAX_AGGREGATES} aggregates"),
+        ));
+    }
+
+    let mut seen = HashSet::new();
+    let mut planned = Vec::with_capacity(aggregates.len());
+
+    for (index, aggregate) in aggregates.iter().enumerate() {
+        let path = format!("aggregates[{index}]");
+        let name = aggregate.name();
+        if !is_answer_name(name) {
+            violations.push(Violation::new(
+                format!("{path}.name"),
+                Reason::Malformed,
+                format!(
+                    "an aggregate name is lowercase snake_case of at most {MAX_NAME_CHARS} characters"
+                ),
+            ));
+            continue;
+        }
+        if !seen.insert(name) {
+            violations.push(Violation::new(
+                format!("{path}.name"),
+                Reason::Duplicate,
+                format!("`{name}` names two aggregates"),
+            ));
+            continue;
+        }
+
+        let Some(fold) = plan_fold(aggregate, &path, dataset, violations) else {
+            continue;
+        };
+        let declared_filter = aggregate.filter();
+        let filter = declared_filter
+            .and_then(|filter| plan_filter(filter, &format!("{path}.filter"), dataset, violations));
+        if declared_filter.is_some() && filter.is_none() {
+            continue;
+        }
+
+        planned.push(PlannedAggregate {
+            index,
+            name: name.to_owned(),
+            fold,
+            filter,
+        });
+    }
+
+    planned
+}
+
+fn plan_fold<'d>(
+    aggregate: &AggregateDto,
+    path: &str,
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Option<PlannedFold<'d>> {
+    let (function, field) = match aggregate {
+        AggregateDto::Count { .. } => return Some(PlannedFold::Rows),
+        AggregateDto::Sum { field, .. } => (FoldFn::Sum, field),
+        AggregateDto::Avg { field, .. } => (FoldFn::Avg, field),
+        AggregateDto::Min { field, .. } => (FoldFn::Min, field),
+        AggregateDto::Max { field, .. } => (FoldFn::Max, field),
+    };
+
+    let Some(measurable) = dataset.measurable(field) else {
+        violations.push(Violation::unknown(
+            format!("{path}.field"),
+            field,
+            &dataset.measurable_names(),
+        ));
+        return None;
+    };
+
+    Some(PlannedFold::Values {
+        function,
+        measurable,
+    })
+}
+
+fn plan_time<'d>(
+    request: &QueryRequest,
+    group_by: &[PlannedAxis<'d>],
+    dataset: &'d Dataset,
+    violations: &mut Vec<Violation>,
+) -> Option<PlannedTime<'d>> {
+    let time = &request.time;
+    if time.from > time.to {
+        violations.push(Violation::new(
+            "time.from",
+            Reason::OutOfRange,
+            "the window starts after it ends",
+        ));
+    } else if (time.to - time.from).num_days() >= MAX_WINDOW_DAYS {
+        violations.push(Violation::new(
+            "time.to",
+            Reason::OutOfRange,
+            format!("a window spans at most {MAX_WINDOW_DAYS} days"),
+        ));
+    }
+    check_window_days_representable(time.from, time.to, violations);
+
+    let buckets = group_by
+        .iter()
+        .any(|axis| matches!(axis, PlannedAxis::Time));
+    match (buckets, time.grain) {
+        (true, None) => violations.push(Violation::new(
+            "time.grain",
+            Reason::Missing,
+            "a time axis needs a bucket width",
+        )),
+        (false, Some(_)) => violations.push(Violation::new(
+            "time.grain",
+            Reason::Unexpected,
+            "a bucket width buckets nothing without an `{\"axis\": \"time\"}` axis",
+        )),
+        (true, Some(_)) | (false, None) => {}
+    }
+
+    let field = match time.field.as_deref() {
+        None => dataset.default_time_field(),
+        Some(named) => {
+            let found = dataset.time_field(named);
+            if found.is_none() {
+                violations.push(Violation::unknown(
+                    "time.field",
+                    named,
+                    &dataset.time_field_names(),
+                ));
+            }
+            found
+        }
+    }?;
+
+    Some(PlannedTime {
+        field,
+        from: time.from,
+        to: time.to,
+        grain: time.grain,
+    })
+}
+
+// SAFETY: the compiler renders every bound day through `toDate`, which clamps a
+// day outside the warehouse's `Date` range instead of refusing it — so a window
+// the caller never asked for would match rows.
+fn check_window_days_representable(
+    from: NaiveDate,
+    to: NaiveDate,
+    violations: &mut Vec<Violation>,
+) {
+    let (earliest, latest) = representable_window_days();
+    for (field, day) in [("time.from", from), ("time.to", to)] {
+        if day < earliest || day > latest {
+            violations.push(Violation::new(
+                field,
+                Reason::OutOfRange,
+                format!("a window day lies between {earliest} and {latest}"),
+            ));
+        }
+    }
+}
+
+/// The range of ClickHouse's `Date`.
+fn representable_window_days() -> (NaiveDate, NaiveDate) {
+    let earliest = NaiveDate::from_ymd_opt(1970, 1, 1);
+    let latest = NaiveDate::from_ymd_opt(2149, 6, 6);
+    match (earliest, latest) {
+        (Some(earliest), Some(latest)) => (earliest, latest),
+        (None, _) | (_, None) => unreachable!("the Date range is a valid calendar range"),
+    }
+}
+
+fn plan_limit(limit: Option<u32>, violations: &mut Vec<Violation>) -> u32 {
+    match limit {
+        None => DEFAULT_ROW_LIMIT,
+        Some(0) => {
+            violations.push(Violation::new(
+                "limit",
+                Reason::OutOfRange,
+                "a limit of zero asks for no rows",
+            ));
+            DEFAULT_ROW_LIMIT
+        }
+        Some(requested) if requested > MAX_ROW_LIMIT => {
+            violations.push(Violation::new(
+                "limit",
+                Reason::OutOfRange,
+                format!("an answer carries at most {MAX_ROW_LIMIT} rows"),
+            ));
+            DEFAULT_ROW_LIMIT
+        }
+        Some(requested) => requested,
+    }
+}
+
+// INVARIANT: no two answer columns share a name, or an order term could not say
+// which one it means.
+fn answer_columns<'d>(
+    group_by: &[PlannedAxis<'d>],
+    aggregates: &[PlannedAggregate<'d>],
+    violations: &mut Vec<Violation>,
+) -> Vec<PlannedColumn<'d>> {
+    let mut columns: Vec<PlannedColumn<'d>> =
+        Vec::with_capacity(2 * group_by.len() + aggregates.len());
+
+    for axis in group_by {
+        match axis {
+            PlannedAxis::Dimension(dimension) => {
+                columns.push(PlannedColumn {
+                    answer: AnswerColumn {
+                        name: dimension.field.clone(),
+                        kind: ColumnKind::Dimension,
+                        value_type: ColumnType::Text,
+                    },
+                    source: ColumnSource::Dimension(dimension),
+                });
+                if dimension.label_field.is_some() {
+                    columns.push(PlannedColumn {
+                        answer: AnswerColumn {
+                            name: label_column_name(dimension),
+                            kind: ColumnKind::Label,
+                            value_type: ColumnType::Text,
+                        },
+                        source: ColumnSource::Label(dimension),
+                    });
+                }
+            }
+            PlannedAxis::Time => columns.push(PlannedColumn {
+                answer: AnswerColumn {
+                    name: BUCKET_COLUMN.to_owned(),
+                    kind: ColumnKind::Bucket,
+                    value_type: ColumnType::Date,
+                },
+                source: ColumnSource::Bucket,
+            }),
+        }
+    }
+
+    for (position, aggregate) in aggregates.iter().enumerate() {
+        if columns
+            .iter()
+            .any(|column| column.answer.name == aggregate.name)
+        {
+            violations.push(Violation::new(
+                format!("aggregates[{}].name", aggregate.index),
+                Reason::Duplicate,
+                format!("`{}` is already a column of this answer", aggregate.name),
+            ));
+            continue;
+        }
+        columns.push(PlannedColumn {
+            answer: AnswerColumn {
+                name: aggregate.name.clone(),
+                kind: ColumnKind::Aggregate,
+                value_type: ColumnType::Number,
+            },
+            source: ColumnSource::Aggregate(position),
+        });
+    }
+
+    columns
+}
+
+fn plan_order(
+    order: &[OrderDto],
+    columns: &[PlannedColumn<'_>],
+    violations: &mut Vec<Violation>,
+) -> Vec<PlannedOrder> {
+    if order.len() > MAX_ORDER_TERMS {
+        violations.push(Violation::new(
+            "order",
+            Reason::OutOfRange,
+            format!("a query orders by at most {MAX_ORDER_TERMS} columns"),
+        ));
+    }
+
+    let names: Vec<&str> = columns
+        .iter()
+        .map(|column| column.answer.name.as_str())
+        .collect();
+    let mut seen = HashSet::new();
+    let mut planned = Vec::with_capacity(order.len());
+
+    for (index, term) in order.iter().enumerate() {
+        let Some(column) = columns
+            .iter()
+            .position(|column| column.answer.name == term.by)
+        else {
+            violations.push(Violation::unknown(
+                format!("order[{index}].by"),
+                &term.by,
+                &names,
+            ));
+            continue;
+        };
+        if !seen.insert(column) {
+            violations.push(Violation::new(
+                format!("order[{index}].by"),
+                Reason::Duplicate,
+                format!("`{}` is already an ordering term", term.by),
+            ));
+            continue;
+        }
+        planned.push(PlannedOrder {
+            column,
+            direction: term.dir,
+        });
+    }
+
+    planned
+}
+
+fn is_answer_name(name: &str) -> bool {
+    if name.chars().count() > MAX_NAME_CHARS {
+        return false;
+    }
+    let mut characters = name.chars();
+    match characters.next() {
+        Some(first) if first.is_ascii_lowercase() => {}
+        Some(_) | None => return false,
+    }
+    characters.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::query::contract::dto::{Direction, Grain};
+    use crate::domain::query::fixtures;
+
+    fn refuse(json: &str) -> Vec<Violation> {
+        let dataset = fixtures::commits();
+        plan_against(&fixtures::query(json), &dataset).expect_err("the query must be refused")
+    }
+
+    fn only(json: &str) -> Violation {
+        let mut violations = refuse(json);
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        violations.remove(0)
+    }
+
+    fn accept(json: &str) -> (Dataset, QueryRequest) {
+        let dataset = fixtures::commits();
+        let request = fixtures::query(json);
+        plan_against(&request, &dataset).expect("the query must be admissible");
+        (dataset, request)
+    }
+
+    const COUNT_BY_WEEK: &str = r#"{
+      "dataset": "git_commits",
+      "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+      "aggregates": [{"name": "commits", "fn": "count"}],
+      "time": {"from": "2026-01-01", "to": "2026-03-31", "grain": "week"},
+      "order": [{"by": "commits", "dir": "desc"}],
+      "limit": 50
+    }"#;
+
+    #[test]
+    fn a_grouped_bucketed_query_binds_every_reference_it_names() {
+        let dataset = fixtures::commits();
+        let plan = plan_against(&fixtures::query(COUNT_BY_WEEK), &dataset).expect("admissible");
+
+        assert_eq!(plan.limit, 50);
+        assert!(plan.group_by.contains(&PlannedAxis::Time));
+        assert_eq!(plan.time.grain, Some(Grain::Week));
+        assert_eq!(plan.time.field.field, "authored_at");
+        assert_eq!(
+            plan.columns
+                .iter()
+                .map(|column| {
+                    (
+                        column.answer.name.as_str(),
+                        column.answer.kind,
+                        column.answer.value_type,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                ("repository", ColumnKind::Dimension, ColumnType::Text),
+                ("repository_label", ColumnKind::Label, ColumnType::Text),
+                ("time", ColumnKind::Bucket, ColumnType::Date),
+                ("commits", ColumnKind::Aggregate, ColumnType::Number),
+            ]
+        );
+        assert_eq!(
+            plan.order,
+            vec![PlannedOrder {
+                column: 3,
+                direction: Direction::Desc,
+            }]
+        );
+    }
+
+    #[test]
+    fn a_dimension_without_a_declared_label_answers_its_value_alone() {
+        let dataset = fixtures::commits();
+        let plan = plan_against(
+            &fixtures::query(
+                r#"{"dataset": "git_commits",
+                     "group_by": [{"axis": "dimension", "field": "author_email"}],
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+            ),
+            &dataset,
+        )
+        .expect("admissible");
+
+        let names: Vec<&str> = plan
+            .columns
+            .iter()
+            .map(|column| column.answer.name.as_str())
+            .collect();
+        assert_eq!(names, ["author_email", "commits"]);
+    }
+
+    #[test]
+    fn an_aggregate_colliding_with_a_group_column_is_refused_at_its_own_request_index() {
+        let violations = refuse(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "source"}],
+                 "aggregates": [{"name": "Bad", "fn": "count"}, {"name": "source", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        let fields: Vec<&str> = violations
+            .iter()
+            .map(|violation| violation.field.as_str())
+            .collect();
+        assert_eq!(fields, ["aggregates[0].name", "aggregates[1].name"]);
+        assert_eq!(violations[1].reason, Reason::Duplicate);
+    }
+
+    #[test]
+    fn a_window_day_the_warehouse_cannot_represent_is_refused_rather_than_clamped() {
+        for (json, field) in [
+            (
+                r#"{"dataset": "git_commits",
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "1960-01-01", "to": "1960-01-31"}}"#,
+                vec!["time.from", "time.to"],
+            ),
+            (
+                r#"{"dataset": "git_commits",
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "2149-06-01", "to": "2149-06-07"}}"#,
+                vec!["time.to"],
+            ),
+        ] {
+            let violations = refuse(json);
+            let fields: Vec<&str> = violations
+                .iter()
+                .map(|violation| violation.field.as_str())
+                .collect();
+            assert_eq!(fields, field, "{json}");
+            assert!(violations.iter().all(|v| v.reason == Reason::OutOfRange));
+        }
+    }
+
+    #[test]
+    fn a_query_naming_no_limit_takes_the_default_ceiling() {
+        let dataset = fixtures::commits();
+        let plan = plan_against(
+            &fixtures::query(
+                r#"{"dataset": "git_commits",
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+            ),
+            &dataset,
+        )
+        .expect("admissible");
+
+        assert_eq!(plan.limit, DEFAULT_ROW_LIMIT);
+        assert_eq!(plan.time.grain, None);
+        assert!(!plan.group_by.contains(&PlannedAxis::Time));
+    }
+
+    #[test]
+    fn a_query_over_the_row_ceiling_is_refused_rather_than_clipped() {
+        let violation = only(&format!(
+            r#"{{"dataset": "git_commits",
+                 "aggregates": [{{"name": "commits", "fn": "count"}}],
+                 "time": {{"from": "2026-01-01", "to": "2026-01-31"}},
+                 "limit": {}}}"#,
+            MAX_ROW_LIMIT + 1
+        ));
+
+        assert_eq!(violation.field, "limit");
+        assert_eq!(violation.reason, Reason::OutOfRange);
+    }
+
+    #[test]
+    fn a_group_axis_the_dataset_does_not_declare_is_refused_with_the_admissible_set() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "branch"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert_eq!(violation.field, "group_by[0].field");
+        assert_eq!(violation.reason, Reason::Unknown);
+        assert!(violation.detail.contains("repository"), "{violation:?}");
+    }
+
+    #[test]
+    fn a_time_axis_and_a_bucket_width_each_require_the_other() {
+        let missing = only(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "time"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(missing.field, "time.grain");
+        assert_eq!(missing.reason, Reason::Missing);
+
+        let unexpected = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31", "grain": "day"}}"#,
+        );
+        assert_eq!(unexpected.field, "time.grain");
+        assert_eq!(unexpected.reason, Reason::Unexpected);
+    }
+
+    #[test]
+    fn a_repeated_axis_is_refused() {
+        for (json, field) in [
+            (
+                r#"{"dataset": "git_commits",
+                     "group_by": [{"axis": "dimension", "field": "repository"}, {"axis": "dimension", "field": "repository"}],
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+                "group_by[1].field",
+            ),
+            (
+                r#"{"dataset": "git_commits",
+                     "group_by": [{"axis": "time"}, {"axis": "time"}],
+                     "aggregates": [{"name": "commits", "fn": "count"}],
+                     "time": {"from": "2026-01-01", "to": "2026-01-31", "grain": "day"}}"#,
+                "group_by[1].axis",
+            ),
+        ] {
+            let violation = only(json);
+            assert_eq!(violation.field, field);
+            assert_eq!(violation.reason, Reason::Duplicate);
+        }
+    }
+
+    #[test]
+    fn a_window_that_ends_before_it_starts_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-03-31", "to": "2026-01-01"}}"#,
+        );
+        assert_eq!(violation.field, "time.from");
+        assert_eq!(violation.reason, Reason::OutOfRange);
+    }
+
+    #[test]
+    fn a_window_wider_than_the_cap_is_refused_and_one_at_the_cap_is_not() {
+        let at_cap = fixtures::query(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2024-01-01", "to": "2025-12-31"}}"#,
+        );
+        plan_against(&at_cap, &fixtures::commits()).expect("731 days inclusive is the cap");
+
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2024-01-01", "to": "2026-01-01"}}"#,
+        );
+        assert_eq!(violation.field, "time.to");
+        assert_eq!(violation.reason, Reason::OutOfRange);
+    }
+
+    #[test]
+    fn a_time_field_the_dataset_does_not_declare_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"field": "ingested_at", "from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "time.field");
+        assert_eq!(violation.reason, Reason::Unknown);
+        assert!(violation.detail.contains("authored_at"), "{violation:?}");
+    }
+
+    #[test]
+    fn a_query_computing_nothing_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits", "aggregates": [],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "aggregates");
+        assert_eq!(violation.reason, Reason::Missing);
+    }
+
+    #[test]
+    fn an_aggregate_over_a_column_that_is_not_a_measurable_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "added", "fn": "sum", "field": "repository"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "aggregates[0].field");
+        assert_eq!(violation.reason, Reason::Unknown);
+        assert!(violation.detail.contains("lines_added"), "{violation:?}");
+    }
+
+    #[test]
+    fn two_answer_columns_may_not_share_a_name() {
+        let repeated = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"},
+                                {"name": "commits", "fn": "sum", "field": "lines_added"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(repeated.field, "aggregates[1].name");
+        assert_eq!(repeated.reason, Reason::Duplicate);
+
+        let shadowing = only(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "repository"}],
+                 "aggregates": [{"name": "repository", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(shadowing.field, "aggregates[0].name");
+        assert_eq!(shadowing.reason, Reason::Duplicate);
+    }
+
+    #[test]
+    fn an_aggregate_name_outside_the_answer_name_shape_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "Commits Merged", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "aggregates[0].name");
+        assert_eq!(violation.reason, Reason::Malformed);
+    }
+
+    #[test]
+    fn an_in_filter_takes_between_one_value_and_the_cap() {
+        let over = format!(
+            "[{}]",
+            (0..=MAX_FILTER_VALUES)
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+
+        for values in ["[]", over.as_str()] {
+            let violation = only(&format!(
+                r#"{{"dataset": "git_commits",
+                     "filters": [{{"field": "lines_added", "op": "in", "values": {values}}}],
+                     "aggregates": [{{"name": "commits", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+            ));
+            assert_eq!(violation.field, "filters[0].values");
+            assert_eq!(violation.reason, Reason::OutOfRange);
+        }
+    }
+    #[test]
+    fn a_measurable_filter_compares_against_numbers_only() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "filters": [{"field": "lines_added", "op": "gte", "value": "500"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "filters[0].value");
+        assert_eq!(violation.reason, Reason::TypeMismatch);
+    }
+
+    #[test]
+    fn an_ordered_test_over_a_dimension_is_refused_rather_than_compared_as_text() {
+        let filters = [
+            r#"{"field": "repository", "op": "gt", "value": "b"}"#,
+            r#"{"field": "repository", "op": "lte", "value": "b"}"#,
+            r#"{"field": "repository", "op": "between", "low": "a", "high": "b"}"#,
+        ];
+        for filter in filters {
+            let violation = only(&format!(
+                r#"{{"dataset": "git_commits",
+                     "filters": [{filter}],
+                     "aggregates": [{{"name": "commits", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+            ));
+            assert_eq!(violation.field, "filters[0].op", "{filter}");
+            assert_eq!(violation.reason, Reason::Unexpected, "{filter}");
+        }
+    }
+
+    #[test]
+    fn a_pattern_test_is_admitted_over_a_dimension_and_refused_over_a_measurable() {
+        let dataset = fixtures::commits();
+        for op in ["like", "match"] {
+            let request = fixtures::query(&format!(
+                r#"{{"dataset": "git_commits",
+                     "filters": [{{"field": "repository", "op": "{op}", "value": "example/%"}}],
+                     "aggregates": [{{"name": "commits", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+            ));
+            plan_against(&request, &dataset).unwrap_or_else(|v| panic!("{op}: {v:?}"));
+
+            let violation = only(&format!(
+                r#"{{"dataset": "git_commits",
+                     "filters": [{{"field": "lines_added", "op": "{op}", "value": "1%"}}],
+                     "aggregates": [{{"name": "commits", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+            ));
+            assert_eq!(violation.field, "filters[0].op", "{op}");
+            assert_eq!(violation.reason, Reason::Unexpected, "{op}");
+        }
+    }
+
+    #[test]
+    fn a_pattern_that_is_not_a_regular_expression_or_is_too_long_is_refused() {
+        let malformed = only(
+            r#"{"dataset": "git_commits",
+                 "filters": [{"field": "repository", "op": "match", "value": "("}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(malformed.field, "filters[0].value");
+        assert_eq!(malformed.reason, Reason::Malformed);
+
+        let long = "%".repeat(MAX_PATTERN_CHARS + 1);
+        let too_long = only(&format!(
+            r#"{{"dataset": "git_commits",
+                 "filters": [{{"field": "repository", "op": "like", "value": "{long}"}}],
+                 "aggregates": [{{"name": "commits", "fn": "count"}}],
+                 "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+        ));
+        assert_eq!(too_long.field, "filters[0].value");
+        assert_eq!(too_long.reason, Reason::OutOfRange);
+    }
+
+    #[test]
+    fn a_filter_over_a_column_that_is_neither_a_dimension_nor_a_measurable_is_refused() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "filters": [{"field": "message", "op": "eq", "value": "x"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "filters[0].field");
+        assert_eq!(violation.reason, Reason::Unknown);
+        assert!(violation.detail.contains("lines_added"), "{violation:?}");
+    }
+
+    #[test]
+    fn a_conditional_aggregate_filter_is_refused_on_its_own_path() {
+        let violation = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count",
+                                 "filter": {"field": "branch", "op": "eq", "value": "main"}}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        assert_eq!(violation.field, "aggregates[0].filter.field");
+        assert_eq!(violation.reason, Reason::Unknown);
+    }
+
+    #[test]
+    fn an_order_term_names_a_column_the_answer_reports() {
+        let unknown = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"},
+                 "order": [{"by": "repository"}]}"#,
+        );
+        assert_eq!(unknown.field, "order[0].by");
+        assert_eq!(unknown.reason, Reason::Unknown);
+        assert!(unknown.detail.contains("commits"), "{unknown:?}");
+
+        let repeated = only(
+            r#"{"dataset": "git_commits",
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"},
+                 "order": [{"by": "commits"}, {"by": "commits", "dir": "desc"}]}"#,
+        );
+        assert_eq!(repeated.field, "order[1].by");
+        assert_eq!(repeated.reason, Reason::Duplicate);
+    }
+
+    #[test]
+    fn every_problem_in_one_query_is_reported_at_once() {
+        let violations = refuse(
+            r#"{"dataset": "git_commits",
+                 "group_by": [{"axis": "dimension", "field": "branch"}],
+                 "aggregates": [{"name": "added", "fn": "sum", "field": "branch_scope"}],
+                 "time": {"from": "2026-03-31", "to": "2026-01-01"},
+                 "limit": 0}"#,
+        );
+
+        let fields: Vec<&str> = violations
+            .iter()
+            .map(|violation| violation.field.as_str())
+            .collect();
+        assert_eq!(
+            fields,
+            vec![
+                "group_by[0].field",
+                "aggregates[0].field",
+                "time.from",
+                "limit"
+            ]
+        );
+    }
+
+    fn refused_by_the_build(json: &str) -> Vec<Violation> {
+        match plan(&fixtures::query(json)) {
+            Err(PlanError::Refused(violations)) => violations,
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_dataset_this_build_does_not_declare_is_refused_with_the_declared_keys() {
+        let violations = refused_by_the_build(
+            r#"{"dataset": "git_tags",
+                 "aggregates": [{"name": "tags", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].field, "dataset");
+        assert!(violations[0].detail.contains("git_commits"));
+    }
+
+    #[test]
+    fn a_dimension_another_dataset_declares_is_still_refused_here() {
+        let axis = r#""group_by": [{"axis": "dimension", "field": "file_extension"}]"#;
+        let query = |dataset: &str| {
+            format!(
+                r#"{{"dataset": "{dataset}", {axis},
+                     "aggregates": [{{"name": "changes", "fn": "count"}}],
+                     "time": {{"from": "2026-01-01", "to": "2026-01-31"}}}}"#
+            )
+        };
+
+        plan(&fixtures::query(&query("git_file_changes")))
+            .expect("the file-change dataset groups by it");
+
+        let violations = refused_by_the_build(&query("git_commits"));
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert_eq!(violations[0].field, "group_by[0].field");
+        assert_eq!(violations[0].reason, Reason::Unknown);
+        let (_, admissible) = violations[0]
+            .detail
+            .split_once("declared: ")
+            .expect("the refusal reports what would have been admissible");
+        assert!(
+            !admissible.contains("file_extension"),
+            "the admissible set must be the commit dataset's own: {admissible:?}"
+        );
+        assert!(admissible.contains("repository"), "{admissible:?}");
+    }
+
+    #[test]
+    fn the_shipped_dataset_answers_the_same_query_the_fixture_does() {
+        plan(&fixtures::query(COUNT_BY_WEEK)).expect("the shipped declaration admits it");
+    }
+
+    #[test]
+    fn a_filter_over_a_nullable_dimension_binds_to_the_dimension_not_the_column() {
+        let (dataset, request) = accept(
+            r#"{"dataset": "git_commits",
+                 "filters": [{"field": "source_id", "op": "eq", "value": "__unknown__"}],
+                 "aggregates": [{"name": "commits", "fn": "count"}],
+                 "time": {"from": "2026-01-01", "to": "2026-01-31"}}"#,
+        );
+        let plan = plan_against(&request, &dataset).expect("admissible");
+
+        assert!(matches!(
+            plan.filters[0].target,
+            FilterTarget::Dimension(dimension) if dimension.absent_value.is_some()
+        ));
+    }
+}

--- a/src/backend/services/analytics/src/domain/query/violation.rs
+++ b/src/backend/services/analytics/src/domain/query/violation.rs
@@ -1,0 +1,105 @@
+//! Why a query is refused: the request field, a machine code, and a sentence.
+
+use std::fmt::Write;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    /// A path into the request document, such as `filters[1].value`.
+    pub field: String,
+    pub reason: Reason,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reason {
+    Unknown,
+    Missing,
+    Unexpected,
+    OutOfRange,
+    Duplicate,
+    /// The field cannot hold a value of that type.
+    TypeMismatch,
+    /// The type fits; the field's own shape rule rejects the value.
+    Malformed,
+}
+
+impl Reason {
+    pub fn as_code(self) -> &'static str {
+        match self {
+            Self::Unknown => "UNKNOWN",
+            Self::Missing => "MISSING",
+            Self::Unexpected => "UNEXPECTED",
+            Self::OutOfRange => "OUT_OF_RANGE",
+            Self::Duplicate => "DUPLICATE",
+            Self::TypeMismatch => "TYPE_MISMATCH",
+            Self::Malformed => "MALFORMED",
+        }
+    }
+}
+
+impl Violation {
+    pub fn new(field: impl Into<String>, reason: Reason, detail: impl Into<String>) -> Self {
+        Self {
+            field: field.into(),
+            reason,
+            detail: detail.into(),
+        }
+    }
+
+    /// A refusal that also reports what would have been admissible.
+    pub fn unknown(field: impl Into<String>, named: &str, admissible: &[&str]) -> Self {
+        let mut detail = format!("`{named}` is not declared here");
+        if admissible.is_empty() {
+            detail.push_str("; this dataset declares none");
+        } else {
+            let _ = write!(detail, "; declared: {}", admissible.join(", "));
+        }
+
+        Self::new(field, Reason::Unknown, detail)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_unknown_field_refusal_reports_the_admissible_set() {
+        let violation =
+            Violation::unknown("group_by[0].field", "branch", &["repository", "source"]);
+
+        assert_eq!(violation.field, "group_by[0].field");
+        assert_eq!(violation.reason, Reason::Unknown);
+        assert_eq!(
+            violation.detail,
+            "`branch` is not declared here; declared: repository, source"
+        );
+    }
+
+    #[test]
+    fn an_unknown_field_refusal_over_an_empty_set_says_so() {
+        let violation = Violation::unknown("aggregates[0].field", "lines", &[]);
+        assert_eq!(
+            violation.detail,
+            "`lines` is not declared here; this dataset declares none"
+        );
+    }
+
+    #[test]
+    fn every_reason_carries_a_distinct_machine_code() {
+        let reasons = [
+            Reason::Unknown,
+            Reason::Missing,
+            Reason::Unexpected,
+            Reason::OutOfRange,
+            Reason::Duplicate,
+            Reason::TypeMismatch,
+            Reason::Malformed,
+        ];
+        let mut codes: Vec<&str> = reasons.iter().map(|reason| reason.as_code()).collect();
+        codes.sort_unstable();
+        codes.dedup();
+        assert_eq!(codes.len(), reasons.len());
+    }
+}

--- a/src/backend/services/analytics/src/infra/metrics.rs
+++ b/src/backend/services/analytics/src/infra/metrics.rs
@@ -14,6 +14,7 @@ use opentelemetry::metrics::{Counter, Histogram, Meter};
 // so the `kind` label on `analytics.metric_query.duration` stays bounded.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum QueryKind {
+    Query,
     Ranking,
     PeriodBatch,
     PeerBatch,
@@ -30,6 +31,7 @@ pub(crate) enum QueryKind {
 impl QueryKind {
     const fn as_str(self) -> &'static str {
         match self {
+            Self::Query => "query",
             Self::Ranking => "ranking",
             Self::PeriodBatch => "period_batch",
             Self::PeerBatch => "peer_batch",

--- a/src/backend/services/analytics/src/infra/query.rs
+++ b/src/backend/services/analytics/src/infra/query.rs
@@ -6,6 +6,9 @@ use sha2::{Digest as _, Sha256};
 use super::metrics::{self, ErrorClass, QueryKind, QueryOutcome};
 
 const QUERY_FETCH_TIMEOUT: Duration = Duration::from_mins(1);
+/// The most an answer may weigh before decoding: a row limit bounds rows, not
+/// the strings in them.
+pub(crate) const MAX_ANSWER_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum QueryFetchError {
@@ -27,6 +30,150 @@ impl QueryFetchError {
             Self::Parse(_) => ErrorClass::ParseFailed,
         }
     }
+}
+
+/// What a bounded fetch can fail with: anything a fetch can, or the ceiling.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum BoundedFetchError {
+    #[error(transparent)]
+    Fetch(#[from] QueryFetchError),
+    #[error("query result exceeded {MAX_ANSWER_BYTES} bytes")]
+    TooLarge,
+}
+
+impl BoundedFetchError {
+    fn class(&self) -> ErrorClass {
+        match self {
+            Self::Fetch(error) => error.class(),
+            Self::TooLarge => ErrorClass::ResourceExhausted,
+        }
+    }
+}
+
+// WORKAROUND: ClickHouse quotes every 64-bit integer by default, which would
+// make an answer's number column arrive as a string.
+pub(crate) async fn fetch_bound_rows(
+    client: &insight_clickhouse::Client,
+    sql: &str,
+    params: &[serde_json::Value],
+    kind: QueryKind,
+    log_comment: &str,
+) -> Result<Vec<serde_json::Value>, BoundedFetchError> {
+    let started = Instant::now();
+    let result = fetch_bound_rows_inner(client, sql, params, log_comment).await;
+
+    match &result {
+        Ok(_) => metrics::record_query(kind, QueryOutcome::Success, started.elapsed()),
+        Err(error) => {
+            metrics::record_query(kind, QueryOutcome::Error, started.elapsed());
+            metrics::record_clickhouse_error(kind, error.class());
+        }
+    }
+    result
+}
+
+async fn fetch_bound_rows_inner(
+    client: &insight_clickhouse::Client,
+    sql: &str,
+    params: &[serde_json::Value],
+    log_comment: &str,
+) -> Result<Vec<serde_json::Value>, BoundedFetchError> {
+    let mut query = client
+        .query(sql)
+        .with_setting("log_comment", log_comment)
+        .with_setting("output_format_json_quote_64bit_integers", "0");
+    for param in params {
+        query = query.bind(param);
+    }
+
+    let mut cursor = query.fetch_bytes("JSONEachRow").map_err(|error| {
+        log_query_failure(
+            &error.to_string(),
+            log_comment,
+            sql,
+            "ClickHouse query failed",
+        );
+        QueryFetchError::Submit(error.to_string())
+    })?;
+
+    let raw_bytes = tokio::time::timeout(QUERY_FETCH_TIMEOUT, collect_bounded(&mut cursor))
+        .await
+        .map_err(|_| {
+            log_query_failure(
+                "timeout",
+                log_comment,
+                sql,
+                "ClickHouse query fetch timed out",
+            );
+            QueryFetchError::Timeout
+        })?
+        .map_err(|error| match error {
+            ChunkError::TooLarge => {
+                tracing::warn!(
+                    comment = log_comment,
+                    "ClickHouse query result exceeded the byte ceiling"
+                );
+                BoundedFetchError::TooLarge
+            }
+            ChunkError::Fetch(message) => {
+                log_query_failure(&message, log_comment, sql, "ClickHouse query fetch failed");
+                BoundedFetchError::Fetch(QueryFetchError::Fetch(message))
+            }
+        })?;
+
+    let parsed = tokio::task::spawn_blocking(move || parse_json_rows(&raw_bytes))
+        .await
+        .map_err(|error| {
+            log_query_failure(
+                &error.to_string(),
+                log_comment,
+                sql,
+                "ClickHouse row parsing task failed",
+            );
+            QueryFetchError::Parse(error.to_string())
+        })?;
+
+    parsed.map_err(|error| {
+        log_query_failure(
+            &error.to_string(),
+            log_comment,
+            sql,
+            "failed to parse ClickHouse query rows",
+        );
+        BoundedFetchError::Fetch(QueryFetchError::Parse(error.to_string()))
+    })
+}
+
+fn parse_json_rows(raw_bytes: &[u8]) -> Result<Vec<serde_json::Value>, serde_json::Error> {
+    raw_bytes
+        .split(|&byte| byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(serde_json::from_slice)
+        .collect()
+}
+
+enum ChunkError {
+    TooLarge,
+    Fetch(String),
+}
+
+// SAFETY: the ceiling is enforced chunk by chunk while receiving, so an
+// oversized result is abandoned rather than buffered and then measured.
+async fn collect_bounded(
+    cursor: &mut clickhouse::query::BytesCursor,
+) -> Result<Vec<u8>, ChunkError> {
+    let mut buffer: Vec<u8> = Vec::new();
+    while let Some(chunk) = cursor
+        .next()
+        .await
+        .map_err(|error| ChunkError::Fetch(error.to_string()))?
+    {
+        if buffer.len() + chunk.len() > MAX_ANSWER_BYTES {
+            return Err(ChunkError::TooLarge);
+        }
+        buffer.extend_from_slice(&chunk);
+    }
+    Ok(buffer)
 }
 
 pub(crate) async fn fetch_json_rows<T>(

--- a/src/ingestion/datasets/git_commits/README.md
+++ b/src/ingestion/datasets/git_commits/README.md
@@ -1,0 +1,32 @@
+# git_commits
+
+One row per commit a person wrote.
+
+## What one row is
+
+A commit, once, per tenant and source system. The same commit reaching the warehouse from a
+fork and its upstream is one row: the hash collapse keeps the first, and every row carries
+the surviving commit's repository and project.
+
+Merge commits are excluded. So are derived commits — a squash or rebase result that
+re-applies work an earlier commit already carried — because counting both would count the
+work twice.
+
+## What the numbers mean
+
+`lines_added` and `lines_removed` are the commit's own stats, less the lines of its file
+changes that lost the content dedup. A commit that introduces nothing new therefore reports
+zero, and its size agrees with the file changes attributed to it. Both are absent, not zero,
+when the source reported no stats at all.
+
+## Where it comes from
+
+The shared commit stage, which resolves the person, the branch scope and the repository
+dimensions; and the authored file-change relation, for the lines to deduct.
+
+## Watch for
+
+- `tenant_id` and `source_id` are nullable on the class relations and stay nullable here;
+  `source_id` groups its absent rows under `__unknown__`.
+- `authored_at` is the author date. A rebase copy and its original share it, which is why the
+  dedup upstream breaks ties on the committer date.

--- a/src/ingestion/datasets/git_commits/dataset.yaml
+++ b/src/ingestion/datasets/git_commits/dataset.yaml
@@ -1,0 +1,37 @@
+key: git_commits
+database: insight
+relation: git_commits
+
+read_discipline: plain
+
+tenant_field: tenant_id
+
+time_fields:
+  - field: authored_at
+    default: true
+
+dimensions:
+  - field: author_email
+    label_field: author_name
+  - field: commit_hash
+  - field: message
+  - field: branch_scope
+    label_field: branch_scope_label
+  - field: repository
+    label_field: repository_label
+  - field: project
+    label_field: project_label
+  - field: source
+    label_field: source_label
+  # Nullable, so its absent rows need a value the answer and a filter can name.
+  - field: source_id
+    absent_value: __unknown__
+
+measurables:
+  - field: lines_added
+  - field: lines_removed
+
+row_identity:
+  - tenant_id
+  - source
+  - commit_hash

--- a/src/ingestion/datasets/git_commits/git_commits.sql
+++ b/src/ingestion/datasets/git_commits/git_commits.sql
@@ -1,0 +1,81 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'author_email', 'authored_at'],
+    partition_by='toYYYYMM(authored_date)',
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Authored commits: one row per commit a person wrote.
+
+WITH
+-- The lines that survived the content dedup, read off the dataset that already
+-- holds them so the two datasets cannot disagree on a commit's size.
+authored_commit_file_lines AS (
+    SELECT
+        tenant_id,
+        source,
+        commit_hash,
+        sum(lines_added) AS lines_added,
+        sum(lines_removed) AS lines_removed
+    FROM {{ ref('git_file_changes') }}
+    GROUP BY tenant_id, source, commit_hash
+)
+
+SELECT
+    commits.tenant_id AS tenant_id,
+    commits.source_id AS source_id,
+    commits.project_key AS project_key,
+    commits.repo_slug AS repo_slug,
+    commits.commit_hash AS commit_hash,
+    commits.entity_id AS author_email,
+    commits.author_name AS author_name,
+    commits.message AS message,
+    -- SAFETY: the stage admits no row without a date, and neither a partition
+    -- key nor a sort key may be nullable.
+    assumeNotNull(commits.observed_at) AS authored_at,
+    assumeNotNull(commits.metric_date) AS authored_date,
+    commits.branch_scope_value AS branch_scope,
+    commits.branch_scope_label AS branch_scope_label,
+    commits.repository_value AS repository,
+    commits.repository_label AS repository_label,
+    commits.project_value AS project,
+    commits.project_label AS project_label,
+    commits.source_value AS source,
+    commits.source_label AS source_label,
+    -- SAFETY: the NULL check is explicit because `greatest` IGNORES NULL
+    -- arguments, which would invent a size for a commit reporting no stats.
+    if(
+        commits.lines_added IS NULL,
+        CAST(NULL AS Nullable(Int64)),
+        toNullable(greatest(
+            toInt64(0),
+            assumeNotNull(commits.lines_added)
+                - (coalesce(reported.lines_added, 0) - coalesce(authored.lines_added, 0))
+        ))
+    ) AS lines_added,
+    if(
+        commits.lines_removed IS NULL,
+        CAST(NULL AS Nullable(Int64)),
+        toNullable(greatest(
+            toInt64(0),
+            assumeNotNull(commits.lines_removed)
+                - (coalesce(reported.lines_removed, 0) - coalesce(authored.lines_removed, 0))
+        ))
+    ) AS lines_removed
+FROM {{ ref('git_authored_commits') }} AS commits
+-- SAFETY: tenant_id is Nullable on the class, and a plain `=` never matches
+-- NULL to NULL — which would read a whole tenant's commits as having no
+-- collected change. The join carries no repository column: those are Nullable
+-- too, and the commit grain is already (tenant, source, hash).
+LEFT JOIN {{ ref('git_commit_file_line_totals') }} AS reported
+    ON reported.tenant_id IS NOT DISTINCT FROM commits.tenant_id
+    AND reported.data_source = commits.data_source
+    AND reported.commit_hash = commits.commit_hash
+LEFT JOIN authored_commit_file_lines AS authored
+    ON authored.tenant_id IS NOT DISTINCT FROM commits.tenant_id
+    AND authored.source = commits.source_value
+    AND authored.commit_hash = commits.commit_hash

--- a/src/ingestion/datasets/git_commits/schema.yml
+++ b/src/ingestion/datasets/git_commits/schema.yml
@@ -1,0 +1,70 @@
+version: 2
+
+models:
+  - name: git_commits
+    description: >
+      Authored commits: one row per commit a person wrote, with the lines that
+      commit actually contributed (its own stats less what lost the file-content
+      dedup). A projection of the shared commit stage, so which commits are one
+      commit — deduplicated across connector instances and mirrored
+      repositories, and excluding the commits whose work another commit already
+      carries — is settled in one place. A query-engine dataset — queries
+      aggregate it and evidence projects it. Identity stays as the source gave
+      it (author_email); the person is resolved when a query runs.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: source_id
+        description: "Connector instance the surviving commit was collected from"
+      - name: project_key
+        description: "Project of the surviving commit, as the source names it"
+      - name: repo_slug
+        description: "Repository of the surviving commit, as the source names it"
+      - name: commit_hash
+        description: "Commit identifier within the repository"
+        tests:
+          - not_null
+      - name: author_email
+        description: "Lowercased source-native author email; the entity a query resolves"
+        tests:
+          - not_null
+      - name: author_name
+        description: "Display name the source recorded for the author; the label of author_email"
+      - name: message
+        description: "Commit message as collected"
+      - name: authored_at
+        description: "When the commit was authored; the dataset's event time"
+      - name: authored_date
+        description: "Authored day, the partition key"
+      - name: branch_scope
+        description: "Whether the commit reached the default branch: default | non_default"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['default', 'non_default']
+      - name: repository
+        description: "Repository dimension value, qualified by source"
+      - name: project
+        description: "Project dimension value, qualified by source"
+      - name: source
+        description: "Source system dimension value"
+      - name: branch_scope_label
+        description: "Display label of branch_scope"
+      - name: repository_label
+        description: "Display label of repository"
+      - name: project_label
+        description: "Display label of project"
+      - name: source_label
+        description: "Display label of source"
+      - name: lines_added
+        description: >
+          Lines this commit contributed: its own reported stats less the lines of
+          the file changes that lost the content dedup, floored at zero. Nullable
+          when the source reports no stats.
+      - name: lines_removed
+        description: >
+          Lines this commit removed: its own reported stats less the lines of the
+          file changes that lost the content dedup, floored at zero. Nullable when
+          the source reports no stats.

--- a/src/ingestion/datasets/git_file_changes/README.md
+++ b/src/ingestion/datasets/git_file_changes/README.md
@@ -1,0 +1,31 @@
+# git_file_changes
+
+One row per path a commit touched.
+
+## What one row is
+
+A tenant, a source, a commit, a file path and a normalized change type. Two content
+identities at one path in one commit fold into a single row carrying the sum of their lines,
+so a line total here always matches the metric evidence.
+
+## What the numbers mean
+
+`lines_added` and `lines_removed` are the lines of the surviving change. A change whose
+content an earlier commit already carried — a cherry-pick, a squashed branch, a
+reverted-then-restored file — is not here at all: it lost the content dedup, and counting it
+would count those lines twice.
+
+## Where it comes from
+
+`git_authored_file_changes`, the shared dedup relation, joined to the surviving commit for
+the person, the dates and the repository dimensions. Those are inherited, never recomputed:
+lines belong to the bucket their commit belongs to.
+
+## Watch for
+
+- `file_path` and `commit_hash` are dimensions, so a question may group by them; the row and
+  answer limits are what keep such a breakdown bounded.
+- `file_extension` and `change_type` are lower-cased, and rows with neither report
+  `__unknown__`.
+- `category` is the shipped classification of a path. A caller who disagrees can filter
+  `file_path` by their own pattern instead.

--- a/src/ingestion/datasets/git_file_changes/dataset.yaml
+++ b/src/ingestion/datasets/git_file_changes/dataset.yaml
@@ -1,0 +1,45 @@
+key: git_file_changes
+database: insight
+relation: git_file_changes
+
+read_discipline: plain
+
+tenant_field: tenant_id
+
+time_fields:
+  - field: authored_at
+    default: true
+
+dimensions:
+  - field: author_email
+    label_field: author_name
+  - field: commit_hash
+  - field: file_path
+  - field: category
+    label_field: category_label
+  - field: file_extension
+    label_field: file_extension_label
+  - field: change_type
+    label_field: change_type_label
+  - field: branch_scope
+    label_field: branch_scope_label
+  - field: repository
+    label_field: repository_label
+  - field: project
+    label_field: project_label
+  - field: source
+    label_field: source_label
+  # Nullable, so its absent rows need a value the answer and a filter can name.
+  - field: source_id
+    absent_value: __unknown__
+
+measurables:
+  - field: lines_added
+  - field: lines_removed
+
+row_identity:
+  - tenant_id
+  - source
+  - commit_hash
+  - file_path
+  - change_type

--- a/src/ingestion/datasets/git_file_changes/git_file_changes.sql
+++ b/src/ingestion/datasets/git_file_changes/git_file_changes.sql
@@ -1,0 +1,77 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'author_email', 'authored_at'],
+    partition_by='toYYYYMM(authored_date)',
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Authored file changes: one row per path and change type a commit touched.
+
+WITH
+-- INVARIANT: one row per (tenant, source, commit, path, lower-cased change
+-- type) is the dataset's row identity. Two content identities under one such
+-- key fold into one row carrying the sum of their lines, so every line total
+-- agrees with the metric evidence.
+folded_file_changes AS (
+    SELECT
+        tenant_id,
+        data_source,
+        commit_hash,
+        file_path,
+        lower(change_type) AS change_kind,
+        min(lower(file_extension)) AS extension,
+        sum(lines_added) AS lines_added,
+        sum(lines_removed) AS lines_removed
+    FROM {{ ref('git_authored_file_changes') }}
+    GROUP BY tenant_id, data_source, commit_hash, file_path, lower(change_type)
+)
+
+SELECT
+    commits.tenant_id AS tenant_id,
+    commits.source_id AS source_id,
+    commits.project_key AS project_key,
+    commits.repo_slug AS repo_slug,
+    commits.commit_hash AS commit_hash,
+    file_changes.file_path AS file_path,
+    commits.entity_id AS author_email,
+    commits.author_name AS author_name,
+    -- SAFETY: the commit stage admits no row without a date, and neither a
+    -- partition key nor a sort key may be nullable.
+    assumeNotNull(commits.observed_at) AS authored_at,
+    assumeNotNull(commits.metric_date) AS authored_date,
+    {{ git_file_category('file_changes.file_path') }} AS category,
+    {{ git_file_category_label('category') }} AS category_label,
+    if(file_changes.extension = '', '__unknown__', file_changes.extension) AS file_extension,
+    if(file_changes.extension = '', 'Unknown', file_changes.extension) AS file_extension_label,
+    if(file_changes.change_kind = '', '__unknown__', file_changes.change_kind) AS change_type,
+    multiIf(
+        file_changes.change_kind = '', 'Unknown',
+        file_changes.change_kind = 'added', 'Added',
+        file_changes.change_kind = 'modified', 'Modified',
+        file_changes.change_kind = 'renamed', 'Renamed',
+        file_changes.change_kind = 'deleted', 'Deleted',
+        file_changes.change_kind
+    ) AS change_type_label,
+    -- INVARIANT: inherited, not recomputed — lines belong to the bucket their
+    -- commit belongs to.
+    commits.branch_scope_value AS branch_scope,
+    commits.branch_scope_label AS branch_scope_label,
+    commits.repository_value AS repository,
+    commits.repository_label AS repository_label,
+    commits.project_value AS project,
+    commits.project_label AS project_label,
+    commits.source_value AS source,
+    commits.source_label AS source_label,
+    file_changes.lines_added AS lines_added,
+    file_changes.lines_removed AS lines_removed
+FROM folded_file_changes AS file_changes
+-- SAFETY: tenant_id is Nullable on the class, and a plain `=` never matches
+-- NULL to NULL — which would drop a whole tenant's file changes.
+INNER JOIN {{ ref('git_authored_commits') }} AS commits
+    ON commits.tenant_id IS NOT DISTINCT FROM file_changes.tenant_id
+    AND commits.data_source = file_changes.data_source
+    AND commits.commit_hash = file_changes.commit_hash

--- a/src/ingestion/datasets/git_file_changes/schema.yml
+++ b/src/ingestion/datasets/git_file_changes/schema.yml
@@ -1,0 +1,77 @@
+version: 2
+
+models:
+  - name: git_file_changes
+    description: >
+      Authored file changes: one row per path and normalized (lower-cased)
+      change type a commit touched, deduplicated by change content so a
+      cherry-pick or a squashed branch counts once. Two content identities under
+      one such key fold into one row carrying the sum of their lines. A projection of the shared file-change stage, so
+      the changes attach to the same surviving commits the metric evidence
+      counts. Commit context (branch_scope, repository, person, time) is
+      inherited from the commit, never recomputed.
+    columns:
+      - name: tenant_id
+        description: "Owning tenant"
+        tests:
+          - not_null
+      - name: source_id
+        description: "Connector instance the surviving commit was collected from"
+      - name: project_key
+        description: "Project of the surviving commit, as the source names it"
+      - name: repo_slug
+        description: "Repository of the surviving commit, as the source names it"
+      - name: commit_hash
+        description: "Commit the change belongs to"
+        tests:
+          - not_null
+      - name: file_path
+        description: "Path of the changed file within the repository"
+        tests:
+          - not_null
+      - name: author_email
+        description: "Lowercased source-native author email; the entity a query resolves"
+        tests:
+          - not_null
+      - name: author_name
+        description: "Display name the source recorded for the author; the label of author_email"
+      - name: authored_at
+        description: "When the change's commit was authored; the dataset's event time"
+      - name: authored_date
+        description: "Authored day, the partition key"
+      - name: category
+        description: "What kind of file changed: code | test | config | docs | vendored | other"
+      - name: file_extension
+        description: "Lowercased file extension, or __unknown__"
+      - name: change_type
+        description: "Lowercased change kind (added, modified, renamed, deleted), or __unknown__"
+      - name: branch_scope
+        description: "Inherited from the commit: default | non_default"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['default', 'non_default']
+      - name: category_label
+        description: "Display label of category"
+      - name: file_extension_label
+        description: "Display label of file_extension"
+      - name: change_type_label
+        description: "Display label of change_type"
+      - name: repository
+        description: "Repository key the commit belongs to; inherited from the commit"
+      - name: project
+        description: "Project key the commit belongs to; inherited from the commit"
+      - name: source
+        description: "Git source (github, gitlab, bitbucket_cloud); inherited from the commit"
+      - name: branch_scope_label
+        description: "Display label of branch_scope"
+      - name: repository_label
+        description: "Display label of repository"
+      - name: project_label
+        description: "Display label of project"
+      - name: source_label
+        description: "Display label of source"
+      - name: lines_added
+        description: "Lines this change added"
+      - name: lines_removed
+        description: "Lines this change removed"

--- a/src/ingestion/dbt/.dbtignore
+++ b/src/ingestion/dbt/.dbtignore
@@ -3,3 +3,5 @@
 **/.venv/**
 **/node_modules/**
 **/__pycache__/**
+# Dataset declarations are read by the analytics service, not by dbt
+**/dataset.yaml

--- a/src/ingestion/dbt/dbt_project.yml
+++ b/src/ingestion/dbt/dbt_project.yml
@@ -8,6 +8,7 @@ model-paths:
   - identity
   - ../silver
   - ../gold
+  - ../datasets
   - ../connectors
 
 macro-paths:

--- a/src/ingestion/dbt/tests/gold/assert_git_commits_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_git_commits_unique.sql
@@ -1,0 +1,10 @@
+-- One row per commit per tenant and source system: the instance dedup is what
+-- keeps a mirrored repository from multiplying a person's work.
+SELECT
+    tenant_id,
+    source,
+    commit_hash,
+    count() AS row_count
+FROM {{ ref('git_commits') }}
+GROUP BY tenant_id, source, commit_hash
+HAVING count() > 1

--- a/src/ingestion/dbt/tests/gold/assert_git_file_changes_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_git_file_changes_unique.sql
@@ -1,0 +1,12 @@
+-- One row per changed path and change type per commit and source: a key that
+-- appears twice would double every line measure built on this dataset.
+SELECT
+    tenant_id,
+    source,
+    commit_hash,
+    file_path,
+    change_type,
+    count() AS row_count
+FROM {{ ref('git_file_changes') }}
+GROUP BY tenant_id, source, commit_hash, file_path, change_type
+HAVING count() > 1

--- a/src/ingestion/gold/git_authored_file_changes.sql
+++ b/src/ingestion/gold/git_authored_file_changes.sql
@@ -1,0 +1,77 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'data_source', 'commit_hash'],
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings(
+        query_settings_overrides={
+            'max_memory_usage': 3221225472,
+            'max_bytes_before_external_sort': 805306368
+        }
+    )
+) }}
+
+-- One row per change CONTENT, not per commit that carries it. The same content
+-- entering a repository on two lines of history — a branch whose copy of a
+-- tree also landed on the default branch, a cherry-pick, a squash that
+-- re-applies its branch's whole span, a reverted-then-restored file — is one
+-- authored change, and summing every carrier's diff would count those lines
+-- more than once. `git_file_content_identity` is what "same content" means.
+--
+-- Earliest commit wins, so the value lands in the period the content was first
+-- authored and does not move when a later commit repeats it.
+--
+-- The commit_hash tie-breaker keeps rows whose identity is UNKNOWN (a source
+-- that reports no oid, or a row collected before the proxy did) distinct per
+-- commit: without it every such row for one path would collapse into one,
+-- because LIMIT 1 BY reads their NULL keys as equal.
+--
+-- The superseded set is the case content identity alone cannot reach: a squash
+-- whose branch was only PARTLY collected carries the collected commits' work
+-- under a span no single commit made, so nothing folds it. See
+-- git_superseded_file_changes.
+--
+-- Materialized so the sort behind LIMIT 1 BY runs once per build in its own
+-- query budget, and every reader — the metric evidence and the query datasets
+-- — scans the same rows rather than re-deriving them.
+
+SELECT
+    tenant_id,
+    source_id,
+    project_key,
+    repo_slug,
+    commit_hash,
+    data_source,
+    file_path,
+    file_extension,
+    change_type,
+    lines_added,
+    lines_removed
+FROM {{ ref('git_commit_file_changes') }}
+-- SAFETY: tenant_id is Nullable, and a tuple holding NULL never matches under
+-- NOT IN — the superseded row would survive and count twice.
+WHERE (coalesce(tenant_id, ''), data_source, commit_hash, file_path) NOT IN (
+    SELECT coalesce(tenant_id, ''), data_source, commit_hash, file_path
+    FROM {{ ref('git_superseded_file_changes') }}
+)
+-- INVARIANT: committer_date breaks the tie, and must stay ahead of the hash.
+-- observed_at is the AUTHOR date, which a rebase preserves — so the copy and
+-- its original tie there, and without this the survivor (and with it the
+-- repository and branch scope the lines are filed under) would be decided by
+-- comparing hashes. #3153
+ORDER BY observed_at, committer_date, commit_hash
+LIMIT 1 BY
+    tenant_id,
+    data_source,
+    project_key,
+    repo_slug,
+    file_path,
+    {{ git_file_content_identity('post_image_oid', 'pre_image_oid') }},
+    if(
+        coalesce(pre_image_oid, '') = ''
+            AND coalesce(post_image_oid, '') = '',
+        commit_hash,
+        ''
+    )

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -57,25 +57,8 @@ repository_default_branches AS (
     WHERE is_default = 1
     GROUP BY tenant_id, source_id, project_key, repo_slug
 ),
--- One row per change CONTENT, not per commit that carries it. The same content
--- entering a repository on two lines of history — a branch whose copy of a
--- tree also landed on the default branch, a cherry-pick, a squash that
--- re-applies its branch's whole span, a reverted-then-restored file — is one
--- authored change, and summing every carrier's diff would count those lines
--- more than once. `git_file_content_identity` is what "same content" means.
---
--- Earliest commit wins, so the value lands in the period the content was first
--- authored and does not move when a later commit repeats it.
---
--- The commit_hash tie-breaker keeps rows whose identity is UNKNOWN (a source
--- that reports no oid, or a row collected before the proxy did) distinct per
--- commit: without it every such row for one path would collapse into one,
--- because LIMIT 1 BY reads their NULL keys as equal.
---
--- The superseded set is the case content identity alone cannot reach: a squash
--- whose branch was only PARTLY collected carries the collected commits' work
--- under a span no single commit made, so nothing folds it. See
--- git_superseded_file_changes.
+-- The content dedup lives in git_authored_file_changes: what "same content"
+-- means, why the earliest commit wins, and why it is a table rather than a CTE.
 deduplicated_file_changes AS (
     SELECT
         tenant_id,
@@ -89,30 +72,7 @@ deduplicated_file_changes AS (
         change_type,
         lines_added,
         lines_removed
-    FROM {{ ref('git_commit_file_changes') }}
-    WHERE (tenant_id, data_source, commit_hash, file_path) NOT IN (
-        SELECT tenant_id, data_source, commit_hash, file_path
-        FROM {{ ref('git_superseded_file_changes') }}
-    )
-    -- INVARIANT: committer_date breaks the tie, and must stay ahead of the
-    -- hash. observed_at is the AUTHOR date, which a rebase preserves — so the
-    -- copy and its original tie there, and without this the survivor (and with
-    -- it the repository and branch scope the lines are filed under) would be
-    -- decided by comparing hashes. #3153
-    ORDER BY observed_at, committer_date, commit_hash
-    LIMIT 1 BY
-        tenant_id,
-        data_source,
-        project_key,
-        repo_slug,
-        file_path,
-        {{ git_file_content_identity('post_image_oid', 'pre_image_oid') }},
-        if(
-            coalesce(pre_image_oid, '') = ''
-                AND coalesce(post_image_oid, '') = '',
-            commit_hash,
-            ''
-        )
+    FROM {{ ref('git_authored_file_changes') }}
 ),
 -- A commit's own line stats, less the lines of the file changes that lost the
 -- content dedup. The stats stay the base — a source can report a commit's

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -102,6 +102,44 @@ models:
         tests:
           - not_null
 
+  - name: git_authored_file_changes
+    description: >
+      One row per authored change CONTENT: the file changes attached to the
+      surviving commits, less the ones an earlier commit already carried (same
+      content identity) and the ones a partly collected squash superseded.
+      Earliest commit wins. Materialized so the sort behind the dedup runs once
+      per build; the metric evidence and the query datasets both read it.
+    columns:
+      - name: tenant_id
+        description: >
+          Tenant isolation field. Nullable on the git class relations and
+          preserved as such here, so no not_null test.
+      - name: source_id
+        description: "Connector instance the surviving commit was collected from"
+      - name: project_key
+        description: "Project of the surviving commit"
+      - name: repo_slug
+        description: "Repository of the surviving commit"
+      - name: commit_hash
+        description: "Commit that first authored the content"
+        tests:
+          - not_null
+      - name: data_source
+        description: "Git source discriminator (insight_github, insight_gitlab, ...)"
+        tests:
+          - not_null
+      - name: file_path
+        description: "Path of the changed file within the repository"
+        tests:
+          - not_null
+      - name: file_extension
+        description: "File extension as collected, empty when the path has none"
+      - name: change_type
+        description: "Change type as collected (added, modified, renamed, deleted)"
+      - name: lines_added
+        description: "Lines added by this change, NULL when the source reports none"
+      - name: lines_removed
+        description: "Lines removed by this change, NULL when the source reports none"
   - name: git_commit_file_changes
     description: >
       File changes attached to the commit row that survived the hash collapse,

--- a/src/ingestion/scripts/bootstrap-db/README.md
+++ b/src/ingestion/scripts/bootstrap-db/README.md
@@ -107,7 +107,7 @@ until curl -sf "http://localhost:8123/ping" >/dev/null; do sleep 1; done
 ./bootstrap-db.sh connectors-config.yaml
 
 set -a; source .env; set +a   # dump-ddl.sh expects the CLICKHOUSE_* vars exported
-./dump-ddl.sh              # refresh ../connectors-ddl/*.sql; commit the diff if any
+./dump-ddl.sh              # refresh ../connectors-ddl/*.sql + the analytics column snapshot; commit the diff if any
 ./check-field-parity.py    # exit 1 on field-contract failures
 
 docker rm -f bootstrap-db-clickhouse
@@ -143,7 +143,7 @@ Contributors whose physical table is not owned by dbt are covered too. `jira__ta
 | `bootstrap-db.sh <config.yaml>` | Sources `pins.env` and `.env` (if present), runs `seed-connectors.sh`, runs all dbt models, runs `../apply-ch-migrations.sh`. |
 | `run-dbt.sh [dbt args]` | Helper: generates a profiles.yml from the `CLICKHOUSE_*` variables and runs `dbt run` in `src/ingestion/dbt`. |
 | `check-field-parity.py [--manifest PATH]` | Audits every staging contributor against its silver union target (column set, positional order, exact type) plus manifest-vs-warehouse coverage. Same `CLICKHOUSE_*` env contract as the other scripts. Non-zero exit on any finding. |
-| `dump-ddl.sh` | Dumps `SHOW CREATE` for every `bronze_*` table, the `identity`/`silver`/`insight` databases (tables and views), and the gold-referenced `staging` tables into `../connectors-ddl/*.sql` — the committed snapshot that `../create-bronze-placeholders.sh` applies on fresh clusters. **Run it manually** after `bootstrap-db.sh` (see step above) whenever a schema changes, and commit the diff. `.github/workflows/connectors-ddl.yml` re-runs the whole pipeline on every `src/ingestion/**` PR and on every commit to `main`, and fails loudly when the committed snapshot no longer matches, with the full diff inline and as the `connectors-ddl-drift` artifact. Regenerate with the one-block recipe above (no credentials needed) and commit the result. |
+| `dump-ddl.sh` | Dumps `SHOW CREATE` for every `bronze_*` table, the `identity`/`silver`/`insight` databases (tables and views), and the gold-referenced `staging` tables into `../connectors-ddl/*.sql` — the committed snapshot that `../create-bronze-placeholders.sh` applies on fresh clusters — and writes the same `silver`/`insight` schema as machine-readable columns into `src/backend/services/analytics/src/domain/field_catalog/columns.snapshot.json`, the validation universe the analytics field catalog embeds. **Run it manually** after `bootstrap-db.sh` (see step above) whenever a schema changes, and commit the diff. `.github/workflows/connectors-ddl.yml` re-runs the whole pipeline on every `src/ingestion/**` PR and on every commit to `main`, and fails loudly when the committed snapshot no longer matches, with the full diff inline and as the `connectors-ddl-drift` artifact. Regenerate with the one-block recipe above (no credentials needed) and commit the result. |
 
 ## Image pins (pins.env)
 

--- a/src/ingestion/scripts/bootstrap-db/dump-ddl.sh
+++ b/src/ingestion/scripts/bootstrap-db/dump-ddl.sh
@@ -11,6 +11,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONNECTORS_DIR="$(cd "${SCRIPT_DIR}/../../connectors" && pwd)"
 DDL_DIR="${SCRIPT_DIR}/../connectors-ddl"
 
+# The same schema in a second serialization: the DDL is what a fresh cluster
+# applies, this is what a program reads. The analytics service's field catalog
+# embeds it as its validation universe, so it covers exactly the databases a
+# dataset declaration may name and it lands inside the service's own tree — the
+# analytics image builds with `src/backend` as its context and cannot reach a
+# file under `src/ingestion`.
+COLUMN_SNAPSHOT="${SCRIPT_DIR}/../../../backend/services/analytics/src/domain/field_catalog/columns.snapshot.json"
+COLUMN_SNAPSHOT_DATABASES="'silver', 'insight'"
+
 ch() {
   curl -sS --fail-with-body "${CLICKHOUSE_PROTOCOL}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/" \
     -H "X-ClickHouse-User: ${CLICKHOUSE_USER}" \
@@ -126,5 +135,24 @@ while IFS= read -r tbl; do
   dump_relation staging "${tbl}" "${staging_out}"
 done < <(grep -ohrE 'staging\.[a-zA-Z0-9_]+' "${DDL_DIR}/insight.sql" "${DDL_DIR}/silver.sql" \
            | sed 's/^staging\.//' | sort -u)
+
+echo "dumping column snapshot -> $(basename "${COLUMN_SNAPSHOT}")"
+ch "SELECT
+      t.database AS database,
+      t.name AS relation,
+      t.engine AS engine,
+      t.sorting_key AS sorting_key,
+      arrayMap(col -> map('name', col.2, 'type', col.3), arraySort(col -> col.1, c.cols)) AS columns
+    FROM system.tables AS t
+    INNER JOIN (
+      SELECT database, table, groupArray((position, name, type)) AS cols
+      FROM system.columns
+      WHERE database IN (${COLUMN_SNAPSHOT_DATABASES})
+      GROUP BY database, table
+    ) AS c ON c.database = t.database AND c.table = t.name
+    WHERE t.database IN (${COLUMN_SNAPSHOT_DATABASES})
+    ORDER BY database, relation
+    FORMAT JSONEachRow" \
+  | jq --sort-keys --slurp '.' > "${COLUMN_SNAPSHOT}"
 
 ls -l "${DDL_DIR}"

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -273,6 +273,25 @@ ORDER BY (tenant_id, data_source, commit_hash)
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS insight.git_authored_file_changes
+(
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `project_key` String,
+    `repo_slug` String,
+    `commit_hash` String,
+    `data_source` String,
+    `file_path` String,
+    `file_extension` String,
+    `change_type` String,
+    `lines_added` Nullable(Int64),
+    `lines_removed` Nullable(Int64)
+)
+ENGINE = MergeTree
+ORDER BY (tenant_id, data_source, commit_hash)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS insight.git_commit_file_changes
 (
     `tenant_id` Nullable(String),
@@ -307,6 +326,35 @@ CREATE TABLE IF NOT EXISTS insight.git_commit_file_line_totals
 )
 ENGINE = MergeTree
 ORDER BY (tenant_id, data_source, commit_hash)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.git_commits
+(
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `project_key` String,
+    `repo_slug` String,
+    `commit_hash` String,
+    `author_email` String,
+    `author_name` String,
+    `message` String,
+    `authored_at` DateTime,
+    `authored_date` Date,
+    `branch_scope` String,
+    `branch_scope_label` String,
+    `repository` String,
+    `repository_label` String,
+    `project` String,
+    `project_label` String,
+    `source` String,
+    `source_label` String,
+    `lines_added` Nullable(Int64),
+    `lines_removed` Nullable(Int64)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(authored_date)
+ORDER BY (tenant_id, author_email, authored_at)
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
@@ -352,6 +400,41 @@ CREATE TABLE IF NOT EXISTS insight.git_file_change_coverage
 )
 ENGINE = MergeTree
 ORDER BY (tenant_id, data_source, source_id)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS insight.git_file_changes
+(
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `project_key` String,
+    `repo_slug` String,
+    `commit_hash` String,
+    `file_path` String,
+    `author_email` String,
+    `author_name` String,
+    `authored_at` DateTime,
+    `authored_date` Date,
+    `category` String,
+    `category_label` String,
+    `file_extension` String,
+    `file_extension_label` String,
+    `change_type` String,
+    `change_type_label` String,
+    `branch_scope` String,
+    `branch_scope_label` String,
+    `repository` String,
+    `repository_label` String,
+    `project` String,
+    `project_label` String,
+    `source` String,
+    `source_label` String,
+    `lines_added` Nullable(Int64),
+    `lines_removed` Nullable(Int64)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(authored_date)
+ORDER BY (tenant_id, author_email, authored_at)
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 

--- a/src/ingestion/tools/seed/insight_seed/generators/git.py
+++ b/src/ingestion/tools/seed/insight_seed/generators/git.py
@@ -232,6 +232,10 @@ def seed_class_git_file_changes(
         "repo_slug",
         "source_id",
         "tenant_id",
+        # INVARIANT: equals the commits' data_source. Gold attaches a file
+        # change to its commit on (tenant_id, data_source, commit_hash); left
+        # unwritten it defaults to '' and no seeded change reaches any commit.
+        "data_source",
         "file_path",
         "lines_added",
         "lines_removed",
@@ -281,6 +285,7 @@ def seed_class_git_file_changes(
                             REPO_SLUG,
                             SOURCE_ID,
                             tenant_uuid,
+                            "insight_github",
                             path,
                             added,
                             removed,

--- a/tests/stand/api/analytics/test_datasets.py
+++ b/tests/stand/api/analytics/test_datasets.py
@@ -1,0 +1,120 @@
+"""`GET /v1/datasets` — what a query may be built over.
+
+    GET /v1/datasets         200 admin · every declared key, described
+                             403 everybody else
+    GET /v1/datasets/{key}   200 admin · the same object the listing carried
+                             403 everybody else
+                             404 · a key this build declares no dataset for
+
+Deployed-path because the declarations are validated against the warehouse's
+column catalog at boot: a 200 is evidence the running image's datasets loaded,
+which is the precondition every `POST /v1/query` depends on.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_stand import ApiClient, PersonaSession, analytics_path
+
+from ..schemas import ProblemDocument
+from ..schemas.analytics import QueryDataset, QueryDatasetList
+
+DATASETS = analytics_path("/v1/datasets")
+
+#: The datasets this build declares.
+GIT_COMMITS = "git_commits"
+GIT_FILE_CHANGES = "git_file_changes"
+
+#: Well-formed as a key — lowercase snake_case — so the refusal is the
+#: declaration's and not a spelling rejection dressed as one.
+UNKNOWN_DATASET = "stand_does_not_exist"
+
+
+def _dataset_path(key: str) -> str:
+    return analytics_path(f"/v1/datasets/{key}")
+
+
+@pytest.fixture(scope="module")
+def api(admin_operator_session: PersonaSession) -> ApiClient:
+    """Gated with the query surface it describes, so every read is the operator's."""
+    return admin_operator_session.client
+
+
+def _listing(api: ApiClient) -> QueryDatasetList:
+    response = api.get(DATASETS)
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+    return response.parse(QueryDatasetList)
+
+
+@pytest.mark.reliability
+def test_the_listing_describes_every_dataset_a_query_may_name(api: ApiClient) -> None:
+    """Axes are asserted non-empty because a key with none lists a dataset nothing
+    can be asked of."""
+    listing = _listing(api)
+
+    keys = [dataset.key for dataset in listing.datasets]
+    assert set(keys) >= {GIT_COMMITS, GIT_FILE_CHANGES}, (
+        f"the build declares datasets the listing does not carry: {keys}"
+    )
+    assert len(keys) == len(set(keys)), f"a dataset is listed twice: {keys}"
+
+    for dataset in listing.datasets:
+        assert dataset.time_fields, f"{dataset.key}: no time field, so no window can be bound"
+        assert dataset.dimensions, f"{dataset.key}: no dimension, so nothing can be grouped"
+        assert dataset.measurables, f"{dataset.key}: no measurable, so nothing can be folded"
+        assert sum(field.default for field in dataset.time_fields) == 1, (
+            f"{dataset.key}: a window binds to exactly one default time field: "
+            f"{dataset.time_fields}"
+        )
+        for dimension in dataset.dimensions:
+            if dimension.label is not None:
+                assert dimension.label == f"{dimension.field}_label", (
+                    f"{dataset.key}.{dimension.field}: the label column is named off "
+                    f"the contract: {dimension.label}"
+                )
+
+
+@pytest.mark.reliability
+@pytest.mark.parametrize("key", [GIT_COMMITS, GIT_FILE_CHANGES])
+def test_a_dataset_reads_back_as_the_object_the_listing_carried(api: ApiClient, key: str) -> None:
+    """A difference between the two reads is a describe path that has drifted."""
+    listed = {dataset.key: dataset for dataset in _listing(api).datasets}
+    assert key in listed, f"{key} is not in the listing"
+
+    response = api.get(_dataset_path(key))
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+
+    assert response.parse(QueryDataset) == listed[key], (
+        f"{key}: the detail and the listing describe the dataset differently"
+    )
+
+
+@pytest.mark.reliability
+def test_a_key_this_build_declares_no_dataset_for_is_404(api: ApiClient) -> None:
+    """404 rather than the 400 `POST /v1/query` answers for the same unknown key:
+    there it is a field of a request, here it is the resource addressed."""
+    response = api.get(_dataset_path(UNKNOWN_DATASET))
+
+    assert response.status_code == 404, f"status={response.status_code} {response.text[:300]}"
+    assert response.parse(ProblemDocument).status == 404
+
+
+@pytest.mark.security
+def test_a_lead_is_refused_both_reads(lead_session: PersonaSession) -> None:
+    """The gate is inside the handler, so this is the only place it is observable."""
+    for path in (DATASETS, _dataset_path(GIT_COMMITS)):
+        response = lead_session.client.get(path)
+        assert response.status_code == 403, (
+            f"{path} answered {response.status_code} for a lead: {response.text[:300]}"
+        )
+        assert response.parse(ProblemDocument).status == 403
+
+
+@pytest.mark.security
+def test_a_description_carries_nothing_about_where_the_rows_live(api: ApiClient) -> None:
+    """A declaration also names the database, relation, tenancy column and row
+    identity; a description that leaked one would hand over the warehouse shape."""
+    body = api.get(DATASETS).text
+
+    for internal in ("database", "relation", "read_discipline", "tenant_field", "row_identity"):
+        assert internal not in body, f"the listing leaks `{internal}`: {body[:300]}"

--- a/tests/stand/api/analytics/test_datasets.py
+++ b/tests/stand/api/analytics/test_datasets.py
@@ -66,6 +66,9 @@ def test_the_listing_describes_every_dataset_a_query_may_name(api: ApiClient) ->
             f"{dataset.key}: a window binds to exactly one default time field: "
             f"{dataset.time_fields}"
         )
+        assert dataset.limits.max_limit >= dataset.limits.default_limit, (
+            f"{dataset.key}: the default row ceiling is above the maximum: {dataset.limits}"
+        )
         for dimension in dataset.dimensions:
             if dimension.label is not None:
                 assert dimension.label == f"{dimension.field}_label", (

--- a/tests/stand/api/analytics/test_query.py
+++ b/tests/stand/api/analytics/test_query.py
@@ -1,0 +1,434 @@
+"""`POST /v1/query` — the query contract over the declared datasets.
+
+    POST /v1/query   200 admin · 403 everybody else
+                     400 (unknown dataset, undeclared dimension, a limit over
+                          the cap, a window over the cap, an ordered test over a
+                          dimension, a body naming a tenant)
+
+Deployed-path because no unit test reaches these: the session's tenant becoming
+the scan's leading predicate, the compiled statement being SQL a real ClickHouse
+accepts, the gold relation the declaration binds having been built, and the
+admin gate — which lives inside the handler, so the edge admits the request and
+the refusal comes from the role check.
+
+No expected number is written into this file; the 200 cases reconcile two
+independent queries against each other.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_stand import ApiClient, ApiResponse, Manifest, PersonaSession, analytics_path
+from insight_stand.api import JsonValue
+
+from ..schemas import ProblemDocument
+from ..schemas.analytics import QueryAnswer
+from . import query_window
+
+QUERY = analytics_path("/v1/query")
+
+#: The datasets this build declares. A key the service does not carry is the
+#: other half of the pair, and it is well-formed so a refusal is the
+#: declaration's rather than a spelling rejection dressed as one.
+GIT_COMMITS = "git_commits"
+GIT_FILE_CHANGES = "git_file_changes"
+UNKNOWN_DATASET = "stand_does_not_exist"
+
+
+def _query(
+    manifest: Manifest, *, grain: str | None = None, **overrides: JsonValue
+) -> dict[str, JsonValue]:
+    start, end = query_window(manifest)
+    time: dict[str, JsonValue] = {"from": start, "to": end}
+    if grain is not None:
+        time["grain"] = grain
+
+    body: dict[str, JsonValue] = {
+        "dataset": GIT_COMMITS,
+        "aggregates": [{"name": "commits", "fn": "count"}],
+        "time": time,
+    }
+    body.update(overrides)
+    return body
+
+
+def _post(api: ApiClient, body: dict[str, JsonValue]) -> ApiResponse:
+    return api.post(QUERY, json_body=body)
+
+
+def _violated_fields(response: ApiResponse) -> list[str]:
+    """Every request field the refusal names, so a caller could repair the query."""
+    violations = response.parse(ProblemDocument).context.get("field_violations")
+    assert isinstance(violations, list), (
+        f"a refusal must carry field_violations: {response.text[:300]}"
+    )
+
+    fields: list[str] = []
+    for violation in violations:
+        assert isinstance(violation, dict), f"a violation must be an object: {violation}"
+        field = violation.get("field")
+        assert isinstance(field, str), f"a violation must name a field: {violation}"
+        fields.append(field)
+    return fields
+
+
+def _column_names(answer: QueryAnswer) -> list[str]:
+    return [column.name for column in answer.columns]
+
+
+def _answered(response: ApiResponse) -> QueryAnswer:
+    """A 200 with at least one row: the seed guarantees commits in the window, so
+    an empty table would be a scan that reached the wrong rows, not a quiet stand."""
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+    answer = response.parse(QueryAnswer)
+    assert answer.rows, f"the seeded window answered no rows: {response.text[:300]}"
+    for row in answer.rows:
+        assert len(row) == len(answer.columns), (
+            f"a row carries {len(row)} values for {len(answer.columns)} columns: {row}"
+        )
+    return answer
+
+
+@pytest.fixture(scope="module")
+def api(admin_operator_session: PersonaSession) -> ApiClient:
+    """The surface is admin-only, so every case below queries as the operator."""
+    return admin_operator_session.client
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_a_bucketed_query_answers_a_typed_table_whose_rows_match_its_columns(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    body = _query(
+        stand_manifest,
+        grain="month",
+        group_by=[{"axis": "dimension", "field": "repository"}, {"axis": "time"}],
+        order=[{"by": "commits", "dir": "desc"}],
+        limit=200,
+    )
+
+    answer = _answered(_post(api, body))
+    assert _column_names(answer) == ["repository", "repository_label", "time", "commits"], (
+        f"the answer's columns are not the ones the query asked for: {answer.columns}"
+    )
+    assert [column.kind for column in answer.columns] == [
+        "dimension",
+        "label",
+        "bucket",
+        "aggregate",
+    ]
+    assert not answer.flags.truncated, "a 200-row ceiling over the seed's repositories truncated"
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_the_buckets_of_a_grouped_count_sum_to_the_same_window_folded_whole(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A bucketed and an ungrouped count read the same rows, so they must agree
+    whatever the stand was seeded with."""
+    total_rows = _answered(_post(api, _query(stand_manifest))).rows
+    assert len(total_rows) == 1, f"an ungrouped query answers one row, got {total_rows}"
+    total = total_rows[0][0]
+    assert isinstance(total, int) and total > 0, f"the seeded window counts no commit: {total}"
+
+    bucketed_body = _query(stand_manifest, grain="month", group_by=[{"axis": "time"}], limit=10_000)
+    bucketed = _answered(_post(api, bucketed_body))
+
+    summed = sum(row[1] for row in bucketed.rows)
+    assert summed == total, (
+        f"the monthly buckets sum to {summed} and the same window folded whole "
+        f"is {total} — grouping changed which rows were counted"
+    )
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_a_filter_on_a_dimension_value_reads_the_rows_its_group_counted(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A group-by answers one count per `source`; an `eq` filter on each value
+    must answer the same count, or a filter and a group read a dimension
+    differently. The two queries are independent scans."""
+    grouped = _answered(
+        _post(api, _query(stand_manifest, group_by=[{"axis": "dimension", "field": "source"}]))
+    )
+    assert _column_names(grouped) == ["source", "source_label", "commits"]
+
+    for source, _label, expected in grouped.rows:
+        filtered = _answered(
+            _post(
+                api,
+                _query(
+                    stand_manifest,
+                    filters=[{"field": "source", "op": "eq", "value": source}],
+                ),
+            )
+        )
+        assert filtered.rows[0][0] == expected, (
+            f"source={source!r}: grouped count {expected}, filtered count {filtered.rows[0][0]}"
+        )
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_a_pattern_over_a_dimension_reads_the_rows_its_exact_values_would(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A `match` alternation over `source` must count what an `in` over the same
+    two values counts, and a `like` on one value what `eq` counts: three
+    independent scans that read one set of rows."""
+    grouped = _answered(
+        _post(api, _query(stand_manifest, group_by=[{"axis": "dimension", "field": "source"}]))
+    )
+    sources = [row[0] for row in grouped.rows]
+    first = sources[0]
+
+    liked = _answered(
+        _post(
+            api, _query(stand_manifest, filters=[{"field": "source", "op": "like", "value": first}])
+        )
+    )
+    exact = _answered(
+        _post(
+            api, _query(stand_manifest, filters=[{"field": "source", "op": "eq", "value": first}])
+        )
+    )
+    assert liked.rows[0][0] == exact.rows[0][0], f"like vs eq on {first!r}"
+
+    pattern = "^(" + "|".join(sources) + ")$"
+    matched = _answered(
+        _post(
+            api,
+            _query(stand_manifest, filters=[{"field": "source", "op": "match", "value": pattern}]),
+        )
+    )
+    listed = _answered(
+        _post(
+            api,
+            _query(stand_manifest, filters=[{"field": "source", "op": "in", "values": sources}]),
+        )
+    )
+    assert matched.rows[0][0] == listed.rows[0][0], f"match vs in over {sources}"
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_a_limit_below_the_group_count_is_reported_truncated_and_at_it_is_not(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """The group count comes from the stand itself: an unclipped daily count
+    says how many buckets there are, then one below it must truncate and
+    exactly it must not."""
+    whole = _answered(
+        _post(api, _query(stand_manifest, grain="day", group_by=[{"axis": "time"}], limit=10_000))
+    )
+    assert not whole.flags.truncated, "the seed has more than 10000 days"
+    buckets = len(whole.rows)
+    if buckets < 2:
+        pytest.skip("the seeded window holds one bucket, so nothing can be clipped")
+
+    clipped = _answered(
+        _post(
+            api,
+            _query(stand_manifest, grain="day", group_by=[{"axis": "time"}], limit=buckets - 1),
+        )
+    )
+    assert clipped.flags.truncated, f"{buckets} buckets behind a limit of {buckets - 1}"
+    assert len(clipped.rows) == buckets - 1
+
+    exact = _answered(
+        _post(api, _query(stand_manifest, grain="day", group_by=[{"axis": "time"}], limit=buckets))
+    )
+    assert not exact.flags.truncated, f"{buckets} buckets behind a limit of {buckets}"
+    assert len(exact.rows) == buckets
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.versatility
+@pytest.mark.parametrize("grain", ["day", "week", "month"])
+def test_every_declared_grain_answers_a_bucket_column(
+    api: ApiClient, stand_manifest: Manifest, grain: str
+) -> None:
+    """Shape only: bucket boundaries are the compiler's rendered-SQL goldens' job."""
+    body = _query(stand_manifest, grain=grain, group_by=[{"axis": "time"}], limit=10_000)
+
+    answer = _answered(_post(api, body))
+    assert _column_names(answer) == ["time", "commits"], f"grain={grain}"
+
+
+@pytest.mark.reliability
+@pytest.mark.parametrize(
+    ("label", "overrides", "field"),
+    [
+        ("a dataset this build does not declare", {"dataset": UNKNOWN_DATASET}, "dataset"),
+        (
+            "a dimension the dataset does not declare",
+            {"group_by": [{"axis": "dimension", "field": "branch"}]},
+            "group_by[0].field",
+        ),
+        ("a row ceiling over the cap", {"limit": 1_000_000}, "limit"),
+        (
+            "a window wider than the cap",
+            {"time": {"from": "2020-01-01", "to": "2026-01-01"}},
+            "time.to",
+        ),
+        (
+            "an ordered test over a dimension",
+            {"filters": [{"field": "repository", "op": "gt", "value": "a"}]},
+            "filters[0].op",
+        ),
+        (
+            "a pattern test over a measurable",
+            {"filters": [{"field": "lines_added", "op": "like", "value": "1%"}]},
+            "filters[0].op",
+        ),
+        (
+            "a pattern that is not a regular expression",
+            {"filters": [{"field": "repository", "op": "match", "value": "("}]},
+            "filters[0].value",
+        ),
+        (
+            "an aggregate over a column that is not a measurable",
+            {"aggregates": [{"name": "added", "fn": "sum", "field": "message"}]},
+            "aggregates[0].field",
+        ),
+    ],
+)
+def test_a_query_the_dataset_cannot_answer_is_refused_naming_the_field(
+    api: ApiClient,
+    stand_manifest: Manifest,
+    label: str,
+    overrides: dict[str, JsonValue],
+    field: str,
+) -> None:
+    """400 rather than 404 throughout, the unknown dataset included: this is a
+    statement about the request, not about a missing resource."""
+    body = _query(stand_manifest)
+    body.update(overrides)
+
+    response = _post(api, body)
+
+    assert response.status_code == 400, (
+        f"{label}: status={response.status_code} {response.text[:300]}"
+    )
+    assert field in _violated_fields(response), (
+        f"{label}: the refusal did not name {field!r}: {response.text[:300]}"
+    )
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.versatility
+def test_the_file_change_dataset_answers_over_its_own_declared_dimensions(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """`file_extension` is a dimension of this dataset alone, so a 200 is evidence
+    the query reached THIS relation rather than the commit one."""
+    body = _query(
+        stand_manifest,
+        grain="month",
+        dataset=GIT_FILE_CHANGES,
+        group_by=[{"axis": "dimension", "field": "file_extension"}, {"axis": "time"}],
+        aggregates=[
+            {"name": "changes", "fn": "count"},
+            {
+                "name": "added_to_tests",
+                "fn": "sum",
+                "field": "lines_added",
+                "filter": {"field": "category", "op": "eq", "value": "test"},
+            },
+        ],
+        limit=500,
+    )
+
+    answer = _answered(_post(api, body))
+    assert _column_names(answer) == [
+        "file_extension",
+        "file_extension_label",
+        "time",
+        "changes",
+        "added_to_tests",
+    ]
+
+
+@pytest.mark.reliability
+def test_a_dimension_belongs_to_its_dataset_and_not_to_the_build(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """The other half of the pair above: the same axis refused on the dataset that
+    does not declare it, which is what proves validation is dataset-scoped."""
+    body = _query(stand_manifest, group_by=[{"axis": "dimension", "field": "file_extension"}])
+
+    response = _post(api, body)
+
+    assert response.status_code == 400, f"status={response.status_code} {response.text[:300]}"
+    assert "group_by[0].field" in _violated_fields(response), (
+        f"the refusal did not name the axis: {response.text[:300]}"
+    )
+
+
+@pytest.mark.reliability
+@pytest.mark.parametrize(
+    ("label", "overrides"),
+    [
+        (
+            "an operand belonging to another filter operator",
+            {"filters": [{"field": "source", "op": "eq", "values": ["github"]}]},
+        ),
+        (
+            "a fold naming a column its variant does not read",
+            {"aggregates": [{"name": "commits", "fn": "count", "field": "lines_added"}]},
+        ),
+        (
+            "a fold missing the column its variant reads",
+            {"aggregates": [{"name": "added", "fn": "sum"}]},
+        ),
+        (
+            "a group axis that names no axis",
+            {"group_by": [{"dimension": "repository"}]},
+        ),
+    ],
+)
+def test_an_operand_from_another_variant_is_refused_before_anything_validates(
+    api: ApiClient, stand_manifest: Manifest, label: str, overrides: dict[str, JsonValue]
+) -> None:
+    """Each body pairs a tag with an operand another variant takes, so the refusal
+    is the body extractor's rather than any dataset rule's."""
+    body = _query(stand_manifest)
+    body.update(overrides)
+
+    response = _post(api, body)
+
+    assert response.status_code in {400, 422}, (
+        f"{label}: status={response.status_code} {response.text[:300]}"
+    )
+
+
+@pytest.mark.security
+def test_a_lead_is_refused_the_query_surface(
+    lead_session: PersonaSession, stand_manifest: Manifest
+) -> None:
+    """An ordinary authenticated caller, not an anonymous one: the datasets carry
+    person columns and declare no visibility policy yet, so nobody below the
+    operator gets a row — a well-formed query included."""
+    response = lead_session.client.post(QUERY, json_body=_query(stand_manifest))
+
+    assert response.status_code == 403, (
+        f"answered {response.status_code} for a lead: {response.text[:300]}"
+    )
+    assert response.parse(ProblemDocument).status == 403
+
+
+@pytest.mark.security
+def test_a_query_cannot_name_a_tenant_of_its_own(api: ApiClient, stand_manifest: Manifest) -> None:
+    """The contract refuses every key it does not declare, so a query has no lever
+    to scope itself to another tenant."""
+    body = _query(stand_manifest)
+    body["tenant_id"] = "00000000-0000-0000-0000-000000000000"
+
+    response = _post(api, body)
+
+    assert response.status_code in {400, 422}, (
+        f"an off-contract key was accepted: status={response.status_code} {response.text[:300]}"
+    )

--- a/tests/stand/api/analytics/test_request_contracts.py
+++ b/tests/stand/api/analytics/test_request_contracts.py
@@ -55,6 +55,7 @@ BODY_ROUTES: tuple[tuple[str, str], ...] = (
     ("PUT", f"/v1/queries/{scratch.UNKNOWN_ID}"),
     ("POST", f"/v1/queries/{scratch.UNKNOWN_ID}/run"),
     ("POST", "/v1/metric-results"),
+    ("POST", "/v1/query"),
     ("POST", "/v1/reports/preview"),
     ("POST", "/v1/reports/export"),
     ("POST", "/v1/metric-drilldown"),

--- a/tests/stand/api/operations.py
+++ b/tests/stand/api/operations.py
@@ -41,6 +41,11 @@ SOME_ACCOUNT_ID: Final[str] = "stand-in-account"
 #: refused before the gate under test was reached.
 SOME_CONNECTOR: Final[str] = "stand-in-connector"
 
+#: Stand-in for `{key}`, the dataset a query names. Lowercase snake_case
+#: because that is the only shape a dataset key takes, so a stand-in outside it
+#: would be a spelling rejection rather than the miss the sweep addresses.
+SOME_DATASET_KEY: Final[str] = "stand_in_dataset"
+
 #: Stand-in for `{metric_key}`, which is a dotted `family.name` string rather
 #: than a UUID. Kept a DOTTED key on purpose: the literal `export`/`import`
 #: segments of the sibling routes must not collide with it, so the template
@@ -54,6 +59,7 @@ SOME_METRIC_KEY: Final[str] = "scratch.probe"
 _PARAMETERS: Final[dict[str, str]] = {
     SOME_ID: "{id}",
     SOME_METRIC_KEY: "{metric_key}",
+    SOME_DATASET_KEY: "{key}",
     SOME_ACCOUNT_ID: "{account_id}",
     SOME_CONNECTOR: "{connector}",
 }
@@ -99,7 +105,7 @@ def _i(method: str, suffix: str) -> Operation:
     return Operation(method=method, path=identity_path(suffix), service="identity")
 
 
-#: analytics — 26 operations.
+#: analytics — 28 operations.
 ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("GET", "/v1/queries"),
     _a("POST", "/v1/queries"),
@@ -109,6 +115,10 @@ ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("POST", f"/v1/queries/{SOME_ID}/run"),
     _a("GET", "/v1/metric-definitions"),
     _a("POST", "/v1/metric-results"),
+    # What a query may be built over. Read-only over the declarations the build
+    # loaded at boot, so both are installation-wide reads with no tenant scope.
+    _a("GET", "/v1/datasets"),
+    _a("GET", f"/v1/datasets/{SOME_DATASET_KEY}"),
     _a("POST", "/v1/reports/preview"),
     _a("POST", "/v1/reports/export"),
     _a("POST", "/v1/metric-drilldown"),

--- a/tests/stand/api/operations.py
+++ b/tests/stand/api/operations.py
@@ -105,7 +105,7 @@ def _i(method: str, suffix: str) -> Operation:
     return Operation(method=method, path=identity_path(suffix), service="identity")
 
 
-#: analytics — 28 operations.
+#: analytics — 29 operations.
 ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("GET", "/v1/queries"),
     _a("POST", "/v1/queries"),
@@ -115,6 +115,9 @@ ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("POST", f"/v1/queries/{SOME_ID}/run"),
     _a("GET", "/v1/metric-definitions"),
     _a("POST", "/v1/metric-results"),
+    # The query contract over the declared datasets. One literal url: it takes a
+    # body and no path parameter, and the dataset it reads is named in the body.
+    _a("POST", "/v1/query"),
     # What a query may be built over. Read-only over the declarations the build
     # loaded at boot, so both are installation-wide reads with no tenant scope.
     _a("GET", "/v1/datasets"),

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -728,6 +728,30 @@ class PutSettingsRequest(BaseModel):
     system_prompt: str
 
 
+class QueryDatasetDimension(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    absent_value: str | None = Field(None, description='The value absent rows group under, and a filter matches them by.')
+    field: str
+    label: str | None = Field(None, description="The answer column carrying this dimension's display label when it is\na group axis; absent when the dataset declares none.")
+
+
+class QueryDatasetMeasurable(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str
+
+
+class QueryDatasetTimeField(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    default: bool = Field(..., description="The field a query's window binds to when it names none.")
+    field: str
+
+
 class ReportCell(RootModel[str | float]):
     root: str | float
 
@@ -1326,6 +1350,23 @@ class MetricSnapshot(BaseModel):
     trend: list[float | None] | None = Field(None, description="The sparkline's readings, oldest first.")
     until: str = Field(..., description='Inclusive end of the window, `YYYY-MM-DD`.')
     value: str = Field(..., description='The formatted value the tile shows.')
+
+
+class QueryDataset(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    dimensions: list[QueryDatasetDimension] = Field(..., description='The axes a query may group by, and filter on beside the measurables.')
+    key: str
+    measurables: list[QueryDatasetMeasurable] = Field(..., description='The columns an aggregate may fold.')
+    time_fields: list[QueryDatasetTimeField] = Field(..., description='The columns a query may bound its window by, and bucket on.')
+
+
+class QueryDatasetList(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    datasets: list[QueryDataset]
 
 
 class ReportExportRequest(BaseModel):

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -28,8 +28,8 @@ from .common import UnzonedDatetime
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 from enum import StrEnum
 from typing import Any
-from uuid import UUID
 from datetime import date as date_aliased
+from uuid import UUID
 
 
 class AiConfigResponse(BaseModel):
@@ -728,6 +728,46 @@ class PutSettingsRequest(BaseModel):
     system_prompt: str
 
 
+class Fn(StrEnum):
+    count = 'count'
+
+
+class Fn1(StrEnum):
+    sum = 'sum'
+
+
+class Fn2(StrEnum):
+    avg = 'avg'
+
+
+class Fn3(StrEnum):
+    min = 'min'
+
+
+class Fn4(StrEnum):
+    max = 'max'
+
+
+class QueryAnswerFlags(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    truncated: bool = Field(..., description="More groups matched than the limit admits; the rows are the first\n`limit` of them in the answer's order.")
+
+
+class QueryColumnKind(StrEnum):
+    dimension = 'dimension'
+    label = 'label'
+    bucket = 'bucket'
+    aggregate = 'aggregate'
+
+
+class QueryColumnType(StrEnum):
+    text = 'text'
+    number = 'number'
+    date = 'date'
+
+
 class QueryDatasetDimension(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
@@ -750,6 +790,158 @@ class QueryDatasetTimeField(BaseModel):
     )
     default: bool = Field(..., description="The field a query's window binds to when it names none.")
     field: str
+
+
+class QueryDirection(StrEnum):
+    asc = 'asc'
+    desc = 'desc'
+
+
+class Op(StrEnum):
+    eq = 'eq'
+
+
+class Op1(StrEnum):
+    in_ = 'in'
+
+
+class Op2(StrEnum):
+    gt = 'gt'
+
+
+class Op3(StrEnum):
+    gte = 'gte'
+
+
+class Op4(StrEnum):
+    lt = 'lt'
+
+
+class Op5(StrEnum):
+    lte = 'lte'
+
+
+class Op6(StrEnum):
+    between = 'between'
+
+
+class Op7(StrEnum):
+    not_null = 'not_null'
+
+
+class QueryFilter8(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared dimension or measurable of the dataset.')
+    op: Op7
+
+
+class Op8(StrEnum):
+    like = 'like'
+
+
+class QueryFilter9(BaseModel):
+    """
+    SQL `LIKE`: `%` matches any run, `_` one character.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared dimension of the dataset.')
+    op: Op8
+    value: str = Field(..., max_length=256)
+
+
+class Op9(StrEnum):
+    match = 'match'
+
+
+class QueryFilter10(BaseModel):
+    """
+    An RE2 regular expression, unanchored.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared dimension of the dataset.')
+    op: Op9
+    value: str = Field(..., max_length=256)
+
+
+class QueryFilterValue(RootModel[str | float | bool]):
+    root: str | float | bool = Field(..., description='A filter value: text, a number, or a boolean')
+
+
+class QueryGrain(StrEnum):
+    day = 'day'
+    week = 'week'
+    month = 'month'
+
+
+class Axis(StrEnum):
+    dimension = 'dimension'
+
+
+class QueryGroupAxis1(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    axis: Axis
+    field: str = Field(..., description='A declared dimension of the dataset.')
+
+
+class Axis1(StrEnum):
+    time = 'time'
+
+
+class QueryGroupAxis2(BaseModel):
+    """
+    The time bucket as a group axis; its width is `time.grain`.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    axis: Axis1
+
+
+class QueryGroupAxis(RootModel[QueryGroupAxis1 | QueryGroupAxis2]):
+    root: QueryGroupAxis1 | QueryGroupAxis2
+
+
+class QueryLimits(BaseModel):
+    """
+    The contract's request bounds, identical for every dataset.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    default_limit: int = Field(..., description='Rows a query gets when it sets no ceiling of its own.', ge=0)
+    max_aggregates: int = Field(..., ge=0)
+    max_filter_values: int = Field(..., ge=0)
+    max_filters: int = Field(..., ge=0)
+    max_group_axes: int = Field(..., ge=0)
+    max_limit: int = Field(..., description='Rows a query may ask for at most; over it the query is refused, not clipped.', ge=0)
+    max_name_chars: int = Field(..., description="Longest an aggregate's name may be, in characters.", ge=0)
+    max_order_terms: int = Field(..., ge=0)
+
+
+class QueryOrder(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    by: str = Field(..., description='A column the answer reports: a grouped dimension, `time`, or an aggregate name.')
+    dir: QueryDirection | None = None
+
+
+class QueryTime(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str | None = Field(None, description="A declared time field; the dataset's default when omitted.")
+    from_: date_aliased = Field(..., alias='from', description='Inclusive first day, UTC.')
+    grain: QueryGrain | None = None
+    to: date_aliased = Field(..., description='Inclusive last day, UTC.')
 
 
 class ReportCell(RootModel[str | float]):
@@ -1352,12 +1544,22 @@ class MetricSnapshot(BaseModel):
     value: str = Field(..., description='The formatted value the tile shows.')
 
 
+class QueryAnswerColumn(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    kind: QueryColumnKind
+    name: str
+    type: QueryColumnType
+
+
 class QueryDataset(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
     dimensions: list[QueryDatasetDimension] = Field(..., description='The axes a query may group by, and filter on beside the measurables.')
     key: str
+    limits: QueryLimits = Field(..., description='The bounds a request against this dataset must stay inside.')
     measurables: list[QueryDatasetMeasurable] = Field(..., description='The columns an aggregate may fold.')
     time_fields: list[QueryDatasetTimeField] = Field(..., description='The columns a query may bound its window by, and bucket on.')
 
@@ -1367,6 +1569,74 @@ class QueryDatasetList(BaseModel):
         extra='forbid',
     )
     datasets: list[QueryDataset]
+
+
+class QueryFilter1(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared dimension or measurable of the dataset.')
+    op: Op
+    value: QueryFilterValue
+
+
+class QueryFilter2(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared dimension or measurable of the dataset.')
+    op: Op1
+    values: list[QueryFilterValue] = Field(..., description="At least one value, and at most the contract's cap.", max_length=256, min_length=1)
+
+
+class QueryFilter3(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    op: Op2
+    value: QueryFilterValue
+
+
+class QueryFilter4(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    op: Op3
+    value: QueryFilterValue
+
+
+class QueryFilter5(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    op: Op4
+    value: QueryFilterValue
+
+
+class QueryFilter6(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    op: Op5
+    value: QueryFilterValue
+
+
+class QueryFilter7(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    high: QueryFilterValue = Field(..., description='Inclusive upper bound.')
+    low: QueryFilterValue = Field(..., description='Inclusive lower bound.')
+    op: Op6
+
+
+class QueryFilter(RootModel[QueryFilter1 | QueryFilter2 | QueryFilter3 | QueryFilter4 | QueryFilter5 | QueryFilter6 | QueryFilter7 | QueryFilter8 | QueryFilter9 | QueryFilter10]):
+    root: QueryFilter1 | QueryFilter2 | QueryFilter3 | QueryFilter4 | QueryFilter5 | QueryFilter6 | QueryFilter7 | QueryFilter8 | QueryFilter9 | QueryFilter10
 
 
 class ReportExportRequest(BaseModel):
@@ -1571,6 +1841,68 @@ class MetricResultViewDto(RootModel[MetricResultViewDto1 | MetricResultViewDto2 
     root: MetricResultViewDto1 | MetricResultViewDto2 | MetricResultViewDto3 | MetricResultViewDto4 | MetricResultViewDto5 | MetricResultViewDto6 | MetricResultViewDto7
 
 
+class QueryAggregate1(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    filter: QueryFilter | None = None
+    fn: Fn
+    name: str = Field(..., description='What the answer column is called.')
+
+
+class QueryAggregate2(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    filter: QueryFilter | None = None
+    fn: Fn1
+    name: str = Field(..., description='What the answer column is called.')
+
+
+class QueryAggregate3(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    filter: QueryFilter | None = None
+    fn: Fn2
+    name: str = Field(..., description='What the answer column is called.')
+
+
+class QueryAggregate4(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    filter: QueryFilter | None = None
+    fn: Fn3
+    name: str = Field(..., description='What the answer column is called.')
+
+
+class QueryAggregate5(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    field: str = Field(..., description='A declared measurable of the dataset.')
+    filter: QueryFilter | None = None
+    fn: Fn4
+    name: str = Field(..., description='What the answer column is called.')
+
+
+class QueryAggregate(RootModel[QueryAggregate1 | QueryAggregate2 | QueryAggregate3 | QueryAggregate4 | QueryAggregate5]):
+    root: QueryAggregate1 | QueryAggregate2 | QueryAggregate3 | QueryAggregate4 | QueryAggregate5
+
+
+class QueryAnswer(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    columns: list[QueryAnswerColumn]
+    flags: QueryAnswerFlags
+    rows: list[list[Any]]
+
+
 class MetricDrilldownResponse(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
@@ -1643,3 +1975,16 @@ class MetricResultsResponse(BaseModel):
         extra='forbid',
     )
     metrics: list[MetricResultDto]
+
+
+class Query(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    aggregates: list[QueryAggregate]
+    dataset: str
+    filters: list[QueryFilter] | None = Field(None, description='Row filters, narrowing the scan before aggregation.')
+    group_by: list[QueryGroupAxis] | None = None
+    limit: int | None = Field(None, description='Row ceiling; a query over the cap is refused rather than clipped.', ge=0)
+    order: list[QueryOrder] | None = None
+    time: QueryTime = Field(..., description='The window every scan is bounded by, and the width of its buckets.')


### PR DESCRIPTION
**Why.** Chart builders lack a reusable description of available data, so new query combinations depend on individual metric definitions and warehouse knowledge.

**What changed.** Adds dataset declarations, schema-snapshot validation, an embedded registry, and admin-only discovery. Each dataset defines its row identity and queryable fields alongside its model, tests, and documentation; shared preparation applies content deduplication for datasets and metric evidence.

**Shipped definitions.** Declarations are embedded with the service to keep changes release-controlled; runtime editing remains a separate extension. Snapshot validation does not verify a running warehouse's schema.

**Coverage.** Two datasets: `git_commits` and `git_file_changes`, each with declared row identity and dbt uniqueness checks.

**Out of scope.** Query execution is [#3187](https://github.com/constructorfabric/insight/pull/3187). Tenant-defined datasets, approval workflows, and access policies remain planned in the [design](https://github.com/constructorfabric/insight/blob/feat/datasets/docs/domain/datasets/DESIGN.md).

**Verified.** Documentation structure, TOCs, IDs, and links checked. Application checks were not rerun for the documentation update. Stand integration tests and the additional-context image build remain unverified.
