### PR TITLE
test(metrics): pin the date a branch-scoped merge is counted on

### DIFF
--- a/tests/datapath/metrics/git/git_branch_prs_merge_window.test.yaml
+++ b/tests/datapath/metrics/git/git_branch_prs_merge_window.test.yaml
@@ -1,0 +1,71 @@
+spec_version: 1
+description: >
+  Metric: git.non_default_branch_prs_merged and its default-branch twin — the
+  date they are counted on, #3063.
+
+  How it's computed (bronze → silver → gold):
+    • bronze: one row per pull request with its destination, creation and merge
+      times, plus the branch list its repository reported
+    • silver: one class row per request and per branch
+    • gold:   a merged request contributes one unit on the day it MERGED, to
+      the default side when its destination is its own repository's default
+      branch and to the other side otherwise
+
+  The pair's own rule is owned by `git_default_branch_prs_created.test.yaml`,
+  which settles which destination lands where. What nothing asserted is the
+  DATE: every request in every fixture that touches these keys is created and
+  merged on the same day, so a rule dating a merge by the request's creation
+  reads identically. This spec separates the two.
+
+  carol's seven requests in one repository whose default branch is `main`,
+  with `release/2026.10` beside it:
+
+    #201 main             created 10-20  merged 11-05
+    #202 main             created 10-22  merged 11-07
+    #203 release/2026.10  created 10-21  merged 11-06
+    #204 main             created 11-25  merged 12-03
+    #205 release/2026.10  created 11-26  merged 12-04
+    #206 release/2026.10  created 11-27  merged 12-05
+    #207 release/2026.10  created 11-10  still open
+
+  So November's merges are 2 into the default branch and 1 elsewhere, while
+  November's CREATIONS are 1 and 3 — disjoint sets of requests, and the two
+  metrics disagree about which period each request belongs to. That is the
+  point: date a merge by its creation instead and November reads 1 and 2, with
+  October and December moving too.
+
+  INVARIANT: the merged counts (2 and 1) must stay DIFFERENT from the created
+  counts on the same side (1 and 3). Equal numbers on both metrics let a rule
+  reading the wrong date pass unnoticed, which is how this gap survived.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: ../templates/people.yaml#/templates/carol
+
+  bronze_github.branches:
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: bpw-br-main, repository: "https://github.com/acme/window.git", name: main, head_sha: head-main, is_default: true}
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: bpw-br-rel, repository: "https://github.com/acme/window.git", name: release/2026.10, head_sha: head-rel, is_default: false}
+
+  bronze_github.pull_requests:
+    # Opened in October, merged in November: this pair is what a creation-dated
+    # rule would file in the wrong month.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: bpw-pr-201, repo_full_name: acme/window, id: 201, number: 201, author_login: carol, base_ref: main, created_at: "2026-10-20T09:00:00Z", closed_at: "2026-11-05T12:00:00Z", merged_at: "2026-11-05T12:00:00Z", merge_commit_sha: bpw-m-201}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: bpw-pr-202, repo_full_name: acme/window, id: 202, number: 202, author_login: carol, base_ref: main, created_at: "2026-10-22T09:00:00Z", closed_at: "2026-11-07T12:00:00Z", merged_at: "2026-11-07T12:00:00Z", merge_commit_sha: bpw-m-202}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: bpw-pr-203, repo_full_name: acme/window, id: 203, number: 203, author_login: carol, base_ref: release/2026.10, created_at: "2026-10-21T09:00:00Z", closed_at: "2026-11-06T12:00:00Z", merged_at: "2026-11-06T12:00:00Z", merge_commit_sha: bpw-m-203}
+    # Opened in November, merged in December: the mirror case.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: bpw-pr-204, repo_full_name: acme/window, id: 204, number: 204, author_login: carol, base_ref: main, created_at: "2026-11-25T09:00:00Z", closed_at: "2026-12-03T12:00:00Z", merged_at: "2026-12-03T12:00:00Z", merge_commit_sha: bpw-m-204}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: bpw-pr-205, repo_full_name: acme/window, id: 205, number: 205, author_login: carol, base_ref: release/2026.10, created_at: "2026-11-26T09:00:00Z", closed_at: "2026-12-04T12:00:00Z", merged_at: "2026-12-04T12:00:00Z", merge_commit_sha: bpw-m-205}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: bpw-pr-206, repo_full_name: acme/window, id: 206, number: 206, author_login: carol, base_ref: release/2026.10, created_at: "2026-11-27T09:00:00Z", closed_at: "2026-12-05T12:00:00Z", merged_at: "2026-12-05T12:00:00Z", merge_commit_sha: bpw-m-206}
+    # Never merged: it counts among November's creations and among no merges.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: bpw-pr-207, repo_full_name: acme/window, id: 207, number: 207, author_login: carol, base_ref: release/2026.10, created_at: "2026-11-10T09:00:00Z", state: open, closed_at: "", merged_at: "", merge_commit_sha: ""}
+
+  bronze_github.pull_request_diff_stats:
+    # A request reaches a person only through this row: bronze pull_requests
+    # carries the author's login and no address.
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: bpw-ds-201, repo_full_name: acme/window, pull_number: 201, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: bpw-ds-202, repo_full_name: acme/window, pull_number: 202, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: bpw-ds-203, repo_full_name: acme/window, pull_number: 203, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: bpw-ds-204, repo_full_name: acme/window, pull_number: 204, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: bpw-ds-205, repo_full_name: acme/window, pull_number: 205, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: bpw-ds-206, repo_full_name: acme/window, pull_number: 206, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: bpw-ds-207, repo_full_name: acme/window, pull_number: 207, author_email: carol@example.com}

