### PR TITLE
ci(e2e): skip both suites when only charts or unit tests change

### DIFF
--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -132,7 +132,7 @@ jobs:
           # Ignored because nothing in this suite reads these paths.
           # INVARIANT: services/*/helm/Chart.yaml is NOT ignored — dev-compose.sh
           # takes the image the stand pulls from its appVersion.
-          IGNORED_PATHS='^src/backend/services/[^/]+/helm/|^src/ingestion/tests/|^src/ingestion/tools/seed/tests/|\.md$'
+          IGNORED_PATHS='^src/backend/services/[^/]+/helm/|^src/ingestion/tests/|^src/ingestion/tools/seed/tests/|^(src/backend|tests)/.*\.md$'
           IMAGE_PIN_PATHS='^src/backend/services/[^/]+/helm/Chart\.yaml$'
           # `|| true`: a grep selecting nothing exits 1 — set -e fails the step.
           changes_to_test="$(printf '%s\n' "$changed" | grep -vE "$IGNORED_PATHS" || true)"

--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -132,7 +132,7 @@ jobs:
           # Ignored because nothing in this suite reads these paths.
           # INVARIANT: services/*/helm/Chart.yaml is NOT ignored — dev-compose.sh
           # takes the image the stand pulls from its appVersion.
-          IGNORED_PATHS='^src/backend/services/[^/]+/helm/|^src/backend/(services|tools)/[^/]+/tests/|^src/ingestion/tests/|^src/ingestion/tools/seed/tests/|\.md$'
+          IGNORED_PATHS='^src/backend/services/[^/]+/helm/|^src/ingestion/tests/|^src/ingestion/tools/seed/tests/|\.md$'
           IMAGE_PIN_PATHS='^src/backend/services/[^/]+/helm/Chart\.yaml$'
           # `|| true`: a grep selecting nothing exits 1 — set -e fails the step.
           changes_to_test="$(printf '%s\n' "$changed" | grep -vE "$IGNORED_PATHS" || true)"

--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -128,16 +128,31 @@ jobs:
           fi
           changed="$(git diff --name-only "$base_point" "$HEAD")"
           echo "$changed" | sed 's/^/  /'
-          if echo "$changed" | grep -qE '^(src/ingestion/|src/backend/|tests/datapath/|tests/lib/|tests/pyproject\.toml|tests/uv\.lock|dev-compose\.sh|docker-compose\.yml|\.env\.compose\.example|deploy/compose/|\.github/workflows/e2e-bronze-to-api\.yml)'; then
+
+          # Ignored because nothing in this suite reads these paths.
+          # INVARIANT: services/*/helm/Chart.yaml is NOT ignored — dev-compose.sh
+          # takes the image the stand pulls from its appVersion.
+          IGNORED_PATHS='^src/backend/services/[^/]+/helm/|^src/backend/(services|tools)/[^/]+/tests/|^src/ingestion/tests/|^src/ingestion/tools/seed/tests/|\.md$'
+          IMAGE_PIN_PATHS='^src/backend/services/[^/]+/helm/Chart\.yaml$'
+          # `|| true`: a grep selecting nothing exits 1 — set -e fails the step.
+          changes_to_test="$(printf '%s\n' "$changed" | grep -vE "$IGNORED_PATHS" || true)"
+          image_pins="$(printf '%s\n' "$changed" | grep -E "$IMAGE_PIN_PATHS" || true)"
+          changes_to_test="$(printf '%s\n%s\n' "$changes_to_test" "$image_pins" | grep -v '^$' || true)"
+          if [ -n "$changes_to_test" ]; then
+            printf '%s\n' "$changes_to_test" | sed 's/^/  affects this run: /'
+          else
+            echo "  affects this run: nothing — no changed file can reach this suite"
+          fi
+
+          if echo "$changes_to_test" | grep -qE '^(src/ingestion/|src/backend/|tests/datapath/|tests/lib/|tests/pyproject\.toml|tests/uv\.lock|dev-compose\.sh|docker-compose\.yml|\.env\.compose\.example|deploy/compose/|\.github/workflows/e2e-bronze-to-api\.yml)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "relevant=false" >> "$GITHUB_OUTPUT"
             echo "nothing on the bronze → dbt → ClickHouse → analytics path changed"
           fi
           # A backend change means the pinned images no longer describe this
