### PR TITLE
ci(ghcr): replace per-branch-delete cleanup with a nightly orphan sweep

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -5,9 +5,10 @@ name: GHCR cleanup
 #   • trunk tags (`YYYY.MM.DD.HH.MM-sha7`, suffix-less) — deleted after 4
 #     weeks on a daily schedule, keeping the 15 newest per package as a
 #     backstop. `latest` and the branch-suffixed tags never match the glob.
-#   • branch tags (`…-sha7.<sanitized-branch>`, #1994) — deleted when their
-#     branch is deleted. `release-*` branches are excluded: their images are
-#     kept forever (customer-release pins).
+#   • branch tags (`…-sha7.<sanitized-branch>`, #1994) — swept nightly:
+#     versions all of whose tags point at branches that no longer exist are
+#     deleted. `release-*` suffixes are exempt: their images are kept
+#     forever (customer-release pins).
 #
 # snok/container-retention-policy v3 is multi-arch aware: it protects
 # untagged per-arch digests referenced by tagged manifest lists.
@@ -16,20 +17,22 @@ on:
   schedule:
     - cron: "5 5 * * *"
   workflow_dispatch:
-  # Branch deletions; the `branch` job filters to ref_type == branch.
-  delete: {}
+    inputs:
+      dry_run:
+        description: "Report orphaned branch tags without deleting"
+        type: boolean
+        default: false
 
 permissions:
   packages: write
   contents: read
 
 env:
-  SERVICE_IMAGES: "insight-analytics insight-authenticator insight-frontend insight-gateway insight-identity-resolution insight-toolbox insight-ui-tests"
-  CONNECTOR_IMAGES: "insight-jira-enrich source-active-directory-insight source-gitlab-insight source-hubspot-insight"
+  SERVICE_IMAGES: "insight-analytics insight-authenticator insight-frontend insight-gateway insight-git-cli-proxy insight-identity-resolution insight-previews insight-seed insight-toolbox"
+  CONNECTOR_IMAGES: "insight-jira-enrich source-active-directory-insight source-bamboohr-insight source-claude-team-invoices-insight source-gitlab-insight source-hubspot-insight"
 
 jobs:
   trunk:
-    if: github.event_name != 'delete'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -45,32 +48,16 @@ jobs:
           keep-n-most-recent: 15
           dry-run: false
 
-  branch:
-    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && !startsWith(github.event.ref, 'release-')
+  orphan-sweep:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      # Same sanitizer as the build-tag computation in build-images.yml —
-      # the deleted branch's tags end with `.<sanitized-branch>`.
-      - name: Sanitize branch name
-        id: suffix
-        env:
-          REF_NAME: ${{ github.event.ref }}
-        run: |
-          SAFE="$(printf '%s' "$REF_NAME" \
-            | tr -c 'a-zA-Z0-9._-' '-' \
-            | sed -E 's/^[-.]+//; s/[-.]+$//' \
-            | cut -c1-60)"
-          echo "safe=$SAFE" >> "$GITHUB_OUTPUT"
-          echo "Cleaning image tags with suffix: .$SAFE"
-      - uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          account: constructorfabric
-          token: ${{ secrets.GITHUB_TOKEN }}
-          image-names: ${{ env.SERVICE_IMAGES }} ${{ env.CONNECTOR_IMAGES }}
-          image-tags: "*.${{ steps.suffix.outputs.safe }}"
-          # SAFETY: with `both`, a concurrent publication's per-arch digests
-          # (untagged until their manifest list lands) get deleted (#3020).
-          tag-selection: tagged
-          cut-off: 0s
-          dry-run: false
+          persist-credentials: false
+      - name: Sweep branch tags whose branch is gone
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGES: ${{ env.SERVICE_IMAGES }} ${{ env.CONNECTOR_IMAGES }}
+          DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+        run: python3 .github/workflows/scripts/ghcr-orphan-sweep.py