--- a/tests/datapath/metrics/git/test_git_bitbucket_merge_time_recovery.py
+++ b/tests/datapath/metrics/git/test_git_bitbucket_merge_time_recovery.py
@@ -77,6 +77,14 @@ def test_each_merge_lands_on_the_day_its_own_evidence_names(spec: SpecRun) -> No
                         "views": [{"view": "period"}, {"view": "timeseries", "bucket": "day"}],
                     },
                     {"metric_key": "git.prs_created", "views": [{"view": "period"}]},
+                    {
+                        "metric_key": "git.non_default_branch_prs_merged",
+                        "views": [{"view": "period"}],
+                    },
+                    {
+                        "metric_key": "git.default_branch_prs_merged",
+                        "views": [{"view": "period"}],
+                    },
                 ],
             },
         }
@@ -85,6 +93,12 @@ def test_each_merge_lands_on_the_day_its_own_evidence_names(spec: SpecRun) -> No
 
     r.row("git.prs_created", "period", entity_id=HEIDI).equals(value=9)
     r.row("git.prs_merged", "period", entity_id=HEIDI).equals(value=6)
+    # The branch-scoped halves read the same close time. This repository reported
+    # no branches, so every request lands on the other side of the split — the
+    # agreed reading for an absent signal — and the two requests with no close
+    # time reach neither.
+    r.row("git.non_default_branch_prs_merged", "period", entity_id=HEIDI).equals(value=6)
+    r.row("git.default_branch_prs_merged", "period", entity_id=HEIDI).equals(value=None)
 
     series = r.row("git.prs_merged", "timeseries", entity_id=HEIDI)
     for day in LANDED:
@@ -113,13 +127,20 @@ def test_a_merge_with_no_usable_evidence_is_dropped_not_dated_at_the_epoch(
             "body": {
                 "entity": {"type": "person", "ids": [HEIDI]},
                 "period": {"from": "1970-01-01", "to": "1970-12-31"},
-                "metrics": [{"metric_key": "git.prs_merged", "views": [{"view": "period"}]}],
+                "metrics": [
+                    {"metric_key": "git.prs_merged", "views": [{"view": "period"}]},
+                    {
+                        "metric_key": "git.non_default_branch_prs_merged",
+                        "views": [{"view": "period"}],
+                    },
+                ],
             },
         }
     )
     assert r.status == 200
 
     r.row("git.prs_merged", "period", entity_id=HEIDI).equals(value=None)
+    r.row("git.non_default_branch_prs_merged", "period", entity_id=HEIDI).equals(value=None)
 
 
 def test_a_recovered_close_time_is_usable_and_not_merely_countable(spec: SpecRun) -> None:

