### PR TITLE
fix(github, bitbucket): send the repository size to the proxy and name a proxy 401

### DIFF
--- a/src/ingestion/connectors/git/bitbucket-cloud/README.md
+++ b/src/ingestion/connectors/git/bitbucket-cloud/README.md
@@ -142,11 +142,15 @@ collapses to current state and a head move is a tracked-column change.
 
 ### Cold repositories
 
-The first request for an uncached repository gets `429` + `Retry-After` while
-the proxy clones it in the background; every proxy stream retries on `429`.
-`409` (the pinned snapshot was superseded) and `413` (repository over the
-proxy's size cap) fail the stream instead — retrying the same page token would
-loop.
+The first request for an uncached repository is held in-connection while the
+proxy clones it, and while it waits for cache headroom; a `429` +
+`Retry-After` is the exception (headroom exhausted for the whole wait) and
+every proxy stream retries it. Every proxy request carries
+`X-Repo-Size-Hint`, the repository's reported size, so the proxy reserves
+that much cache instead of its per-repository cap. `409` (the pinned snapshot
+was superseded) restarts the walk from the last record already seen; `413`
+(repository over the proxy's size cap) fails the stream; `401` is the proxy
+token and fails as a config error.
 
 ## The start-date bound
 

--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -88,9 +88,11 @@ definitions:
 
   proxy_error_handler: &proxy_error_handler
     type: DefaultErrorHandler
-    # Generous on purpose: a cold blobless clone of a large repository runs
-    # for many Retry-After cycles before the first page can be served.
-    max_retries: 100
+    # The proxy holds a cold request in-connection while it clones, so a 429
+    # is the exception: cache headroom that stayed exhausted for the whole
+    # in-connection wait. 200 x the 30 s the proxy asks for outlasts a cold
+    # clone queue on a large installation.
+    max_retries: 200
     backoff_strategies:
       - type: WaitTimeFromHeader
         header: Retry-After
@@ -104,6 +106,11 @@ definitions:
     response_filters:
       # The repository is being cloned in the background: the proxy is
       # working, the caller waits.
+      - type: HttpResponseFilter
+        http_codes: [401]
+        action: FAIL
+        failure_type: config_error
+        error_message: The git-cli-proxy rejected git_proxy_token; it must match the token the proxy was started with
       - type: HttpResponseFilter
         http_codes: [429]
         action: RETRY
@@ -251,6 +258,9 @@ definitions:
       X-Source-Id: "{{ config['insight_source_id'] }}"
       X-Git-Username: "{{ 'x-bitbucket-api-token-auth' if config.get('bitbucket_username') else 'x-token-auth' }}"
       X-Git-Token: "{{ config['bitbucket_token'] }}"
+      # The proxy reserves cache headroom from the repository's reported size
+      # instead of its per-repository cap.
+      X-Repo-Size-Hint: "{{ stream_slice.extra_fields.get('size') or '' }}"
     error_handler: *proxy_error_handler
 
 check:
@@ -608,6 +618,8 @@ streams:
           - type: ParentStreamConfig
             parent_key: clone_url
             partition_field: repo_clone_url
+            extra_fields:
+              - [size]
             # `incremental_dependency` is what keeps the sync proportional to
             # activity: the parent is itself incremental, so only repositories
             # touched since the last sync are visited. The CDK persists parent
@@ -628,6 +640,7 @@ streams:
                   properties:
                     uuid: {type: [string, "null"]}
                     clone_url: {type: [string, "null"]}
+                    size: {type: [integer, "null"]}
                     updated_on: {type: [string, "null"]}
                   additionalProperties: true
               retriever:
@@ -808,6 +821,8 @@ streams:
           - type: ParentStreamConfig
             parent_key: clone_url
             partition_field: repo_clone_url
+            extra_fields:
+              - [size]
             incremental_dependency: true
             stream:
               type: DeclarativeStream
@@ -822,6 +837,7 @@ streams:
                   properties:
                     uuid: {type: [string, "null"]}
                     clone_url: {type: [string, "null"]}
+                    size: {type: [integer, "null"]}
                     updated_on: {type: [string, "null"]}
                   additionalProperties: true
               retriever:
@@ -982,6 +998,8 @@ streams:
           - type: ParentStreamConfig
             parent_key: clone_url
             partition_field: repo_clone_url
+            extra_fields:
+              - [size]
             # No `incremental_dependency` here: this stream is full refresh, so
             # the CDK would not persist parent state anyway. Branch heads are
             # cheap and must be re-read for every repository each sync.
@@ -998,6 +1016,7 @@ streams:
                   properties:
                     uuid: {type: [string, "null"]}
                     clone_url: {type: [string, "null"]}
+                    size: {type: [integer, "null"]}
                   additionalProperties: true
               retriever:
                 type: SimpleRetriever
@@ -3429,6 +3448,7 @@ streams:
                       partition_field: repo_clone_url
                       extra_fields:
                         - [full_name]
+                        - [size]
                       incremental_dependency: true
                       stream:
                         type: DeclarativeStream
@@ -3443,6 +3463,7 @@ streams:
                             properties:
                               uuid: {type: [string, "null"]}
                               clone_url: {type: [string, "null"]}
+                              size: {type: [integer, "null"]}
                               full_name: {type: [string, "null"]}
                               updated_on: {type: [string, "null"]}
                             additionalProperties: true

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
@@ -275,3 +275,17 @@ def test_a_superseded_proxy_snapshot_restarts_the_walk_instead_of_failing_it() -
         assert on_409 == ["RESET_PAGINATION"], f"{path}: a 409 must reset pagination, got {on_409}"
         reset = retriever.get("pagination_reset")
         assert reset == {"type": "PaginationReset", "action": _PROXY_RESET_ACTIONS[path]}, f"{path}: {reset}"
+
+
+def test_every_proxy_request_carries_the_repository_size_hint() -> None:
+    """The proxy reserves cache headroom from the hint instead of its per-repository
+    cap; a proxy requester without it, or a proxy parent that does not pass the size
+    along, silently falls back to the cap."""
+    retrievers = _proxy_retrievers(_streams())
+    assert retrievers
+    for retriever in retrievers:
+        hint = (retriever["requester"].get("request_headers") or {}).get("X-Repo-Size-Hint", "")
+        assert "extra_fields.get('size')" in hint, retriever["requester"]["path"]
+        for parent in retriever["partition_router"]["parent_stream_configs"]:
+            if parent.get("partition_field") == "repo_clone_url":
+                assert ["size"] in (parent.get("extra_fields") or []), retriever["requester"]["path"]

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
@@ -51,6 +51,7 @@ def _repo() -> dict[str, Any]:
     return {
         "uuid": "{r-1}",
         "full_name": "acme/app",
+        "size": 734003200,
         "updated_on": "2026-06-20T10:00:00.000000+00:00",
     }
 
@@ -238,6 +239,7 @@ def test_credential_family_drives_both_the_rest_scheme_and_the_clone_username(
     proxy = next(h for u, h in by_host.items() if u.startswith(PROXY_URL))
     assert rest["Authorization"].startswith(rest_scheme), rest["Authorization"][:16]
     assert proxy["X-Git-Username"] == clone_username
+    assert proxy["X-Repo-Size-Hint"] == "734003200", "the proxy reserves cache from the reported size"
 
 
 @freezegun.freeze_time(_FROZEN)
@@ -645,6 +647,25 @@ def _author_row(email: str, sha: str) -> dict[str, Any]:
         "last_committed_date": "2026-06-15T10:00:00+00:00",
         "commit_count": 4,
     }
+
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_proxy_401_is_the_proxy_token_and_fails_as_a_config_error(http_mocker: HttpMocker) -> None:
+    config = BitbucketCloudConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_repo_with_clone()]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/branches", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body="", status_code=401),
+    )
+
+    output = read_stream(_CONNECTOR, "branches", config, expecting_exception=True)
+
+    assert output.errors
+    assert output.errors[-1].trace.error.failure_type == FailureType.config_error
 
 
 def _repo_with_clone() -> dict[str, Any]:

