### PR TITLE
fix(jira): count an issue linked twice as one element of issuelinks

### DIFF
--- a/src/ingestion/dbt/macros/jira/jira_field_value.sql
+++ b/src/ingestion/dbt/macros/jira/jira_field_value.sql
@@ -180,10 +180,10 @@
     A SUBTASK element is the referenced issue itself, with the key at the top
     level, so the same rule applies one level shallower.
 
-    Direction is not part of the identity. An issue holds each link once, and
-    which side of it the issue is on is a property of the link, not of the
-    element — the changelog's rendered text carries it ("blocks", "is caused
-    by"), which is why the display keeps that text where it has it. -#}
+    Direction is not part of the identity: which side of a link the issue is on
+    is a property of the link, not of the element — the changelog's rendered
+    text carries it ("blocks", "is caused by"), which is why the display keeps
+    that text where it has it. -#}
 {% macro jira_json_link_key(v) %}
     coalesce(
         nullIf(JSONExtractString({{ v }}, 'outwardIssue', 'key'), ''),
@@ -202,13 +202,21 @@
 
 
 {#- kind = link_array: the linked issue key as both value and identifier, which
-    is what makes the two sides reconcile at all. -#}
+    is what makes the two sides reconcile at all.
+
+    The keys are deduplicated because two link objects can name the same issue —
+    one issue related to another by two link types is two elements of
+    `issuelinks` and one element here. The changelog cannot express the
+    difference either: it names the linked issue, so a second link to an issue
+    already linked reconciles against the element that is already present.
+    Leaving the repeat in makes the snapshot longer than any history that could
+    reproduce it, and the round trip reports the field forever. -#}
 {% macro jira_norm_link_array(v) %}
     (
-        CAST(arrayMap(x -> {{ jira_json_link_key('x') }},
-             JSONExtractArrayRaw(if({{ v }} IN ('', 'null'), '[]', {{ v }}))) AS Array(String)),
-        CAST(arrayMap(x -> {{ jira_json_link_key('x') }},
-             JSONExtractArrayRaw(if({{ v }} IN ('', 'null'), '[]', {{ v }}))) AS Array(String))
+        CAST(arrayDistinct(arrayMap(x -> {{ jira_json_link_key('x') }},
+             JSONExtractArrayRaw(if({{ v }} IN ('', 'null'), '[]', {{ v }})))) AS Array(String)),
+        CAST(arrayDistinct(arrayMap(x -> {{ jira_json_link_key('x') }},
+             JSONExtractArrayRaw(if({{ v }} IN ('', 'null'), '[]', {{ v }})))) AS Array(String))
     )
 {% endmacro %}
 

--- a/src/ingestion/dbt/tests/jira/assert_jira_field_value_fixtures.sql
+++ b/src/ingestion/dbt/tests/jira/assert_jira_field_value_fixtures.sql
@@ -55,6 +55,12 @@ WITH fixtures AS (
             -- level, and there is no link object around it
             ('subtask element',   'link_array',   '[{"id":"1364577","key":"PROJ-4","fields":{"summary":"child"}}]',
                                                                               ['PROJ-4'],            ['PROJ-4']),
+            -- two link types to the SAME issue are two link objects and one
+            -- element: the changelog names only the linked issue, so a repeat
+            -- has no history that could reproduce it
+            ('link repeated key', 'link_array',
+             '[{"id":"1","outwardIssue":{"key":"PROJ-5"},"type":{"name":"Blocks"}},{"id":"2","inwardIssue":{"key":"PROJ-5"},"type":{"name":"Relates"}}]',
+                                                                              ['PROJ-5'],            ['PROJ-5']),
             ('link empty',        'link_array',   '[]',                       CAST([] AS Array(String)), CAST([] AS Array(String))),
 
             -- single objects


### PR DESCRIPTION
**Why.** An issue can be linked to the same other issue twice — once per link type. Both links land in `issuelinks` with the same linked-issue key, so the snapshot holds two identical elements where the reconstructed history holds one, and the round-trip check reports the field forever.

**What changed.** `jira_norm_link_array` deduplicates the linked-issue keys, on the id and the display side alike so the parallel arrays keep the same length.

**Deduplicating rather than making the link type part of the element.** The changelog names only the linked issue, never which link type was used, so a type-aware element would have nothing on the history side to reconcile against. Reversible: the type is still in the issue JSON.

**Out of scope.** Two smaller findings from the same review — durations normalising `0` and empty to the same state, and list fields whose changelog supplies names but no identifiers. Both need a contract decision, tracked separately.

**Verified.** New fixture `link repeated key` in `assert_jira_field_value_fixtures`; the normalizer's output for every `link_array` fixture checked against a local ClickHouse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate linked issues from appearing when Jira link data contains repeated references to the same issue.
  * Link direction is no longer treated as creating separate linked-issue entries.

* **Tests**
  * Added coverage confirming repeated links are consolidated into a single issue identifier and display value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->