### PR TITLE
fix(bitbucket-cloud): fail the sync when the token reaches no repository

### DIFF
--- a/src/ingestion/connectors/git/bitbucket-cloud/README.md
+++ b/src/ingestion/connectors/git/bitbucket-cloud/README.md
@@ -15,8 +15,18 @@ API and (forwarded per request, never stored) for the clone the proxy performs.
 
 ## Prerequisites
 
-1. A Bitbucket API token with `repository:read`, plus the account username or
-   email it belongs to.
+1. A credential that can read both repositories and pull requests — neither
+   permission implies the other, and a token holding only the first lists
+   repositories while every pull-request call 403s, which the per-repository
+   handler skips silently. The two families name them differently:
+
+   | credential | `bitbucket_username` | permissions |
+   |---|---|---|
+   | Atlassian API token | account email | `read:repository:bitbucket`, `read:pullrequest:bitbucket` |
+   | workspace / project / repository access token | empty | `repository`, `pullrequest` |
+
+   The roster stream additionally wants workspace membership read; without it
+   `workspace_members` 403s and is skipped, costing account display names.
 2. A reachable git-cli-proxy deployment and its bearer token. In-cluster the
    umbrella composes both (`insight-git-cli-proxy-config`); the proxy accepts
    traffic only from the namespaces its NetworkPolicy allows.
@@ -53,7 +63,7 @@ repository nobody has touched since it is never listed, so never cloned.
 | Field | Required | Description |
 |-------|----------|-------------|
 | `bitbucket_username` | No | Atlassian account email/username. Set for personal API tokens (Basic `username:token`); leave empty for workspace/repository access tokens (Bearer). The clone username the proxy presents is derived from the same choice |
-| `bitbucket_token` | Yes | API token with `repository:read` |
+| `bitbucket_token` | Yes | API token or access token; see Prerequisites for the permissions each family names |
 | `bitbucket_workspaces` | Yes | JSON array of workspace slugs |
 | `bitbucket_api_base_url` | No | API base URL (default `https://api.bitbucket.org/2.0`) |
 | `bitbucket_exclude_repositories` | No | JSON array of regular expressions matched against a repository slug; a match is never listed, cloned or walked. Matched with `search`, so anchor with `$` for "ends with" (e.g. `["\\.rospecs$"]`). Empty collects everything |
@@ -80,6 +90,7 @@ kubectl apply -f src/ingestion/secrets/connectors/bitbucket-cloud.yaml
 | Stream | Upstream | Sync Mode | Cursor |
 |--------|----------|-----------|--------|
 | `repositories` | Bitbucket `/2.0/repositories/{workspace}` | incremental | `updated_on` |
+| `repository_visibility` | Bitbucket `/2.0/repositories/{workspace}`, unfiltered, one row | full refresh | — |
 | `commits` | proxy `/v1/commits` | incremental, per repository | `committed_date` |
 | `file_changes` | proxy `/v1/file-changes` | incremental, per repository | `committed_date` |
 | `branches` | proxy `/v1/branches` | full refresh, per repository | — |
@@ -142,13 +153,21 @@ forms so an omission is visible:
 
 | anchor | applies to | form |
 |---|---|---|
-| `repos_since_start` | every repository listing (12 of them) | `q=updated_on >= start_date`, server-side |
+| `repos_since_start` | every repository listing that feeds partitions (12 of them) | `q=updated_on >= start_date`, server-side |
 | `prs_since_start` | the four per-PR fan-out parents | `q=updated_on >= max(start_date, now - 30d)` |
 
 Filtering repositories server-side is what bounds the clone cost: an untouched
 repository is never returned, so the proxy never walks it. VERIFIED against the
 live API — a workspace of 407 public repositories returns 47 for a cutoff six
 weeks back, and no row below the cutoff.
+
+That filtering is also why an empty repository listing is ordinary rather than
+alarming, and why the one listing that must mean something is exempt from it:
+`repository_visibility` asks for a single repository with no `q`, so its empty
+answer has exactly one cause — the token reaches nothing. A token that has lost
+repository access is served `200` with an empty page, not an error code, so
+without that probe every stream lands zero rows and the sync still reports
+success.
 
 One stream cannot comply. The deployments endpoint rejects `sort=created_on`
 (400) and **accepts a `q` on `created_on` while silently ignoring it** — a

--- a/src/ingestion/connectors/git/bitbucket-cloud/README.md
+++ b/src/ingestion/connectors/git/bitbucket-cloud/README.md
@@ -10,8 +10,10 @@ proxy serves the same rows from a bare clone.
 Repository discovery still uses the Bitbucket API — one call per page of
 repositories, not per commit.
 
-Auth: an Atlassian API token used as HTTP basic `username:token`, both for the
-API and (forwarded per request, never stored) for the clone the proxy performs.
+Auth: an Atlassian API token as HTTP basic `username:token`, or a workspace /
+project / repository access token as `Bearer` with the username left empty —
+both for the API and (forwarded per request, never stored) for the clone the
+proxy performs.
 
 ## Prerequisites
 
