### PR TITLE
fix(observability): grant the grafana role the system tables its dashboards read

### DIFF
--- a/src/ingestion/scripts/bootstrap-db/grafana-role.sql
+++ b/src/ingestion/scripts/bootstrap-db/grafana-role.sql
@@ -13,3 +13,8 @@ GRANT SELECT ON insight.* TO grafana_ro;
 GRANT SELECT ON presentation.* TO grafana_ro;
 GRANT SELECT ON product_usage.* TO grafana_ro;
 GRANT SELECT ON ingestion_history.* TO grafana_ro;
+
+-- The disk-usage and slow-query dashboards read these two system tables;
+-- without an explicit grant the server refuses SELECT on them.
+GRANT SELECT ON system.parts TO grafana_ro;
+GRANT SELECT ON system.query_log TO grafana_ro;


### PR DESCRIPTION
**Why.** The ClickHouse disk-usage and slow-query dashboards render empty: the datasource's `grafana` user is refused SELECT on `system.parts` and `system.query_log`, while the datasource health check passes on a trivial query, so nothing surfaces the denial.

**What changed.** `grafana-role.sql` grants `grafana_ro` SELECT on exactly those two system tables — the only `system.*` relations any provisioned dashboard queries. The provisioning hook is additive and idempotent, so existing installs converge on their next deploy.

**Verified.** On ClickHouse 25.7, `SELECT count() FROM system.parts` as a user holding only the role's database grants fails with ACCESS_DENIED and succeeds once these grants are applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Grafana disk-usage and slow-query dashboards by granting the read-only reporting role access to the required system data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->