### PR TITLE
fix(gold): a commit has not landed on content the default branch already held

### DIFF
--- a/src/ingestion/gold/git_default_branch_commits.sql
+++ b/src/ingestion/gold/git_default_branch_commits.sql
@@ -22,7 +22,11 @@
 -- squash rewrites history, so the originals are unreachable from the default
 -- branch for good. The second half of this model reads the content instead: a
 -- change whose object id sits on a default-branch commit at the same path
--- landed, whichever commit carries it there.
+-- landed, whichever commit carries it there — unless the default branch
+-- already held that content when the commit was written, which makes the
+-- match no evidence about the commit at all. One change is enough and scope
+-- lives on the commit, so without that test a restored file carries a whole
+-- commit across. #3340
 --
 -- INVARIANT: content can only heal what SURVIVED into the default branch. A
 -- path a branch touched more than once keeps its intermediate versions
@@ -50,38 +54,63 @@ repository_default_branches AS (
     GROUP BY tenant_id, source_id, project_key, repo_slug
 ),
 
--- The content that reached the default branch, by path. Object ids only: a
--- source that reports none says nothing about where its content is, and an
--- empty identity would match every such row to every other.
+-- The content that reached the default branch, by path, and the FIRST time it
+-- got there. Object ids only: a source that reports none says nothing about
+-- where its content is, and an empty identity would match every such row to
+-- every other.
+--
+-- INVARIANT: the earliest carrier, so the comparison below reads "the default
+-- branch did not already hold this". A later carrier of content the branch
+-- already had proves nothing about a commit written in between, and taking the
+-- latest would let an unrelated trunk commit decide.
+--
+-- INVARIANT: committer_date over the author date, because that is when the
+-- object was written — a rebase and a cherry-pick both preserve the author
+-- date. It arrived on the class after the column it falls back to and is not
+-- backfilled, so a row synced before then answers with the author date.
 landed_content AS (
-    SELECT DISTINCT
+    SELECT
         landed_change.tenant_id AS tenant_id,
         landed_change.source_id AS source_id,
         landed_change.project_key AS project_key,
         landed_change.repo_slug AS repo_slug,
         landed_change.file_path AS file_path,
-        {{ git_file_content_identity('landed_change.post_image_oid', 'landed_change.pre_image_oid') }} AS content_identity
+        {{ git_file_content_identity('landed_change.post_image_oid', 'landed_change.pre_image_oid') }} AS content_identity,
+        min(coalesce(carrier.committer_date, carrier.date)) AS arrived_at
     FROM {{ ref('class_git_file_changes') }} AS landed_change FINAL
-    WHERE (landed_change.tenant_id, landed_change.source_id, landed_change.project_key, landed_change.repo_slug, landed_change.commit_hash) IN (
-        SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
-        FROM {{ ref('class_git_commits') }} FINAL
-        WHERE is_default_branch = 1
-    )
+    INNER JOIN {{ ref('class_git_commits') }} AS carrier FINAL
+        ON carrier.tenant_id IS NOT DISTINCT FROM landed_change.tenant_id
+        AND carrier.source_id IS NOT DISTINCT FROM landed_change.source_id
+        AND carrier.project_key = landed_change.project_key
+        AND carrier.repo_slug = landed_change.repo_slug
+        AND carrier.commit_hash = landed_change.commit_hash
+    WHERE carrier.is_default_branch = 1
       AND NOT (
           coalesce(landed_change.pre_image_oid, '') = ''
               AND coalesce(landed_change.post_image_oid, '') = ''
       )
+    GROUP BY
+        landed_change.tenant_id,
+        landed_change.source_id,
+        landed_change.project_key,
+        landed_change.repo_slug,
+        landed_change.file_path,
+        content_identity
 ),
