### PR TITLE
fix(bitbucket): date a merge the vendor recorded without an activity entry

### DIFF
--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
@@ -39,6 +39,81 @@ terminal_activity AS (
     WHERE kind = 'update'
       AND update_state IN ('MERGED', 'DECLINED', 'SUPERSEDED')
     GROUP BY tenant_id, source_id, repo_full_name, pr_id
+),
+
+-- Every entry in the activity that is NOT a terminal state change. What it
+-- gives is the moment the request last visibly moved for a reason we can name,
+-- which is how the projection below tells a bumped `updated_on` that means "the
+-- vendor closed this silently" from one that merely means "someone commented".
+non_terminal_activity AS (
+    SELECT
+        tenant_id,
+        source_id,
+        repo_full_name,
+        pr_id,
+        max(parseDateTimeBestEffortOrNull(event_date)) AS last_seen_at,
+        max(_airbyte_extracted_at) AS _airbyte_extracted_at
+    FROM {{ source('bronze_bitbucket_cloud', 'pull_request_activity') }} FINAL
+    WHERE NOT (kind = 'update' AND update_state IN ('MERGED', 'DECLINED', 'SUPERSEDED'))
+    GROUP BY tenant_id, source_id, repo_full_name, pr_id
+),
+
+-- WORKAROUND: a merge reached by pushing a commit that carries the request's
+-- head changes the state with no merge ACTION, so the activity holds no
+-- terminal entry to date it by — and a merged request with no close time is
+-- dropped by every measure that dates by the close. The commit the request
+-- names as its merge is the corroboration that the merge happened. #3051
+--
+-- INVARIANT: Bitbucket answers `merge_commit.hash` with exactly 12 characters
+-- where the commit stream carries the full 40, so the join matches on 12 and
+-- the projection verifies the whole reported hash against the one that
+-- resolved. Same rule as `git_merge_result_match`, which resolves the same
+-- hash in gold.
+merge_commit_times AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        commit_prefix,
+        -- INVARIANT: the HAVING below leaves exactly one distinct hash per
+        -- group, so this IS that commit's hash.
+        min(commit_hash) AS resolved_hash,
+        min(landed_at) AS landed_at,
+        1 AS matched,
+        max(_airbyte_extracted_at) AS _airbyte_extracted_at
+    FROM (
+        SELECT
+            tenant_id,
+            source_id,
+            arrayElement(splitByChar('/', COALESCE(repository, '')), -2) AS project_key,
+            replaceRegexpOne(arrayElement(splitByChar('/', COALESCE(repository, '')), -1), '\\.git$', '') AS repo_slug,
+            substring(COALESCE(sha, ''), 1, 12) AS commit_prefix,
+            COALESCE(sha, '') AS commit_hash,
+            -- The committer date, unlike `class_git_commits`, which prefers the
+            -- author date: a rebase keeps the author date, so it says when the
+            -- work was written, and what is wanted here is when this commit
+            -- came into being. Author date only as a fallback, for a source
+            -- that left the committer date empty.
+            COALESCE(
+                parseDateTimeBestEffortOrNull(committed_date),
+                parseDateTimeBestEffortOrNull(authored_date)
+            ) AS landed_at,
+            _airbyte_extracted_at
+        FROM {{ source('bronze_bitbucket_cloud', 'commits') }} FINAL
+        WHERE COALESCE(sha, '') != ''
+          -- Bound the scan to hashes some merged request actually names.
+          AND substring(COALESCE(sha, ''), 1, 12) IN (
+              SELECT substring(COALESCE(merge_commit_sha, ''), 1, 12)
+              FROM {{ source('bronze_bitbucket_cloud', 'pull_requests') }} FINAL
+              WHERE state = 'MERGED' AND COALESCE(merge_commit_sha, '') != ''
+          )
+    )
+    GROUP BY tenant_id, source_id, project_key, repo_slug, commit_prefix
+    -- A prefix is a weak key. Two commits sharing it in one repository leave
+    -- nothing to say which merge this was, so such a prefix resolves nothing
+    -- rather than guessing.
+    HAVING uniqExact(commit_hash) = 1
 )
 
 SELECT
@@ -66,8 +141,41 @@ SELECT
     COALESCE(pr.destination_branch, '') AS destination_branch,
     parseDateTimeBestEffortOrNull(pr.created_on) AS created_on,
     parseDateTimeBestEffortOrNull(pr.updated_on) AS updated_on,
