### PR TITLE
chore(release): start the 0.7 chart line

### DIFF
--- a/charts/insight/Chart.yaml
+++ b/charts/insight/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # version    — packaging version of the chart. Bump on EVERY chart change.
 # appVersion — product version. Matches the image tag of all insight-* images.
 # Release pipeline: git tag v0.1.0 → version=0.1.0, appVersion="0.1.0".
-version: 0.6.92
+version: 0.7.1
 appVersion: "2026.09.08.09.17-a3582f2"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/constructorfabric/insight


### PR DESCRIPTION
## Problem

release-2026.09 starts from chart version 0.6.92. Leaving main on the same minor line would let future main and release builds publish overlapping patch versions.

## Fix

Start the main chart stream at 0.7.1. The release pipeline will advance it after merge, while release-2026.09 remains on the 0.6.x patch stream.

## Verification

- `helm dependency update charts/insight`
- `helm lint charts/insight`
- Verified the commit changes only `charts/insight/Chart.yaml`.
- Full code test suites were not run because this only changes chart version metadata.