--- a/src/ingestion/connectors/git/github/README.md
+++ b/src/ingestion/connectors/git/github/README.md
@@ -174,11 +174,14 @@ identities) reach no account and stay unattributed.
   (body message, `x-ratelimit-remaining: 0`) run before any 403 handling;
   what remains of 403 — plus 404/410 — on repo-scoped streams skips that
   repository and the sync continues. 401 fails fast as a config error.
-- The proxy answers 429 + Retry-After while a repository is being cloned in
-  the background; proxy requesters retry generously (a cold clone of a large
-  repository runs many Retry-After cycles). 404/413 skip the repository;
-  409 (superseded snapshot) fails the attempt — the rerun resumes from the
-  stored cursor.
+- The proxy holds a request in-connection while it clones or waits for cache
+  headroom, so a 429 + Retry-After is the exception (headroom exhausted for
+  the whole wait) and proxy requesters retry it generously. Every proxy
+  request carries `X-Repo-Size-Hint`, the repository's reported size, so the
+  proxy reserves that much cache instead of its per-repository cap. 404/413
+  skip the repository; 409 (superseded snapshot) restarts the walk from the
+  last record already seen; 401 is the proxy token and fails as a config
+  error.
 - GraphQL errors arrive as HTTP 200. GitHub types an exhausted budget both
   `RATE_LIMIT` and `RATE_LIMITED`, so the throttle predicates match either and
   fall back to the message; anything else fails with GitHub's own message.

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -205,9 +205,11 @@ definitions:
 
   proxy_error_handler: &proxy_error_handler
     type: DefaultErrorHandler