-    parseDateTimeBestEffortOrNull(
-        if(pr.state IN ('MERGED', 'DECLINED', 'SUPERSEDED'), COALESCE(activity.closed_on, ''), '')
+    -- The close time, spelled out in silver/git/README.md. Branch order is the
+    -- rule: the terminal activity entry decides whenever one parses; failing
+    -- that, a MERGED request the collected commits corroborate takes its own
+    -- last update when nothing in its activity accounts for that update, and
+    -- the merge commit's timestamp when something does; a request nothing
+    -- corroborates gets no close time at all. #3051
+    --
+    -- INVARIANT: the RECOVERED candidates are taken only from the creation
+    -- onwards, and none is invented — where no candidate qualifies the answer
+    -- is no close time rather than the creation. The terminal entry above is
+    -- taken as the source reports it.
+    multiIf(
+        COALESCE(pr.state, '') NOT IN ('MERGED', 'DECLINED', 'SUPERSEDED'), CAST(NULL AS Nullable(DateTime)),
+        -- The PARSE, not the string: an unparseable event date must fall
+        -- through to the recovery rather than answer with nothing. #3153
+        parseDateTimeBestEffortOrNull(activity.closed_on) IS NOT NULL,
+            parseDateTimeBestEffortOrNull(activity.closed_on),
+        COALESCE(pr.state, '') != 'MERGED', CAST(NULL AS Nullable(DateTime)),
+        -- Uncorroborated: no commit resolved for the reported hash, or the one
+        -- that did does not carry the whole of it. WORKAROUND: the second half
+        -- belongs in the join, but ClickHouse refuses a non-equality over both
+        -- sides there under `join_use_nulls`.
+        COALESCE(merge_commit.matched, 0) != 1
+            OR NOT startsWith(
+                COALESCE(merge_commit.resolved_hash, ''),
+                COALESCE(pr.merge_commit_sha, '')
+            ), CAST(NULL AS Nullable(DateTime)),
+        COALESCE(seen.last_seen_at IS NULL OR updated_on > seen.last_seen_at, 0)
+            AND updated_on IS NOT NULL
+            AND COALESCE(updated_on >= created_on, 1), updated_on,
+        merge_commit.landed_at IS NOT NULL
+            AND COALESCE(merge_commit.landed_at >= created_on, 1), merge_commit.landed_at,
+        updated_on IS NOT NULL
+            AND COALESCE(updated_on >= created_on, 1), updated_on,
+        CAST(NULL AS Nullable(DateTime))
     ) AS closed_on,
     COALESCE(pr.merge_commit_sha, '') AS merge_commit_hash,
     -- An unmatched join partner and a genuinely empty pull request both read
@@ -78,12 +186,14 @@ SELECT
     if(ds.matched = 1, toNullable(toInt64(COALESCE(ds.lines_removed, 0))), NULL) AS lines_removed,
     'insight_bitbucket_cloud' AS data_source,
     toUnixTimestamp64Milli(now64()) AS _version,
-    -- Diff stats and activity are their own streams: a late arrival must
-    -- re-trigger the pull-request row, which is not re-fetched on its own.
+    -- Diff stats, activity and commits are their own streams: a late arrival
+    -- must re-trigger the pull-request row, which is not re-fetched on its own.
     greatest(
         pr._airbyte_extracted_at,
         COALESCE(ds._airbyte_extracted_at, pr._airbyte_extracted_at),
-        COALESCE(activity._airbyte_extracted_at, pr._airbyte_extracted_at)
+        COALESCE(activity._airbyte_extracted_at, pr._airbyte_extracted_at),
+        COALESCE(seen._airbyte_extracted_at, pr._airbyte_extracted_at),
+        COALESCE(merge_commit._airbyte_extracted_at, pr._airbyte_extracted_at)
     ) AS _airbyte_extracted_at
 FROM {{ source('bronze_bitbucket_cloud', 'pull_requests') }} AS pr FINAL
 LEFT JOIN diff_stats AS ds
@@ -96,10 +206,25 @@ LEFT JOIN terminal_activity AS activity
     AND activity.source_id = pr.source_id
     AND activity.repo_full_name = pr.repo_full_name
     AND activity.pr_id = pr.id
+LEFT JOIN non_terminal_activity AS seen
+    ON seen.tenant_id = pr.tenant_id
+    AND seen.source_id = pr.source_id
+    AND seen.repo_full_name = pr.repo_full_name
+    AND seen.pr_id = pr.id
+-- Scoped to the request's own repository: a 12-character prefix is a weak key,
+-- and a commit elsewhere that happens to share it is another repository's work.
+LEFT JOIN merge_commit_times AS merge_commit
+    ON merge_commit.tenant_id = pr.tenant_id
+    AND merge_commit.source_id = pr.source_id
+    AND merge_commit.project_key = splitByChar('/', COALESCE(pr.repo_full_name, ''))[1]
+    AND merge_commit.repo_slug = splitByChar('/', COALESCE(pr.repo_full_name, ''))[2]
+    AND merge_commit.commit_prefix = substring(COALESCE(pr.merge_commit_sha, ''), 1, 12)
 {% if is_incremental() %}
 WHERE greatest(
     pr._airbyte_extracted_at,
     COALESCE(ds._airbyte_extracted_at, pr._airbyte_extracted_at),
-    COALESCE(activity._airbyte_extracted_at, pr._airbyte_extracted_at)
+    COALESCE(activity._airbyte_extracted_at, pr._airbyte_extracted_at),
+    COALESCE(seen._airbyte_extracted_at, pr._airbyte_extracted_at),
+    COALESCE(merge_commit._airbyte_extracted_at, pr._airbyte_extracted_at)
 ) > (SELECT max(_airbyte_extracted_at) FROM {{ this }})
 {% endif %}

--- a/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
@@ -23,7 +23,25 @@ name: bitbucket-cloud
 #   scoped `dbt --full-refresh` a major bump dispatches re-materializes them.
 #   Safe: both dates have been in Bronze all along, and the author date falls
 #   back to the committer date where a source left it empty. #3153
-version: "6.0.1"
+# 7.0.0: the class-contract column `closed_on` now has a fallback for a
+#   merge the vendor recorded without a terminal activity entry. The merge
+#   commit the request names is what corroborates such a merge — without one
+#   collected the request still keeps no close time — and the time is then the
+#   request's own last update where nothing in its activity accounts for that
+#   update, the commit's own timestamp where something does, and nothing at
+#   all where neither candidate is at or after the creation. Bitbucket reports
+#   no close time of its own, and a merge reached by pushing a commit that
+#   carries the request's head produces no merge action to read one from — so
+#   those requests carried no close time and were dropped by every measure
+#   that dates by the close, while the rate measures, which read the state
+#   alone, kept counting them. MAJOR for the same reason as 6.0.0: staging is
+#   incremental on _airbyte_extracted_at and never re-reads Bronze, so
+#   already-materialized requests keep their empty close time forever and the
+#   install would run in two regimes. Only the one-shot scoped full refresh a
+#   major bump dispatches re-materializes them. Safe: the merge hash and the
+#   commits have been in Bronze all along, and a request the activity does
+#   date is untouched. #3051
+version: "7.0.0"
 # A slot of its own: replication pods sharing a slot with other connector
 # syncs can be starved of workers, which surfaces as startup and activity
 # timeouts rather than as a connector error.

--- a/src/ingestion/silver/git/README.md
+++ b/src/ingestion/silver/git/README.md
@@ -74,10 +74,20 @@ dbt run --select tag:silver
 
 ## Caveats
 
-- `cycle_time_h` for Bitbucket Cloud uses `pr.closed_on` which is a
-  staging-level heuristic (set to `updated_on` on terminal states). Accurate
-  to within sync cadence for typical PRs; improves when the Bitbucket Cloud
-  `pr_activity` stream lands.
+- Bitbucket Cloud reports no close time on a pull request, so `closed_on` is
+  derived in staging. The terminal entry in the request's activity supplies it
+  whenever there is one. A merge reached by pushing a commit that carries the
+  request's head produces no merge action and so no such entry, and for those
+  the merge commit the request names is what corroborates that the merge
+  happened: with no such commit collected — or a reported prefix that names two
+  commits in the repository — the request keeps NO close time and reaches no
+  close-dated measure. With one, the time is the request's own last update when
+  nothing in its activity accounts for that update (an unexplained update IS
+  the silent state change), and the merge commit's own timestamp when a comment
+  does account for it. Whichever is chosen is never earlier than the creation,
+  and nothing is invented: if neither candidate qualifies there is no close
+  time. All of this is MERGED-only — a declined or superseded request without a
+  terminal entry keeps no close time whatever hash it carries.
 - `mtr_git_person_weekly` buckets every metric by **commit-date week**,
   including `prs_merged` (week is the PR's merge-commit week when
   `merge_commit_hash` resolves, else `closed_on` week). All CTEs share the

--- a/tests/datapath/metrics/git/git_bitbucket_merge_time_recovery.test.yaml
+++ b/tests/datapath/metrics/git/git_bitbucket_merge_time_recovery.test.yaml
@@ -1,0 +1,130 @@
+spec_version: 1
+description: >
+  A Bitbucket merge the source recorded without an activity entry still has a
+  close time — and so still counts, #3051.
+
+  How it's computed (bronze → silver → gold):
+    • bronze: the pull request (which carries no close time of its own), its
+      activity, and the commits the proxy collected
+    • silver: the terminal activity entry supplies the close time whenever one
+      parses. Where the source recorded the merge without one, the merge commit
+      the request names — resolved against the collected commits by the
+      12-character prefix the vendor reports, inside the request's own
+      repository — corroborates that the merge happened; with nothing
+      corroborating it the request keeps no close time at all. With
+      corroboration the time is the request's last update when nothing in its
+      activity accounts for that update (an unexplained update IS the silent
+      state change), the merge commit's own timestamp when a comment does
+      account for it, and nothing when neither is at or after the creation
+    • gold:   a request in the MERGED state with a known close time contributes
+      exactly 1 to git.prs_merged, dated by the CLOSE — so a merge with no
+      close time reaches no period at all. The same close time feeds the
+      duration measures, which discard an interval that does not run forwards
+
+  Cases, one request each: the terminal entry wins even when the merge commit
+  sits on another day; a silent close with no other activity is dated by the
+  update; a close whose update a comment explains is dated by the merge commit;
+  a merge commit older than the request cannot date it, so the update answers;
+  a merge commit that was never collected leaves the request uncounted, which
+  is the boundary of the recovery; a request whose every candidate precedes it
+  keeps no close time rather than being dated at its own creation; a request
+  whose creation date is unusable still has its corroborated merge dated; a
+  prefix naming two commits in one repository resolves nothing rather than
+  guessing; a commit reporting only an author date still dates its merge. Plus three guards: a commit in ANOTHER
+  repository sharing a reported prefix must not be reachable; an uncounted
+  request must reach NO period rather than the epoch, which a month window
+  structurally cannot show; and a DECLINED request carrying a merge hash must
+  gain no close time, or it would count as an abandonment that never happened.
+
+  Beyond git.prs_merged the module reads git.prs_created as a vacuity guard,
+  git.pr_cycle_time_h to prove a recovered close is usable and not merely
+  countable, and git.pr_abandonment_rate for the DECLINED guard.
+
+  The fixture's commits carry no author address on purpose: they exist to carry
+  a date, and an addressless commit reaches no commit or line metric, so
+  heidi's own commit and line figures stay empty.
+
+identity_accounts:
+  # Bitbucket exposes no author address on a request, so the account binding is
+  # the only way one reaches a person.
+  - {source_type: bitbucket, source_id: bitbucket-test, account_id: "heidi-acct", person: heidi@example.com}
+  - {source_type: bitbucket, source_id: bitbucket-test, account_id: "dave-acct", person: dave@example.com}
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: ../templates/people.yaml#/templates/heidi
+    - $ref: ../templates/people.yaml#/templates/dave
+
+  bronze_bitbucket_cloud.commits:
+    # 401's merge commit, on a different day from its activity entry.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:mt-401", repository: https://bitbucket.org/acme/mergetime.git, sha: a1b2c3d400010000000000000000000000000000, authored_date: "2026-10-09T10:00:00Z", committed_date: "2026-10-09T10:00:00Z", is_merge: true}
+    # 402's, which loses to the update because nothing explains that update.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:mt-402", repository: https://bitbucket.org/acme/mergetime.git, sha: b2c3d4e500020000000000000000000000000000, authored_date: "2026-10-12T10:00:00Z", committed_date: "2026-10-12T10:00:00Z", is_merge: true}
+    # 403's. Its two dates differ, so their precedence is visible: the
+    # committer date decides and the author date is only a fallback.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:mt-403", repository: https://bitbucket.org/acme/mergetime.git, sha: c3d4e5f600030000000000000000000000000000, authored_date: "2026-10-15T09:00:00Z", committed_date: "2026-10-17T10:00:00Z", is_merge: true}
+    # 404's, written before its request was opened — the shape a fast-forward
+    # of an older branch leaves.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:mt-404", repository: https://bitbucket.org/acme/mergetime.git, sha: d4e5f60700040000000000000000000000000000, authored_date: "2026-10-20T10:00:00Z", committed_date: "2026-10-20T10:00:00Z"}
+    # 406's prefix names TWO commits in this repository. Neither may date it.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:mt-406a", repository: https://bitbucket.org/acme/mergetime.git, sha: f6a7b8c900060000000000000000000000000000, authored_date: "2026-10-28T10:00:00Z", committed_date: "2026-10-28T10:00:00Z", is_merge: true}
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:mt-406b", repository: https://bitbucket.org/acme/mergetime.git, sha: f6a7b8c900069999999999999999999999999999, authored_date: "2026-10-28T11:00:00Z", committed_date: "2026-10-28T11:00:00Z", is_merge: true}
+    # 407's, collected with no committer date at all.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:mt-407", repository: https://bitbucket.org/acme/mergetime.git, sha: 0a1b2c3d00070000000000000000000000000000, authored_date: "2026-10-30T10:00:00Z", committed_date: null, is_merge: true}
+    # 409's, older than its request — as are 409's own other candidates.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:mt-409", repository: https://bitbucket.org/acme/mergetime.git, sha: 0b2c3d4e00090000000000000000000000000000, authored_date: "2026-10-22T10:00:00Z", committed_date: "2026-10-22T10:00:00Z", is_merge: true}
+    # 410's, for the request whose creation date is unusable.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:mt-410", repository: https://bitbucket.org/acme/mergetime.git, sha: 1c2d3e4f00100000000000000000000000000000, authored_date: "2026-10-16T10:00:00Z", committed_date: "2026-10-16T10:00:00Z", is_merge: true}
+    # 412's, collected — so only the DECLINED state keeps it from dating that
+    # request.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:mt-412", repository: https://bitbucket.org/acme/mergetime.git, sha: e5f6071800120000000000000000000000000000, authored_date: "2026-10-04T10:00:00Z", committed_date: "2026-10-04T10:00:00Z", is_merge: true}
+    # The cross-repository guard, and 408's ONLY candidate: the prefix 408
+    # reports exists in another repository and nowhere in its own. Resolution
+    # must stay inside the request's repository, so 408 stays undated — one
+    # matched row either way, which a duplicate-producing guard would not give.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/commit, unique_key: "c:ot-408", repository: https://bitbucket.org/acme/othertime.git, sha: bbbbccccdddd0000000000000000000000000000, authored_date: "2026-10-18T10:00:00Z", committed_date: "2026-10-18T10:00:00Z", is_merge: true}
+
+  bronze_bitbucket_cloud.pull_requests:
+    # Terminal entry on the 5th, merge commit on the 9th. The entry wins.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:401", repo_full_name: acme/mergetime, id: 401, author_display_name: Heidi Eta, author_account_id: heidi-acct, created_on: "2026-10-01T08:00:00Z", updated_on: "2026-10-09T13:00:00Z", merge_commit_sha: a1b2c3d40001}
+    # No activity at all: nothing accounts for the update, so the update is the
+    # silent state change and dates the merge.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:402", repo_full_name: acme/mergetime, id: 402, author_display_name: Heidi Eta, author_account_id: heidi-acct, created_on: "2026-10-10T08:00:00Z", updated_on: "2026-10-13T13:00:00Z", merge_commit_sha: b2c3d4e50002}
+    # A comment sits exactly at the update, so the update is explained and the
+    # merge commit is the closer record.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:403", repo_full_name: acme/mergetime, id: 403, author_display_name: Heidi Eta, author_account_id: heidi-acct, created_on: "2026-10-16T08:00:00Z", updated_on: "2026-10-19T15:00:00Z", merge_commit_sha: c3d4e5f60003}
+    # Same shape, but the merge commit predates the request, so it cannot be
+    # the landing and the update answers after all.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:404", repo_full_name: acme/mergetime, id: 404, author_display_name: Heidi Eta, author_account_id: heidi-acct, created_on: "2026-10-22T08:00:00Z", updated_on: "2026-10-25T13:00:00Z", merge_commit_sha: d4e5f6070004}
+    # Reported merge commit never collected: no corroboration, no close time.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:405", repo_full_name: acme/mergetime, id: 405, author_display_name: Heidi Eta, author_account_id: heidi-acct, created_on: "2026-10-26T08:00:00Z", updated_on: "2026-10-27T13:00:00Z", merge_commit_sha: aaaabbbbcccc}
+    # Reported prefix names two commits here: resolves nothing.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:406", repo_full_name: acme/mergetime, id: 406, author_display_name: Heidi Eta, author_account_id: heidi-acct, created_on: "2026-10-28T08:00:00Z", updated_on: "2026-10-29T13:00:00Z", merge_commit_sha: f6a7b8c90006}
+    # A comment explains the update, and the commit carries only an author date.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:407", repo_full_name: acme/mergetime, id: 407, author_display_name: Heidi Eta, author_account_id: heidi-acct, created_on: "2026-10-30T08:00:00Z", updated_on: "2026-10-31T15:00:00Z", merge_commit_sha: 0a1b2c3d0007}
+    # The prefix this one reports exists only in ANOTHER repository, so nothing
+    # here may date it. It has no activity either, so a scope leak would date it
+    # by its update and be plainly visible.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:408", repo_full_name: acme/mergetime, id: 408, author_display_name: Heidi Eta, author_account_id: heidi-acct, created_on: "2026-10-18T08:00:00Z", updated_on: "2026-10-18T13:00:00Z", merge_commit_sha: bbbbccccdddd}
+    # Every candidate precedes the request: the update is older than the
+    # creation and so is the merge commit. Nothing here can be the landing, and
+    # nothing may be invented from the creation either — the answer is no close
+    # time.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:409", repo_full_name: acme/mergetime, id: 409, author_display_name: Heidi Eta, author_account_id: heidi-acct, created_on: "2026-10-24T08:00:00Z", updated_on: "2026-10-23T13:00:00Z", merge_commit_sha: 0b2c3d4e0009}
+    # An unusable creation date must not erase a corroborated merge: the update
+    # still dates it. Such a request contributes no CREATION, so it raises the
+    # merged count without raising the created count.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:410", repo_full_name: acme/mergetime, id: 410, author_display_name: Heidi Eta, author_account_id: heidi-acct, created_on: "not-a-date", updated_on: "2026-10-21T13:00:00Z", merge_commit_sha: 1c2d3e4f0010}
+    # dave's pair, for the DECLINED guard. This one closed with an entry.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:411", repo_full_name: acme/mergetime, id: 411, state: DECLINED, author_display_name: Dave Delta, author_account_id: dave-acct, created_on: "2026-10-02T08:00:00Z", updated_on: "2026-10-03T13:00:00Z"}
+    # Declined with no entry, yet carrying a merge hash whose commit WAS
+    # collected. It must stay without a close time.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:412", repo_full_name: acme/mergetime, id: 412, state: DECLINED, author_display_name: Dave Delta, author_account_id: dave-acct, created_on: "2026-10-02T09:00:00Z", updated_on: "2026-10-05T13:00:00Z", merge_commit_sha: e5f607180012}
+
+  bronze_bitbucket_cloud.pull_request_activity:
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/activity, unique_key: "bb-ac:401", repo_full_name: acme/mergetime, pr_id: 401, update_state: MERGED, event_date: "2026-10-05T09:00:00Z"}
+    # Comments, not state changes: they explain an update without dating a merge.
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/activity, unique_key: "bb-ac:403", repo_full_name: acme/mergetime, pr_id: 403, kind: comment, update_state: null, event_date: "2026-10-19T15:00:00Z"}
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/activity, unique_key: "bb-ac:404", repo_full_name: acme/mergetime, pr_id: 404, kind: comment, update_state: null, event_date: "2026-10-25T13:00:00Z"}
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/activity, unique_key: "bb-ac:407", repo_full_name: acme/mergetime, pr_id: 407, kind: comment, update_state: null, event_date: "2026-10-31T15:00:00Z"}
+    - {$ref: ../templates/bitbucket_git.yaml#/templates/activity, unique_key: "bb-ac:411", repo_full_name: acme/mergetime, pr_id: 411, update_state: DECLINED, event_date: "2026-10-03T09:00:00Z"}

--- a/tests/datapath/metrics/git/git_merge_rate_creation_window.test.yaml
+++ b/tests/datapath/metrics/git/git_merge_rate_creation_window.test.yaml
@@ -1,0 +1,83 @@
+spec_version: 1
+description: >
+  Metric: git.merge_rate — share of created pull requests that merged, #3055.
+  How it's computed (bronze → silver → gold):
+    • bronze: the pull requests the connector reports, with whatever each says
+      about having merged
+    • silver: one class row per request, its state normalised and its close
+      time in one column
+    • gold:   both inputs are emitted per request and dated by the CREATION.
+      The denominator is every request created in the period; the numerator is
+      the same rows, contributing 1 where the request is merged NOW
+
+  The population is what this spec is about. Because both inputs ride the same
+  row and are dated the same way, the rate is the share of the period's OWN
+  requests that have merged — not the period's merges over the period's
+  creations, which is a different question with a different answer. A request
+  merged after the period ends still counts for the period it was opened in,
+  and a request opened earlier never enters, however plainly its merge lands
+  inside.
+
+  Every window asserted here is sized so that the other reading — the period's
+  merges over its creations — produces a DIFFERENT number, so no case passes
+  by coincidence.
+
+  Cases: the rate counts a merge that happened after the period closed and
+  ignores a request opened before the period even when that request merged
+  inside it, with the merged COUNT asserted beside the rate for the same window
+  where the two disagree by construction; the day series places each
+  contribution on the creation day rather than the merge day; both period
+  bounds are exercised, with a creation the day after the upper bound that must
+  not count; a declined request and an open one stay in the denominator and
+  lower the rate; a population that created but merged nothing reads zero,
+  while a period with no creations at all reads null.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: ../templates/people.yaml#/templates/carol
+    - $ref: ../templates/people.yaml#/templates/dave
+
+  bronze_github.pull_requests:
+    # ON the lower bound, and merged well after the period closed. Both halves
+    # matter: the bound must be inclusive and the merge must still count.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: mr-501, id: 501, number: 501, author_login: carol, created_at: "2026-10-01T08:00:00Z", updated_at: "2026-11-20T09:00:00Z", closed_at: "2026-11-20T09:00:00Z", merged_at: "2026-11-20T09:00:00Z", merge_commit_sha: merge-501}
+    # Opened inside the period and still open: denominator, not numerator. Its
+    # day is also the one-day window the zero case asks about.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: mr-502, id: 502, number: 502, state: open, author_login: carol, created_at: "2026-10-06T08:00:00Z", updated_at: "2026-10-06T08:00:00Z", closed_at: "", merged_at: "", merge_commit_sha: ""}
+    # Opened BEFORE the period and merged inside it. It must not enter the
+    # rate at all, though it does raise the merged count for the period.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: mr-503, id: 503, number: 503, author_login: carol, created_at: "2026-09-20T08:00:00Z", updated_at: "2026-10-10T09:00:00Z", closed_at: "2026-10-10T09:00:00Z", merged_at: "2026-10-10T09:00:00Z", merge_commit_sha: merge-503}
+    # Opened and merged inside the period: the only request the rate and the
+    # merged count for October have in common.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: mr-504, id: 504, number: 504, author_login: carol, created_at: "2026-10-08T08:00:00Z", updated_at: "2026-10-09T09:00:00Z", closed_at: "2026-10-09T09:00:00Z", merged_at: "2026-10-09T09:00:00Z", merge_commit_sha: merge-504}
+    # ON the upper bound, merged after it. Also what makes the quotient exact:
+    # three of four rather than two of three.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: mr-505, id: 505, number: 505, author_login: carol, created_at: "2026-10-31T08:00:00Z", updated_at: "2026-11-25T09:00:00Z", closed_at: "2026-11-25T09:00:00Z", merged_at: "2026-11-25T09:00:00Z", merge_commit_sha: merge-505}
+    # One day PAST the upper bound: an inclusive bound must stop here.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: mr-506, id: 506, number: 506, author_login: carol, created_at: "2026-11-01T08:00:00Z", updated_at: "2026-11-05T09:00:00Z", closed_at: "2026-11-05T09:00:00Z", merged_at: "2026-11-05T09:00:00Z", merge_commit_sha: merge-506}
+
+    # dave's five, all opened on one day: the denominator is every request,
+    # whatever became of it.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: mr-511, id: 511, number: 511, author_login: dave, created_at: "2026-10-02T08:00:00Z", updated_at: "2026-10-03T09:00:00Z", closed_at: "2026-10-03T09:00:00Z", merged_at: "2026-10-03T09:00:00Z", merge_commit_sha: merge-511}
+    # Merged after the period, which is what keeps dave's own window from
+    # reading the same under either question.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: mr-515, id: 515, number: 515, author_login: dave, created_at: "2026-10-02T12:00:00Z", updated_at: "2026-11-10T09:00:00Z", closed_at: "2026-11-10T09:00:00Z", merged_at: "2026-11-10T09:00:00Z", merge_commit_sha: merge-515}
+    # Closed without merging, twice over.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: mr-512, id: 512, number: 512, author_login: dave, created_at: "2026-10-02T09:00:00Z", updated_at: "2026-10-04T09:00:00Z", closed_at: "2026-10-04T09:00:00Z", merged_at: "", merge_commit_sha: ""}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: mr-514, id: 514, number: 514, author_login: dave, created_at: "2026-10-02T11:00:00Z", updated_at: "2026-10-05T09:00:00Z", closed_at: "2026-10-05T09:00:00Z", merged_at: "", merge_commit_sha: ""}
+    # Still open.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: mr-513, id: 513, number: 513, state: open, author_login: dave, created_at: "2026-10-02T10:00:00Z", updated_at: "2026-10-02T10:00:00Z", closed_at: "", merged_at: "", merge_commit_sha: ""}
+
+  bronze_github.pull_request_diff_stats:
+    # GitHub staging reads a request's author_email from here and nowhere else.
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-501, pull_number: 501, additions: 10, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-502, pull_number: 502, additions: 10, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-503, pull_number: 503, additions: 10, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-504, pull_number: 504, additions: 10, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-505, pull_number: 505, additions: 10, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-506, pull_number: 506, additions: 10, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-511, pull_number: 511, additions: 10, author_email: dave@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-512, pull_number: 512, additions: 10, author_email: dave@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-513, pull_number: 513, additions: 10, author_email: dave@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-514, pull_number: 514, additions: 10, author_email: dave@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-515, pull_number: 515, additions: 10, author_email: dave@example.com}