-          # tree, so the stand compiles the backend instead of pulling it. A
-          # service's own test tree is not in its image, so it does not count.
-          if echo "$changed" | grep -vE '^src/backend/services/[^/]+/tests/' | grep -qE '^src/backend/'; then
+          # tree, so the stand compiles the backend instead of pulling it.
+          if echo "$changes_to_test" | grep -qE '^src/backend/'; then
             echo "backend=true" >> "$GITHUB_OUTPUT"
           else
             echo "backend=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -150,6 +150,21 @@ jobs:
           fi
           changed="$(git diff --name-only "$base_point" "$HEAD")"
           printf '  %s\n' "${changed//$'\n'/$'\n  '}"
+
+          # Ignored because nothing this stand raises or runs reads these paths.
+          # INVARIANT: */helm/Chart.yaml is NOT ignored — dev-compose.sh takes
+          # the image the stand pulls from its appVersion.
+          IGNORED_PATHS='^src/(backend/services/[^/]+|frontend)/helm/|^src/backend/(services|tools)/[^/]+/tests/|^src/ingestion/tools/seed/tests/|^tests/datapath/|\.md$'
+          IMAGE_PIN_PATHS='^src/(backend/services/[^/]+|frontend)/helm/Chart\.yaml$'
+          # `|| true`: a grep selecting nothing exits 1 — set -e fails the step.
+          changes_to_test="$(printf '%s\n' "$changed" | grep -vE "$IGNORED_PATHS" || true)"
+          image_pins="$(printf '%s\n' "$changed" | grep -E "$IMAGE_PIN_PATHS" || true)"
+          changes_to_test="$(printf '%s\n%s\n' "$changes_to_test" "$image_pins" | grep -v '^$' || true)"
+          if [ -n "$changes_to_test" ]; then
+            printf '%s\n' "$changes_to_test" | sed 's/^/  affects this run: /'
+          else
+            echo "  affects this run: nothing — no changed file can reach this stand"
+          fi
           relevant="$forced"
           backend=false
           frontend=false
@@ -159,20 +174,20 @@ jobs:
           identity_resolution=false
           gateway=false
           gateway_checks=false
-          if echo "$changed" | grep -qE '^(tests/|deploy/compose/|src/ingestion/tools/seed/|docker-compose\.yml|dev-compose\.sh|src/backend/|src/frontend/|docs/components/backend/.*/openapi\.json|\.github/workflows/(build-images|e2e-stand)\.yml|\.github/workflows/scripts/redact-playwright-trace\.py|scripts/ci/prebuilt_images\.py)'; then
+          if echo "$changes_to_test" | grep -qE '^(tests/|deploy/compose/|src/ingestion/tools/seed/|docker-compose\.yml|dev-compose\.sh|src/backend/|src/frontend/|docs/components/backend/.*/openapi\.json|\.github/workflows/(build-images|e2e-stand)\.yml|\.github/workflows/scripts/redact-playwright-trace\.py|scripts/ci/prebuilt_images\.py)'; then
             relevant=true
           elif [ "$forced" = true ]; then
             echo "nothing the stand covers changed — running anyway, this event has no pull request to filter"
           else
             echo "nothing the stand covers changed"
           fi
