### PR TITLE
fix(github, bitbucket-cloud): resolve only the commit authors active since the last sync, and keep future-dated commits out of the cursors

### DIFF
--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -692,6 +692,10 @@ streams:
       type: DatetimeBasedCursor
       cursor_field: committed_date
       datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      # A future-dated commit would otherwise become the cursor and silence the
+      # stream: a `since` past now yields no slice on every later sync. Bounding
+      # records client-side drops such a row before the cursor observes it.
+      is_client_side_incremental: true
       # `git log --since` is a traversal cutoff: after a rebase the
       # replacement commits can carry dates BELOW the stored cursor and
       # would never be visited again. Re-enumerating one window each
@@ -886,6 +890,10 @@ streams:
       type: DatetimeBasedCursor
       cursor_field: committed_date
       datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      # A future-dated commit would otherwise become the cursor and silence the
+      # stream: a `since` past now yields no slice on every later sync. Bounding
+      # records client-side drops such a row before the cursor observes it.
+      is_client_side_incremental: true
       # `git log --since` is a traversal cutoff: after a rebase the
       # replacement commits can carry dates BELOW the stored cursor and
       # would never be visited again. Re-enumerating one window each
@@ -3375,8 +3383,9 @@ streams:
           - type: ParentStreamConfig
             parent_key: sample_sha
             partition_field: commit_sha
-            # INVARIANT: the parent's `since` cursor persists only because this child
-            # is itself incremental; the CDK seeds parent state from the child's.
+            # `incremental_dependency` keeps the sync proportional to activity:
+            # the author list's `since` persists only because this child is
+            # itself incremental.
             incremental_dependency: true
             extra_fields:
               - [repo_full_name]
@@ -3502,6 +3511,14 @@ streams:
                 cursor_datetime_formats:
                   - "%Y-%m-%dT%H:%M:%S%z"
                   - "%Y-%m-%dT%H:%M:%SZ"
+                # A future-dated commit would otherwise become the cursor and silence the
+                # stream: a `since` past now yields no slice on every later sync. Bounding
+                # records client-side drops such a row before the cursor observes it.
+                is_client_side_incremental: true
+                # An author's last commit can predate its push by days, and another
+                # author's push moves `since` past it in the meantime. Re-listing one
+                # window each sync recovers them; bronze dedups the re-read rows.
+                lookback_window: "P1M"
                 # An author already resolved keeps their claim, so a later sync
                 # only needs the ones who have committed since — which is what
                 # keeps this O(active authors) rather than O(authors).
@@ -3527,6 +3544,11 @@ streams:
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
         - "%Y-%m-%dT%H:%M:%SZ"
+      # The partition is one author's sample commit and changes with every
+      # commit, so per-partition state would grow by one entry per (repository,
+      # author) and never shrink. Nothing reads this cursor's value; it exists so
+      # the parent's `since` persists.
+      global_substream_cursor: true
       start_datetime:
         type: MinMaxDatetime
         datetime: "{{ config['bitbucket_start_date'] }}"

--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -3312,6 +3312,7 @@ streams:
           author_nickname: {type: [string, "null"]}
           author_display_name: {type: [string, "null"]}
           sample_sha: {type: [string, "null"]}
+          last_committed_date: {type: [string, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -3374,9 +3375,13 @@ streams:
           - type: ParentStreamConfig
             parent_key: sample_sha
             partition_field: commit_sha
+            # INVARIANT: the parent's `since` cursor persists only because this child
+            # is itself incremental; the CDK seeds parent state from the child's.
+            incremental_dependency: true
             extra_fields:
               - [repo_full_name]
               - [author_email]
+              - [last_committed_date]
             stream:
               type: DeclarativeStream
               name: repository_authors
@@ -3515,6 +3520,17 @@ streams:
                       path: [repo_full_name]
                       value: "{{ stream_slice.extra_fields['full_name'] }}"
                       value_type: string
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: last_committed_date
+      datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config['bitbucket_start_date'] }}"
+        datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
         fields:
@@ -3544,6 +3560,10 @@ streams:
           - type: AddedFieldDefinition
             path: [sample_sha]
             value: "{{ stream_partition.commit_sha }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [last_committed_date]
+            value: "{{ stream_slice.extra_fields['last_committed_date'] }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [author_account_id]

