### PR TITLE
test(metrics): pin where a commit's reported size goes when its branch has not landed

### DIFF
--- a/tests/datapath/metrics/git/git_uncollected_file_changes.test.yaml
+++ b/tests/datapath/metrics/git/git_uncollected_file_changes.test.yaml
@@ -7,7 +7,10 @@ description: >-
   nothing, so his size reads zero rather than absent — the two cases a blank
   cell used to share. carol draws the boundary from the other side: her second
   commit's change WAS collected and then lost the content dedup, which is not
-  the same thing as never arriving.
+  the same thing as never arriving. dave carries alice's pair again on a
+  branch that has NOT landed, which is where the reported size has to reach
+  the branch-scoped line measures and stay out of the branch-scoped code one —
+  the halves of that rule nothing else exercises.
 
   Commit size reads the same corrected numbers: alice's sizes are {11, 22}
   (median 22 — quantileExact(0.5) on an even count takes the upper middle),
@@ -15,11 +18,17 @@ description: >-
   part of its own stats the dedup did not remove: 26 reported less the 11
   deduplicated lines is 15, so her median over {11, 15} is 15.
 
+  INVARIANT: dave's commits must stay on the other side of the branch split —
+  no default-branch flag, no merged request listing them, and no change whose
+  content a default-branch commit also holds. Any of the three promotes them
+  and his case stops being about the non-default side at all.
+
 bronze:
   bronze_bamboohr.employees:
     - $ref: ../templates/people.yaml#/templates/alice
     - $ref: ../templates/people.yaml#/templates/bob
     - $ref: ../templates/people.yaml#/templates/carol
+    - $ref: ../templates/people.yaml#/templates/dave
   bronze_github.branches:
     - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: br-main, repository: "https://github.com/constructor/insight.git", name: main, head_sha: head-main, is_default: true}
   bronze_github.commits:
@@ -33,6 +42,9 @@ bronze:
     # would hand it that difference as an uncollected size.
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-carol-first, sha: sha-carol-first, authored_date: "2026-10-01T09:00:00Z", committed_date: "2026-10-01T09:00:00Z", author_name: carol, author_email: carol@example.com, committer_name: carol, committer_email: carol@example.com, additions: 10, deletions: 1, is_in_default_branch: true}
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-carol-repeat, sha: sha-carol-repeat, authored_date: "2026-10-01T15:00:00Z", committed_date: "2026-10-01T15:00:00Z", author_name: carol, author_email: carol@example.com, committer_name: carol, committer_email: carol@example.com, additions: 25, deletions: 1, is_in_default_branch: true}
+    # dave: alice's pair again, on a branch that has not landed.
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-dave-detailed, sha: sha-dave-detailed, authored_date: "2026-10-01T10:00:00Z", committed_date: "2026-10-01T10:00:00Z", author_name: dave, author_email: dave@example.com, committer_name: dave, committer_email: dave@example.com, additions: 12, deletions: 3, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-dave-uncollected, sha: sha-dave-uncollected, authored_date: "2026-10-01T11:00:00Z", committed_date: "2026-10-01T11:00:00Z", author_name: dave, author_email: dave@example.com, committer_name: dave, committer_email: dave@example.com, additions: 30, deletions: 4, is_in_default_branch: false}
   bronze_github.file_changes:
     # Only alice's first commit. `.rs` under src/ classifies as code, so Code
     # lines reads off this row alone.
@@ -41,3 +53,6 @@ bronze:
     # later one loses the content dedup — collected, then deduplicated away.
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-carol-first, sha: sha-carol-first, filename: src/shared.rs, additions: 10, deletions: 1, pre_image_oid: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee5, post_image_oid: fffffffffffffffffffffffffffffffffffffff6}
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-carol-repeat, sha: sha-carol-repeat, filename: src/shared.rs, additions: 10, deletions: 1, pre_image_oid: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee5, post_image_oid: fffffffffffffffffffffffffffffffffffffff6}
+    # dave's first commit only. Its content is his alone, so nothing on the
+    # default branch matches it and his flag decides the split.
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-dave-detailed, sha: sha-dave-detailed, filename: src/dave.rs, additions: 12, deletions: 3, pre_image_oid: dddddddddddddddddddddddddddddddddddddd11, post_image_oid: dddddddddddddddddddddddddddddddddddddd12}

--- a/tests/datapath/metrics/git/test_git_uncollected_file_changes.py
+++ b/tests/datapath/metrics/git/test_git_uncollected_file_changes.py
@@ -20,6 +20,9 @@ SPEC = "git_uncollected_file_changes"
 ALICE = "alice@example.com"
 BOB = "bob@example.com"
 CAROL = "carol@example.com"