--- The candidates: commits the default branch does not reach. Narrowing here
--- rather than filtering afterwards is what keeps a commit from matching its
--- own content and reporting itself as healed.
+-- The candidates: commits the default branch does not reach, each with the
+-- time it was written. Narrowing here rather than filtering afterwards is what
+-- keeps a commit from matching its own content and reporting itself as healed.
+--
+-- INVARIANT: a commit no source dated compares with nothing, and an unknown
+-- order promotes nothing — the comparison below is false for it.
 unlanded_commits AS (
     SELECT
         tenant_id,
         source_id,
         project_key,
         repo_slug,
-        commit_hash
+        commit_hash,
+        coalesce(committer_date, date) AS made_at
     FROM {{ ref('class_git_commits') }} FINAL
     WHERE coalesce(is_default_branch, 0) != 1
       AND is_merge_commit = 0
@@ -123,6 +152,12 @@ FROM (
         branch_change.repo_slug AS repo_slug,
         branch_change.commit_hash AS commit_hash
     FROM {{ ref('class_git_file_changes') }} AS branch_change FINAL
+    INNER JOIN unlanded_commits AS candidate
+        ON candidate.tenant_id IS NOT DISTINCT FROM branch_change.tenant_id
+        AND candidate.source_id IS NOT DISTINCT FROM branch_change.source_id
+        AND candidate.project_key = branch_change.project_key
+        AND candidate.repo_slug = branch_change.repo_slug
+        AND candidate.commit_hash = branch_change.commit_hash
     INNER JOIN landed_content AS landed
         ON landed.tenant_id IS NOT DISTINCT FROM branch_change.tenant_id
         AND landed.source_id IS NOT DISTINCT FROM branch_change.source_id
@@ -130,8 +165,5 @@ FROM (
         AND landed.repo_slug = branch_change.repo_slug
         AND landed.file_path = branch_change.file_path
         AND landed.content_identity = {{ git_file_content_identity('branch_change.post_image_oid', 'branch_change.pre_image_oid') }}
-    WHERE (branch_change.tenant_id, branch_change.source_id, branch_change.project_key, branch_change.repo_slug, branch_change.commit_hash) IN (
-        SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
-        FROM unlanded_commits
-    )
+    WHERE landed.arrived_at >= candidate.made_at
 )

--- a/src/ingestion/gold/git_default_branch_commits.sql
+++ b/src/ingestion/gold/git_default_branch_commits.sql
@@ -68,6 +68,11 @@ repository_default_branches AS (
 -- object was written — a rebase and a cherry-pick both preserve the author
 -- date. It arrived on the class after the column it falls back to and is not
 -- backfilled, so a row synced before then answers with the author date.
+--
+-- SAFETY: one undated carrier makes the whole arrival unknown. `min` SKIPS
+-- nulls, so without the guard an undated carrier would be invisible and a
+-- later dated one would answer for it — promoting a commit the default branch
+-- may well have preceded. Unknown must refuse, not guess.
 landed_content AS (
     SELECT
         landed_change.tenant_id AS tenant_id,
@@ -76,7 +81,11 @@ landed_content AS (
         landed_change.repo_slug AS repo_slug,
         landed_change.file_path AS file_path,
         {{ git_file_content_identity('landed_change.post_image_oid', 'landed_change.pre_image_oid') }} AS content_identity,
-        min(coalesce(carrier.committer_date, carrier.date)) AS arrived_at
+        if(
+            countIf(coalesce(carrier.committer_date, carrier.date) IS NULL) > 0,
+            CAST(NULL AS Nullable(DateTime)),
+            min(coalesce(carrier.committer_date, carrier.date))
+        ) AS arrived_at
     FROM {{ ref('class_git_file_changes') }} AS landed_change FINAL
     INNER JOIN {{ ref('class_git_commits') }} AS carrier FINAL
         ON carrier.tenant_id IS NOT DISTINCT FROM landed_change.tenant_id

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -158,7 +158,9 @@ models:
     description: >
       Commits that reached a repository's default branch, either through a
       merged pull request or by carrying content a default-branch commit also
-      carries at the same path: one row per tenant/source/project/repo/commit.
+      carries at the same path, unless the default branch already held that
+      content when the commit was written: one row per
+      tenant/source/project/repo/commit.
       Materialized so the membership joins run once per build in their own
       query budget; the git evidence build reads it as a semi-join set
       alongside the sync-time is_default_branch flag.

--- a/tests/datapath/metrics/git/git_branch_scope_content_order.test.yaml
+++ b/tests/datapath/metrics/git/git_branch_scope_content_order.test.yaml
@@ -1,0 +1,121 @@
+spec_version: 1
+description: >
+  Metric: git.non_default_branch_commits and its default-branch twin — the
+  order the content heal never checked, #3340.
+
+  How it's computed (bronze → silver → gold):
+    • bronze: one row per commit with the flag its connector set, and one row
+      per file it touched, carrying the object ids before and after
+    • silver: one class row per commit and per file change
+    • gold:   a commit counts on the default side when the flag says so, when
+      a request merged into the default branch lists it, or when one of its
+      changes has content the default branch holds and did NOT already hold
+      when the commit was written — the last of those is this spec's subject
+
+  The heal exists because a squash leaves its originals unreachable for good,
+  so reachability cannot answer "did this work land" and the content has to.
+  What it never asked is whether the trunk already held that content. One
+  change is enough and scope lives on the commit, so a restored file used to
+  carry a whole commit across, incidental files and all.
+
+  Thirteen commits, all heidi's, in one repository. Times are the same day and
+  each commit owns its own two-hour block, so a breakdown names which commit a
+  wrong rule moved rather than only shifting a total:
+
+    00 twice-early  flagged  twice.rs   W +2
+    02 tie-trunk    flagged  tie.rs     Z +3
+    02 tie-branch   branch   tie.rs     Z +3   the trunk holds that content at
+                                               the same instant, so the
+                                               comparison is inclusive: lands
+    04 trunk-first  flagged  shared.rs  X +6
+    06 clock-trunk  flagged  clock.rs   R +13  authored 06, WRITTEN 10
+    08 clock-work   branch   clock.rs   R +13  the carrier's author date
+                                               precedes it and its committer
+                                               date follows: lands
+    12 work         branch   feature.rs Y +5   the ordinary squash: lands
+    14 twice-work   branch   twice.rs   W +4   the trunk held W at 00 and takes
+                                               it again at 23 — the FIRST
+                                               arrival answers: does not land
+    16 restore      branch   shared.rs  X +8   the trunk held X twelve hours
+                            only.rs    U +9   earlier, so the match is no
+                                               evidence: does not land, and the
+                                               nine lines of only.rs stay with
+                                               it
+    18 carry-work   branch   carry.rs   P +7   one change matches later, the
+                            extra.rs   Q +11  other matches nothing at all:
+                                               lands, and all eighteen lines
+                                               cross with it
+    20 squash       flagged  feature.rs Y +5
+    21 carry-trunk  flagged  carry.rs   P +7
+    23 twice-late   flagged  twice.rs   W +2
+
+  So eleven commits land and two do not. Lines follow the earliest carrier of
+  each content, which puts 2 + 3 + 6 + 13 + 5 + 7 + 11 on the default side and
+  leaves only.rs alone on the other: restore's own copy of shared.rs loses the
+  dedup to the trunk commit that held it first. That is the shape of the harm —
+  the file that triggers a heal need not be the file whose lines move.
+
+  INVARIANT: tie-trunk and tie-branch must keep the SAME author AND committer
+  timestamps, and `bco-tie-branch` must keep sorting before `bco-tie-trunk`.
+  The timestamps are what make the comparison inclusive rather than strict;
+  the sha order is what decides which of the two tied carriers keeps the three
+  lines of tie.rs, and with it which side those lines are served on.
+
+  INVARIANT: clock-trunk is the only commit whose two dates differ, and it is
+  what tells the committer date from the author date. Equalize them and a rule
+  reading the author date passes.
+
+  INVARIANT: all three twice.rs rows carry the same pre-image id. Content
+  identity reads the post image alone, and this keeps the case from resting on
+  that.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: ../templates/people.yaml#/templates/heidi
+
+  bronze_github.branches:
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: bco-br-main, repository: "https://github.com/acme/border.git", name: main, head_sha: head-main, is_default: true}
+
+  bronze_github.commits:
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-twice-early, repository: "https://github.com/acme/border.git", sha: bco-twice-early, authored_date: "2026-10-01T00:00:00Z", committed_date: "2026-10-01T00:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 2, changed_files: 1, is_in_default_branch: true}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-tie-trunk, repository: "https://github.com/acme/border.git", sha: bco-tie-trunk, authored_date: "2026-10-01T02:00:00Z", committed_date: "2026-10-01T02:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 3, changed_files: 1, is_in_default_branch: true}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-tie-branch, repository: "https://github.com/acme/border.git", sha: bco-tie-branch, authored_date: "2026-10-01T02:00:00Z", committed_date: "2026-10-01T02:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 3, changed_files: 1, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-trunk-first, repository: "https://github.com/acme/border.git", sha: bco-trunk-first, authored_date: "2026-10-01T04:00:00Z", committed_date: "2026-10-01T04:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 6, changed_files: 1, is_in_default_branch: true}
+    # The one commit whose two dates differ: written four hours after it was
+    # authored, which is what a rebase or a cherry-pick onto the trunk does.
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-clock-trunk, repository: "https://github.com/acme/border.git", sha: bco-clock-trunk, authored_date: "2026-10-01T06:00:00Z", committed_date: "2026-10-01T10:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 13, changed_files: 1, is_in_default_branch: true}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-clock-work, repository: "https://github.com/acme/border.git", sha: bco-clock-work, authored_date: "2026-10-01T08:00:00Z", committed_date: "2026-10-01T08:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 13, changed_files: 1, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-work, repository: "https://github.com/acme/border.git", sha: bco-work, authored_date: "2026-10-01T12:00:00Z", committed_date: "2026-10-01T12:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 5, changed_files: 1, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-twice-work, repository: "https://github.com/acme/border.git", sha: bco-twice-work, authored_date: "2026-10-01T14:00:00Z", committed_date: "2026-10-01T14:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 4, changed_files: 1, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-restore, repository: "https://github.com/acme/border.git", sha: bco-restore, authored_date: "2026-10-01T16:00:00Z", committed_date: "2026-10-01T16:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 17, changed_files: 2, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-carry-work, repository: "https://github.com/acme/border.git", sha: bco-carry-work, authored_date: "2026-10-01T18:00:00Z", committed_date: "2026-10-01T18:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 18, changed_files: 2, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-squash, repository: "https://github.com/acme/border.git", sha: bco-squash, authored_date: "2026-10-01T20:00:00Z", committed_date: "2026-10-01T20:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 5, changed_files: 1, is_in_default_branch: true}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-carry-trunk, repository: "https://github.com/acme/border.git", sha: bco-carry-trunk, authored_date: "2026-10-01T21:00:00Z", committed_date: "2026-10-01T21:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 7, changed_files: 1, is_in_default_branch: true}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-twice-late, repository: "https://github.com/acme/border.git", sha: bco-twice-late, authored_date: "2026-10-01T23:00:00Z", committed_date: "2026-10-01T23:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 2, changed_files: 1, is_in_default_branch: true}
+
+  bronze_github.file_changes:
+    # src/twice.rs — the trunk holds content W first, and holds it again last.
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-twice-early, repository: "https://github.com/acme/border.git", sha: bco-twice-early, filename: src/twice.rs, status: modified, additions: 2, deletions: 0, pre_image_oid: bc0000000000000000000000000000000000000v, post_image_oid: bc0000000000000000000000000000000000000w}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-twice-work, repository: "https://github.com/acme/border.git", sha: bco-twice-work, filename: src/twice.rs, status: modified, additions: 4, deletions: 0, pre_image_oid: bc0000000000000000000000000000000000000v, post_image_oid: bc0000000000000000000000000000000000000w}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-twice-late, repository: "https://github.com/acme/border.git", sha: bco-twice-late, filename: src/twice.rs, status: modified, additions: 2, deletions: 0, pre_image_oid: bc0000000000000000000000000000000000000v, post_image_oid: bc0000000000000000000000000000000000000w}
+    # src/tie.rs — the trunk holds this content at the branch commit's instant.
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-tie-trunk, repository: "https://github.com/acme/border.git", sha: bco-tie-trunk, filename: src/tie.rs, status: modified, additions: 3, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000z}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-tie-branch, repository: "https://github.com/acme/border.git", sha: bco-tie-branch, filename: src/tie.rs, status: modified, additions: 3, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000z}
+    # src/shared.rs — the trunk holds content X first; the branch restores it.
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-shared-trunk, repository: "https://github.com/acme/border.git", sha: bco-trunk-first, filename: src/shared.rs, status: modified, additions: 6, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000x}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-shared-restore, repository: "https://github.com/acme/border.git", sha: bco-restore, filename: src/shared.rs, status: modified, additions: 8, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000x}
+    # The file that rides along with the restore and nothing else carries: its
+    # lines are what a false landing moves.
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-only, repository: "https://github.com/acme/border.git", sha: bco-restore, filename: src/only.rs, status: added, additions: 9, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000u}
+    # src/clock.rs — the carrier's author date precedes the branch commit, its
+    # committer date follows.
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-clock-trunk, repository: "https://github.com/acme/border.git", sha: bco-clock-trunk, filename: src/clock.rs, status: modified, additions: 13, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000r}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-clock-work, repository: "https://github.com/acme/border.git", sha: bco-clock-work, filename: src/clock.rs, status: modified, additions: 13, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000r}
+    # src/feature.rs — the ordinary squash: the trunk gets it afterwards.
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-feature-work, repository: "https://github.com/acme/border.git", sha: bco-work, filename: src/feature.rs, status: added, additions: 5, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000y}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-feature-squash, repository: "https://github.com/acme/border.git", sha: bco-squash, filename: src/feature.rs, status: modified, additions: 5, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000y}
+    # src/carry.rs matches the trunk later; src/extra.rs matches nothing. One
+    # of the two is enough, and both files' lines cross.
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-carry-work, repository: "https://github.com/acme/border.git", sha: bco-carry-work, filename: src/carry.rs, status: added, additions: 7, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000p}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-extra, repository: "https://github.com/acme/border.git", sha: bco-carry-work, filename: src/extra.rs, status: added, additions: 11, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000q}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-carry-trunk, repository: "https://github.com/acme/border.git", sha: bco-carry-trunk, filename: src/carry.rs, status: modified, additions: 7, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000p}