--- a/tests/datapath/metrics/git/git_prs_merged.test.yaml
+++ b/tests/datapath/metrics/git/git_prs_merged.test.yaml
@@ -92,9 +92,12 @@ bronze:
     # metric's date can only be right if it came from the activity row.
     - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:301", id: 301, author_display_name: Carol Gamma, author_account_id: carol-acct, created_on: "2026-09-25T08:00:00Z", updated_on: "2026-10-02T13:00:00Z", source_commit_sha: bb-src-301, destination_commit_sha: bb-dst-301, merge_commit_sha: bb-merge-301}
     - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:302", id: 302, state: DECLINED, author_display_name: Carol Gamma, author_account_id: carol-acct, created_on: "2026-09-25T08:00:00Z", updated_on: "2026-10-02T13:00:00Z", source_commit_sha: bb-src-302, destination_commit_sha: bb-dst-302}
-    # Reported MERGED, and no terminal event was ever collected for it, so
-    # nothing says when it closed. Bitbucket takes the close time from the
-    # activity stream alone — see the gap this leaves in the module.
+    # Reported MERGED with no terminal event collected AND no commit seeded
+    # for the merge hash it names, so nothing corroborates the merge and
+    # nothing says when it closed. Both halves are needed: with the commit
+    # collected the close time is recovered (see
+    # git_bitbucket_merge_time_recovery), so seeding one here would silently
+    # retire this case. #3051
     - {$ref: ../templates/bitbucket_git.yaml#/templates/pull_request, unique_key: "bb-pr:303", id: 303, author_display_name: Carol Gamma, author_account_id: carol-acct, created_on: "2026-09-25T08:00:00Z", updated_on: "2026-10-02T13:00:00Z", source_commit_sha: bb-src-303, destination_commit_sha: bb-dst-303, merge_commit_sha: bb-merge-303}
 
   bronze_bitbucket_cloud.pull_request_activity:

--- a/tests/datapath/metrics/git/test_git_bitbucket_merge_time_recovery.py
+++ b/tests/datapath/metrics/git/test_git_bitbucket_merge_time_recovery.py
@@ -1,0 +1,176 @@
+"""A Bitbucket merge recorded without an activity entry still has a close time.
+
+Bitbucket reports no close time on a pull request; the terminal entry in its activity is
+what supplies one. A merge reached by pushing a commit that carries the request's head
+changes the state with no merge action, so no such entry exists — and a merged request
+with no close time reaches no period at all, because every measure that dates by the
+close has nowhere to file it.
+
+The merge commit the request names is the corroboration that the merge happened. Which
+timestamp then dates it depends on what the activity can account for: an update nothing
+explains is the silent state change itself, while an update a comment explains leaves the
+commit as the closer record.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_datapath.spec_runner import SpecRun
+
+pytestmark = pytest.mark.fixture
+
+SPEC = "git_bitbucket_merge_time_recovery"
+
+HEIDI = "heidi@example.com"
+DAVE = "dave@example.com"
+WINDOW = {"from": "2026-10-01", "to": "2026-10-31"}
+
+# One day per request, and each comes from a different piece of evidence: the terminal
+# entry, the unexplained update, the merge commit, the update after the commit was ruled
+# out, and a commit reporting only an author date.
+LANDED = (
+    "2026-10-05",
+    "2026-10-13",
+    "2026-10-17",
+    "2026-10-21",
+    "2026-10-25",
+    "2026-10-30",
+)
+
+# Every day some losing candidate would have produced. Each is a real timestamp in the
+# fixture, so a rule reading the wrong evidence fills one of these rather than merely
+# shifting a total.
+LOSING = (
+    "2026-10-09",  # 401's merge commit, which loses to the terminal entry
+    "2026-10-12",  # 402's merge commit, which loses to the unexplained update
+    "2026-10-15",  # 403's commit's AUTHOR date, which loses to its committer date
+    "2026-10-16",  # 410's merge commit, which loses to that request's update
+    "2026-10-18",  # 408's own day: its prefix exists only in another repository
+    "2026-10-19",  # 403's update, explained by a comment and so not the close
+    "2026-10-20",  # 404's merge commit, older than the request that carried it
+    "2026-10-26",  # 405's own days: its merge commit was never collected
+    "2026-10-27",
+    "2026-10-28",  # 406's own days, and the two commits its prefix names
+    "2026-10-29",
+    "2026-10-22",  # 409's merge commit, older than the request it belongs to
+    "2026-10-23",  # 409's update, also older than its creation
+    "2026-10-24",  # 409's own creation day: nothing may be invented from it
+    "2026-10-31",  # 407's update, explained by a comment
+)
+
+
+def test_each_merge_lands_on_the_day_its_own_evidence_names(spec: SpecRun) -> None:
+    """Five of heidi's eight requests reach a period, on five different days. Three do not:
+    one names a merge commit that was never collected, one a prefix that names two commits
+    in its repository, and one a prefix that exists only in another repository.
+    """
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [HEIDI]},
+                "period": WINDOW,
+                "metrics": [
+                    {
+                        "metric_key": "git.prs_merged",
+                        "views": [{"view": "period"}, {"view": "timeseries", "bucket": "day"}],
+                    },
+                    {"metric_key": "git.prs_created", "views": [{"view": "period"}]},
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.prs_created", "period", entity_id=HEIDI).equals(value=9)
+    r.row("git.prs_merged", "period", entity_id=HEIDI).equals(value=6)
+
+    series = r.row("git.prs_merged", "timeseries", entity_id=HEIDI)
+    for day in LANDED:
+        series.contains(points={"bucket_start": day, "value": 1})
+
+    filled = [
+        point["bucket_start"]
+        for point in series.fields["points"]
+        if point["value"] and point["bucket_start"] in LOSING
+    ]
+    assert not filled, f"a merge was filed under evidence that should have lost: {filled!r}"
+
+
+def test_a_merge_with_no_usable_evidence_is_dropped_not_dated_at_the_epoch(
+    spec: SpecRun,
+) -> None:
+    """The two requests that resolve nothing must reach NO period, not the beginning of
+    time. This is the failure the October window cannot see: a close time that resolves to
+    a type default instead of to nothing keeps October's total right and files the merge in
+    1970. A period may not exceed 400 days, so the epoch needs a window of its own.
+    """
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [HEIDI]},
+                "period": {"from": "1970-01-01", "to": "1970-12-31"},
+                "metrics": [{"metric_key": "git.prs_merged", "views": [{"view": "period"}]}],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.prs_merged", "period", entity_id=HEIDI).equals(value=None)
+
+
+def test_a_recovered_close_time_is_usable_and_not_merely_countable(spec: SpecRun) -> None:
+    """A recovered close time has to survive the guards every duration measure applies —
+    a close before the opening yields no value at all — so the cycle time is what proves
+    the recovery produced a coherent interval and not just a countable row.
+
+    Of the five requests that landed, the four the recovery dated span 77, 26, 77 and 2
+    hours from opening to close; the one the terminal entry dated spans 97. The median of
+    those five is 77 — a value only reachable if the recovered closes are both present and
+    ordered after their openings.
+    """
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [HEIDI]},
+                "period": WINDOW,
+                "metrics": [{"metric_key": "git.pr_cycle_time_h", "views": [{"view": "period"}]}],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.pr_cycle_time_h", "period", entity_id=HEIDI).equals(value=77)
+
+
+def test_a_declined_request_carrying_a_merge_hash_gains_no_close_time(spec: SpecRun) -> None:
+    """dave's two requests were both declined, but only one closed with an entry. The other
+    carries a merge hash whose commit WAS collected, and the recovery must not reach it: a
+    close time there would make a request that merely went stale look abandoned on a date.
+
+    The abandonment rate is what discriminates — both count as created, one as abandoned,
+    so the rate is half. Were the merge hash to supply a close time it would read whole.
+    """
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [DAVE]},
+                "period": WINDOW,
+                "metrics": [
+                    {"metric_key": "git.prs_created", "views": [{"view": "period"}]},
+                    {"metric_key": "git.pr_abandonment_rate", "views": [{"view": "period"}]},
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.prs_created", "period", entity_id=DAVE).equals(value=2)
+    r.row("git.pr_abandonment_rate", "period", entity_id=DAVE).equals(value=50.0)

--- a/tests/datapath/metrics/git/test_git_merge_rate_creation_window.py
+++ b/tests/datapath/metrics/git/test_git_merge_rate_creation_window.py
@@ -1,0 +1,175 @@
+"""The merge rate is a share of the period's OWN requests, not of the period's merges.
+
+Both of its inputs ride the same pull-request row and are dated by the creation, so the
+denominator is every request opened in the period and the numerator is the same rows that
+have merged by now. Two consequences follow, and they are what this spec pins: a request
+merged after the period closed still counts for the period it was opened in, and a request
+opened earlier never counts, however plainly its merge lands inside.
+
+Every window here is sized so that the other reading — the period's merges over its
+creations — gives a different number, so no case can pass by coincidence.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_datapath.spec_runner import SpecRun
+
+pytestmark = pytest.mark.fixture
+
+SPEC = "git_merge_rate_creation_window"
+
+CAROL = "carol@example.com"
+DAVE = "dave@example.com"
+WINDOW = {"from": "2026-10-01", "to": "2026-10-31"}
+
+
+def test_the_rate_counts_a_merge_that_happened_after_the_period_closed(spec: SpecRun) -> None:
+    """Four of carol's six requests were opened in the period — one on each bound — and
+    three of those have merged, two of them only in November. The rate is three quarters.
+
+    The merged COUNT for the same period is two, and the two populations share exactly one
+    member: the request opened and merged inside October. The other count member was opened
+    in September, and the other two rate members merged in November. Asking the period's
+    merges over its creations would read half.
+    """
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [CAROL]},
+                "period": WINDOW,
+                "metrics": [
+                    {
+                        "metric_key": "git.merge_rate",
+                        "views": [{"view": "period"}, {"view": "timeseries", "bucket": "day"}],
+                    },
+                    {"metric_key": "git.prs_created", "views": [{"view": "period"}]},
+                    {"metric_key": "git.prs_merged", "views": [{"view": "period"}]},
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.merge_rate", "period", entity_id=CAROL).equals(value=75)
+    # The denominator. September's request is not among these, and neither is the one
+    # opened the day after the upper bound — both bounds are inclusive and stop there.
+    r.row("git.prs_created", "period", entity_id=CAROL).equals(value=4)
+    # Dated by the close, so this counts September's request and neither November one.
+    r.row("git.prs_merged", "period", entity_id=CAROL).equals(value=2)
+
+    # Each creation day holds exactly one request, so each bucket reads whole or nothing —
+    # and the bucket is the CREATION day even where the merge happened in November. A rule
+    # that bucketed by the merge instead would empty every one of these.
+    series = r.row("git.merge_rate", "timeseries", entity_id=CAROL)
+    for day, rate in (
+        ("2026-10-01", 100),  # merged in November
+        ("2026-10-06", 0),  # still open
+        ("2026-10-08", 100),  # merged the next day
+        ("2026-10-31", 100),  # merged in November
+    ):
+        series.contains(points={"bucket_start": day, "value": rate})
+
+
+def test_a_request_opened_before_the_period_never_enters_the_rate(spec: SpecRun) -> None:
+    """September holds one creation, and that request merged in October. Asked about
+    September the rate reads whole, because the question is what became of September's
+    requests — not what merged in September, where the answer is nothing.
+    """
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [CAROL]},
+                "period": {"from": "2026-09-01", "to": "2026-09-30"},
+                "metrics": [
+                    {"metric_key": "git.merge_rate", "views": [{"view": "period"}]},
+                    {"metric_key": "git.prs_created", "views": [{"view": "period"}]},
+                    {"metric_key": "git.prs_merged", "views": [{"view": "period"}]},
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.merge_rate", "period", entity_id=CAROL).equals(value=100)
+    r.row("git.prs_created", "period", entity_id=CAROL).equals(value=1)
+    r.row("git.prs_merged", "period", entity_id=CAROL).equals(value=None)
+
+
+def test_a_declined_request_and_an_open_one_both_stay_in_the_denominator(
+    spec: SpecRun,
+) -> None:
+    """dave opened five on one day: two merged — one of them in November — two were closed
+    without merging, one is still open. The rate is two fifths: an outcome other than a
+    merge lowers it rather than leaving the population.
+
+    The November merge is also what keeps this window from reading the same under either
+    question — the period's merges over its creations would give one fifth.
+    """
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [DAVE]},
+                "period": WINDOW,
+                "metrics": [
+                    {"metric_key": "git.merge_rate", "views": [{"view": "period"}]},
+                    {"metric_key": "git.prs_created", "views": [{"view": "period"}]},
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.merge_rate", "period", entity_id=DAVE).equals(value=40)
+    r.row("git.prs_created", "period", entity_id=DAVE).equals(value=5)
+
+
+def test_no_merges_reads_zero_while_no_creations_reads_null(spec: SpecRun) -> None:
+    """Two different emptinesses, asserted together because the distinction is the point.
+
+    A single-day window holding only carol's open request has a population and nothing
+    merged in it: the rate is zero. August holds no creation at all, so there is no
+    population and the rate has no value. Collapsing either into the other — a null where
+    a zero belongs, or a zero standing in for "nothing to measure" — is a reporting bug
+    that no total would reveal.
+    """
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [CAROL]},
+                "period": {"from": "2026-10-06", "to": "2026-10-06"},
+                "metrics": [
+                    {"metric_key": "git.merge_rate", "views": [{"view": "period"}]},
+                    {"metric_key": "git.prs_created", "views": [{"view": "period"}]},
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.merge_rate", "period", entity_id=CAROL).equals(value=0)
+    r.row("git.prs_created", "period", entity_id=CAROL).equals(value=1)
+
+    empty = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [CAROL, DAVE]},
+                "period": {"from": "2026-08-01", "to": "2026-08-31"},
+                "metrics": [{"metric_key": "git.merge_rate", "views": [{"view": "period"}]}],
+            },
+        }
+    )
+    assert empty.status == 200
+
+    for person in (CAROL, DAVE):
+        empty.row("git.merge_rate", "period", entity_id=person).equals(value=None)