-    # Generous on purpose: a cold blobless clone of a large repository runs
-    # for many Retry-After cycles before the first page can be served.
-    max_retries: 100
+    # The proxy holds a cold request in-connection while it clones, so a 429
+    # is the exception: cache headroom that stayed exhausted for the whole
+    # in-connection wait. 200 x the 30 s the proxy asks for outlasts a cold
+    # clone queue on a large installation.
+    max_retries: 200
     backoff_strategies:
       - type: WaitTimeFromHeader
         header: Retry-After
@@ -221,6 +223,11 @@ definitions:
     response_filters:
       # The repository is being cloned or purged in the background: the proxy
       # is working, the caller waits.
+      - type: HttpResponseFilter
+        http_codes: [401]
+        action: FAIL
+        failure_type: config_error
+        error_message: The git-cli-proxy rejected git_proxy_token; it must match the token the proxy was started with
       - type: HttpResponseFilter
         http_codes: [429]
         action: RETRY
@@ -260,6 +267,9 @@ definitions:
       X-Source-Id: "{{ config['insight_source_id'] }}"
       X-Git-Username: x-access-token
       X-Git-Token: "{{ config['github_token'] }}"
+      # GitHub reports `size` in kilobytes; the proxy reserves cache headroom
+      # from this instead of its per-repository cap.
+      X-Repo-Size-Hint: "{{ ((stream_slice.extra_fields.get('size') or 0) * 1024) or '' }}"
     error_handler: *proxy_error_handler
 
   standard_fields: &standard_fields
@@ -301,6 +311,7 @@ definitions:
           full_name: {type: [string, "null"]}
           clone_url: {type: [string, "null"]}
           pushed_at: {type: [string, "null"]}
+          size: {type: [integer, "null"]}
         additionalProperties: true
     retriever:
       type: SimpleRetriever
@@ -658,6 +669,8 @@ streams:
           - type: ParentStreamConfig
             parent_key: clone_url
             partition_field: repo_clone_url
+            extra_fields:
+              - [size]
             # `incremental_dependency` keeps the sync proportional to
             # activity: parent state persists only because this child is
             # itself incremental.
@@ -773,6 +786,8 @@ streams:
           - type: ParentStreamConfig
             parent_key: clone_url
             partition_field: repo_clone_url
+            extra_fields:
+              - [size]
             # `incremental_dependency` keeps the sync proportional to
             # activity: parent state persists only because this child is
             # itself incremental.
@@ -869,6 +884,8 @@ streams:
           - type: ParentStreamConfig
             parent_key: clone_url
             partition_field: repo_clone_url