--- a/.github/workflows/scripts/ghcr-orphan-sweep.py
+++ b/.github/workflows/scripts/ghcr-orphan-sweep.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+ghcr-orphan-sweep.py — delete GHCR branch-tag image versions whose branch is gone.
+
+build-images.yml tags branch builds `YYYY.MM.DD.HH.MM-sha7.<sanitized-branch>`
+(#1994). This sweep lists the repo's live branches, sanitizes each name with
+the exact tag-suffix computation from build-images.yml, and deletes package
+versions ALL of whose tags are branch tags pointing at branches that no longer
+exist. Suffix-less trunk tags, `latest`, `sha256-*` attestation tags,
+`release-*` suffixes (kept forever) and anything of unrecognized shape are
+never touched.
+
+Env:
+  GH_TOKEN   token for `gh api` (packages: write)
+  PACKAGES   whitespace-separated container package names
+  DRY_RUN    anything but "false" reports without deleting (default: true)
+
+Stdout: per-package summary. Exit: non-zero, deleting nothing further, on API
+errors other than a package that was never published (404 → logged, skipped),
+and on an implausibly small live-branch set.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+ORG = "constructorfabric"
+REPO = f"{ORG}/insight"
+TRUNK_TAG_RE = re.compile(r"^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}$")
+BRANCH_TAG_RE = re.compile(r"^\d{4}\.\d{2}\.\d{2}\.\d{2}\.\d{2}-[0-9a-f]{7}\.(.+)$")
+# SAFETY: only suffixes the build sanitizer can emit count as branch tags —
+# anything else is an unrecognized shape and is kept, never matched-and-deleted.
+SANITIZED_SUFFIX_RE = re.compile(r"^(?![-.])[A-Za-z0-9._-]{1,60}(?<![-.])$")
+# attest-build-provenance pushes attestations tagged `sha256-<subject digest>`.
+ATTESTATION_TAG_RE = re.compile(r"^sha256-[0-9a-f]{64}$")
+SUFFIX_MAX_CHARS = 60
+# SAFETY: main always exists; fewer than 2 live branches means the branches
+# listing is broken, and sweeping against it would orphan nearly everything.
+MIN_LIVE_BRANCHES = 2
+
+
+def emit(message: str) -> None:
+    """Write one report line to the job log."""
+    print(message)  # noqa: T201 — the job log is this script's interface
+
+
+def gh_api(path: str, *args: str) -> str:
+    """Run `gh api` and return its stdout, raising on any failure."""
+    result = subprocess.run(["gh", "api", path, *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"gh api {path} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def sanitize_branch(name: str) -> str:
+    """Turn a branch name into the image-tag suffix build-images.yml would use."""
+    # INVARIANT: byte-for-byte the build-tag suffix computation in
+    # build-images.yml (tr -c 'a-zA-Z0-9._-' '-'; strip edge [-.]; cut -c1-60).
+    replaced = re.sub(r"[^a-zA-Z0-9._-]", "-", name)
+    trimmed = re.sub(r"^[-.]+", "", re.sub(r"[-.]+$", "", replaced))
+    return trimmed[:SUFFIX_MAX_CHARS]
+
+
+def live_suffixes() -> set[str]:
+    """Sanitized tag suffixes of every branch that currently exists."""
+    raw = gh_api(f"repos/{REPO}/branches", "--paginate", "--jq", ".[].name")
+    names = [line for line in raw.splitlines() if line]
+    return {sanitize_branch(name) for name in names}
+
+
+def branch_tag_suffix(tag: str) -> str | None:
+    """Extract a branch tag's sanitized-branch suffix; None for any other shape."""
+    match = BRANCH_TAG_RE.match(tag)
+    if match is None:
+        return None
+    suffix = match.group(1)
+    return suffix if SANITIZED_SUFFIX_RE.match(suffix) else None
+
+
+def is_recognized(tag: str) -> bool:
+    """Whether the tag has a shape this sweep knows how to classify."""
+    if tag == "latest" or TRUNK_TAG_RE.match(tag) or ATTESTATION_TAG_RE.match(tag):
+        return True
+    return branch_tag_suffix(tag) is not None
+
+
+def is_orphan_tag(tag: str, live: set[str]) -> bool:
+    """Whether the tag names a non-release branch that no longer exists."""
+    suffix = branch_tag_suffix(tag)
+    if suffix is None or suffix in live:
+        return False
+    # SAFETY: release-suffixed tags are exempt by SUFFIX SHAPE alone — customer
+    # clusters pin them, so they survive even when no release-* branch exists.
+    return not suffix.startswith("release-")
+
+
+def list_versions(package: str) -> list[dict] | None:
+    """All versions of an org container package; None if it was never published."""
+    encoded = package.replace("/", "%2F")
+    path = f"/orgs/{ORG}/packages/container/{encoded}/versions"
+    try:
+        raw = gh_api(path, "--paginate", "--jq", ".")
+    except RuntimeError as err:
+        if "404" in str(err) or "Not Found" in str(err):
+            return None
+        raise
+
+    versions: list[dict] = []
+    for page in raw.splitlines():
+        if page:
+            versions.extend(json.loads(page))
+    return versions
+
+
+def delete_version(package: str, version_id: int) -> None:
+    """Permanently delete one package version."""
+    encoded = package.replace("/", "%2F")
+    gh_api(f"/orgs/{ORG}/packages/container/{encoded}/versions/{version_id}", "-X", "DELETE")
+
+
+def sweep_package(package: str, live: set[str], dry_run: bool) -> None:
+    """Classify one package's versions and delete the orphans (unless dry_run)."""
+    versions = list_versions(package)
+    if versions is None:
+        emit(f"{package}: never published (404), skipping")
+        return
+
+    kept = 0
+    skipped = 0
+    orphans: list[tuple[int, list[str]]] = []
+    for version in versions:
+        tags: list[str] = version["metadata"]["container"]["tags"]
+        # SAFETY: untagged versions include per-arch digests of an in-flight
+        # multi-arch publish (tagged only once the manifest list lands, #3020).
+        if not tags:
+            kept += 1
+            continue
+        if not all(is_recognized(tag) for tag in tags):
+            emit(f"{package}: skipping version {version['id']} with unrecognized tags {tags}")
+            skipped += 1
+            continue
+        if all(is_orphan_tag(tag, live) for tag in tags):
+            orphans.append((version["id"], tags))
+        else:
+            kept += 1
+
+    for version_id, tags in orphans:
+        action = "would delete" if dry_run else "deleting"
+        emit(f"{package}: {action} version {version_id} tags {tags}")
+        if not dry_run:
+            delete_version(package, version_id)
+
+    emit(f"{package}: kept={kept} orphaned={len(orphans)} skipped={skipped}")
+
+
+def main() -> int:
+    """Sweep every configured package against the live-branch set."""
+    packages = os.environ.get("PACKAGES", "").split()
+    if not packages:
+        sys.stderr.write("PACKAGES is empty — nothing to sweep\n")
+        return 1
+
+    dry_run = os.environ.get("DRY_RUN", "true").lower() != "false"
+    live = live_suffixes()
+    if len(live) < MIN_LIVE_BRANCHES:
+        sys.stderr.write(
+            f"aborting: only {len(live)} live branches listed — refusing to treat the registry as orphaned\n"
+        )
+        return 1
+    emit(f"live branch suffixes: {len(live)}; dry_run={dry_run}")
+
+    for package in packages:
+        sweep_package(package, live, dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Why.** The branch-delete event fired the cleanup dozens of times a day, each run enumerating every package version — and a single missed event leaked that branch's image tags forever.

**What changed.** The `delete` trigger and `branch` job are gone; a nightly `orphan-sweep` job (same 05:05 cron, plus `workflow_dispatch` with a `dry_run` input) runs `ghcr-orphan-sweep.py`, which sanitizes every live branch name with the exact tag-suffix computation from build-images.yml and deletes versions whose tags all point at branches that no longer exist. A missed night self-heals the next one.

**A version with any live, trunk, `latest`, or attestation tag is kept** — only tags prove nothing else references the version, so deletion requires every tag to be a confirmed orphan.

**Untagged versions are never touched.** They include per-arch digests of an in-flight multi-arch publish, tagged only once the manifest list lands (#3020).

**`release-*` suffixes are exempt by tag shape alone**, matching the old job's filter: release-branch images are long-lived pins, so they survive even an accidental deletion of the release branch itself.

**An implausibly small live-branch set aborts the run.** Fewer than 2 listed branches (main always exists) means the branches API is broken, and sweeping against it would classify nearly every branch tag as orphaned — the script exits non-zero and deletes nothing.

**Package lists corrected** to what build-images.yml and the connector descriptors publish: adds `insight-seed`, `insight-git-cli-proxy`, `insight-previews`, `source-bamboohr-insight`, `source-claude-team-invoices-insight`; drops `insight-ui-tests` (never published). Applied to both jobs.

**Out of scope.** Attestation manifests (`sha256-*` tags) of deleted versions are not swept.

**Verified.** `py_compile` and ruff green; sanitizer output matched the shell pipeline on six edge cases; a read-only dry-run classification over all 15 packages (4,000+ tags via the registry API) found 9 orphaned branch tags, 0 unrecognized, 0 deletions. Stub-exercised paths: 404 log-and-continue, delete issued only when not dry-run, release-suffixed tag kept with no matching branch, empty branch list → non-zero abort with zero deletions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dry-run option for container image cleanup, allowing changes to be reviewed before deletion.
  * Added automated nightly cleanup of branch tags associated with branches that no longer exist.
  * Improved cleanup reporting with counts of retained, orphaned, and skipped image versions.

* **Bug Fixes**
  * Protects trunk, release, latest, attestation, unrecognized, and in-flight multi-architecture tags from removal.
  * Prevents cleanup from running when too few live branches are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->