--- a/tests/datapath/metrics/git/test_git_branch_prs_merge_window.py
+++ b/tests/datapath/metrics/git/test_git_branch_prs_merge_window.py
@@ -1,0 +1,127 @@
+"""A branch-scoped merge is counted on the day it merged, not the day it was opened.
+
+Which destination lands on which side of the split is owned by
+`git_default_branch_prs_created`. What no fixture separated is the DATE: every request
+touching these keys was created and merged on the same day, so a rule dating a merge by
+the request's creation read identically. Here the two dates fall in different months, and
+each month's merges and creations come from disjoint sets of requests. #3063
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_datapath.spec_runner import SpecRun
+
+pytestmark = pytest.mark.fixture
+
+SPEC = "git_branch_prs_merge_window"
+
+CAROL = "carol@example.com"
+
+OCTOBER = {"from": "2026-10-01", "to": "2026-10-31"}
+NOVEMBER = {"from": "2026-11-01", "to": "2026-11-30"}
+DECEMBER = {"from": "2026-12-01", "to": "2026-12-31"}
+
+MERGED_KEYS = (
+    "git.default_branch_prs_merged",
+    "git.non_default_branch_prs_merged",
+    "git.prs_merged",
+)
+CREATED_KEYS = (
+    "git.default_branch_prs_created",
+    "git.non_default_branch_prs_created",
+    "git.prs_created",
+)
+
+
+def both_pairs(period: dict[str, str]) -> dict[str, object]:
+    return {
+        "url": "/v1/metric-results",
+        "method": "POST",
+        "body": {
+            "entity": {"type": "person", "ids": [CAROL]},
+            "period": period,
+            "metrics": [
+                {"metric_key": key, "views": [{"view": "period"}]}
+                for key in MERGED_KEYS + CREATED_KEYS
+            ],
+        },
+    }
+
+
+def test_a_months_merges_and_creations_are_different_requests(spec: SpecRun) -> None:
+    """November merged two requests into the default branch and one elsewhere, all three
+    opened in October; it opened one and three, none of which merged that month. Dating a
+    merge by its creation would swap those figures into 1 and 2."""
+    r = spec.call(both_pairs(NOVEMBER))
+    assert r.status == 200
+
+    r.row("git.default_branch_prs_merged", "period", entity_id=CAROL).equals(value=2)
+    r.row("git.non_default_branch_prs_merged", "period", entity_id=CAROL).equals(value=1)
+    r.row("git.prs_merged", "period", entity_id=CAROL).equals(value=3)
+
+    r.row("git.default_branch_prs_created", "period", entity_id=CAROL).equals(value=1)
+    r.row("git.non_default_branch_prs_created", "period", entity_id=CAROL).equals(value=3)
+    r.row("git.prs_created", "period", entity_id=CAROL).equals(value=4)
+
+
+def test_the_month_the_requests_were_opened_has_no_merges_in_it(spec: SpecRun) -> None:
+    """October opened three requests and merged none. A creation-dated rule would report
+    two and one here instead of nothing at all."""
+    r = spec.call(both_pairs(OCTOBER))
+    assert r.status == 200
+
+    for key in MERGED_KEYS:
+        r.row(key, "period", entity_id=CAROL).equals(value=None)
+
+    r.row("git.default_branch_prs_created", "period", entity_id=CAROL).equals(value=2)
+    r.row("git.non_default_branch_prs_created", "period", entity_id=CAROL).equals(value=1)
+    r.row("git.prs_created", "period", entity_id=CAROL).equals(value=3)
+
+
+def test_a_request_merged_after_its_month_counts_in_the_month_it_merged(spec: SpecRun) -> None:
+    """The three opened in November merged in December, and December opened nothing. The
+    request still open belongs to neither."""
+    r = spec.call(both_pairs(DECEMBER))
+    assert r.status == 200
+
+    r.row("git.default_branch_prs_merged", "period", entity_id=CAROL).equals(value=1)
+    r.row("git.non_default_branch_prs_merged", "period", entity_id=CAROL).equals(value=2)
+    r.row("git.prs_merged", "period", entity_id=CAROL).equals(value=3)
+
+    for key in CREATED_KEYS:
+        r.row(key, "period", entity_id=CAROL).equals(value=None)
+
+
+def test_each_merge_lands_on_its_own_day(spec: SpecRun) -> None:
+    """The day, not only the month: a rule reading the creation would put these points in
+    October, where the series has no days at all."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [CAROL]},
+                "period": NOVEMBER,
+                "metrics": [
+                    {
+                        "metric_key": key,
+                        "views": [{"view": "timeseries", "bucket": "day"}],
+                    }
+                    for key in (
+                        "git.default_branch_prs_merged",
+                        "git.non_default_branch_prs_merged",
+                    )
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    default_series = r.row("git.default_branch_prs_merged", "timeseries", entity_id=CAROL)
+    default_series.contains(points={"bucket_start": "2026-11-05", "value": 1})
+    default_series.contains(points={"bucket_start": "2026-11-07", "value": 1})
+
+    r.row("git.non_default_branch_prs_merged", "timeseries", entity_id=CAROL).contains(
+        points={"bucket_start": "2026-11-06", "value": 1}
+    )


### PR DESCRIPTION
Which destination lands on which side of the branch split was asserted. **The date was not**: every request in every fixture touching `git.default_branch_prs_merged` and its twin was created and merged on the same day, so a rule dating a merge by the request's *creation* read exactly the same. That is measured rather than assumed — under that mutation the pre-existing specs pass 14 of 14.

A new spec separates the two dates. Seven requests: three opened one month and merged the next, three opened the next and merged the one after, one left open. So each month's merges and its creations are disjoint sets of requests, and the counts differ by side — dating a merge by its creation then moves three windows at once instead of coincidentally matching in one. A fourth case pins the day rather than the month.

The other half of the rule — a request the source records as merged but for which it reports no close time reaches no period at all — was asserted for the unscoped key only. The spec that owns that case now asserts the branch-scoped pair beside it, in a repository that reported no branches, where every request therefore lands on the non-default side.

Two mutations turn the new cases red and leave every pre-existing one green: dating the scoped pair by creation, and emitting it without a close time.

Tests only, no product change. Came out of validating `git.non_default_branch_prs_merged` (#3063).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pull request merge metrics to count merges by their actual merge date rather than creation date.
  * Added accurate default-branch and non-default-branch merge reporting.
  * Prevented merges without usable merge-date evidence from appearing in date-based results.

* **Tests**
  * Added coverage for monthly and daily merge timelines, branch-specific results, and merges occurring after the creation month.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->