-          if echo "$changed" | grep -q '^src/backend/'; then backend=true; fi
-          if echo "$changed" | grep -q '^src/frontend/'; then frontend=true; fi
-          if echo "$changed" | grep -qE '^(src/backend/services/analytics/|src/backend/libs/insight-clickhouse/|src/backend/docker-entrypoint\.sh$|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(build-images|e2e-stand)\.yml$)'; then analytics=true; fi
-          if echo "$changed" | grep -qE '^(src/backend/services/authenticator/|src/backend/libs/authenticator-sdk/|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/prebuilt_images\.py$)'; then authenticator=true; fi
-          if echo "$changed" | grep -qE '^(src/backend/services/identity-resolution/|src/backend/libs/insight-clickhouse/|src/backend/docker-entrypoint\.sh$|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(build-images|e2e-stand)\.yml$)'; then identity_resolution=true; fi
-          if echo "$changed" | grep -qE '^(src/backend/services/gateway/|src/backend/tools/routegen/|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/prebuilt_images\.py$)'; then gateway=true; fi
-          if echo "$changed" | grep -qE '^(src/backend/tools/routegen/|src/backend/services/gateway/|src/backend/services/authenticator/|src/backend/libs/authenticator-sdk/|src/backend/Cargo\.(toml|lock)$|src/ingestion/tools/seed/insight_seed/|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/(prebuilt_images|test_prebuilt_images)\.py$)'; then gateway_checks=true; fi
+          if echo "$changes_to_test" | grep -q '^src/backend/'; then backend=true; fi
+          if echo "$changes_to_test" | grep -q '^src/frontend/'; then frontend=true; fi
+          if echo "$changes_to_test" | grep -qE '^(src/backend/services/analytics/|src/backend/libs/insight-clickhouse/|src/backend/docker-entrypoint\.sh$|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(build-images|e2e-stand)\.yml$)'; then analytics=true; fi
+          if echo "$changes_to_test" | grep -qE '^(src/backend/services/authenticator/|src/backend/libs/authenticator-sdk/|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/prebuilt_images\.py$)'; then authenticator=true; fi
+          if echo "$changes_to_test" | grep -qE '^(src/backend/services/identity-resolution/|src/backend/libs/insight-clickhouse/|src/backend/docker-entrypoint\.sh$|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(build-images|e2e-stand)\.yml$)'; then identity_resolution=true; fi
+          if echo "$changes_to_test" | grep -qE '^(src/backend/services/gateway/|src/backend/tools/routegen/|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/prebuilt_images\.py$)'; then gateway=true; fi
+          if echo "$changes_to_test" | grep -qE '^(src/backend/tools/routegen/|src/backend/services/gateway/|src/backend/services/authenticator/|src/backend/libs/authenticator-sdk/|src/backend/Cargo\.(toml|lock)$|src/ingestion/tools/seed/insight_seed/|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/(prebuilt_images|test_prebuilt_images)\.py$)'; then gateway_checks=true; fi
           if [[ "$GITHUB_EVENT_NAME" == merge_group ]] && \
              [[ "$analytics" == true || "$authenticator" == true || "$identity_resolution" == true || "$gateway" == true ]]; then
             backend_artifacts=true

--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -154,7 +154,7 @@ jobs:
           # Ignored because nothing this stand raises or runs reads these paths.
           # INVARIANT: */helm/Chart.yaml is NOT ignored — dev-compose.sh takes
           # the image the stand pulls from its appVersion.
-          IGNORED_PATHS='^src/(backend/services/[^/]+|frontend)/helm/|^src/backend/(services|tools)/[^/]+/tests/|^src/ingestion/tools/seed/tests/|^tests/datapath/|\.md$'
+          IGNORED_PATHS='^src/(backend/services/[^/]+|frontend)/helm/|^src/ingestion/tools/seed/tests/|^tests/datapath/|\.md$'
           IMAGE_PIN_PATHS='^src/(backend/services/[^/]+|frontend)/helm/Chart\.yaml$'
           # `|| true`: a grep selecting nothing exits 1 — set -e fails the step.
           changes_to_test="$(printf '%s\n' "$changed" | grep -vE "$IGNORED_PATHS" || true)"
@@ -184,10 +184,13 @@ jobs:
           if echo "$changes_to_test" | grep -q '^src/backend/'; then backend=true; fi
           if echo "$changes_to_test" | grep -q '^src/frontend/'; then frontend=true; fi
           if echo "$changes_to_test" | grep -qE '^(src/backend/services/analytics/|src/backend/libs/insight-clickhouse/|src/backend/docker-entrypoint\.sh$|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(build-images|e2e-stand)\.yml$)'; then analytics=true; fi
-          if echo "$changes_to_test" | grep -qE '^(src/backend/services/authenticator/|src/backend/libs/authenticator-sdk/|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/prebuilt_images\.py$)'; then authenticator=true; fi
+          # INVARIANT: these three cross into gateway.yml, which lints the chart
+          # and runs its own e2e suite from these trees — so they read the raw
+          # diff, not the stand's filtered list.
+          if echo "$changed" | grep -qE '^(src/backend/services/authenticator/|src/backend/libs/authenticator-sdk/|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/prebuilt_images\.py$)'; then authenticator=true; fi
           if echo "$changes_to_test" | grep -qE '^(src/backend/services/identity-resolution/|src/backend/libs/insight-clickhouse/|src/backend/docker-entrypoint\.sh$|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(build-images|e2e-stand)\.yml$)'; then identity_resolution=true; fi