@@ -45,7 +47,7 @@ metadata:
     insight.cyberfabric.com/source-id: bitbucket-cloud-main
 type: Opaque
 stringData:
-  bitbucket_username: "CHANGE_ME"
+  bitbucket_username: "CHANGE_ME"   # account email for an API token; empty for an access token
   bitbucket_token: "CHANGE_ME"
   bitbucket_workspaces: '["acme"]'
   bitbucket_start_date: "2026-01-01"
@@ -62,7 +64,7 @@ repository nobody has touched since it is never listed, so never cloned.
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `bitbucket_username` | No | Atlassian account email/username. Set for personal API tokens (Basic `username:token`); leave empty for workspace/repository access tokens (Bearer). The clone username the proxy presents is derived from the same choice |
+| `bitbucket_username` | No | Atlassian account email/username. Set for personal API tokens (Basic `username:token`); leave empty for workspace, project and repository access tokens (Bearer). The clone username the proxy presents is derived from the same choice |
 | `bitbucket_token` | Yes | API token or access token; see Prerequisites for the permissions each family names |
 | `bitbucket_workspaces` | Yes | JSON array of workspace slugs |
 | `bitbucket_api_base_url` | No | API base URL (default `https://api.bitbucket.org/2.0`) |
@@ -167,10 +169,10 @@ weeks back, and no row below the cutoff.
 That filtering is also why an empty repository listing is ordinary rather than
 alarming, and why the one listing that must mean something is exempt from it:
 `repository_visibility` asks for a single repository with no `q`, so its empty
-answer has exactly one cause — the token reaches nothing. A token that has lost
-repository access is served `200` with an empty page, not an error code, so
-without that probe every stream lands zero rows and the sync still reports
-success.
+answer means one thing to the connector — no repository is reachable. A token
+that has lost repository access is served `200` with an empty page, not an
+error code, so without that probe every stream lands zero rows and the sync
+still reports success.
 
 One stream cannot comply. The deployments endpoint rejects `sort=created_on`
 (400) and **accepts a `q` on `created_on` while silently ignoring it** — a
@@ -218,7 +220,8 @@ source that shares it.
 | `pull_request_commits` | `bitbucket_cloud__pull_requests_commits` | `class_git_pull_requests_commits` |
 
 `pipelines`, `deployments` and `workspace_members` land in bronze only; no class
-consumes them yet.
+consumes them yet. `repository_visibility` is diagnostic and stays that way: one
+row per workspace recording that the token reached something, fed to no class.
 
 ## Not in git
 

--- a/src/ingestion/connectors/git/bitbucket-cloud/README.md
+++ b/src/ingestion/connectors/git/bitbucket-cloud/README.md
@@ -131,9 +131,12 @@ collapses to current state and a head move is a tracked-column change.
   consumed via `RequestPath`.
 - **`fields=`** trims the response to the used properties; the full repository
   object is large and most of it is unused here.
-- **No server-side "updated after" filter** exists on `/repositories`, so the
-  cursor filters client-side. The listing is requested `sort=updated_on`
-  (ascending) so the cursor still advances monotonically across pages.
+- **The "updated after" bound is server-side**, expressed as
+  `q=updated_on >= start_date` (the `repos_since_start` anchor). It has to be:
+  a cursor's `start_datetime` filters no records unless the stream also sets
+  `is_client_side_incremental`, and none of these do. The listing is requested
+  `sort=updated_on` (ascending) so the cursor still advances monotonically
+  across pages.
 
 ### Cold repositories
 

--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -169,6 +169,43 @@ definitions:
         action: RETRY
         error_message: Transient Bitbucket error
 
+  # The `repository_visibility` probe, which asks for repositories without a
+  # date filter. Only there does an empty page mean the token reaches nothing:
+  # on the date-filtered discovery above the same body also means "nothing
+  # changed since bitbucket_start_date", which is not an error.
+  visibility_error_handler: &visibility_error_handler
+    type: DefaultErrorHandler
+    max_retries: 5
+    backoff_strategies: *vendor_backoff
+    response_filters:
+      - type: HttpResponseFilter
+        http_codes: [429]
+        action: RATE_LIMITED
+        error_message: Bitbucket hourly rate budget exhausted
+      - type: HttpResponseFilter
+        http_codes: [401]
+        action: FAIL
+        failure_type: config_error
+        error_message: >-
+          Bitbucket rejected the credentials. Personal API tokens need
+          bitbucket_username set (Basic auth); workspace access tokens must
+          NOT set it (Bearer). Mixing the two is the most common cause.
+      - type: HttpResponseFilter
+        http_codes: [500, 502, 503, 504]
+        action: RETRY
+        error_message: Transient Bitbucket error
+      # A token that reaches no repository is answered 200 with an empty page,
+      # not an error code, so only the body shape catches it. An error body
+      # carries no `values` key and cannot match.
+      - type: HttpResponseFilter
+        predicate: "{{ response.get('values') is not none and response.get('values') | length == 0 }}"
+        action: FAIL
+        failure_type: config_error
+        error_message: >-
+          No repository in this workspace is visible to the token. Check that
+          bitbucket_workspaces names the right workspace and that the token
+          still carries repository read on it.
+
   # Per-repository pull-request listings, standalone stream and the fan-out
   # parents inside every PR child stream alike. Unlike workspace discovery,
   # a 403/404 here is about ONE repository (suspended, deleted, or denied to
