### PR TITLE
ci(e2e): stop the seed step rebaking backend images in the data-path shards

### DIFF
--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -1,4 +1,4 @@
-name: E2E — Bronze to API
+name: E2E bronze to API
 
 # End-to-end data-path tests: a spec seeds bronze, dbt builds staging, silver
 # and gold on a ClickHouse the stand raised, identity mints the spec's people
@@ -87,7 +87,7 @@ jobs:
   #
   # src/frontend/ and docs/ are absent on purpose: nothing here loads them.
   changes:
-    name: changes
+    name: Detect changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -149,7 +149,7 @@ jobs:
   # compiling the same workspace. Five identical compiles per queue entry is
   # what pushed backend-touching entries past the merge queue's check timeout.
   build-backend:
-    name: Build backend binaries
+    name: Build backend
     needs: changes
     if: ${{ needs.changes.outputs.relevant == 'true' && needs.changes.outputs.backend == 'true' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
@@ -170,7 +170,7 @@ jobs:
           if-no-files-found: error
 
   e2e-datapath:
-    name: data path (shard ${{ matrix.shard }})
+    name: Data path (${{ matrix.shard }})
     needs: [changes, build-backend]
     # `!cancelled()` so a skipped build-backend (backend untouched → pinned
     # images) does not skip the shards along with it; the result check keeps a
@@ -249,7 +249,7 @@ jobs:
 
       # `test-stand test` picks the suite's own dependency group for a tree
       # under tests/datapath and aims it at the stand it just raised.
-      - name: Data-path suite — shard
+      - name: Run the data-path shard
         id: suite
         env:
           SHARD: ${{ matrix.shard }}

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1267,7 +1267,8 @@ cmd_seed() {
   # the wrong directory — it surfaces as an EACCES on /app/manifest.json after
   # the whole seed has run. The source is bind-mounted anyway, so the rebuild
   # is layer-cached and only refreshes entrypoint/WORKDIR/deps.
-  "${compose_cmd[@]}" --profile seed run --build --rm seed-sample "${args[@]}"
+  # --no-deps: --build would otherwise also rebake every depends_on image.
+  "${compose_cmd[@]}" --profile seed run --build --no-deps --rm seed-sample "${args[@]}"
   local seed_status=$?
   if [[ $seed_status -ne 0 ]]; then
     return $seed_status
@@ -1281,7 +1282,7 @@ cmd_seed() {
       seed_identity_projection "$env_file" "${compose_cmd[@]}" || return $?
       echo
       echo "=== rebuilding gold over the refreshed identity map ==="
-      "${compose_cmd[@]}" --profile seed run --rm seed-sample gold || return $?
+      "${compose_cmd[@]}" --profile seed run --no-deps --rm seed-sample gold || return $?
 
       # Restart analytics when ClickHouse data was touched. Its schema
       # validator caches schema_status at startup and never re-checks; without


### PR DESCRIPTION
**Why.** On a backend-touching merge-queue entry every data-path shard still compiled `identity-resolution` from source for about six minutes, even though the binaries arrive prebuilt and `up` skips the bake.

**What changed.** The seed step's `compose run --build` also rebakes every `depends_on` image; it now passes `--no-deps`, so `--build` refreshes only the seed image. The workflow and its jobs take sentence-case names; the required `Run E2E suite` check keeps its name.

**`--no-deps` applies to local `./dev-compose.sh seed` too.** Seeding against a down stand now fails instead of auto-starting it; the help text already required the stack to be up.

**Out of scope.** Shard count and the 60-minute queue check timeout, queue policy, detector and gate job consolidation, Rust cache sharing — separate PRs.

**Verified.** YAML parse, actionlint (pre-existing SC2001 only), `bash -n dev-compose.sh`. The shard path runs only in the merge queue; its first backend-touching entry is the measurement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated testing workflow labels for clearer reporting.
  - Streamlined sample data seeding by avoiding unnecessary rebuilds of dependent services, reducing setup time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->