+DAVE = "dave@example.com"
+
+REPOSITORY = "git-test:constructor/insight"
 
 
 def test_a_commit_with_no_file_changes_still_reports_its_own_size(spec: SpecRun) -> None:
@@ -140,3 +143,97 @@ def test_commit_that_lost_the_content_dedup_is_not_treated_as_uncollected(spec: 
     assert unknown_grain == []
 
     r.row("git.commit_size", "period", entity_id=CAROL).equals(value=15)
+
+
+def test_an_uncollected_size_on_a_branch_reaches_the_lines_but_not_the_code_lines(
+    spec: SpecRun,
+) -> None:
+    """dave's pair sits on a branch that has not landed. The commit whose diff never
+    arrived carries its reported size into the branch-scoped line measures under the
+    unknown grain, and contributes nothing to the branch-scoped code lines, which count
+    only the file whose category is known. The default side of every pair is absent, not
+    zero."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [DAVE]},
+                "period": {"from": "2026-10-01", "to": "2026-10-02"},
+                "metrics": [
+                    {"metric_key": "git.non_default_branch_commits", "views": [{"view": "period"}]},
+                    {
+                        "metric_key": "git.non_default_branch_lines_added",
+                        "views": [
+                            {"view": "period"},
+                            {"view": "breakdown", "dimensions": ["category"]},
+                        ],
+                    },
+                    {
+                        "metric_key": "git.non_default_branch_lines_removed",
+                        "views": [{"view": "period"}],
+                    },
+                    {
+                        "metric_key": "git.non_default_branch_code_lines",
+                        "views": [{"view": "period"}],
+                    },
+                    {"metric_key": "git.default_branch_lines_added", "views": [{"view": "period"}]},
+                    {"metric_key": "git.default_branch_code_lines", "views": [{"view": "period"}]},
+                    {"metric_key": "git.lines_added", "views": [{"view": "period"}]},
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.non_default_branch_commits", "period", entity_id=DAVE).equals(value=2)
+    r.row("git.non_default_branch_lines_added", "period", entity_id=DAVE).equals(value=42)
+    r.row("git.non_default_branch_lines_removed", "period", entity_id=DAVE).equals(value=7)
+    r.row("git.non_default_branch_code_lines", "period", entity_id=DAVE).equals(value=12)
+    r.row("git.lines_added", "period", entity_id=DAVE).equals(value=42)
+
+    for category, lines in (("code", 12), ("__unknown__", 30)):
+        r.row(
+            "git.non_default_branch_lines_added",
+            "breakdown",
+            entity_id=DAVE,
+            dimensions={"key": "category", "value": category},
+        ).equals(value=lines)
+
+    r.row("git.default_branch_lines_added", "period", entity_id=DAVE).equals(value=None)
+    r.row("git.default_branch_code_lines", "period", entity_id=DAVE).equals(value=None)
+
+
+def test_an_uncollected_size_files_under_the_same_repository_as_the_rows_beside_it(
+    spec: SpecRun,
+) -> None:
+    """The reported size is built from a different dimension tuple than the file-derived
+    rows, and a key missing from it would split one repository into two — so the whole of
+    dave's branch total has to arrive under a single repository."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [DAVE]},
+                "period": {"from": "2026-10-01", "to": "2026-10-02"},
+                "metrics": [
+                    {
+                        "metric_key": "git.non_default_branch_lines_added",
+                        "views": [{"view": "breakdown", "dimensions": ["repository"]}],
+                    }
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row(
+        "git.non_default_branch_lines_added",
+        "breakdown",
+        entity_id=DAVE,
+        dimensions={"key": "repository", "value": REPOSITORY},
+    ).equals(value=42)
+    assert len(r.breakdown("git.non_default_branch_lines_added")) == 1, (
+        "one repository, so one row — a key missing from either tuple would split it"
+    )


### PR DESCRIPTION
A commit whose file changes never reached the warehouse still reports the size its source gave, filed under an unknown file grain. Where that size is allowed to land was asserted for the default branch only — every commit in the fixture carried the default-branch flag — so the branch-scoped half of the rule was unasserted in both directions: the size reaching **Lines added** and **Lines removed** while **Code lines** counts only the files whose category is actually known.

A fourth person now carries the same pair on a branch that has not landed, and two cases pin it: the reported size reaching the branch-scoped line measures and staying out of the branch-scoped code one, with the default side of each pair absent rather than zero; and the whole branch total arriving under a single repository, which is the invariant the model states about those rows carrying the same dimension keys as the file-derived ones.

Each of three mutations turns the new cases red while the four that existed stay green: routing the reported size into the branch-scoped code measure, dropping its branch-scoped emission altogether, and removing one key from its dimension tuple — that last one failing only the repository case.

Tests only, no product change. Closes the coverage gap named on #3058, #3060 and #3061.