+            extra_fields:
+              - [size]
             # Full-refresh child: parent state would not persist, so no
             # incremental_dependency.
             incremental_dependency: false
@@ -1001,6 +1018,7 @@ streams:
                       partition_field: repo_clone_url
                       extra_fields:
                         - [full_name]
+                        - [size]
                       incremental_dependency: true
                       stream: *repositories_pushed_parent
               incremental_sync:

--- a/src/ingestion/connectors/git/github/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github/tests/test_github_streams.py
@@ -19,7 +19,7 @@ import json
 
 import freezegun
 import pytest
-from airbyte_cdk.models import SyncMode
+from airbyte_cdk.models import FailureType, SyncMode
 from config import GH_URL, PROXY_URL, GithubConfigBuilder
 from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, assert_records_conform, read_stream
 from connector_tests.source import load_manifest
@@ -60,6 +60,7 @@ def _repo() -> dict:
         "private": True,
         "clone_url": "https://github.com/acme/app.git",
         "pushed_at": "2026-06-20T10:00:00Z",
+        "size": 716800,
         "created_at": "2020-01-01T00:00:00Z",
         "updated_at": "2026-06-20T10:00:00Z",
     }
@@ -171,6 +172,10 @@ def test_proxy_429_then_success(http_mocker: HttpMocker) -> None:
     output = read_stream(_CONNECTOR, "commits", config)
 
     assert not output.errors
+    hints = {r.headers.get("X-Repo-Size-Hint") for r in http_mocker._mocker.request_history if "/v1/commits" in r.url}
+    assert hints == {"734003200"}, (
+        f"every proxy call carries the repository's size in bytes (GitHub reports KiB): {hints}"
+    )
     assert len(output.records) == 1
     _no_literal_none(output.records)
 
@@ -2011,6 +2016,35 @@ _PROXY_RESET_ACTIONS = {
     "/v1/branches": "RESET",
     "/v1/authors": "RESET",
 }
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_proxy_401_is_the_proxy_token_and_fails_as_a_config_error(http_mocker: HttpMocker) -> None:
+    config = GithubConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/branches", query_params=ANY_QUERY_PARAMS), HttpResponse(body="", status_code=401)
+    )
+
+    output = read_stream(_CONNECTOR, "branches", config, expecting_exception=True)
+
+    assert output.errors
+    assert output.errors[-1].trace.error.failure_type == FailureType.config_error
+
+
+def test_every_proxy_request_carries_the_repository_size_hint() -> None:
+    """The proxy reserves cache headroom from the hint instead of its per-repository
+    cap; a proxy requester without it, or a proxy parent that does not pass the size
+    along, silently falls back to the cap."""
+    retrievers = _proxy_retrievers(load_manifest(_CONNECTOR)["streams"])
+    assert retrievers
+    for retriever in retrievers:
+        hint = (retriever["requester"].get("request_headers") or {}).get("X-Repo-Size-Hint", "")
+        assert "extra_fields.get('size')" in hint, retriever["requester"]["path"]
+        parents = retriever["partition_router"]["parent_stream_configs"]
+        for parent in parents:
+            if parent.get("partition_field") == "repo_clone_url":
+                assert ["size"] in (parent.get("extra_fields") or []), retriever["requester"]["path"]
 
 
 def _proxy_retrievers(node, out=None):


### PR DESCRIPTION
**Why.** On a cold sync the proxy connectors met a wall of `429`s: the proxy refused every request for a repository it had not cloned yet, and the manifests retried on a 30 second header up to 100 times, about 52 minutes, which a large clone queue can outlast. A wrong `git_proxy_token` surfaced as the CDK's generic 401 text with no pointer to the proxy.

**What changed.** GitHub and Bitbucket proxy requesters send `X-Repo-Size-Hint` from the roster's reported size (GitHub's kilobytes converted), so the proxy reserves that much cache instead of its per-repository cap; every proxy parent passes the size along. The proxy handler names a `401` as the proxy token, a config error, and retries a `429` up to 200 times.

**Verified.** GitHub and Bitbucket mock suites on the airbyte-cdk 7 harness, 78 passed; new tests pin the header on every proxy requester and parent, its value on a proxy call, and the 401 classification.
