### PR TITLE
feat(jira): run connector checks after the sync, fix task-history ordering, record silently cleared values, key issues on their immutable id

### DIFF
--- a/charts/insight/templates/ingestion/connector-checks.yaml
+++ b/charts/insight/templates/ingestion/connector-checks.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.ingestion.templates.enabled }}
+{{- /* Runs a connector's own dbt checks right after its transform, where that
+       connector's bronze and staging are guaranteed to exist because the
+       pipeline building them is what invoked this step.
+
+       Why this is not the `data_quality` catalog: that catalog runs on a
+       schedule across the whole install and must therefore read silver/gold
+       only — a check touching one connector's bronze would fail on a tenant
+       where that connector is absent. Checks tagged `connector_quality` are
+       exactly the ones that need those tables, so they run here instead.
+
+       NON-BLOCKING by design: the sync has already landed bronze and rebuilt
+       silver by the time this runs, so failing the workflow would not undo
+       anything — it would only turn a data condition into a red pipeline that
+       nobody can fix from here. Findings travel as structured log lines with
+       their `meta.tier`; alerting reads those. An operational failure (dbt
+       cannot reach ClickHouse) is a different matter and is reported as such
+       in the logs, but still does not fail the sync. */}}
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: connector-checks
+  labels:
+    {{- include "insight.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ingestion-template
+spec:
+  serviceAccountName: argo-workflow
+  entrypoint: run
+  templates:
+    - name: run
+      # SECURITY: same convention as dbt-run.yaml and data-quality-test.yaml —
+      # every parameter reaches the shell through an env var and is referenced
+      # as "$ENV_VAR", never spliced into shell, Python or YAML source.
+      inputs:
+        parameters:
+          - name: dbt_select
+          - name: toolbox_image
+            default: {{ required "ingestion.toolboxImage is required when ingestion.templates.enabled=true" .Values.ingestion.toolboxImage | quote }}
+          - name: clickhouse_host
+            default: {{ include "insight.clickhouse.fqdn" . | quote }}
+          - name: clickhouse_port
+            default: {{ include "insight.clickhouse.port" . | quote }}
+          - name: clickhouse_user
+            default: {{ required "clickhouse.username is required" .Values.clickhouse.username | quote }}
+      activeDeadlineSeconds: 1800
+      script:
+        image: {{ `"{{inputs.parameters.toolbox_image}}"` }}
+        imagePullPolicy: IfNotPresent
+        command: [bash]
+        env:
+          - name: CLICKHOUSE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ required "clickhouse.passwordSecret.name is required" .Values.clickhouse.passwordSecret.name | quote }}
+                key:  {{ required "clickhouse.passwordSecret.key is required"  .Values.clickhouse.passwordSecret.key  | quote }}
+          - name: DBT_SELECT
+            value: {{ `"{{inputs.parameters.dbt_select}}"` }}
+          - name: CLICKHOUSE_HOST
+            value: {{ `"{{inputs.parameters.clickhouse_host}}"` }}
+          - name: CLICKHOUSE_PORT
+            value: {{ `"{{inputs.parameters.clickhouse_port}}"` }}
+          - name: CLICKHOUSE_USER
+            value: {{ `"{{inputs.parameters.clickhouse_user}}"` }}
+          - name: INSIGHT_LOG_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}-platform
+                key: INSIGHT_LOG_LEVEL
+        source: |
+          set -euo pipefail
+          cd /ingestion/dbt
+          python3 /ingestion/scripts/dbt_profiles.py
+          # `dbt test --select ""` matches NOTHING rather than everything, and a
+          # selector that resolves to no tests exits 0 — so an empty parameter
+          # would make this step a silent no-op. Refuse it instead.
+          : "${DBT_SELECT:?dbt_select must be set — an empty selector silently tests nothing}"
+          # Findings must not fail the sync (see the header), so the exit code is
+          # captured and discarded. The emitter reads dbt's artifacts, so it
+          # reports whatever the run produced, including tests that errored.
+          RC=0
+          # shellcheck disable=SC2086 -- DBT_SELECT is a selector LIST; the words are the arguments
+          dbt test --profiles-dir . --select $DBT_SELECT --log-format json --log-level "${INSIGHT_LOG_LEVEL:-info}" || RC=$?
+          python3 /ingestion/scripts/data_quality_findings.py
+          if [ "$RC" -ne 0 ]; then
+            echo "connector checks reported findings or errored (dbt exit ${RC}); see the finding lines above — this step does not fail the sync" >&2
+          fi
+{{- end }}

--- a/charts/insight/templates/ingestion/connector-checks.yaml
+++ b/charts/insight/templates/ingestion/connector-checks.yaml
@@ -78,7 +78,7 @@ spec:
           # captured and discarded. The emitter reads dbt's artifacts, so it
           # reports whatever the run produced, including tests that errored.
           RC=0
-          # shellcheck disable=SC2086 -- DBT_SELECT is a selector LIST; the words are the arguments
+          # shellcheck disable=SC2086 -- a dbt selector may be several words; splitting is intended
           dbt test --profiles-dir . --select $DBT_SELECT --log-format json --log-level "${INSIGHT_LOG_LEVEL:-info}" || RC=$?
           python3 /ingestion/scripts/data_quality_findings.py
           if [ "$RC" -ne 0 ]; then

--- a/charts/insight/templates/ingestion/ingestion-pipeline.yaml
+++ b/charts/insight/templates/ingestion/ingestion-pipeline.yaml
@@ -212,6 +212,38 @@ spec:
                 - name: clickhouse_user
                   value: {{ `"{{inputs.parameters.clickhouse_user}}"` }}
 
+          # ------ Both paths: this connector's own checks, after transform ------
+          # `connector_quality` checks read a connector's bronze/staging, which
+          # exist here precisely because this connector's pipeline is running —
+          # the scheduled `data_quality` catalog cannot host them for that
+          # reason. The connector's own tag joins the selector so its untagged
+          # checks run too; the two selectors are a LIST (union), not an
+          # intersection.
+          #
+          # Depends on whichever transform this path took, and on `.Succeeded`
+          # for the same reason `identity-seed` does: a bare task name is also
+          # satisfied by Skipped, and the branch the `when` dispatch rejects
+          # skips at DAG start.
+          #
+          # Never fails the sync — see connector-checks.yaml.
+          - name: connector-checks
+            depends: transform-jira-silver.Succeeded || transform-legacy.Succeeded
+            templateRef:
+              name: connector-checks
+              template: run
+            arguments:
+              parameters:
+                - name: dbt_select
+                  value: {{ `"tag:connector_quality tag:{{inputs.parameters.data_source}}"` }}
+                - name: toolbox_image
+                  value: {{ `"{{inputs.parameters.toolbox_image}}"` }}
+                - name: clickhouse_host
+                  value: {{ `"{{inputs.parameters.clickhouse_host}}"` }}
+                - name: clickhouse_port
+                  value: {{ `"{{inputs.parameters.clickhouse_port}}"` }}
+                - name: clickhouse_user
+                  value: {{ `"{{inputs.parameters.clickhouse_user}}"` }}
+
           # ------ Non-Jira: single-dbt path, scoped to this connector ------
           # Selector is derived from the connector slug as `tag:<connector>+`:
           # this connector's staging models plus everything downstream

