### PR TITLE
fix(ingestion): restore gold DDL snapshot convergence

### DIFF
--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -310,6 +310,25 @@ ORDER BY (tenant_id, data_source, commit_hash)
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS insight.git_deduplicated_file_changes
+(
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `project_key` String,
+    `repo_slug` String,
+    `commit_hash` String,
+    `data_source` String,
+    `file_path` String,
+    `file_extension` String,
+    `change_type` String,
+    `lines_added` Nullable(Int64),
+    `lines_removed` Nullable(Int64)
+)
+ENGINE = MergeTree
+ORDER BY (tenant_id, data_source, commit_hash)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS insight.git_default_branch_commits
 (
     `tenant_id` Nullable(String),


### PR DESCRIPTION
**Why.** The committed DDL snapshot omits a gold table, causing the connectors-DDL convergence check to fail.

**What changed.** Add the missing `git_deduplicated_file_changes` table definition manually, matching the schema produced by the gold model.

**Evidence.** The 19 inserted lines match the CI drift artifact byte-for-byte.

**Out of scope.** Field-parity execution after snapshot drift remains a separate follow-up.

**Verified.** `git diff --check` passed. Compared the branch diff with the CI artifact. Full snapshot generation was not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing deduplicated Git file-change records, including repository, commit, file, change type, and line-count details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->