--- a/tests/datapath/metrics/git/git_branch_scope_content_order.test.yaml
+++ b/tests/datapath/metrics/git/git_branch_scope_content_order.test.yaml
@@ -48,8 +48,19 @@ description: >
     20 squash       flagged  feature.rs Y +5
     21 carry-trunk  flagged  carry.rs   P +7
     23 twice-late   flagged  twice.rs   W +2
+    -- blind-undated  flagged  blind.rs   S +21  neither date parses
+    10 blind-work    branch   blind.rs   S +21  one carrier of that content is
+                                               undated, so the arrival is
+                                               unknown and refuses: does not
+                                               land
+    22 blind-later   flagged  blind.rs   S +21  dated after blind-work, and on
+                                               its own it would promote
 
-  So eleven commits land and two do not. Lines follow the earliest carrier of
+  So twelve commits land and three do not — the undated carrier reaches no
+  commit measure at all, because a commit no source dated is not an authored
+  commit.
+
+  Twelve and three, not eleven and two: Lines follow the earliest carrier of
   each content, which puts 2 + 3 + 6 + 13 + 5 + 7 + 11 on the default side and
   leaves only.rs alone on the other: restore's own copy of shared.rs loses the
   dedup to the trunk commit that held it first. That is the shape of the harm —
@@ -68,6 +79,11 @@ description: >
   INVARIANT: all three twice.rs rows carry the same pre-image id. Content
   identity reads the post image alone, and this keeps the case from resting on
   that.