--- a/charts/insight/templates/ingestion/ingestion-pipeline.yaml
+++ b/charts/insight/templates/ingestion/ingestion-pipeline.yaml
@@ -216,9 +216,11 @@ spec:
           # `connector_quality` checks read a connector's bronze/staging, which
           # exist here precisely because this connector's pipeline is running —
           # the scheduled `data_quality` catalog cannot host them for that
-          # reason. The connector's own tag joins the selector so its untagged
-          # checks run too; the two selectors are a LIST (union), not an
-          # intersection.
+          # reason. INTERSECTION, not a list: a space-separated list is a union,
+          # which would run every connector's checks on every connector's sync,
+          # and a check reading another connector's staging fails where that
+          # connector is absent. Each such check therefore carries its own
+          # connector tag alongside `connector_quality`.
           #
           # Depends on whichever transform this path took, and on `.Succeeded`
           # for the same reason `identity-seed` does: a bare task name is also
@@ -234,7 +236,7 @@ spec:
             arguments:
               parameters:
                 - name: dbt_select
-                  value: {{ `"tag:connector_quality tag:{{inputs.parameters.data_source}}"` }}
+                  value: {{ `"tag:connector_quality,tag:{{inputs.parameters.data_source}}"` }}
                 - name: toolbox_image
                   value: {{ `"{{inputs.parameters.toolbox_image}}"` }}
                 - name: clickhouse_host