@@ -413,6 +450,97 @@ streams:
           - [workspace]
           - [owner]
           - [links]
+
+  # ── Repository visibility probe (Bitbucket API) ─────────────────────────
+  # One unfiltered repository per workspace, purely so an empty answer has a
+  # single meaning. Every other repository listing carries
+  # `updated_on >= bitbucket_start_date`, where an empty page is ordinary; here
+  # there is no date filter, so an empty page means the token reaches nothing
+  # and `visibility_error_handler` fails the sync on it.
+  #
+  # pagelen=1 and no paginator: one request per workspace per sync. The record
+  # is kept rather than dropped so the answer is auditable in bronze.
+  - type: DeclarativeStream
+    name: repository_visibility
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          workspace: {type: [string, "null"]}
+          repository_uuid: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+        authenticator:
+          type: ApiKeyAuthenticator
+          inject_into:
+            type: RequestOption
+            inject_into: header
+            field_name: Authorization
+          # Personal API tokens are Basic username:token; workspace access
+          # tokens are Bearer and must leave bitbucket_username empty.
+          api_token: >-
+            {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
+        path: "/repositories/{{ stream_partition.workspace }}"
+        http_method: GET
+        request_parameters:
+          pagelen: "1"
+          fields: "next,values.uuid"
+        error_handler: *visibility_error_handler
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [values]
+      partition_router:
+        type: ListPartitionRouter
+        values: "{{ config['bitbucket_workspaces'] }}"
+        cursor_field: workspace
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_cloud
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [workspace]
+            value: "{{ stream_partition.workspace }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [repository_uuid]
+            value: "{{ record.get('uuid') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.workspace | replace(':', '%3A') }}
+      - type: RemoveFields
+        # Hoisted above; the nested original stays out of bronze.
+        field_pointers:
+          - [uuid]
 
   # ── Commits (git-cli-proxy) ─────────────────────────────────────────────
   - type: DeclarativeStream

--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -162,7 +162,7 @@ definitions:
         failure_type: config_error
         error_message: >-
           Bitbucket rejected the credentials. Personal API tokens need
-          bitbucket_username set (Basic auth); workspace access tokens must
+          bitbucket_username set (Basic auth); workspace, project and repository access tokens must
           NOT set it (Bearer). Mixing the two is the most common cause.
       - type: HttpResponseFilter
         http_codes: [500, 502, 503, 504]
@@ -188,7 +188,7 @@ definitions:
         failure_type: config_error
         error_message: >-
           Bitbucket rejected the credentials. Personal API tokens need
-          bitbucket_username set (Basic auth); workspace access tokens must
+          bitbucket_username set (Basic auth); workspace, project and repository access tokens must
           NOT set it (Bearer). Mixing the two is the most common cause.
       - type: HttpResponseFilter
         http_codes: [500, 502, 503, 504]
@@ -232,7 +232,7 @@ definitions:
         failure_type: config_error
         error_message: >-
           Bitbucket rejected the credentials. Personal API tokens need
-          bitbucket_username set (Basic auth); workspace access tokens must
+          bitbucket_username set (Basic auth); workspace, project and repository access tokens must
           NOT set it (Bearer). Mixing the two is the most common cause.
       - type: HttpResponseFilter
         http_codes: [500, 502, 503, 504]
@@ -317,8 +317,8 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: Authorization
-          # Personal API tokens are Basic username:token; workspace access
-          # tokens are Bearer and must leave bitbucket_username empty.
+          # Personal API tokens are Basic username:token; workspace, project
+          # and repository access tokens are Bearer and leave it empty.
           api_token: >-
             {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/repositories/{{ stream_partition.workspace }}"
@@ -491,8 +491,8 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: Authorization
-          # Personal API tokens are Basic username:token; workspace access
-          # tokens are Bearer and must leave bitbucket_username empty.
+          # Personal API tokens are Basic username:token; workspace, project
+          # and repository access tokens are Bearer and leave it empty.
           api_token: >-
             {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/repositories/{{ stream_partition.workspace }}"
@@ -641,8 +641,8 @@ streams:
                       type: RequestOption
                       inject_into: header
                       field_name: Authorization
-                    # Personal API tokens are Basic username:token; workspace access
-                    # tokens are Bearer and must leave bitbucket_username empty.
+                    # Personal API tokens are Basic username:token; workspace, project
+                    # and repository access tokens are Bearer and leave it empty.
                     api_token: >-
                       {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
@@ -835,8 +835,8 @@ streams:
                       type: RequestOption
                       inject_into: header
                       field_name: Authorization
-                    # Personal API tokens are Basic username:token; workspace access
-                    # tokens are Bearer and must leave bitbucket_username empty.
+                    # Personal API tokens are Basic username:token; workspace, project
+                    # and repository access tokens are Bearer and leave it empty.
                     api_token: >-
                       {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
@@ -1010,8 +1010,8 @@ streams:
                       type: RequestOption
                       inject_into: header
                       field_name: Authorization
-                    # Personal API tokens are Basic username:token; workspace access
-                    # tokens are Bearer and must leave bitbucket_username empty.
+                    # Personal API tokens are Basic username:token; workspace, project
+                    # and repository access tokens are Bearer and leave it empty.
                     api_token: >-
                       {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
@@ -1130,8 +1130,8 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: Authorization
-          # Personal API tokens are Basic username:token; workspace access
-          # tokens are Bearer and must leave bitbucket_username empty.
+          # Personal API tokens are Basic username:token; workspace, project
+          # and repository access tokens are Bearer and leave it empty.
           api_token: >-
             {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
@@ -1192,8 +1192,8 @@ streams:
                       type: RequestOption
                       inject_into: header
                       field_name: Authorization
-                    # Personal API tokens are Basic username:token; workspace access
-                    # tokens are Bearer and must leave bitbucket_username empty.
+                    # Personal API tokens are Basic username:token; workspace, project
+                    # and repository access tokens are Bearer and leave it empty.
                     api_token: >-
                       {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
@@ -1388,8 +1388,8 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: Authorization
-          # Personal API tokens are Basic username:token; workspace access
-          # tokens are Bearer and must leave bitbucket_username empty.
+          # Personal API tokens are Basic username:token; workspace, project
+          # and repository access tokens are Bearer and leave it empty.
           api_token: >-
             {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/repositories/{{ stream_slice.extra_fields['repo_full_name'] }}/pullrequests/{{ stream_partition.pr_id }}/comments"
@@ -1418,7 +1418,7 @@ streams:
               failure_type: config_error
               error_message: >-
                 Bitbucket rejected the credentials. Personal API tokens need
-                bitbucket_username set (Basic auth); workspace access tokens must
+                bitbucket_username set (Basic auth); workspace, project and repository access tokens must
                 NOT set it (Bearer). Mixing the two is the most common cause.
             - type: HttpResponseFilter
               http_codes: [500, 502, 503, 504]
@@ -1478,8 +1478,8 @@ streams:
                       type: RequestOption
                       inject_into: header
                       field_name: Authorization
-                    # Personal API tokens are Basic username:token; workspace access
-                    # tokens are Bearer and must leave bitbucket_username empty.
+                    # Personal API tokens are Basic username:token; workspace, project
+                    # and repository access tokens are Bearer and leave it empty.
                     api_token: >-
                       {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
@@ -1539,8 +1539,8 @@ streams:
                                 type: RequestOption
                                 inject_into: header
                                 field_name: Authorization
-                              # Personal API tokens are Basic username:token; workspace access
-                              # tokens are Bearer and must leave bitbucket_username empty.
+                              # Personal API tokens are Basic username:token; workspace, project
+                              # and repository access tokens are Bearer and leave it empty.
                               api_token: >-
                                 {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                             path: "/repositories/{{ stream_partition.workspace }}"
@@ -1713,8 +1713,8 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: Authorization
-          # Personal API tokens are Basic username:token; workspace access
-          # tokens are Bearer and must leave bitbucket_username empty.
+          # Personal API tokens are Basic username:token; workspace, project
+          # and repository access tokens are Bearer and leave it empty.
           api_token: >-
             {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/repositories/{{ stream_slice.extra_fields['repo_full_name'] }}/pullrequests/{{ stream_partition.pr_id }}/commits"
@@ -1741,7 +1741,7 @@ streams:
               failure_type: config_error
               error_message: >-
                 Bitbucket rejected the credentials. Personal API tokens need
-                bitbucket_username set (Basic auth); workspace access tokens must
+                bitbucket_username set (Basic auth); workspace, project and repository access tokens must
                 NOT set it (Bearer). Mixing the two is the most common cause.
             - type: HttpResponseFilter
               http_codes: [500, 502, 503, 504]
@@ -1801,8 +1801,8 @@ streams:
                       type: RequestOption
                       inject_into: header
                       field_name: Authorization
-                    # Personal API tokens are Basic username:token; workspace access
-                    # tokens are Bearer and must leave bitbucket_username empty.
+                    # Personal API tokens are Basic username:token; workspace, project
+                    # and repository access tokens are Bearer and leave it empty.
                     api_token: >-
                       {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
@@ -1862,8 +1862,8 @@ streams:
                                 type: RequestOption
                                 inject_into: header
                                 field_name: Authorization
-                              # Personal API tokens are Basic username:token; workspace access
-                              # tokens are Bearer and must leave bitbucket_username empty.
+                              # Personal API tokens are Basic username:token; workspace, project
+                              # and repository access tokens are Bearer and leave it empty.
                               api_token: >-
                                 {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                             path: "/repositories/{{ stream_partition.workspace }}"
@@ -2065,8 +2065,8 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: Authorization
-          # Personal API tokens are Basic username:token; workspace access
-          # tokens are Bearer and must leave bitbucket_username empty.
+          # Personal API tokens are Basic username:token; workspace, project
+          # and repository access tokens are Bearer and leave it empty.
           api_token: >-
             {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/repositories/{{ stream_slice.extra_fields['repo_full_name'] }}/pullrequests/{{ stream_partition.pr_id }}/diffstat"
@@ -2102,7 +2102,7 @@ streams:
               failure_type: config_error
               error_message: >-
                 Bitbucket rejected the credentials. Personal API tokens need
-                bitbucket_username set (Basic auth); workspace access tokens must
+                bitbucket_username set (Basic auth); workspace, project and repository access tokens must
                 NOT set it (Bearer). Mixing the two is the most common cause.
             - type: HttpResponseFilter
               http_codes: [500, 502, 503, 504]
@@ -2162,8 +2162,8 @@ streams:
                       type: RequestOption
                       inject_into: header
                       field_name: Authorization
-                    # Personal API tokens are Basic username:token; workspace access
-                    # tokens are Bearer and must leave bitbucket_username empty.
+                    # Personal API tokens are Basic username:token; workspace, project
+                    # and repository access tokens are Bearer and leave it empty.
                     api_token: >-
                       {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
@@ -2223,8 +2223,8 @@ streams:
                                 type: RequestOption
                                 inject_into: header
                                 field_name: Authorization
-                              # Personal API tokens are Basic username:token; workspace access
-                              # tokens are Bearer and must leave bitbucket_username empty.
+                              # Personal API tokens are Basic username:token; workspace, project
+                              # and repository access tokens are Bearer and leave it empty.
                               api_token: >-
                                 {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                             path: "/repositories/{{ stream_partition.workspace }}"
@@ -2381,8 +2381,8 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: Authorization
-          # Personal API tokens are Basic username:token; workspace access
-          # tokens are Bearer and must leave bitbucket_username empty.
+          # Personal API tokens are Basic username:token; workspace, project
+          # and repository access tokens are Bearer and leave it empty.
           api_token: >-
             {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/repositories/{{ stream_slice.extra_fields['repo_full_name'] }}/pullrequests/{{ stream_partition.pr_id }}/activity"
@@ -2410,7 +2410,7 @@ streams:
               failure_type: config_error
               error_message: >-
                 Bitbucket rejected the credentials. Personal API tokens need
-                bitbucket_username set (Basic auth); workspace access tokens must
+                bitbucket_username set (Basic auth); workspace, project and repository access tokens must
                 NOT set it (Bearer). Mixing the two is the most common cause.
             - type: HttpResponseFilter
               http_codes: [500, 502, 503, 504]
@@ -2470,8 +2470,8 @@ streams:
                       type: RequestOption
                       inject_into: header
                       field_name: Authorization
-                    # Personal API tokens are Basic username:token; workspace access
-                    # tokens are Bearer and must leave bitbucket_username empty.
+                    # Personal API tokens are Basic username:token; workspace, project
+                    # and repository access tokens are Bearer and leave it empty.
                     api_token: >-
                       {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
@@ -2531,8 +2531,8 @@ streams:
                                 type: RequestOption
                                 inject_into: header
                                 field_name: Authorization
-                              # Personal API tokens are Basic username:token; workspace access
-                              # tokens are Bearer and must leave bitbucket_username empty.
+                              # Personal API tokens are Basic username:token; workspace, project
+                              # and repository access tokens are Bearer and leave it empty.
                               api_token: >-
                                 {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                             path: "/repositories/{{ stream_partition.workspace }}"
@@ -2721,8 +2721,8 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: Authorization
-          # Personal API tokens are Basic username:token; workspace access
-          # tokens are Bearer and must leave bitbucket_username empty.
+          # Personal API tokens are Basic username:token; workspace, project
+          # and repository access tokens are Bearer and leave it empty.
           api_token: >-
             {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/workspaces/{{ stream_partition.workspace }}/members"
@@ -2751,7 +2751,7 @@ streams:
               failure_type: config_error
               error_message: >-
                 Bitbucket rejected the credentials. Personal API tokens need
-                bitbucket_username set (Basic auth); workspace access tokens must
+                bitbucket_username set (Basic auth); workspace, project and repository access tokens must
                 NOT set it (Bearer). Mixing the two is the most common cause.
             - type: HttpResponseFilter
               http_codes: [500, 502, 503, 504]
@@ -2864,8 +2864,8 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: Authorization
-          # Personal API tokens are Basic username:token; workspace access
-          # tokens are Bearer and must leave bitbucket_username empty.
+          # Personal API tokens are Basic username:token; workspace, project
+          # and repository access tokens are Bearer and leave it empty.
           api_token: >-
             {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         # Trailing slash is load-bearing: without it this endpoint 404s.
@@ -2897,7 +2897,7 @@ streams:
               failure_type: config_error
               error_message: >-
                 Bitbucket rejected the credentials. Personal API tokens need
-                bitbucket_username set (Basic auth); workspace access tokens must
+                bitbucket_username set (Basic auth); workspace, project and repository access tokens must
                 NOT set it (Bearer). Mixing the two is the most common cause.
             - type: HttpResponseFilter
               http_codes: [500, 502, 503, 504]
@@ -2948,8 +2948,8 @@ streams:
                       type: RequestOption
                       inject_into: header
                       field_name: Authorization
-                    # Personal API tokens are Basic username:token; workspace access
-                    # tokens are Bearer and must leave bitbucket_username empty.
+                    # Personal API tokens are Basic username:token; workspace, project
+                    # and repository access tokens are Bearer and leave it empty.
                     api_token: >-
                       {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
@@ -3097,8 +3097,8 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: Authorization
-          # Personal API tokens are Basic username:token; workspace access
-          # tokens are Bearer and must leave bitbucket_username empty.
+          # Personal API tokens are Basic username:token; workspace, project
+          # and repository access tokens are Bearer and leave it empty.
           api_token: >-
             {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         # Trailing slash is load-bearing: without it this endpoint 404s.
@@ -3135,7 +3135,7 @@ streams:
               failure_type: config_error
               error_message: >-
                 Bitbucket rejected the credentials. Personal API tokens need
-                bitbucket_username set (Basic auth); workspace access tokens must
+                bitbucket_username set (Basic auth); workspace, project and repository access tokens must
                 NOT set it (Bearer). Mixing the two is the most common cause.
             - type: HttpResponseFilter
               http_codes: [500, 502, 503, 504]
@@ -3186,8 +3186,8 @@ streams:
                       type: RequestOption
                       inject_into: header
                       field_name: Authorization
-                    # Personal API tokens are Basic username:token; workspace access
-                    # tokens are Bearer and must leave bitbucket_username empty.
+                    # Personal API tokens are Basic username:token; workspace, project
+                    # and repository access tokens are Bearer and leave it empty.
                     api_token: >-
                       {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
@@ -3350,7 +3350,7 @@ streams:
               failure_type: config_error
               error_message: >-
                 Bitbucket rejected the credentials. Personal API tokens need
-                bitbucket_username set (Basic auth); workspace access tokens must
+                bitbucket_username set (Basic auth); workspace, project and repository access tokens must
                 NOT set it (Bearer). Mixing the two is the most common cause.
             - type: HttpResponseFilter
               http_codes: [500, 502, 503, 504]
@@ -3650,15 +3650,20 @@ spec:
         description: >-
           Atlassian account email/username. Set it for personal API tokens
           (HTTP Basic username:token, both against the API and the clone the
-          proxy performs). Leave empty for workspace/repository access tokens,
-          which authenticate as Bearer.
+          proxy performs). Leave empty for workspace, project and repository
+          access tokens, which authenticate as Bearer.
         title: Username / Email (personal API tokens only)
         order: 2
       bitbucket_token:
         type: string
         description: >-
-          Bitbucket API token with `repository:read`. Forwarded to the proxy per request for the clone and never stored there.
-        title: API Token
+          An Atlassian API token (`read:repository:bitbucket` and
+          `read:pullrequest:bitbucket`) or a workspace / project / repository
+          access token (`repository` and `pullrequest`). Neither read implies
+          the other: granted only the repository one, the connector lists
+          repositories while every pull-request call is refused and skipped.
+          Forwarded to the proxy per request for the clone and never stored there.
+        title: API Token or Access Token
         airbyte_secret: true
         order: 4
       bitbucket_workspaces:

--- a/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
@@ -41,7 +41,7 @@ name: bitbucket-cloud
 #   major bump dispatches re-materializes them. Safe: the merge hash and the
 #   commits have been in Bronze all along, and a request the activity does
 #   date is untouched. #3051
-version: "7.0.0"
+version: "7.1.0"
 # A slot of its own: replication pods sharing a slot with other connector
 # syncs can be starved of workers, which surfaces as startup and activity
 # timeouts rather than as a connector error.

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
@@ -189,7 +189,15 @@ def test_every_repository_listing_projects_the_field_the_exclusion_reads() -> No
     """
     listings = _repository_listings(_streams())
     assert listings, "no repository listing found — the audit is not looking at anything"
-    missing = sorted(owner for owner, fields in listings if "values.slug" not in fields)
+    # repository_visibility answers "does the token reach anything at all". It
+    # generates no partitions and clones nothing, and an excluded repository is
+    # an operator's choice rather than an access failure, so it deliberately
+    # reads the workspace unfiltered.
+    missing = sorted(
+        owner
+        for owner, fields in listings
+        if "values.slug" not in fields and owner != "repository_visibility"
+    )
     assert not missing, (
         "these repository listings do not project values.slug, so the exclusion "
         f"filter cannot see it: {missing}"

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
@@ -21,9 +21,8 @@ from urllib.parse import unquote_plus
 
 import freezegun
 import pytest
-from airbyte_cdk.models import AirbyteMessage, SyncMode
+from airbyte_cdk.models import AirbyteMessage, FailureType, SyncMode
 from config import BB_URL, PROXY_URL, BitbucketCloudConfigBuilder
-
 from connector_tests import (
     ANY_QUERY_PARAMS,
     HttpMocker,
@@ -149,6 +148,96 @@ def test_a_403_repository_is_skipped_not_fatal(http_mocker: HttpMocker) -> None:
 
     assert not output.errors
     assert len(output.records) == 0
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_date_filtered_listing_with_no_matches_is_not_an_error(
+    http_mocker: HttpMocker,
+) -> None:
+    """Every discovery listing carries `updated_on >= bitbucket_start_date`, so
+    an empty page there means nothing changed in the window — the same body a
+    token with no access gets. Discovery must not treat it as a failure."""
+    config = BitbucketCloudConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": []}), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_requests", config)
+
+    assert not output.errors
+    assert len(output.records) == 0
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_visibility_probe_that_reaches_no_repository_fails_the_sync(
+    http_mocker: HttpMocker,
+) -> None:
+    """The probe asks without a date filter, so its empty page has one meaning:
+    the token reaches nothing. Left unguarded the sync collects nothing and
+    still reports success."""
+    config = BitbucketCloudConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": []}), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, "repository_visibility", config)
+
+    assert output.errors
+    message = output.errors[0].trace.error.message
+    assert "visible to the token" in message, message
+    assert output.errors[0].trace.error.failure_type == FailureType.config_error
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_reachable_workspace_passes_the_visibility_probe(
+    http_mocker: HttpMocker,
+) -> None:
+    """One repository is enough; the probe asks for a single one."""
+    config = BitbucketCloudConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+
+    output = read_stream(_CONNECTOR, "repository_visibility", config)
+
+    assert not output.errors
+    assert len(output.records) == 1
+    assert output.records[0].record.data["workspace"] == "acme"
+
+
+@freezegun.freeze_time(_FROZEN)
+@pytest.mark.parametrize(
+    ("username", "rest_scheme", "clone_username"),
+    [
+        pytest.param("bot@example.com", "Basic ", "x-bitbucket-api-token-auth", id="api-token"),
+        pytest.param("", "Bearer ", "x-token-auth", id="access-token"),
+    ],
+)
+def test_credential_family_drives_both_the_rest_scheme_and_the_clone_username(
+    http_mocker: HttpMocker, username: str, rest_scheme: str, clone_username: str
+) -> None:
+    """Bitbucket takes an API token as Basic with the account address and an
+    access token as Bearer, and the two use different static clone usernames.
+    `bitbucket_username` is the only field that tells them apart, so the REST
+    header and the username the proxy presents must move together with it."""
+    config = BitbucketCloudConfigBuilder().with_field("bitbucket_username", username).build()
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_repo_with_clone()]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/authors", query_params=ANY_QUERY_PARAMS),
+        _authors_page(),
+    )
+
+    output = read_stream(_CONNECTOR, "commit_authors", config)
+
+    assert not output.errors
+    by_host = {r.url: r.headers for r in http_mocker._mocker.request_history}
+    rest = next(h for u, h in by_host.items() if u.startswith(BB_URL))
+    proxy = next(h for u, h in by_host.items() if u.startswith(PROXY_URL))
+    assert rest["Authorization"].startswith(rest_scheme), rest["Authorization"][:16]
+    assert proxy["X-Git-Username"] == clone_username
 
 
 @freezegun.freeze_time(_FROZEN)

--- a/src/ingestion/reconcile-connectors/tests/test_normalize_catalog_to_append.py
+++ b/src/ingestion/reconcile-connectors/tests/test_normalize_catalog_to_append.py
@@ -1,0 +1,77 @@
+"""What `normalize_catalog_to_append.py` promises the connection PATCH.
+
+The catalog it emits is built from the discover response, not from whatever the
+connection already carries, and every advertised stream comes out selected.
+That is what makes a stream added by a version bump reach an existing
+installation: reconcile republishes the definition, re-discovers with the cache
+disabled, and PATCHes this catalog in. Without it a new stream would sync only
+where somebody refreshed the connection by hand.
+
+Run: pytest src/ingestion/reconcile-connectors/tests
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+NORMALIZER = Path(__file__).resolve().parents[1] / "python" / "normalize_catalog_to_append.py"
+
+
+def _stream(name: str, *, cursor: list[str] | None = None) -> dict:
+    stream: dict = {
+        "name": name,
+        "jsonSchema": {"type": "object", "properties": {"unique_key": {"type": "string"}}},
+        "supportedSyncModes": ["full_refresh", "incremental"] if cursor else ["full_refresh"],
+    }
+    if cursor:
+        stream["defaultCursorField"] = cursor
+    return stream
+
+
+def _normalize(streams: list[dict]) -> dict:
+    payload = json.dumps({"catalog": {"streams": [{"stream": s} for s in streams]}})
+    done = subprocess.run(
+        [sys.executable, str(NORMALIZER)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+    return json.loads(done.stdout)
+
+
+def test_a_stream_the_connection_has_never_seen_comes_out_selected() -> None:
+    """The upgrade path for a connector that gains a stream: the bump
+    republishes the definition and this catalog is PATCHed onto the existing
+    connection, so the new stream must arrive enabled with no operator step."""
+    out = _normalize([_stream("repositories", cursor=["updated_on"]), _stream("brand_new")])
+
+    selected = {e["stream"]["name"]: e["config"]["selected"] for e in out["streams"]}
+    assert selected == {"repositories": True, "brand_new": True}
+
+
+def test_every_stream_appends_and_keeps_all_its_fields() -> None:
+    """Append-only at the destination, and no inherited field exclusion: an
+    update PATCH must not carry a stale `selectedFields` list."""
+    out = _normalize([_stream("brand_new")])
+
+    config = out["streams"][0]["config"]
+    assert config["destinationSyncMode"] == "append"
+    assert config["fieldSelectionEnabled"] is False
+    assert "selectedFields" not in config
+
+
+def test_a_cursor_bearing_stream_is_incremental_and_a_bare_one_is_not() -> None:
+    """The sync mode follows what the stream advertises, so a full-refresh
+    probe stream does not acquire a cursor it cannot honour."""
+    out = _normalize([_stream("with_cursor", cursor=["updated_on"]), _stream("without")])
+
+    by_name = {e["stream"]["name"]: e["config"] for e in out["streams"]}
+    assert by_name["with_cursor"]["syncMode"] == "incremental"
+    assert by_name["with_cursor"]["cursorField"] == ["updated_on"]
+    assert by_name["without"]["syncMode"] == "full_refresh"
+    assert "cursorField" not in by_name["without"]

--- a/src/ingestion/scripts/connectors-ddl/bitbucket-cloud.sql
+++ b/src/ingestion/scripts/connectors-ddl/bitbucket-cloud.sql
@@ -372,6 +372,25 @@ ORDER BY unique_key
 SETTINGS allow_nullable_key = 1, index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_cloud.repository_visibility
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `workspace` Nullable(String),
+    `repository_uuid` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_bitbucket_cloud.workspace_members
 (
     `_airbyte_raw_id` String,


### PR DESCRIPTION
Closes #3325.

**Why.** A token that reaches no repository is answered on the workspace listing with `200` and an empty page, not an error code, so every stream lands zero rows and the sync finishes green while everything downstream reports a healthy pipeline.

**What changed.** A new `repository_visibility` stream asks each workspace for one repository with no date filter, and fails the sync when the answer is empty.

**The guard cannot live on the listings that do the work.** All twelve request `updated_on >= bitbucket_start_date`, where an empty page also means nothing changed in the window — the same body, an ordinary outcome.

**Dropping that date filter instead would have changed what reaches bronze.** A `DatetimeBasedCursor` only tracks state; it filters records solely under `is_client_side_incremental`, which none of these streams set.

**The probe is exempt from the exclusion-projection invariant.** It answers whether the token reaches anything, not whether a repository is wanted; it generates no partitions and clones nothing. One request per workspace per sync.

**Permissions were named in neither family's vocabulary.** An API token grants `read:repository:bitbucket` and `read:pullrequest:bitbucket`; an access token grants `repository` and `pullrequest`. Neither read implies the other, and a credential holding only the repository one lists repositories while every pull-request call 403s into the per-repository skip.

**Existing installations pick the stream up without an operator step.** A version bump republishes the definition, and reconcile then re-discovers with the cache disabled and PATCHes the catalog `normalize_catalog_to_append.py` builds from that response — every advertised stream selected, per-stream state untouched. Newly pinned by three tests, which nothing covered before.

**Out of scope.** The third commit regenerates the snapshot block for `git_deduplicated_file_changes` — pre-existing drift on `main`, emitted by the same generator run and kept in its own commit rather than hand-edited out.

**Verified.** Connector suite 35 passed, four regressions new: a date-filtered listing with no matches is not an error; an unfiltered probe with no repository fails as `config_error`; and the REST scheme and the clone username the proxy presents both follow `bitbucket_username` across the two credential families. Whole nocode suite 277 passed, 2 skipped; reconciler suite 110 passed, 15 skipped. Snapshot regenerated with `bootstrap-db.sh` + `dump-ddl.sh`; `check-field-parity.py` reports 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Bitbucket Cloud repository visibility stream to verify repository access across workspaces.
  - Added support for workspace, project, and repository access tokens, including token-specific usernames and permissions.
  - Credential types now consistently determine API authentication and repository clone credentials.

- **Bug Fixes**
  - Improved access detection by distinguishing genuinely inaccessible workspaces from empty date-filtered repository results.
  - Syncs now report a configuration error when no repositories are visible to the configured token.

- **Documentation**
  - Expanded Bitbucket Cloud setup requirements, token guidance, permissions, and workspace membership details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->