+
+  INVARIANT: blind-undated must keep BOTH dates unparseable, and blind-later must
+  stay dated after blind-work. An aggregate over arrival times skips nulls, so
+  it is blind-later that would answer for the content and promote blind-work;
+  date blind-undated and the case proves nothing.
 
 bronze:
   bronze_bamboohr.employees:
@@ -91,6 +107,14 @@ bronze:
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-carry-work, repository: "https://github.com/acme/border.git", sha: bco-carry-work, authored_date: "2026-10-01T18:00:00Z", committed_date: "2026-10-01T18:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 18, changed_files: 2, is_in_default_branch: false}
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-squash, repository: "https://github.com/acme/border.git", sha: bco-squash, authored_date: "2026-10-01T20:00:00Z", committed_date: "2026-10-01T20:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 5, changed_files: 1, is_in_default_branch: true}
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-carry-trunk, repository: "https://github.com/acme/border.git", sha: bco-carry-trunk, authored_date: "2026-10-01T21:00:00Z", committed_date: "2026-10-01T21:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 7, changed_files: 1, is_in_default_branch: true}
+    # Neither date parses, so the class has none: the arrival of its content is
+    # unknown, and unknown has to refuse rather than let the later carrier
+    # below answer instead. It is not an authored commit either, so it reaches
+    # no commit measure. The cursor field is never absent in bronze, so an
+    # empty string is what a date the source could not give looks like.
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-blind-undated, repository: "https://github.com/acme/border.git", sha: bco-blind-undated, authored_date: null, committed_date: "", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 21, changed_files: 1, is_in_default_branch: true}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-blind-work, repository: "https://github.com/acme/border.git", sha: bco-blind-work, authored_date: "2026-10-01T10:00:00Z", committed_date: "2026-10-01T10:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 21, changed_files: 1, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-blind-later, repository: "https://github.com/acme/border.git", sha: bco-blind-later, authored_date: "2026-10-01T22:00:00Z", committed_date: "2026-10-01T22:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 21, changed_files: 1, is_in_default_branch: true}
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: bco-twice-late, repository: "https://github.com/acme/border.git", sha: bco-twice-late, authored_date: "2026-10-01T23:00:00Z", committed_date: "2026-10-01T23:00:00Z", author_name: heidi, author_email: heidi@example.com, committer_name: heidi, committer_email: heidi@example.com, additions: 2, changed_files: 1, is_in_default_branch: true}
 
   bronze_github.file_changes:
@@ -118,4 +142,9 @@ bronze:
     # of the two is enough, and both files' lines cross.
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-carry-work, repository: "https://github.com/acme/border.git", sha: bco-carry-work, filename: src/carry.rs, status: added, additions: 7, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000p}
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-extra, repository: "https://github.com/acme/border.git", sha: bco-carry-work, filename: src/extra.rs, status: added, additions: 11, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000q}
+    # src/blind.rs — three carriers of one content, and the earliest of them
+    # is the one nobody dated.
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-blind-undated, repository: "https://github.com/acme/border.git", sha: bco-blind-undated, filename: src/blind.rs, status: modified, additions: 21, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000s}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-blind-work, repository: "https://github.com/acme/border.git", sha: bco-blind-work, filename: src/blind.rs, status: modified, additions: 21, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000s}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-blind-later, repository: "https://github.com/acme/border.git", sha: bco-blind-later, filename: src/blind.rs, status: modified, additions: 21, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000s}
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: bco-f-carry-trunk, repository: "https://github.com/acme/border.git", sha: bco-carry-trunk, filename: src/carry.rs, status: modified, additions: 7, deletions: 0, post_image_oid: bc0000000000000000000000000000000000000p}

--- a/tests/datapath/metrics/git/test_git_branch_scope_content_order.py
+++ b/tests/datapath/metrics/git/test_git_branch_scope_content_order.py
@@ -30,9 +30,9 @@ LANDED_BLOCKS = (
     ("12", 1),
     ("18", 1),
     ("20", 2),
-    ("22", 1),
+    ("22", 2),
 )