--- a/tests/datapath/metrics/git/test_git_prs_merged.py
+++ b/tests/datapath/metrics/git/test_git_prs_merged.py
@@ -1,8 +1,8 @@
 """Pull requests merged, credited to the request's author and dated by the close.
 
 Each connector says a request landed its own way — GitHub's and GitLab's merged_at, and
-Bitbucket's terminal update event — and silver normalises all three to one state and one
-close time. Gold counts a request in the merged state with a known close time exactly once,
+Bitbucket's terminal update entry, falling back to the commit its merge names — and silver
+normalises all of them to one state and one close time. Gold counts a request in the merged state with a known close time exactly once,
 so an open one, a closed-but-never-merged one, a re-synced duplicate and a request whose
 state says merged while its close time is missing all stay out.
 """
@@ -177,13 +177,14 @@ def test_a_bitbucket_request_is_dated_by_its_terminal_merge_event_and_a_declined
 
 def test_a_merged_state_without_a_close_time_counts_for_nobody(spec: SpecRun) -> None:
     """A request whose state says merged while its close time is missing has no date to be
-    filed under, and the gate drops it rather than guessing one from the request's own
-    last update.
+    filed under, and the gate drops it rather than guessing one. What the pipeline will
+    guess from, where a merge commit corroborates the merge, is
+    git_bitbucket_merge_time_recovery's subject; here nothing corroborates it.
 
     Both halves of the pair are seeded, because the two connectors reach the state by
-    different routes: Bitbucket takes the close time from the activity stream and from
-    nowhere else, so a request reported MERGED whose terminal event was never collected
-    has none; GitLab copies the state from the source and derives the close time from
+    different routes: Bitbucket reads the close time from the activity stream, falling back
+    to the commit the merge names, so a request reported MERGED whose terminal event was
+    never collected AND whose merge commit was never collected either has none; GitLab copies the state from the source and derives the close time from
     merged_at and closed_at alone, so a request reported merged with neither is in the
     same position. Only GitHub is immune by construction — there the merged state IS a
     non-empty merge timestamp.


### PR DESCRIPTION
On Bitbucket, a pull request merged by pushing to the destination branch — rather than by pressing the merge button — left no record of *when* it merged. Every metric that counts merges by date had nowhere to put such a request, so it vanished: not counted late, not counted twice, simply absent from every period.

That also made two figures on the same card contradict each other. The merge rate counted those requests, because it only asks whether a request merged. The merged count did not, because it also asks when. Anyone comparing the two was right to be confused.

Those merges are now dated, using the evidence the source does leave behind. Where there is nothing to go on, the request stays uncounted rather than being given an invented date.

**This changes past numbers on installations that use Bitbucket.** Merges that were invisible will appear, in the months they actually happened — so a month already reported as closed can gain merges, and anything derived from merge dates (cycle time, review times, the merged column on the team heatmap) moves with them. GitHub and GitLab are unaffected: they report merge times directly and never had the gap.

A second commit adds test coverage for the merge rate, which came out of the same validation work and carries no product change.