--- a/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
@@ -41,7 +41,7 @@ name: bitbucket-cloud
 #   major bump dispatches re-materializes them. Safe: the merge hash and the
 #   commits have been in Bronze all along, and a request the activity does
 #   date is untouched. #3051
-version: "7.1.0"
+version: "7.2.0"
 # A slot of its own: replication pods sharing a slot with other connector
 # syncs can be starved of workers, which surfaces as startup and activity
 # timeouts rather than as a connector error.

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
@@ -17,7 +17,7 @@ import json
 from collections.abc import Iterable
 from datetime import datetime
 from typing import Any
-from urllib.parse import unquote_plus
+from urllib.parse import parse_qs, unquote_plus, urlparse
 
 import freezegun
 import pytest
@@ -38,7 +38,11 @@ _FROZEN = "2026-07-01T00:00:00Z"
 
 
 def _instant(stamp: str) -> datetime:
-    return datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    normalized = stamp.replace("Z", "+00:00")
+    try:
+        return datetime.strptime(normalized, "%Y-%m-%dT%H:%M:%S.%f%z")
+    except ValueError:
+        return datetime.strptime(normalized, "%Y-%m-%dT%H:%M:%S%z")
 
 
 def _no_literal_none(records: Iterable[AirbyteMessage]) -> None:
@@ -742,6 +746,114 @@ def test_commit_authors_drops_an_email_with_no_bitbucket_account(
 
     assert not output.errors
     assert len(output.records) == 0, "an unmatched e-mail claims no account"
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_commit_authors_state_carries_the_authors_since_date(http_mocker: HttpMocker) -> None:
+    """The child carries a cursor so the author list's state persists. Without
+    it every sync re-lists every author since the start date and re-resolves
+    each one against Bitbucket; with it, the run emits the date the next run
+    lists from."""
+    config = BitbucketCloudConfigBuilder().build()
+    committed = "2026-06-15T10:00:00+00:00"
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_repo_with_clone()]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/authors", query_params=ANY_QUERY_PARAMS),
+        _authors_page(_author_row("ada@example.com", "a" * 40)),
+    )
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/repositories/acme/app/commit/{'a' * 40}", query_params=ANY_QUERY_PARAMS),
+        _resolved_commit("a" * 40, "ada@example.com", "acc-42"),
+    )
+
+    output = read_stream(_CONNECTOR, "commit_authors", config)
+
+    assert not output.errors
+    assert len(output.records) == 1
+    # The record has no date of its own; it carries the author's last commit
+    # date, which is what the cursor observes.
+    assert output.records[0].record.data["last_committed_date"] == committed
+    assert output.state_messages, "an incremental child must emit state"
+    state = output.state_messages[-1].state.stream.stream_state.__dict__
+    resumed = state["parent_state"]["repository_authors"]["state"]["last_committed_date"]
+    assert _instant(resumed) == _instant(committed), f"parent state must carry the author's date: {state}"
+    assert_records_conform(output.records, _CONNECTOR, "commit_authors", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_resumed_commit_authors_sync_lists_only_authors_active_since(
+    http_mocker: HttpMocker,
+) -> None:
+    """The start date is a floor paid once. A run carrying state asks the proxy
+    for the authors who committed since the saved date, so the Bitbucket
+    lookups it spends follow the day's activity rather than the whole history."""
+    config = BitbucketCloudConfigBuilder().build()  # start date 2026-06-01
+    committed = "2026-06-15T10:00:00+00:00"
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_repo_with_clone()]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/authors", query_params=ANY_QUERY_PARAMS),
+        _authors_page(_author_row("ada@example.com", "a" * 40)),
+    )
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/repositories/acme/app/commit/{'a' * 40}", query_params=ANY_QUERY_PARAMS),
+        _resolved_commit("a" * 40, "ada@example.com", "acc-42"),
+    )
+    first = read_stream(_CONNECTOR, "commit_authors", config)
+    assert not first.errors
+    state = [m.state for m in first.state_messages][-1:]
+
+    resume_mocker = HttpMocker()
+    with resume_mocker:
+        resume_mocker.get(
+            HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+            HttpResponse(body=json.dumps({"values": [_repo_with_clone()]}), status_code=200),
+        )
+        resume_mocker.get(
+            HttpRequest(f"{PROXY_URL}/v1/authors", query_params=ANY_QUERY_PARAMS),
+            _authors_page(),
+        )
+
+        second = read_stream(_CONNECTOR, "commit_authors", config, state=state)
+
+        assert not second.errors
+        since = [
+            parse_qs(urlparse(r.url).query)["since"][0]
+            for r in resume_mocker._mocker.request_history
+            if r.url.startswith(f"{PROXY_URL}/v1/authors")
+        ]
+        assert since, "the resumed run must list authors"
+        assert all(_instant(value) == _instant(committed) for value in since), since
+        lookups = [r.url for r in resume_mocker._mocker.request_history if "/commit/" in r.url]
+        assert not lookups, "no author committed since, so nothing to resolve"
+
+
+def _resolved_commit(sha: str, email: str, account_id: str) -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps(
+            {
+                "hash": sha,
+                "date": "2026-06-15T10:00:00+00:00",
+                "message": "feat: x",
+                "author": {
+                    "raw": f"Dev <{email}>",
+                    "user": {
+                        "account_id": account_id,
+                        "uuid": "{u-42}",
+                        "nickname": "dev",
+                        "display_name": "Dev",
+                    },
+                },
+                "parents": [],
+            }
+        ),
+        status_code=200,
+    )
 
 
 def _pr_listing(pr_id: int, updated_on: str) -> HttpResponse:

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
@@ -641,12 +641,12 @@ def _authors_page(*rows: dict[str, Any]) -> HttpResponse:
     )
 
 