-          if echo "$changes_to_test" | grep -qE '^(src/backend/services/gateway/|src/backend/tools/routegen/|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/prebuilt_images\.py$)'; then gateway=true; fi
-          if echo "$changes_to_test" | grep -qE '^(src/backend/tools/routegen/|src/backend/services/gateway/|src/backend/services/authenticator/|src/backend/libs/authenticator-sdk/|src/backend/Cargo\.(toml|lock)$|src/ingestion/tools/seed/insight_seed/|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/(prebuilt_images|test_prebuilt_images)\.py$)'; then gateway_checks=true; fi
+          if echo "$changed" | grep -qE '^(src/backend/services/gateway/|src/backend/tools/routegen/|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/prebuilt_images\.py$)'; then gateway=true; fi
+          if echo "$changed" | grep -qE '^(src/backend/tools/routegen/|src/backend/services/gateway/|src/backend/services/authenticator/|src/backend/libs/authenticator-sdk/|src/backend/Cargo\.(toml|lock)$|src/ingestion/tools/seed/insight_seed/|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/(prebuilt_images|test_prebuilt_images)\.py$)'; then gateway_checks=true; fi
           if [[ "$GITHUB_EVENT_NAME" == merge_group ]] && \
              [[ "$analytics" == true || "$authenticator" == true || "$identity_resolution" == true || "$gateway" == true ]]; then
             backend_artifacts=true

--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -154,7 +154,7 @@ jobs:
           # Ignored because nothing this stand raises or runs reads these paths.
           # INVARIANT: */helm/Chart.yaml is NOT ignored — dev-compose.sh takes
           # the image the stand pulls from its appVersion.
-          IGNORED_PATHS='^src/(backend/services/[^/]+|frontend)/helm/|^src/ingestion/tools/seed/tests/|^tests/datapath/|\.md$'
+          IGNORED_PATHS='^src/(backend/services/[^/]+|frontend)/helm/|^src/ingestion/tools/seed/tests/|^tests/datapath/|^(src/backend|src/frontend|tests|deploy/compose)/.*\.md$'
           IMAGE_PIN_PATHS='^src/(backend/services/[^/]+|frontend)/helm/Chart\.yaml$'
           # `|| true`: a grep selecting nothing exits 1 — set -e fails the step.
           changes_to_test="$(printf '%s\n' "$changed" | grep -vE "$IGNORED_PATHS" || true)"


### PR DESCRIPTION
**Why.** A diff confined to a service's Helm chart lands under `src/backend/`, so both e2e suites treated it as a backend change: five data-path stands plus the full compose stand, for every queue entry.

**What changed.** Each `changes` job now drops the paths nothing it raises or runs reads, then decides relevance on what is left.

**`*/helm/Chart.yaml` is exempt from the drop.** `dev-compose.sh` takes the pulled image's `appVersion` from it, so a pin bump stays a real change. Deleting one pattern undoes the exemption.

**`gateway`, `gateway_checks` and `authenticator` keep reading the raw diff.** They cross into `gateway.yml`, which helm-lints the gateway chart and runs its own e2e suite from `services/*/tests` — trees the compose stand never reads. A chart-only diff therefore skips both suites while `Gateway checks` stays armed.

**Markdown is ignored only where nothing parses it.** dbt's doc paths default to its resource paths and the data-path suite runs `dbt parse`, so markdown under `src/ingestion/**` is a parser input; the rule is anchored to `src/backend` and `tests` instead.

**Out of scope.** Per-shard relevance for the metric matrix — it needs the coverage gate scoped to the shards that ran, or a partial run reds a required check. A change to the gateway or authenticator e2e suite also still runs the data-path suite, since `^src/backend/` is what makes that workflow relevant.

**Verified.** Both `filter` scripts extracted from the YAML and replayed over 15 file lists with a stubbed `git` — 30 executions, 0 failures. A real chart-only file list (#3322) yields `relevant=false` on both workflows with `gateway_checks=true`; `dbt` data tests, markdown under the dbt trees, chart pin bumps and every service source change are unchanged. `actionlint` reports only a pre-existing `SC2001`, confirmed present at `HEAD`.