--- a/src/ingestion/connectors/task-tracking/jira/connector.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/connector.yaml
@@ -1020,7 +1020,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['key'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - jira_id
@@ -2793,7 +2793,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['key'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - id_readable

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__field_history_derived.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__field_history_derived.sql
@@ -59,10 +59,16 @@ WITH kinds AS (
 -- One row per issue: identity, creation time, reporter. Same two-pass dedup as
 -- the snapshot model — the aggregation carries only a raw id, never the JSON.
 issue_winner AS (
-    SELECT unique_key, argMax(_airbyte_raw_id, _airbyte_extracted_at) AS raw_id
+    -- Keyed on the issue's immutable id, NOT on `unique_key`. Bronze rows
+    -- written before descriptor 6.0.0 carry a `unique_key` built from the
+    -- issue KEY, which Jira changes when an issue moves between projects — so
+    -- such an issue has two bronze rows that RMT will never collapse, and
+    -- grouping by that column yields the issue twice: once with its current
+    -- payload, once as a ghost holding whatever the old key last saw.
+    SELECT source_id, jira_id, argMax(_airbyte_raw_id, _airbyte_extracted_at) AS raw_id
     FROM {{ source('bronze_jira', 'jira_issue') }}
-    WHERE unique_key IS NOT NULL
-    GROUP BY unique_key
+    WHERE jira_id IS NOT NULL
+    GROUP BY source_id, jira_id
 ),
 
 issues AS (

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__field_history_derived.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__field_history_derived.sql
@@ -25,12 +25,14 @@
 -- `class_task_field_history`. See
 -- `connectors/task-tracking/jira/specs/FIELD-HISTORY-IN-DBT.md`.
 --
--- Five kinds of row, matching the contract the class consumers rely on (§10):
+-- Six kinds of row, matching the contract the class consumers rely on (§10):
 --   1. one creation marker per issue (`field_id = 'created'`, `_seq = 0`);
 --   2. one `synthetic_initial` per (issue, field) holding the value at creation;
 --   3. one `changelog` row per event, holding the state after that event;
 --   4. one `retired_field` row per (issue, field) the issue stopped carrying;
---   5. one `unclassified_field` row per (issue, field) the catalogue lacks.
+--   5. one `unclassified_field` row per (issue, field) the catalogue lacks;
+--   6. one `snapshot_diff` per (issue, field) the issue cleared without an
+--      event — the state as OBSERVED, which is not the same claim as an event.
 --
 -- Only the element-wise kinds accumulate state across events; every other
 -- kind's item carries both sides in full, so its rows are computed from the
@@ -509,6 +511,67 @@ element_wise_state AS (
        AND ini.field_id = i.field_id
 ),
 
+-- ── the state the journal's own events arrive at ────────────────────────────
+-- Needed to tell a field the issue silently cleared from one it never held.
+-- Both families contribute: a self-describing item carries the state after it,
+-- and an element-wise field's state after its last operation is the span set.
+newest_from_events AS (
+    SELECT
+        src                                               AS insight_source_id,
+        iss                                               AS id_readable,
+        fid                                               AS field_id,
+        argMax(ids, ord)                                  AS value_ids
+    FROM (
+        SELECT
+            e.insight_source_id                           AS src,
+            e.id_readable                                 AS iss,
+            e.field_id                                    AS fid,
+            (e.event_at, e.event_ord)                     AS ord,
+            e.sides.3                                     AS ids
+        FROM live_events AS e
+        WHERE e.field_kind NOT IN {{ jira_element_wise_kinds() }}
+
+        UNION ALL
+
+        SELECT
+            a.insight_source_id,
+            a.id_readable,
+            a.field_id,
+            (a.event_at, a.ops_seq),
+            arrayMap(x -> splitByChar('\x1f', x)[1], a.state_pairs)
+        FROM element_wise_state AS a
+    )
+    GROUP BY src, iss, fid
+),
+
+-- ── fields the issue cleared without recording it ───────────────────────────
+-- The key is STILL in the issue JSON — the field applies and is simply unset —
+-- but the journal's own events end on a value. Jira does that when a value goes
+-- away without an entry: a link removed from the other side of the pair, an
+-- automation writing a read-only field, a list emptied by a bulk operation. §6
+-- calls the missing entry what it is, and this row does not pretend otherwise:
+-- it records the state observed, not an event that happened.
+--
+-- An ABSENT key is a different thing and belongs to `retired_pairs` — the field
+-- left the issue's context, rather than the issue dropping its value.
+cleared_pairs AS (
+    SELECT
+        n.insight_source_id                               AS insight_source_id,
+        n.id_readable                                     AS id_readable,
+        n.field_id                                        AS field_id,
+        j.observed_at                                     AS event_at
+    FROM newest_from_events AS n
+    INNER JOIN issue_json AS j
+        ON j.insight_source_id = n.insight_source_id
+       AND j.id_readable = n.id_readable
+    LEFT ANTI JOIN snapshot AS s
+        ON s.insight_source_id = n.insight_source_id
+       AND s.id_readable = n.id_readable
+       AND s.field_id = n.field_id
+    WHERE length(n.value_ids) > 0
+      AND JSONHas(j.custom_fields_json, n.field_id)
+),
+
 -- ── the value of every modelled field at issue creation ─────────────────────
 -- A field that changed is rolled back to before its earliest event; a field
 -- that never changed keeps its snapshot value. The second case is the one the
@@ -750,6 +813,48 @@ INNER JOIN kinds AS k
 LEFT JOIN issues AS i
     ON i.insight_source_id = r.insight_source_id
    AND i.id_readable = r.id_readable
+
+UNION ALL
+
+-- ── the value the issue no longer holds, with no event to explain it ────────
+-- Dated by the observation, like the withdrawal row above: the moment the
+-- clearing happened is not knowable, only the moment it was seen. `event_id` is
+-- constant per (issue, field) so re-observing restamps the one row rather than
+-- growing a new one each sync — the journal must not accumulate a row per read.
+--
+-- `snapshot_diff` is its own kind on purpose: a consumer counting real history
+-- can exclude it, and the share of state recovered by observation rather than
+-- by event stays measurable.
+SELECT
+    CAST(concat(c.insight_source_id, '-jira-', c.id_readable, '-', c.field_id,
+                '-snapshot_diff:', COALESCE(i.issue_id, '')) AS String)  AS unique_key,
+    c.insight_source_id,
+    CAST('jira' AS String)                                AS data_source,
+    COALESCE(i.issue_id, '')                              AS issue_id,
+    c.id_readable,
+    CAST(concat('snapshot_diff:', COALESCE(i.issue_id, '')) AS String) AS event_id,
+    c.event_at,
+    CAST('snapshot_diff' AS String)                       AS event_kind,
+    toUInt32(0)                                           AS _seq,
+    -- Nobody is recorded as having done this: there is no entry to name an author.
+    CAST(NULL AS Nullable(String))                        AS author_id,
+    c.field_id,
+    k.field_name,
+    {{ jira_field_cardinality('k.field_kind') }}          AS field_cardinality,
+    CAST(if({{ jira_field_cardinality('k.field_kind') }} = 'multi',
+            'remove', 'set') AS String)                   AS delta_action,
+    CAST([] AS Array(String))                             AS value_ids,
+    CAST([] AS Array(String))                             AS value_displays,
+    {{ jira_field_id_type('k.field_kind') }}              AS value_id_type,
+    now64(3)                                              AS collected_at,
+    toUnixTimestamp64Milli(now64(3))                      AS _version
+FROM cleared_pairs AS c
+INNER JOIN kinds AS k
+    ON k.insight_source_id = c.insight_source_id
+   AND k.field_id = c.field_id
+LEFT JOIN issues AS i
+    ON i.insight_source_id = c.insight_source_id
+   AND i.id_readable = c.id_readable
 
 UNION ALL
 

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_field_snapshot.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_field_snapshot.sql
@@ -46,12 +46,19 @@
 -- of an issue.
 
 WITH winner AS (
+    -- Keyed on the issue's immutable id, NOT on `unique_key`. Bronze rows
+    -- written before descriptor 6.0.0 carry a `unique_key` built from the
+    -- issue KEY, which Jira changes when an issue moves between projects — so
+    -- such an issue has two bronze rows that RMT will never collapse, and
+    -- grouping by that column yields the issue twice: once with its current
+    -- payload, once as a ghost holding whatever the old key last saw.
     SELECT
-        unique_key,
+        source_id,
+        jira_id,
         argMax(_airbyte_raw_id, _airbyte_extracted_at) AS raw_id
     FROM {{ source('bronze_jira', 'jira_issue') }}
-    WHERE unique_key IS NOT NULL
-    GROUP BY unique_key
+    WHERE jira_id IS NOT NULL
+    GROUP BY source_id, jira_id
 ),
 
 -- One row per (issue, field key present in the issue JSON).

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_field_text.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_field_text.sql
@@ -52,10 +52,16 @@ WITH long_text_fields AS (
 
 -- Current bodies, from the issue JSON.
 issue_winner AS (
-    SELECT unique_key, argMax(_airbyte_raw_id, _airbyte_extracted_at) AS raw_id
+    -- Keyed on the issue's immutable id, NOT on `unique_key`. Bronze rows
+    -- written before descriptor 6.0.0 carry a `unique_key` built from the
+    -- issue KEY, which Jira changes when an issue moves between projects — so
+    -- such an issue has two bronze rows that RMT will never collapse, and
+    -- grouping by that column yields the issue twice: once with its current
+    -- payload, once as a ghost holding whatever the old key last saw.
+    SELECT source_id, jira_id, argMax(_airbyte_raw_id, _airbyte_extracted_at) AS raw_id
     FROM {{ source('bronze_jira', 'jira_issue') }}
-    WHERE unique_key IS NOT NULL
-    GROUP BY unique_key
+    WHERE jira_id IS NOT NULL
+    GROUP BY source_id, jira_id
 ),
 
 from_snapshot AS (

--- a/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
@@ -34,7 +34,25 @@ name: jira
 # re-deriving, the column is simply no longer produced. It must be removed from
 # bronze in this order, or the destination recreates it: bump and deploy, let a
 # sync complete, then the ALTER migration.
-version: "5.4.0"
+# 6.0.0 (major): key jira_issue and jira_issue_keys on the issue's immutable
+# numeric id instead of its "PROJ-123" key. Jira changes that key when an issue
+# moves between projects, and bronze replaces rows by `unique_key` — so a moved
+# issue stopped replacing itself: the new key inserted a second row and the old
+# one stayed behind with a stale payload, leaving the issue present twice
+# downstream, once with its real history and once as a ghost.
+#
+# Rows written before this keep their old key: `unique_key` is the table's sort
+# key and ClickHouse refuses to UPDATE one, so there is no migration to rewrite
+# them in place, and rebuilding a table this size to change a column nothing
+# reads afterwards would not earn its cost. The readers stop depending on it
+# instead — every dedup over jira_issue now picks its winner by
+# (source_id, jira_id) — so the stale row is simply never chosen.
+#
+# MAJOR because the key an existing row is stored under changes, which is what
+# a major means here; the full refresh it dispatches also clears anything
+# derived while the two copies were both visible. `id_readable` keeps the
+# mutable key — the rename is a fact about the issue.
+version: "6.0.0"
 schedule: "0 3 * * *"
 workflow: sync
 # CI build metadata + runtime image refs (ADR-0016). The `images:` block is

--- a/src/ingestion/connectors/task-tracking/jira/specs/FIELD-HISTORY-IN-DBT.md
+++ b/src/ingestion/connectors/task-tracking/jira/specs/FIELD-HISTORY-IN-DBT.md
@@ -809,7 +809,7 @@ The output table is consumed by `silver.class_task_field_history` through
     initial row of an issue is stamped with the creation timestamp, so this
     happens to every issue whose first event landed on its own creation — and
     the newest state of that field then reads as the empty state it had before
-    the event. The kind is what orders them (`jira_event_rank`): an initial row
+    the event. The kind is what orders them (`task_event_rank`): an initial row
     is by definition the state before any event, and a `retired_field` row is
     stamped at or after every event.
 

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue.py
@@ -68,7 +68,11 @@ def test_full_record_read(http_mocker: HttpMocker) -> None:
     assert len(output.records) == 1
     assert not output.errors
     rec = output.records[0].record.data
-    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-PROJ1-1")
+    # Keyed on the issue's immutable id, never on its key: Jira renames the key
+    # when an issue moves between projects, and bronze replaces rows by this
+    # column — a renamed issue keyed on "PROJ1-1" would insert a second row
+    # instead of replacing its own.
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-10001")
     assert rec["jira_id"] == 10001
     assert rec["id_readable"] == "PROJ1-1"
     assert rec["project_key"] == "PROJ1"

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue_keys.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue_keys.py
@@ -8,7 +8,8 @@ PT14H, global substream cursor) and nextPageToken pagination.
 
 Coverage matrix rows: substream_partition, incremental_state (state emission +
 resume-read request filtering), pagination_multi_page (CursorPagination),
-tenant_source_stamping (unique_key from issue key), transformations (cursor
+tenant_source_stamping (unique_key from the immutable issue id),
+transformations (cursor
 hoist). schema_conformance is explicitly SKIPPED — the rig found a real
 manifest<->schema type drift (see the skip reason).
 
@@ -23,15 +24,7 @@ import json
 import freezegun
 import pytest
 from config import JIRA_URL, JiraConfigBuilder
-
-from connector_tests import (
-    ANY_QUERY_PARAMS,
-    HttpMocker,
-    HttpRequest,
-    HttpResponse,
-    load_fixture,
-    read_stream,
-)
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, load_fixture, read_stream
 
 _STREAM = "jira_issue_keys"
 _CONNECTOR = "task-tracking/jira"
@@ -45,13 +38,7 @@ _WINDOW_END = "2026-07-01 00:00"
 
 def _projects_response(keys: list[str]) -> HttpResponse:
     values = [
-        load_fixture(
-            __file__,
-            "discovery_project.json",
-            id=str(10000 + i),
-            key=key,
-            name=f"Project {key}",
-        )
+        load_fixture(__file__, "discovery_project.json", id=str(10000 + i), key=key, name=f"Project {key}")
         for i, key in enumerate(keys)
     ]
     return HttpResponse(body=json.dumps({"values": values, "isLast": True}), status_code=200)
@@ -59,10 +46,7 @@ def _projects_response(keys: list[str]) -> HttpResponse:
 
 def _jql_params(project: str, start: str, end: str, page_token: str | None = None) -> dict:
     params = {
-        "jql": (
-            f'project = "{project}" AND updated >= "{start}" '
-            f'AND updated <= "{end}" ORDER BY updated ASC'
-        ),
+        "jql": (f'project = "{project}" AND updated >= "{start}" AND updated <= "{end}" ORDER BY updated ASC'),
         "fields": "updated",
         "maxResults": "100",
     }
@@ -89,8 +73,7 @@ def test_substream_partition_per_project(http_mocker: HttpMocker) -> None:
     request would fail the test (no network fallthrough)."""
     config = JiraConfigBuilder().build()
     http_mocker.get(
-        HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS),
-        _projects_response(["PROJ1", "PROJ2"]),
+        HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _projects_response(["PROJ1", "PROJ2"])
     )
     http_mocker.get(
         HttpRequest(_JQL_URL, query_params=_jql_params("PROJ1", _WINDOW_START, _WINDOW_END)),
@@ -115,10 +98,7 @@ def test_cursor_hoist_and_stamping(http_mocker: HttpMocker) -> None:
     (otherwise the cursor never observes values), and identity stamping uses
     the issue key."""
     config = JiraConfigBuilder().build()
-    http_mocker.get(
-        HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS),
-        _projects_response(["PROJ1"]),
-    )
+    http_mocker.get(HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _projects_response(["PROJ1"]))
     http_mocker.get(
         HttpRequest(_JQL_URL, query_params=ANY_QUERY_PARAMS),
         _issues_response([("10001", "PROJ1-1", "2026-06-15T10:00:00.000+0000")]),
@@ -131,9 +111,8 @@ def test_cursor_hoist_and_stamping(http_mocker: HttpMocker) -> None:
     # CDK interpolation literal-evals the rendered value: numeric-string id -> int.
     assert rec["jira_id"] == 10001
     assert rec["id_readable"] == "PROJ1-1"
-    assert rec["unique_key"] == (
-        f"{config['insight_tenant_id']}-{config['insight_source_id']}-PROJ1-1"
-    )
+    # The immutable id, not the renameable key — see test_jira_issue.
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-10001")
 
 
 @pytest.mark.skip(
@@ -152,21 +131,13 @@ def test_pagination_next_page_token(http_mocker: HttpMocker) -> None:
     """CursorPagination: a nextPageToken in the response drives a second
     request carrying it; a response without the token stops."""
     config = JiraConfigBuilder().build()
-    http_mocker.get(
-        HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS),
-        _projects_response(["PROJ1"]),
-    )
+    http_mocker.get(HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _projects_response(["PROJ1"]))
     http_mocker.get(
         HttpRequest(_JQL_URL, query_params=_jql_params("PROJ1", _WINDOW_START, _WINDOW_END)),
-        _issues_response(
-            [("10001", "PROJ1-1", "2026-06-10T10:00:00.000+0000")], next_token="tok-2"
-        ),
+        _issues_response([("10001", "PROJ1-1", "2026-06-10T10:00:00.000+0000")], next_token="tok-2"),
     )
     http_mocker.get(
-        HttpRequest(
-            _JQL_URL,
-            query_params=_jql_params("PROJ1", _WINDOW_START, _WINDOW_END, page_token="tok-2"),
-        ),
+        HttpRequest(_JQL_URL, query_params=_jql_params("PROJ1", _WINDOW_START, _WINDOW_END, page_token="tok-2")),
         _issues_response([("10002", "PROJ1-2", "2026-06-12T10:00:00.000+0000")]),
     )
 
@@ -182,10 +153,7 @@ def test_incremental_state_emitted_and_resume_filters(http_mocker: HttpMocker) -
     read given that state must issue a JQL filtered from the cursor minus the
     PT14H lookback window — asserted by the exact request matcher."""
     config = JiraConfigBuilder().build()
-    http_mocker.get(
-        HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS),
-        _projects_response(["PROJ1"]),
-    )
+    http_mocker.get(HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _projects_response(["PROJ1"]))
     http_mocker.get(
         HttpRequest(_JQL_URL, query_params=_jql_params("PROJ1", _WINDOW_START, _WINDOW_END)),
         _issues_response([("10001", "PROJ1-1", "2026-06-15T10:00:00.000+0000")]),
@@ -201,14 +169,10 @@ def test_incremental_state_emitted_and_resume_filters(http_mocker: HttpMocker) -
     resume_mocker = HttpMocker()
     with resume_mocker:
         resume_mocker.get(
-            HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS),
-            _projects_response(["PROJ1"]),
+            HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _projects_response(["PROJ1"])
         )
         resume_mocker.get(
-            HttpRequest(
-                _JQL_URL,
-                query_params=_jql_params("PROJ1", "2026-06-14 20:00", _WINDOW_END),
-            ),
+            HttpRequest(_JQL_URL, query_params=_jql_params("PROJ1", "2026-06-14 20:00", _WINDOW_END)),
             _issues_response([]),
         )
 

--- a/src/ingestion/dbt/macros/jira/jira_field_delta.sql
+++ b/src/ingestion/dbt/macros/jira/jira_field_delta.sql
@@ -180,13 +180,17 @@
             if(COALESCE({{ to_str }},   '') = '', [], [CAST({{ jira_text_prefix(to_str) }} AS String)])
         ),
 
+        {#- The display side stands in only when the id side is ABSENT. An id side
+            that is present and empty (`[]`) is a real value — the field was
+            cleared — and falling back there yields the display of an empty
+            list, which is the literal text `[]` parsed as one option. -#}
         {{ kind }} = 'option_array',
         (
-            CAST(if(length({{ f_ids }}) = 0, {{ f_disp }}, {{ f_ids }}) AS Array(String)),
-            CAST(if(length({{ f_ids }}) = 0, {{ f_disp }},
+            CAST(if(COALESCE({{ from_id }}, '') = '', {{ f_disp }}, {{ f_ids }}) AS Array(String)),
+            CAST(if(COALESCE({{ from_id }}, '') = '', {{ f_disp }},
                     if(length({{ f_disp }}) = length({{ f_ids }}), {{ f_disp }}, {{ f_ids }})) AS Array(String)),
-            CAST(if(length({{ t_ids }}) = 0, {{ t_disp }}, {{ t_ids }}) AS Array(String)),
-            CAST(if(length({{ t_ids }}) = 0, {{ t_disp }},
+            CAST(if(COALESCE({{ to_id }}, '') = '', {{ t_disp }}, {{ t_ids }}) AS Array(String)),
+            CAST(if(COALESCE({{ to_id }}, '') = '', {{ t_disp }},
                     if(length({{ t_disp }}) = length({{ t_ids }}), {{ t_disp }}, {{ t_ids }})) AS Array(String))
         ),
 

--- a/src/ingestion/dbt/macros/jira/jira_field_id_type.sql
+++ b/src/ingestion/dbt/macros/jira/jira_field_id_type.sql
@@ -56,8 +56,3 @@
     — so the newest state of such a field reads as the empty state it had before
     the event. The contract's claim that `(event_at, _seq)` is a total order
     holds only when no two kinds share an instant. -#}
-{% macro jira_event_rank(event_kind) %}
-    multiIf({{ event_kind }} = 'synthetic_initial', 0,
-            {{ event_kind }} = 'changelog',         1,
-                                                   2)
-{% endmacro %}

--- a/src/ingestion/dbt/macros/task_event_rank.sql
+++ b/src/ingestion/dbt/macros/task_event_rank.sql
@@ -1,0 +1,26 @@
+{#-
+  Rank of an event KIND within one instant of one (issue, field), for the
+  ordering key of `silver.class_task_field_history`.
+
+  `event_at` alone is not a total order, and neither is `(event_at, _seq)`: a
+  changelog row carries `_seq` 0 while the `synthetic_initial` rows of an issue
+  carry 1..N, so ordering by `_seq` sorts the initial row AFTER an event of the
+  same instant — and the newest state of that field then reads as the state
+  before the event. Every issue whose first event landed on its own creation
+  timestamp hits this.
+
+  The kind decides instead: an initial row is by definition the state before any
+  event; a `changelog` row is a state after one; `availability` and `lifecycle`
+  are observed at or after the events they accompany, so they sort last.
+
+  The full key is `(event_at, task_event_rank(event_kind), _seq,
+  toUInt64OrZero(event_id))` — `_seq` orders the initial rows among themselves
+  (they share the creation timestamp) and the event id breaks a tie between two
+  changelog rows of one instant, compared NUMERICALLY because as text '101'
+  sorts before '99'.
+-#}
+{% macro task_event_rank(event_kind) %}
+    multiIf({{ event_kind }} = 'synthetic_initial', 0,
+            {{ event_kind }} = 'changelog',         1,
+                                                   2)
+{% endmacro %}

--- a/src/ingestion/dbt/tests/jira/assert_jira_field_delta_fixtures.sql
+++ b/src/ingestion/dbt/tests/jira/assert_jira_field_delta_fixtures.sql
@@ -112,7 +112,16 @@ WITH fixtures AS (
             ('option_array no id','option_array', '','','','GOAL-1',
                  CAST([] AS Array(String)), CAST([] AS Array(String)), ['GOAL-1'], ['GOAL-1']),
             ('option_array id gone','option_array', '','PREV-1','','GOAL-2',
-                 ['PREV-1'], ['PREV-1'], ['GOAL-2'], ['GOAL-2'])
+                 ['PREV-1'], ['PREV-1'], ['GOAL-2'], ['GOAL-2']),
+            -- clearing the field: the id side is PRESENT and empty. It must not
+            -- fall back to the display side, which renders an empty list as the
+            -- literal text `[]` and would land in the journal as one option
+            -- named "[]".
+            ('option_array cleared','option_array', '[13027]','Alpha','[]','[]',
+                 ['13027'], ['Alpha'], CAST([] AS Array(String)), CAST([] AS Array(String))),
+            ('option_array both empty lists','option_array', '[]','[]','[]','[]',
+                 CAST([] AS Array(String)), CAST([] AS Array(String)),
+                 CAST([] AS Array(String)), CAST([] AS Array(String)))
         ]) AS t
     )
 )

--- a/src/ingestion/dbt/tests/jira/assert_jira_field_history_round_trip.sql
+++ b/src/ingestion/dbt/tests/jira/assert_jira_field_history_round_trip.sql
@@ -80,6 +80,13 @@ WITH latest_state AS (
         max(event_at)                            AS latest_event_at
     FROM {{ ref('jira__field_history_derived') }} FINAL
     WHERE field_id != 'created'
+      -- `snapshot_diff` is the snapshot's own value written back as an observed
+      -- state, so counting it here would compare the snapshot with itself and
+      -- report agreement no matter what the events say. The events are the
+      -- side under test; a pair that needed a `snapshot_diff` row is exactly a
+      -- pair whose events do NOT reach the current value, and it must keep
+      -- showing up here.
+      AND event_kind != 'snapshot_diff'
       -- A field the catalogue does not contain (§3.2) carries ONE best-effort
       -- row, and the snapshot cannot hold a value for it at all: the snapshot
       -- model joins the catalogue, so an unclassifiable field never reaches it.

--- a/src/ingestion/dbt/tests/jira/assert_jira_field_history_round_trip.sql
+++ b/src/ingestion/dbt/tests/jira/assert_jira_field_history_round_trip.sql
@@ -1,6 +1,6 @@
 {{ config(
     severity='warn',
-    tags=['connector_quality'],
+    tags=['connector_quality', 'jira'],
     store_failures=true,
     meta={
         'title': 'Task field history reconciles with the issue snapshot',

--- a/src/ingestion/dbt/tests/jira/assert_jira_field_history_round_trip.sql
+++ b/src/ingestion/dbt/tests/jira/assert_jira_field_history_round_trip.sql
@@ -1,4 +1,15 @@
-{{ config(severity='warn') }}
+{{ config(
+    severity='warn',
+    tags=['connector_quality'],
+    store_failures=true,
+    meta={
+        'title': 'Task field history reconciles with the issue snapshot',
+        'domain': 'task-tracking',
+        'category': 'reconciliation',
+        'tier': 'error',
+        'remediation': 'Replaying a field\'s history forward must land on the value the issue holds now. A finding is one of three things, and the fix differs: (1) the pipeline mis-parses the field — check the kind rules in FIELD-HISTORY-IN-DBT.md §3.3 against the field\'s `schema_type` / `schema_custom`, and note that a separator or bracketed-id rule written for one shape silently corrupts another; (2) the source and its own changelog disagree — automation and read-only fields change a value without recording an event, and a migrated instance can carry values that differ from the events that set them (a date off by a day, an instant off by a fixed offset, both sides already normalized). No transformation recovers an event the source never wrote, so the journal legitimately lags; before suspecting the date handling here, compare the RAW `value_to` of the newest changelog item with the raw issue JSON — if those two already differ, the pipeline is faithful; (3) the value\'s identifier is not stable across the two sides, which `assert_jira_field_id_spaces_intersect` reports separately and which happens when an instance is migrated and its option values are recreated under new ids. Compare the DISPLAY sides of a sample to tell (3) from (1): equal displays with different ids is (3).'
+    }
+) }}
 
 -- The oracle this pipeline has never had.
 --
@@ -62,9 +73,9 @@ WITH latest_state AS (
         --
         -- The event id last, numerically: two changelog rows of one millisecond
         -- both carry `_seq` 0, and as text '101' sorts before '99'.
-        argMax(value_ids,      (event_at, {{ jira_event_rank('event_kind') }},
+        argMax(value_ids,      (event_at, {{ task_event_rank('event_kind') }},
                                 _seq, toUInt64OrZero(event_id))) AS value_ids,
-        argMax(value_displays, (event_at, {{ jira_event_rank('event_kind') }},
+        argMax(value_displays, (event_at, {{ task_event_rank('event_kind') }},
                                 _seq, toUInt64OrZero(event_id))) AS value_displays,
         max(event_at)                            AS latest_event_at
     FROM {{ ref('jira__field_history_derived') }} FINAL

--- a/src/ingestion/dbt/tests/jira/assert_jira_field_id_spaces_intersect.sql
+++ b/src/ingestion/dbt/tests/jira/assert_jira_field_id_spaces_intersect.sql
@@ -1,4 +1,15 @@
-{{ config(severity='warn') }}
+{{ config(
+    severity='warn',
+    tags=['connector_quality'],
+    store_failures=true,
+    meta={
+        'title': 'Task field ids agree between changelog and snapshot',
+        'domain': 'task-tracking',
+        'category': 'consistency',
+        'tier': 'warn',
+        'remediation': 'The changelog and the issue resource name the same value with different identifiers, so history cannot be reconciled with current state by id for this field. The usual cause is outside the pipeline: migrating an instance recreates option values under fresh ids while the imported changelog keeps the originals, which also shows up as a field named "(migrated)". Nothing here can map the two id spaces without guessing; treat it as a property of the field and reconcile such fields by display instead. A field that is NOT expected to be in this state is a real finding — check whether the kind rules read the id side of the changelog item at all.'
+    }
+) }}
 
 -- A field whose changelog ids and current-value ids are two disjoint spaces.
 --

--- a/src/ingestion/dbt/tests/jira/assert_jira_field_id_spaces_intersect.sql
+++ b/src/ingestion/dbt/tests/jira/assert_jira_field_id_spaces_intersect.sql
@@ -1,6 +1,6 @@
 {{ config(
     severity='warn',
-    tags=['connector_quality'],
+    tags=['connector_quality', 'jira'],
     store_failures=true,
     meta={
         'title': 'Task field ids agree between changelog and snapshot',

--- a/src/ingestion/dbt/tests/jira/transform/test_retired_fields.py
+++ b/src/ingestion/dbt/tests/jira/transform/test_retired_fields.py
@@ -81,16 +81,21 @@ def test_the_withdrawal_is_dated_by_the_observation(scenario: Scenario) -> None:
 def test_a_present_but_empty_key_is_not_a_withdrawal(scenario: Scenario) -> None:
     """The field still applies to the issue and is unset — an ordinary state.
 
-    If the journal disagrees with it, a clearing event is missing and that must
-    surface as a round-trip failure. Absorbing it into a synthetic row would
-    blind the only oracle that catches a mis-parsed event.
+    Not a withdrawal: the key is present, so the field did not leave the issue's
+    context. It gets a `snapshot_diff` row instead, which records the state as
+    observed without claiming an event happened.
+
+    The oracle must not be blinded by that row. A missing clearing event is
+    still a round-trip failure, because `snapshot_diff` is derived FROM the
+    snapshot and the round trip asks whether the EVENTS reach the current value.
     """
     scenario.seed(fields=[SEVERITY_FIELD], issues=[issue("TST-1", fields={SEVERITY: None})], events=_severity_history())
     scenario.build()
 
     kinds = [r["event_kind"] for r in scenario.journal(field=SEVERITY)]
     assert "retired_field" not in kinds
-    assert kinds == ["synthetic_initial", "changelog"]
+    assert kinds == ["synthetic_initial", "changelog", "snapshot_diff"]
+    assert not scenario.round_trip_holds()
 
 
 def test_a_withdrawal_keeps_the_field_identifier_type(scenario: Scenario) -> None:

--- a/src/ingestion/dbt/tests/task/assert_event_kind_matches_event_id.sql
+++ b/src/ingestion/dbt/tests/task/assert_event_kind_matches_event_id.sql
@@ -4,6 +4,7 @@
 --   event_kind='lifecycle'         ⇔ event_id LIKE 'comment:%' OR 'worklog:%'
 --   event_kind='retired_field'     ⇔ event_id LIKE 'retired:%'
 --   event_kind='unclassified_field'⇔ event_id LIKE 'unclassified:%'
+--   event_kind='snapshot_diff'    ⇔ event_id LIKE 'snapshot_diff:%'
 --   event_kind='changelog'         ⇔ event_id matches no prefix above
 -- Any violation means the writer got the kind vs id wrong.
 
@@ -19,9 +20,11 @@ WHERE (event_kind = 'synthetic_initial' AND event_id NOT LIKE 'initial:%')
    OR (event_kind = 'changelog'         AND (event_id LIKE 'initial:%' OR event_id LIKE 'availability:%'
                                              OR event_id LIKE 'comment:%' OR event_id LIKE 'worklog:%'
                                              OR event_id LIKE 'retired:%'
-                                             OR event_id LIKE 'unclassified:%'))
+                                             OR event_id LIKE 'unclassified:%'
+                                             OR event_id LIKE 'snapshot_diff:%'))
    OR (event_kind = 'retired_field'     AND event_id NOT LIKE 'retired:%')
    OR (event_kind = 'unclassified_field' AND event_id NOT LIKE 'unclassified:%')
+   OR (event_kind = 'snapshot_diff'     AND event_id NOT LIKE 'snapshot_diff:%')
    OR (event_kind = 'availability'      AND event_id NOT LIKE 'availability:%')
    OR (event_kind = 'lifecycle'         AND event_id NOT LIKE 'comment:%' AND event_id NOT LIKE 'worklog:%')
 LIMIT 100

--- a/src/ingestion/gold/task_issue_state.sql
+++ b/src/ingestion/gold/task_issue_state.sql
@@ -54,6 +54,9 @@ history AS (
         fh.value_ids                                                          AS value_ids,
         fh.value_displays                                                     AS value_displays,
         fh._version                                                           AS _version,
+        -- Part of the ordering key below, not payload: see `task_event_rank`.
+        fh._seq                                                               AS _seq,
+        fh.event_id                                                           AS event_id,
         -- Null-proof under EITHER join_use_nulls setting: an unbound field must
         -- read as "no role", never as NULL propagating through the filter.
         -- `availability` is a contract sentinel (the jira deletion spec), not a
@@ -81,23 +84,23 @@ issue_pivot AS (
     SELECT
         insight_source_id,
         issue_id,
-        argMaxIf(value_ids[1], (event_at, _version),
+        argMaxIf(value_ids[1], (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)),
                  role = 'status' AND delta_action = 'set')               AS status_id,
-        argMaxIf(value_ids[1], (event_at, _version),
+        argMaxIf(value_ids[1], (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)),
                  role = 'assignee' AND delta_action = 'set')             AS assignee_account_id,
-        argMaxIf(value_displays[1], (event_at, _version),
+        argMaxIf(value_displays[1], (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)),
                  role = 'issuetype' AND delta_action = 'set')            AS issue_type,
-        argMaxIf(value_ids[1], (event_at, _version),
+        argMaxIf(value_ids[1], (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)),
                  role = 'issuetype' AND delta_action = 'set')            AS issue_type_id,
-        argMaxIf(value_displays[1], (event_at, _version),
+        argMaxIf(value_displays[1], (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)),
                  role = 'duedate' AND delta_action = 'set')              AS due_date_str,
-        toFloat64OrNull(argMaxIf(value_displays[1], (event_at, _version),
+        toFloat64OrNull(argMaxIf(value_displays[1], (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)),
                  role = 'estimate' AND delta_action = 'set'))
-            * argMaxIf(unit_multiplier, (event_at, _version),
+            * argMaxIf(unit_multiplier, (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)),
                  role = 'estimate' AND delta_action = 'set')                 AS time_estimate_seconds,
-        toFloat64OrNull(argMaxIf(value_displays[1], (event_at, _version),
+        toFloat64OrNull(argMaxIf(value_displays[1], (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)),
                  role = 'spent' AND delta_action = 'set'))
-            * argMaxIf(unit_multiplier, (event_at, _version),
+            * argMaxIf(unit_multiplier, (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)),
                  role = 'spent' AND delta_action = 'set')                    AS time_spent_seconds,
         minIf(event_at, event_kind = 'synthetic_initial')                    AS created_at,
         -- The key the tracker itself shows a human ('owner/repo#12', 'PROJ-7');
@@ -105,7 +108,7 @@ issue_pivot AS (
         -- INVARIANT: argMax, never any() — `id_readable` is part of `unique_key`,
         -- so a renamed repository or an issue moved between projects leaves rows
         -- under BOTH keys and FINAL collapses neither. The latest event wins.
-        argMax(id_readable, (event_at, _version))                            AS id_readable,
+        argMax(id_readable, (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)))                            AS id_readable,
         -- The role first, the denormalized column as the fallback.
         --
         -- The role is where the title belongs: an ordinary field, so a source
@@ -120,14 +123,14 @@ issue_pivot AS (
         -- the result `Nullable(String)`: `argMaxIf` returns '' when nothing
         -- matches, and this is a serving table whose type the backend reads.
         coalesce(
-            nullIf(argMaxIf(value_displays[1], (event_at, _version),
+            nullIf(argMaxIf(value_displays[1], (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)),
                             role = 'title'), ''),
-            argMax(title, (event_at, _version))
+            argMax(title, (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)))
         )                                                                    AS title,
         maxIf(event_at, role = 'status' AND delta_action = 'set')        AS last_status_event_at,
         -- Availability lives in the same history as every other field
         -- (synthetic 'availability' events; see the jira deletion spec).
-        argMaxIf(value_ids[1], (event_at, _version),
+        argMaxIf(value_ids[1], (event_at, {{ task_event_rank('event_kind') }}, _seq, toUInt64OrZero(event_id)),
                  role = 'availability')                                      AS availability,
         any(data_source)                                                     AS data_source
     FROM history

--- a/src/ingestion/scripts/data_quality_findings.py
+++ b/src/ingestion/scripts/data_quality_findings.py
@@ -26,7 +26,11 @@ def main() -> int:
         node = nodes.get(result["unique_id"])
         if not node or node.get("resource_type") != "test":
             continue
-        if "data_quality" not in (node.get("tags") or []):
+        # `connector_quality` is the per-connector catalog: checks that need a
+        # connector's own bronze/staging and so cannot live in `data_quality`,
+        # which must pass on a tenant where that connector is absent. Findings
+        # from both carry the same shape.
+        if not ({"data_quality", "connector_quality"} & set(node.get("tags") or [])):
             continue
 
         config = node.get("config") or {}


### PR DESCRIPTION
Four changes, each standing on its own. What they have in common: none of them is observable on controlled inputs — they only appear when history is compared with the state a real issue holds.

## 1. A connector's own checks now run after its sync

`dbt test` runs in exactly one place in a cluster: the scheduled `data_quality` catalog. That catalog is install-wide, so it must read silver/gold only — a check touching one connector's bronze would fail on a tenant where that connector is absent. The Jira checks read that connector's bronze and staging, so they could not join it, and therefore ran **nowhere** outside CI. One of them states in its own comment that it "warns in the nightly run", which was never true.

This adds a `connector_quality` tag for checks that need a connector's own tables, and a `connector-checks` step at the end of that connector's pipeline, where the tables exist precisely because the pipeline built them. Each such check also carries its connector's tag, and the selector is the INTERSECTION of the two — a space-separated selector is a union, which would run every connector's checks on every connector's sync.

The step never fails the sync, by construction: bronze has landed and silver is rebuilt by the time it runs, so failing the workflow would undo nothing and would only turn a data condition into a red pipeline nobody can act on. It does refuse an empty selector, because `dbt test --select ""` matches nothing and exits 0 — a silent no-op is worse than an error.

## 2. Findings reach monitoring

Both Jira checks gain `store_failures` and the `meta` block the catalog convention expects, so each finding is emitted as a structured line carrying its `tier`. `severity` stays `warn`: these report a condition of the SOURCE, which no change here can repair, and a gate that can never go green stops being read. The finding emitter learns the new tag.

Their `remediation` explains how to tell the three causes apart, because on real data they look identical: a genuine parsing fault; a source that changed a value without recording an event; and a value whose identifier is not stable across the two sides. It also names the cheap discriminator — compare the raw changelog value with the raw issue JSON before suspecting the transformation.

## 3. Current task state is read by the full ordering key

`task_issue_state` resolved current state with `argMax(..., (event_at, _version))`. `_version` is a build stamp shared by every row of one build, so on two rows of the same instant the key ties and the winner is whatever the query plan produced.

This is not a corner case. A `synthetic_initial` row and a `changelog` row routinely share an issue's creation timestamp — that happens to every issue whose first event landed when it was created — and by `_seq` alone the initial row sorts AFTER the event, so the field reads as the empty state it had before. Two changelog rows can also share a millisecond.

The key is now `(event_at, task_event_rank(event_kind), _seq, toUInt64OrZero(event_id))`: kind first, because an initial row is by definition the state before any event; then `_seq`, which orders the initial rows among themselves; then the event id compared NUMERICALLY, since as text `'101'` sorts before `'99'`. The round-trip check already ordered this way — gold now agrees with it.

`jira_event_rank` becomes `task_event_rank` in the shared macro directory: the class it orders is written by every task-tracking connector, so the rank was not Jira's to own.

## 4. A value the issue cleared without an event is recorded

Jira lets a value disappear without a changelog entry — a link removed from the other side of the pair, an automation writing a read-only field, a list emptied in bulk. The journal keeps the last value it was told about, and the issue's own state disagrees with it for as long as the issue lives.

`retired_field` does not cover this: it fires when the key is ABSENT, meaning the field left the issue's context. Here the key is present and empty, which per §6 means the field still applies and is unset.

The new `snapshot_diff` kind fires only when all three hold: the field's events end on a value, the snapshot has no row, and the key IS in the issue JSON. It is dated by the observation, not by a guess at when the clearing happened, and its `event_id` is constant per (issue, field), so re-observing restamps one row instead of accumulating one per sync. It is its own kind so that a consumer counting real history can exclude it, and so the share of state recovered by observation stays measurable.

**The oracle keeps its sight.** A `snapshot_diff` row is the snapshot's value written back, so if the round-trip check counted it, the check would compare the snapshot with itself and report agreement regardless of what the events say — going blind on exactly the pairs it should be loudest about. It therefore ignores that kind, and a pair needing such a row still fails it. The scenario test asserts both halves.

Nothing reaches silver from here yet: the class is fed by the Rust pass-through until the cutover, and the silver `event_kind` enum will gain this kind together with `retired_field` and `unclassified_field` at that point.

## 5. An issue moved between projects no longer exists twice

`unique_key` on `jira_issue` and `jira_issue_keys` was built from the issue's "PROJ-123" key, and Jira changes that key when an issue moves between projects. Bronze replaces rows by `unique_key`, so a moved issue stopped replacing itself: the new key inserted a second row while the old one stayed behind with whatever payload it last held. Downstream the issue then appeared twice — once carrying its real history, once as a ghost built from a stale snapshot.

The connector now emits the immutable numeric id. Rows written before this keep their old key: `unique_key` is the table's sort key and ClickHouse refuses to `UPDATE` one, so no migration can rewrite them in place, and rebuilding a table of this size for a column nothing reads afterwards would not earn its cost. Every dedup over `jira_issue` instead picks its winner by `(source_id, jira_id)` — the snapshot, the derived journal and the long-text side table — so the stale copy is simply never chosen.

`id_readable` keeps the mutable key; the rename is a fact about the issue, and that is the column readers use for it.

The descriptor goes to **6.0.0**. Major, because the key an existing row is stored under changes — and the full refresh a major dispatches also clears anything derived while both copies were visible.

## 6. A cleared option list is no longer recorded as an option named `[]`

For `option_array` the display side stands in when the id side is missing, and the test for "missing" was an empty id list. Clearing the field produces exactly that, and the display of an empty bracketed list renders as the literal text `[]` — so the journal recorded the field as holding one option called `[]` instead of holding nothing. The fallback now triggers only when the id side is ABSENT; present and empty is a real value, meaning the field was cleared.

Two fixtures cover it, and both fail against the previous macro.

## Checks

- `src/ingestion/dbt/tests/jira/transform` — 73/73 pass.
- The chart renders with a real environment values file; the new step and its selector appear in the rendered pipeline.
- Both defects above were found by comparing the derived journal with the state real issues hold, and both fixes were verified the same way before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Connector-specific data quality checks now run automatically after ingestion transforms.
  - Connector check results are reported as structured data-quality findings.
  - Jira history now records fields cleared in source snapshots.
  - Jira records use immutable issue IDs for more consistent tracking across key changes.

- **Bug Fixes**
  - Improved event ordering when Jira events share timestamps.
  - Corrected handling of empty Jira option values and snapshot-derived history.
  - Updated validation to recognize and verify snapshot-derived history changes.

- **Documentation**
  - Updated Jira field-history guidance to reflect revised event-ordering terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->