-def _author_row(email: str, sha: str) -> dict[str, Any]:
+def _author_row(email: str, sha: str, committed: str = "2026-06-15T10:00:00+00:00") -> dict[str, Any]:
     return {
         "author_email": email,
         "author_name": "Dev",
         "sample_sha": sha,
-        "last_committed_date": "2026-06-15T10:00:00+00:00",
+        "last_committed_date": committed,
         "commit_count": 4,
     }
 
@@ -784,14 +784,17 @@ def test_commit_authors_state_carries_the_authors_since_date(http_mocker: HttpMo
 
 
 @freezegun.freeze_time(_FROZEN)
-def test_a_resumed_commit_authors_sync_lists_only_authors_active_since(
+def test_a_resumed_commit_authors_sync_lists_from_one_window_before_the_saved_date(
     http_mocker: HttpMocker,
 ) -> None:
     """The start date is a floor paid once. A run carrying state asks the proxy
-    for the authors who committed since the saved date, so the Bitbucket
-    lookups it spends follow the day's activity rather than the whole history."""
-    config = BitbucketCloudConfigBuilder().build()  # start date 2026-06-01
-    committed = "2026-06-15T10:00:00+00:00"
+    for the authors who committed since one lookback window before the saved
+    date — a commit can be pushed days after it was made — so the Bitbucket
+    lookups it spends follow recent activity rather than the whole history."""
+    config = BitbucketCloudConfigBuilder().build()
+    # Far enough back that one window before the saved date is not clamped to it.
+    config["bitbucket_start_date"] = "2026-01-01"
+    one_window_before = "2026-05-15T10:00:00+00:00"
     http_mocker.get(
         HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
         HttpResponse(body=json.dumps({"values": [_repo_with_clone()]}), status_code=200),
@@ -814,9 +817,14 @@ def test_a_resumed_commit_authors_sync_lists_only_authors_active_since(
             HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
             HttpResponse(body=json.dumps({"values": [_repo_with_clone()]}), status_code=200),
         )
+        # The proxy bound is inclusive, so the author on the boundary is listed again.
         resume_mocker.get(
             HttpRequest(f"{PROXY_URL}/v1/authors", query_params=ANY_QUERY_PARAMS),
-            _authors_page(),
+            _authors_page(_author_row("ada@example.com", "a" * 40)),
+        )
+        resume_mocker.get(
+            HttpRequest(f"{BB_URL}/repositories/acme/app/commit/{'a' * 40}", query_params=ANY_QUERY_PARAMS),
+            _resolved_commit("a" * 40, "ada@example.com", "acc-42"),
         )
 
         second = read_stream(_CONNECTOR, "commit_authors", config, state=state)
@@ -828,9 +836,65 @@ def test_a_resumed_commit_authors_sync_lists_only_authors_active_since(
             if r.url.startswith(f"{PROXY_URL}/v1/authors")
         ]
         assert since, "the resumed run must list authors"
-        assert all(_instant(value) == _instant(committed) for value in since), since
+        assert all(_instant(value) == _instant(one_window_before) for value in since), since
         lookups = [r.url for r in resume_mocker._mocker.request_history if "/commit/" in r.url]
-        assert not lookups, "no author committed since, so nothing to resolve"
+        assert len(lookups) == 1, f"one author listed, one lookup: {lookups}"
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_future_dated_commit_never_becomes_the_commits_cursor(http_mocker: HttpMocker) -> None:
+    """A committer clock set ahead would otherwise become the saved cursor, and
+    every later sync would ask for commits since a date that has not come. The
+    row is dropped at the client and the cursor stays on the newest real date."""
+    config = BitbucketCloudConfigBuilder().build()
+    sane, future = "2026-06-15T10:00:00+00:00", "2099-01-01T00:00:00+00:00"
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_repo_with_clone()]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/commits", query_params=ANY_QUERY_PARAMS),
+        _commits_page(_commit_row("a" * 40, sane), _commit_row("b" * 40, future), next_page_token=None),
+    )
+
+    output = read_stream(_CONNECTOR, "commits", config)
+
+    assert not output.errors
+    assert [r.record.data["sha"] for r in output.records] == ["a" * 40]
+    saved = json.dumps(output.state_messages[-1].state.stream.stream_state.__dict__)
+    assert "2099" not in saved, f"the future date leaked into state: {saved}"
+    assert "2026-06-15T10:00:00" in saved, f"the newest real date must be the cursor: {saved}"
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_future_dated_author_never_becomes_the_authors_since(http_mocker: HttpMocker) -> None:
+    """The author list is what a later sync bounds with `since`; an author whose
+    last commit is dated ahead would push that bound past now and the list
+    would come back empty forever. The author is dropped before the cursor
+    sees them, and the others are still resolved."""
+    config = BitbucketCloudConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_repo_with_clone()]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/authors", query_params=ANY_QUERY_PARAMS),
+        _authors_page(
+            _author_row("ada@example.com", "a" * 40),
+            _author_row("zed@example.com", "b" * 40, committed="2099-01-01T00:00:00+00:00"),
+        ),
+    )
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/repositories/acme/app/commit/{'a' * 40}", query_params=ANY_QUERY_PARAMS),
+        _resolved_commit("a" * 40, "ada@example.com", "acc-42"),
+    )
+
+    output = read_stream(_CONNECTOR, "commit_authors", config)
+
+    assert not output.errors
+    assert [r.record.data["author_email"] for r in output.records] == ["ada@example.com"]
+    saved = json.dumps(output.state_messages[-1].state.stream.stream_state.__dict__)
+    assert "2099" not in saved, f"the future date leaked into state: {saved}"
 
 
 def _resolved_commit(sha: str, email: str, account_id: str) -> HttpResponse:

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -667,6 +667,10 @@ streams:
       type: DatetimeBasedCursor
       cursor_field: committed_date
       datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      # A future-dated commit would otherwise become the cursor and silence the
+      # stream: a `since` past now yields no slice on every later sync. Bounding
+      # records client-side drops such a row before the cursor observes it.
+      is_client_side_incremental: true
       # `git log --since` is a traversal cutoff: after a rebase the
       # replacement commits can carry dates BELOW the stored cursor and would
       # never be visited again. Re-enumerating one window each sync recovers
@@ -782,6 +786,10 @@ streams:
       type: DatetimeBasedCursor
       cursor_field: committed_date
       datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      # A future-dated commit would otherwise become the cursor and silence the
+      # stream: a `since` past now yields no slice on every later sync. Bounding
+      # records client-side drops such a row before the cursor observes it.
+      is_client_side_incremental: true
       # `git log --since` is a traversal cutoff: after a rebase the
       # replacement commits can carry dates BELOW the stored cursor and would
       # never be visited again. Re-enumerating one window each sync recovers
@@ -919,6 +927,7 @@ streams:
           author_id: {type: [integer, "null"]}
           author_type: {type: [string, "null"]}
           sample_sha: {type: [string, "null"]}
+          last_committed_date: {type: [string, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -946,9 +955,14 @@ streams:
           - type: ParentStreamConfig
             parent_key: sample_sha
             partition_field: commit_sha
+            # `incremental_dependency` keeps the sync proportional to activity:
+            # the author list's `since` persists only because this child is
+            # itself incremental.
+            incremental_dependency: true
             extra_fields:
               - [repo_full_name]
               - [author_email]
+              - [last_committed_date]
             stream:
               type: DeclarativeStream
               name: repository_authors
@@ -1010,6 +1024,14 @@ streams:
                 cursor_datetime_formats:
                   - "%Y-%m-%dT%H:%M:%S%z"
                   - "%Y-%m-%dT%H:%M:%SZ"
+                # A future-dated commit would otherwise become the cursor and silence the
+                # stream: a `since` past now yields no slice on every later sync. Bounding
+                # records client-side drops such a row before the cursor observes it.
+                is_client_side_incremental: true
+                # An author's last commit can predate its push by days, and another
+                # author's push moves `since` past it in the meantime. Re-listing one
+                # window each sync recovers them; bronze dedups the re-read rows.
+                lookback_window: "P1M"
                 # An author already resolved keeps their claim, so a later sync
                 # only needs the ones who have committed since — which is what
                 # keeps this O(active authors) rather than O(authors).
@@ -1028,6 +1050,22 @@ streams:
                       path: [repo_full_name]
                       value: "{{ stream_slice.extra_fields['full_name'] }}"
                       value_type: string
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: last_committed_date
+      datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      # The partition is one author's sample commit and changes with every
+      # commit, so per-partition state would grow by one entry per (repository,
+      # author) and never shrink. Nothing reads this cursor's value; it exists so
+      # the parent's `since` persists.
+      global_substream_cursor: true
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config['github_start_date'] }}"
+        datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
         fields: *standard_fields
@@ -1047,6 +1085,10 @@ streams:
           - type: AddedFieldDefinition
             path: [sample_sha]
             value: "{{ stream_partition.commit_sha }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [last_committed_date]
+            value: "{{ stream_slice.extra_fields['last_committed_date'] }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [author_login]
@@ -1567,6 +1609,10 @@ streams:
       type: DatetimeBasedCursor
       cursor_field: committed_date
       datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      # A future-dated commit would otherwise become the cursor and silence the
+      # stream: a `since` past now yields no slice on every later sync. Bounding
+      # records client-side drops such a row before the cursor observes it.
+      is_client_side_incremental: true
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
         - "%Y-%m-%dT%H:%M:%SZ"

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -46,7 +46,16 @@ name: github
 #   scoped `dbt --full-refresh` a major bump dispatches re-materializes them.
 #   Safe: both dates have been in Bronze all along, and the author date falls
 #   back to the committer date where a source left it empty. #3153
-version: "8.0.1"
+# 8.1.0: `commit_authors` carries the author's `last_committed_date` and an
+#   incremental cursor over it, so the author list's `since` survives between
+#   syncs and a later run resolves only the authors who committed inside one
+#   lookback window of the saved date. An e-mail GitHub matches to nobody is
+#   therefore retried only when that author commits again. The proxy-fed
+#   cursors and `pull_request_commits` bound records client-side so a
+#   future-dated commit cannot become the saved cursor. MINOR: one additive
+#   bronze column the reconciler adds at sync time; no downstream model reads
+#   it.
+version: "8.1.0"
 schedule: "0 */4 * * *"
 workflow: sync
 

--- a/src/ingestion/connectors/git/github/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github/tests/test_github_streams.py
@@ -16,6 +16,8 @@ transformations (None-guard).
 from __future__ import annotations
 
 import json
+from datetime import datetime
+from urllib.parse import parse_qs, urlparse
 
 import freezegun
 import pytest
@@ -41,6 +43,10 @@ def _graphql_body(stream_name: str, variables: dict, cursor: str | None = None) 
     if cursor is not None:
         body["variables"]["cursor"] = cursor
     return body
+
+
+def _instant(stamp: str) -> datetime:
+    return datetime.strptime(stamp.replace("Z", "+00:00"), "%Y-%m-%dT%H:%M:%S%z")
 
 
 def _no_literal_none(records) -> None:
@@ -141,30 +147,7 @@ def test_proxy_429_then_success(http_mocker: HttpMocker) -> None:
         HttpRequest(f"{PROXY_URL}/v1/commits", query_params=ANY_QUERY_PARAMS),
         [
             HttpResponse(body="", status_code=429, headers={"Retry-After": "0"}),
-            HttpResponse(
-                body=json.dumps(
-                    {
-                        "items": [
-                            {
-                                "sha": "d" * 40,
-                                "message": "m",
-                                "committed_date": "2026-06-15T10:00:00Z",
-                                "authored_date": "2026-06-15T10:00:00Z",
-                                "author_name": "Dev",
-                                "author_email": "dev@example.com",
-                                "committer_name": "Dev",
-                                "committer_email": "dev@example.com",
-                                "parent_hashes": [],
-                                "is_merge": False,
-                                "is_in_default_branch": True,
-                                "patch_id": None,
-                            }
-                        ],
-                        "next_page_token": None,
-                    }
-                ),
-                status_code=200,
-            ),
+            _commits_page(_commit_row("d" * 40, "2026-06-15T10:00:00Z")),
         ],
     )
 
@@ -932,14 +915,51 @@ def _authors_page(*rows: dict) -> HttpResponse:
     return HttpResponse(body=json.dumps({"items": list(rows), "next_page_token": None}), status_code=200)
 
 
-def _author(email: str, sha: str, name: str = "Dev") -> dict:
+def _author(email: str, sha: str, name: str = "Dev", committed: str = "2026-06-15T10:00:00+00:00") -> dict:
     return {
         "author_email": email,
         "author_name": name,
         "sample_sha": sha,
-        "last_committed_date": "2026-06-15T10:00:00+00:00",
+        "last_committed_date": committed,
         "commit_count": 3,
     }
+
+
+def _commit_row(sha: str, committed: str) -> dict:
+    return {
+        "sha": sha,
+        "message": "m",
+        "committed_date": committed,
+        "authored_date": committed,
+        "author_name": "Dev",
+        "author_email": "dev@example.com",
+        "committer_name": "Dev",
+        "committer_email": "dev@example.com",
+        "parent_hashes": [],
+        "is_merge": False,
+        "is_in_default_branch": True,
+        "patch_id": None,
+    }
+
+
+def _commits_page(*rows: dict) -> HttpResponse:
+    return HttpResponse(body=json.dumps({"items": list(rows), "next_page_token": None}), status_code=200)
+
+
+def _resolved_commit(sha: str, email: str, login: str, account_id: int) -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps(
+            {
+                "sha": sha,
+                "node_id": "C_1",
+                "commit": {"author": {"name": "Dev", "email": email}},
+                "author": {"login": login, "id": account_id, "type": "User"},
+                "committer": {"login": login, "id": account_id, "type": "User"},
+                "parents": [],
+            }
+        ),
+        status_code=200,
+    )
 
 
 @freezegun.freeze_time(_FROZEN)
@@ -955,19 +975,7 @@ def test_commit_authors_resolve_a_proxy_author_to_an_account(http_mocker: HttpMo
     )
     http_mocker.get(
         HttpRequest(f"{GH_URL}/repos/acme/app/commits/{'a' * 40}", query_params=ANY_QUERY_PARAMS),
-        HttpResponse(
-            body=json.dumps(
-                {
-                    "sha": "a" * 40,
-                    "node_id": "C_1",
-                    "commit": {"author": {"name": "Ada", "email": "ada@example.com"}},
-                    "author": {"login": "ada", "id": 4242, "type": "User"},
-                    "committer": {"login": "ada", "id": 4242, "type": "User"},
-                    "parents": [],
-                }
-            ),
-            status_code=200,
-        ),
+        _resolved_commit("a" * 40, "ada@example.com", "ada", 4242),
     )
 
     output = read_stream(_CONNECTOR, "commit_authors", config)
@@ -1015,6 +1023,138 @@ def test_commit_authors_drops_an_email_github_matches_to_nobody(http_mocker: Htt
 
     assert not output.errors
     assert len(output.records) == 0, "an unmatched e-mail claims no account"
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_commit_authors_state_carries_the_authors_since_date(http_mocker: HttpMocker) -> None:
+    """The child carries a cursor so the author list's state persists. Without
+    it every sync re-lists every author since the start date and re-resolves
+    each one against GitHub; with it, the run emits the date the next run
+    lists from."""
+    config = GithubConfigBuilder().build()
+    committed = "2026-06-15T10:00:00+00:00"
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/authors", query_params=ANY_QUERY_PARAMS),
+        _authors_page(_author("ada@example.com", "a" * 40)),
+    )
+    http_mocker.get(
+        HttpRequest(f"{GH_URL}/repos/acme/app/commits/{'a' * 40}", query_params=ANY_QUERY_PARAMS),
+        _resolved_commit("a" * 40, "ada@example.com", "ada", 4242),
+    )
+
+    output = read_stream(_CONNECTOR, "commit_authors", config)
+
+    assert not output.errors
+    assert len(output.records) == 1
+    # The record has no date of its own; it carries the author's last commit
+    # date, which is what the cursor observes.
+    assert output.records[0].record.data["last_committed_date"] == committed
+    assert output.state_messages, "an incremental child must emit state"
+    state = output.state_messages[-1].state.stream.stream_state.__dict__
+    resumed = state["parent_state"]["repository_authors"]["state"]["last_committed_date"]
+    assert _instant(resumed) == _instant(committed), f"parent state must carry the author's date: {state}"
+    assert_records_conform(output.records, _CONNECTOR, "commit_authors", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_resumed_commit_authors_sync_lists_from_one_window_before_the_saved_date(http_mocker: HttpMocker) -> None:
+    """The start date is a floor paid once. A run carrying state asks the proxy
+    for the authors who committed since one lookback window before the saved
+    date — a commit can be pushed days after it was made — so the GitHub
+    lookups it spends follow recent activity rather than the whole history."""
+    config = GithubConfigBuilder().build()
+    # Far enough back that one window before the saved date is not clamped to it.
+    config["github_start_date"] = "2026-01-01"
+    one_window_before = "2026-05-15T10:00:00+00:00"
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/authors", query_params=ANY_QUERY_PARAMS),
+        _authors_page(_author("ada@example.com", "a" * 40)),
+    )
+    http_mocker.get(
+        HttpRequest(f"{GH_URL}/repos/acme/app/commits/{'a' * 40}", query_params=ANY_QUERY_PARAMS),
+        _resolved_commit("a" * 40, "ada@example.com", "ada", 4242),
+    )
+    first = read_stream(_CONNECTOR, "commit_authors", config)
+    assert not first.errors
+    state = [m.state for m in first.state_messages][-1:]
+
+    resume_mocker = HttpMocker()
+    with resume_mocker:
+        resume_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+        # The proxy bound is inclusive, so the author on the boundary is listed again.
+        resume_mocker.get(
+            HttpRequest(f"{PROXY_URL}/v1/authors", query_params=ANY_QUERY_PARAMS),
+            _authors_page(_author("ada@example.com", "a" * 40)),
+        )
+        resume_mocker.get(
+            HttpRequest(f"{GH_URL}/repos/acme/app/commits/{'a' * 40}", query_params=ANY_QUERY_PARAMS),
+            _resolved_commit("a" * 40, "ada@example.com", "ada", 4242),
+        )
+
+        second = read_stream(_CONNECTOR, "commit_authors", config, state=state)
+
+        assert not second.errors
+        since = [
+            parse_qs(urlparse(r.url).query)["since"][0]
+            for r in resume_mocker._mocker.request_history
+            if r.url.startswith(f"{PROXY_URL}/v1/authors")
+        ]
+        assert since, "the resumed run must list authors"
+        assert all(_instant(value) == _instant(one_window_before) for value in since), since
+        lookups = [r.url for r in resume_mocker._mocker.request_history if "/commits/" in r.url]
+        assert len(lookups) == 1, f"one author listed, one lookup: {lookups}"
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_future_dated_commit_never_becomes_the_commits_cursor(http_mocker: HttpMocker) -> None:
+    """A committer clock set ahead would otherwise become the saved cursor, and
+    every later sync would ask for commits since a date that has not come. The
+    row is dropped at the client and the cursor stays on the newest real date."""
+    config = GithubConfigBuilder().build()
+    sane, future = "2026-06-15T10:00:00+00:00", "2099-01-01T00:00:00+00:00"
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/commits", query_params=ANY_QUERY_PARAMS),
+        _commits_page(_commit_row("a" * 40, sane), _commit_row("b" * 40, future)),
+    )
+
+    output = read_stream(_CONNECTOR, "commits", config)
+
+    assert not output.errors
+    assert [r.record.data["sha"] for r in output.records] == ["a" * 40]
+    saved = json.dumps(output.state_messages[-1].state.stream.stream_state.__dict__)
+    assert "2099" not in saved, f"the future date leaked into state: {saved}"
+    assert "2026-06-15T10:00:00" in saved, f"the newest real date must be the cursor: {saved}"
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_future_dated_author_never_becomes_the_authors_since(http_mocker: HttpMocker) -> None:
+    """The author list is what a later sync bounds with `since`; an author whose
+    last commit is dated ahead would push that bound past now and the list
+    would come back empty forever. The author is dropped before the cursor
+    sees them, and the others are still resolved."""
+    config = GithubConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/authors", query_params=ANY_QUERY_PARAMS),
+        _authors_page(
+            _author("ada@example.com", "a" * 40),
+            _author("zed@example.com", "b" * 40, committed="2099-01-01T00:00:00+00:00"),
+        ),
+    )
+    http_mocker.get(
+        HttpRequest(f"{GH_URL}/repos/acme/app/commits/{'a' * 40}", query_params=ANY_QUERY_PARAMS),
+        _resolved_commit("a" * 40, "ada@example.com", "ada", 4242),
+    )
+
+    output = read_stream(_CONNECTOR, "commit_authors", config)
+
+    assert not output.errors
+    assert [r.record.data["author_email"] for r in output.records] == ["ada@example.com"]
+    saved = json.dumps(output.state_messages[-1].state.stream.stream_state.__dict__)
+    assert "2099" not in saved, f"the future date leaked into state: {saved}"
 
 
 @freezegun.freeze_time(_FROZEN)

--- a/src/ingestion/scripts/connectors-ddl/bitbucket-cloud.sql
+++ b/src/ingestion/scripts/connectors-ddl/bitbucket-cloud.sql
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS bronze_bitbucket_cloud.commit_authors
     `author_uuid` Nullable(String),
     `author_nickname` Nullable(String),
     `author_display_name` Nullable(String),
-    `sample_sha` Nullable(String)
+    `sample_sha` Nullable(String),
+    `last_committed_date` Nullable(String)
 )
 ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
 ORDER BY unique_key

--- a/src/ingestion/scripts/connectors-ddl/github.sql
+++ b/src/ingestion/scripts/connectors-ddl/github.sql
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS bronze_github.commit_authors
     `author_login` Nullable(String),
     `author_id` Nullable(Int64),
     `author_type` Nullable(String),
-    `sample_sha` Nullable(String)
+    `sample_sha` Nullable(String),
+    `last_committed_date` Nullable(String)
 )
 ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
 ORDER BY unique_key


### PR DESCRIPTION
**Why.** Every github and bitbucket-cloud sync re-resolves every commit author since the start date against the vendor: one lookup per (repository, author) pair, metered by the hourly API budget, mostly repeating answers already stored. Separately, one commit with a clock set ahead becomes a stream's saved cursor and the next sync asks for everything since a date that has not come, so the stream goes silent.

**What changed.** `commit_authors` carries an incremental cursor over the author's `last_committed_date` with `incremental_dependency` on the proxy author list, so the list's `since` persists between syncs and a later run lists only the authors active inside one lookback window. Every cursor fed by a git date (`commits`, `file_changes`, `repository_authors`, github `pull_request_commits`) bounds records client-side, so a future-dated row is dropped before the cursor observes it.

**`global_substream_cursor` on the child.** Its partition is the author's sample commit and changes with every commit; per-partition state would grow by one entry per (repository, author) and never shrink. Nothing reads the child's value.

**`lookback_window: P1M` on the author list.** A commit can be pushed days after it was made while another author's push moves `since` past it. Same window the commit streams use; cost is one lookup per author active in the window, per sync.

**An e-mail the vendor matches to nobody is now retried only when that author commits again.** Previously every sync retried it. Accepted; the alternative re-spends the budget nightly for a rare case.

**Out of scope.** A repository first seen after the initial sync inherits the global cursor rather than the start date, for every `repositories_pushed` child. The proxy's author list reports the author's newest date, so one future-dated commit hides that author entirely. Already-poisoned cursor state needs a reset. gitlab follows in its own PR.

**Verified.** github mock suite 44 passed, bitbucket-cloud 39 passed, on CDK 7.28.3: state carries the author date, a resumed run asks the proxy with `since` one window before it and makes one lookup, a future-dated commit and a future-dated author never reach the saved state. Not exercised against a live source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GitHub and Bitbucket Cloud commit-author records now include each author’s latest commit date.
  - Incremental syncs resume with a lookback window to capture updated author activity.
  - Future-dated commits and authors are excluded from synced records and progress tracking.

- **Improvements**
  - Commit-author data tables now store the latest commit date.
  - Connector versions updated: GitHub 8.1.0 and Bitbucket Cloud 7.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->