-UNLANDED_BLOCKS = (("14", 1), ("16", 1))
+UNLANDED_BLOCKS = (("10", 1), ("14", 1), ("16", 1))
 
 
 def hour_block(value: str) -> dict[str, str]:
@@ -42,10 +42,11 @@ def hour_block(value: str) -> dict[str, str]:
 def test_a_commit_restoring_content_the_trunk_already_held_has_not_landed(
     spec: SpecRun,
 ) -> None:
-    """Eleven of the thirteen commits land. The two that do not each match content the
-    trunk took earlier — one restoring it, one repeating a state the trunk holds both
-    before and after. Before the ordering both read as landed and the other side
-    reported nothing at all."""
+    """Twelve of the fifteen commits land. The three that do not each fail the ordering
+    a different way: one restores content the trunk took earlier, one repeats a state the
+    trunk holds both before and after, and one matches content whose earliest carrier the
+    source never dated. A sixteenth commit is that undated carrier, and it reaches no
+    commit measure at all — a commit nobody dated is not an authored commit."""
     r = spec.call(
         {
             "url": "/v1/metric-results",
@@ -63,15 +64,15 @@ def test_a_commit_restoring_content_the_trunk_already_held_has_not_landed(
     )
     assert r.status == 200
 
-    r.row("git.default_branch_commits", "period", entity_id=HEIDI).equals(value=11)
-    r.row("git.non_default_branch_commits", "period", entity_id=HEIDI).equals(value=2)
-    r.row("git.commits", "period", entity_id=HEIDI).equals(value=13)
+    r.row("git.default_branch_commits", "period", entity_id=HEIDI).equals(value=12)
+    r.row("git.non_default_branch_commits", "period", entity_id=HEIDI).equals(value=3)
+    r.row("git.commits", "period", entity_id=HEIDI).equals(value=15)
 
 
 def test_only_the_commits_the_trunk_preceded_report_not_landing(spec: SpecRun) -> None:
     """The hour block names the commit, so a rule that moved the wrong one is not merely
-    a different total: 14 repeats content the trunk already had, 16 restores it, and
-    nothing else may appear."""
+    a different total: 10 matches content with an undated carrier, 14 repeats content the
+    trunk already had, 16 restores it, and nothing else may appear."""
     r = spec.call(
         {
             "url": "/v1/metric-results",
@@ -107,7 +108,9 @@ def test_each_landing_rule_carries_its_own_commit(spec: SpecRun) -> None:
     """One block per commit that landed. 02 is the inclusive boundary, beside the trunk
     commit it ties with; 08 is the commit whose carrier was AUTHORED before it and
     WRITTEN after, which only the committer date answers for; 12 is the ordinary squash;
-    18 is the commit one of whose two changes matches nothing."""
+    18 is the commit one of whose two changes matches nothing. 22 holds two: the trunk
+    commit that takes back a content it already had, and the dated carrier that would
+    promote block 10 if the undated carrier beside it were skipped rather than obeyed."""
     r = spec.call(
         {
             "url": "/v1/metric-results",
@@ -146,8 +149,9 @@ def test_the_lines_of_a_commit_follow_the_side_the_commit_itself_is_on(
     """The file that triggers a heal need not be the file whose lines move. src/extra.rs
     matches nothing on the trunk and its eleven lines still cross, because the commit
     beside it does; src/only.rs is the same shape on the losing side and its nine lines
-    stay. The restore's own copy of src/shared.rs loses the content dedup to the trunk
-    commit that held it first, so it contributes nothing either way."""
+    stay, as do the twenty-one of src/blind.rs. The restore's own copy of src/shared.rs
+    loses the content dedup to the trunk commit that held it first, so it contributes
+    nothing either way."""
     r = spec.call(
         {
             "url": "/v1/metric-results",
@@ -169,5 +173,5 @@ def test_the_lines_of_a_commit_follow_the_side_the_commit_itself_is_on(
     assert r.status == 200
 
     r.row("git.default_branch_code_lines", "period", entity_id=HEIDI).equals(value=47)
-    r.row("git.non_default_branch_code_lines", "period", entity_id=HEIDI).equals(value=9)
-    r.row("git.code_lines", "period", entity_id=HEIDI).equals(value=56)
+    r.row("git.non_default_branch_code_lines", "period", entity_id=HEIDI).equals(value=30)
+    r.row("git.code_lines", "period", entity_id=HEIDI).equals(value=77)

--- a/tests/datapath/metrics/git/test_git_branch_scope_content_order.py
+++ b/tests/datapath/metrics/git/test_git_branch_scope_content_order.py
@@ -1,0 +1,173 @@
+"""A commit lands on the default branch only if the trunk did not already hold its content.
+
+The content heal answers "did this work land" where reachability cannot, because a squash
+leaves its originals unreachable for good. It compares a change's object id at a path
+against the default branch's own changes — and it has to ask whether the trunk already
+held that content, because then the match says nothing about this commit. One change is
+enough and branch scope lives on the commit, so a restored file used to carry the whole
+commit across, incidental files and all. #3340
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_datapath.metric_expect import some
+from insight_datapath.spec_runner import SpecRun
+
+pytestmark = pytest.mark.fixture
+
+SPEC = "git_branch_scope_content_order"
+
+HEIDI = "heidi@example.com"
+PERIOD = {"from": "2026-10-01", "to": "2026-10-02"}
+
+LANDED_BLOCKS = (
+    ("00", 1),
+    ("02", 2),
+    ("04", 1),
+    ("06", 1),
+    ("08", 1),
+    ("12", 1),
+    ("18", 1),
+    ("20", 2),
+    ("22", 1),
+)
+UNLANDED_BLOCKS = (("14", 1), ("16", 1))
+
+
+def hour_block(value: str) -> dict[str, str]:
+    return {"key": "hour_block", "value": value}
+
+
+def test_a_commit_restoring_content_the_trunk_already_held_has_not_landed(
+    spec: SpecRun,
+) -> None:
+    """Eleven of the thirteen commits land. The two that do not each match content the
+    trunk took earlier — one restoring it, one repeating a state the trunk holds both
+    before and after. Before the ordering both read as landed and the other side
+    reported nothing at all."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [HEIDI]},
+                "period": PERIOD,
+                "metrics": [
+                    {"metric_key": "git.default_branch_commits", "views": [{"view": "period"}]},
+                    {"metric_key": "git.non_default_branch_commits", "views": [{"view": "period"}]},
+                    {"metric_key": "git.commits", "views": [{"view": "period"}]},
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.default_branch_commits", "period", entity_id=HEIDI).equals(value=11)
+    r.row("git.non_default_branch_commits", "period", entity_id=HEIDI).equals(value=2)
+    r.row("git.commits", "period", entity_id=HEIDI).equals(value=13)
+
+
+def test_only_the_commits_the_trunk_preceded_report_not_landing(spec: SpecRun) -> None:
+    """The hour block names the commit, so a rule that moved the wrong one is not merely
+    a different total: 14 repeats content the trunk already had, 16 restores it, and
+    nothing else may appear."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [HEIDI]},
+                "period": PERIOD,
+                "metrics": [
+                    {
+                        "metric_key": "git.non_default_branch_commits",
+                        "views": [{"view": "breakdown", "dimensions": ["hour_block"]}],
+                    }
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    for block, commits in UNLANDED_BLOCKS:
+        r.row(
+            "git.non_default_branch_commits",
+            "breakdown",
+            entity_id=HEIDI,
+            dimensions=hour_block(block),
+        ).equals(value=commits)
+
+    assert len(r.breakdown("git.non_default_branch_commits")) == len(UNLANDED_BLOCKS), (
+        "those two commits are the only ones that did not land"
+    )
+
+
+def test_each_landing_rule_carries_its_own_commit(spec: SpecRun) -> None:
+    """One block per commit that landed. 02 is the inclusive boundary, beside the trunk
+    commit it ties with; 08 is the commit whose carrier was AUTHORED before it and
+    WRITTEN after, which only the committer date answers for; 12 is the ordinary squash;
+    18 is the commit one of whose two changes matches nothing."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [HEIDI]},
+                "period": PERIOD,
+                "metrics": [
+                    {
+                        "metric_key": "git.default_branch_commits",
+                        "views": [{"view": "breakdown", "dimensions": ["hour_block"]}],
+                    }
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    for block, commits in LANDED_BLOCKS:
+        r.row(
+            "git.default_branch_commits",
+            "breakdown",
+            entity_id=HEIDI,
+            dimensions=hour_block(block),
+        ).equals(value=commits)
+
+    for block, _ in UNLANDED_BLOCKS:
+        assert not some(r.breakdown("git.default_branch_commits"), dimensions=hour_block(block)), (
+            f"the commit in block {block} did not land"
+        )
+
+
+def test_the_lines_of_a_commit_follow_the_side_the_commit_itself_is_on(
+    spec: SpecRun,
+) -> None:
+    """The file that triggers a heal need not be the file whose lines move. src/extra.rs
+    matches nothing on the trunk and its eleven lines still cross, because the commit
+    beside it does; src/only.rs is the same shape on the losing side and its nine lines
+    stay. The restore's own copy of src/shared.rs loses the content dedup to the trunk
+    commit that held it first, so it contributes nothing either way."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [HEIDI]},
+                "period": PERIOD,
+                "metrics": [
+                    {"metric_key": "git.default_branch_code_lines", "views": [{"view": "period"}]},
+                    {
+                        "metric_key": "git.non_default_branch_code_lines",
+                        "views": [{"view": "period"}],
+                    },
+                    {"metric_key": "git.code_lines", "views": [{"view": "period"}]},
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.default_branch_code_lines", "period", entity_id=HEIDI).equals(value=47)
+    r.row("git.non_default_branch_code_lines", "period", entity_id=HEIDI).equals(value=9)
+    r.row("git.code_lines", "period", entity_id=HEIDI).equals(value=56)


### PR DESCRIPTION
A commit read as having reached the default branch whenever any one of its files happened to hold content the default branch also holds — with no question of **whether the branch already held it**. So restoring a file to the state the trunk already has, copying a file across from the trunk, or reverting your own edit was enough to mark the commit as landed. One incidental file was enough, and the whole commit went with it: every file, every line.

The comparison now takes the first time that content reached the default branch and refuses a match the branch already carried. A squash or a fast-forward is unaffected — there the content arrives afterwards, which is the whole reason the rule exists.

Which reading to use was settled by calibration against the commits whose landing a merged pull request proves on its own: taking the latest arrival instead of the first, or the author date instead of the committer date, each discriminates worse at the same cost on that population.

**Historical figures move**: the four default-branch metrics read slightly lower, the four non-default ones slightly higher, and the `branch_scope` breakdown with them. The unscoped totals — commits, lines, code lines — do not move, because only the split does. Gold only: no migration, no descriptor bump, no re-ingestion.

Found while validating `git.non_default_branch_commits` (#3059). Closes #3340.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved branch-scope metrics to identify when commits first reach the default branch.
  - Prevented commits from being counted as landed when their content was already present before they were written.
  - Improved handling of undated commits, timestamp ordering, repeated or restored content, squash merges, and multi-file commits.
  - Improved attribution of code lines to the correct commit side.

- **Documentation**
  - Clarified the rules used to determine whether commits are counted as landed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->