### PR TITLE
fix(jira): run the task completeness checks, and catch an issue no stream fetched

### DIFF
--- a/src/ingestion/dbt/tests/task/assert_availability_ids_and_timestamps.sql
+++ b/src/ingestion/dbt/tests/task/assert_availability_ids_and_timestamps.sql
@@ -1,3 +1,15 @@
+{{ config(
+    tags=['connector_quality', 'jira'],
+    store_failures=true,
+    meta={
+        'title': 'Availability rows carry their ids and timestamps',
+        'domain': 'task-tracking',
+        'category': 'completeness',
+        'tier': 'error',
+        'remediation': 'The census emitted a record without the id, state or last-seen timestamp that deletion classification reads, so the issue it describes cannot be told present from gone. Check the census stream\'s AddFields transformations and the availability staging model that folds them.'
+    }
+) }}
+
 -- API-to-Bronze completeness (#2419): every availability row must carry the
 -- identifiers and timestamps downstream classification depends on. A NULL/empty
 -- jira_id or a missing last_seen_at for a PRESENT issue means the census

--- a/src/ingestion/dbt/tests/task/assert_census_issue_has_full_record.sql
+++ b/src/ingestion/dbt/tests/task/assert_census_issue_has_full_record.sql
@@ -1,17 +1,45 @@
--- API-to-Bronze completeness (#2419): an issue the census observed as present
--- AND that the incremental scan enumerated (a jira_issue_keys row exists) must
--- have its full bronze_jira.jira_issue record. A violation means the sync
--- committed the lightweight parent row but lost the full-record emission —
--- exactly the green-but-empty failure mode this check exists to catch.
+{{ config(
+    tags=['connector_quality', 'jira'],
+    store_failures=true,
+    meta={
+        'title': 'A censused issue of the recent window has its full record',
+        'domain': 'task-tracking',
+        'category': 'completeness',
+        'tier': 'error',
+        'remediation': 'The census enumerated an issue the incremental scan never fetched, so bronze holds no record for it and every substream keyed on the issue -- changelog, comments, worklogs -- is empty too. Nothing downstream can see the omission, because every relation simply lacks the issue. Check the slice bounds the issue stream sends: an issue whose `updated` is always newer than the slice ceiling is never inside any slice, and the lookback on the floor does not reach it. Compare the newest `updated` bronze holds against the time the scan ran; a gap that never closes is the ceiling, not the source.'
+    }
+) }}
+
+-- API-to-Bronze completeness (#2419): an issue the census observed as present,
+-- and that is recent enough to be inside the incremental stream's remit, must
+-- have its full bronze_jira.jira_issue record. A violation means the sync never
+-- fetched the issue at all -- the green-but-empty failure mode this check
+-- exists to catch.
 --
 -- The census alone is not enough to demand a full record: issues untouched
 -- since jira_start_date are censused but legitimately never scanned in full.
+-- What bounds the demand here is the issue id rather than a date. Jira assigns
+-- ids in creation order, so the smallest id among issues created inside the
+-- recent window is a floor: every id at or above it belongs to an issue created
+-- inside that window, hence after any plausible start date, hence one the
+-- incremental scan is required to hold.
 --
--- The two streams scan a project at slightly different moments inside one
--- sync, so an issue updated mid-sync can land in jira_issue_keys before
--- jira_issue has seen it — the next incremental sync closes that gap on its
--- own. Only flag issues whose key-row `updated` predates the full stream's
--- last scan by more than the race window.
+-- The floor is derived rather than configured for two reasons. The start date
+-- is connector config and is not in the warehouse; and the census row cannot
+-- carry a creation date, because the census asks for `id` alone -- which is
+-- what lets Jira serve it in 5000-row pages -- and a second field would cost
+-- that page size across every issue in the instance.
+--
+-- Deliberately NOT gated on a jira_issue_keys row. The lightweight stream
+-- filters and sorts on the same mutating cursor as the full one, so the two
+-- fail together: requiring a key row makes the check blind to exactly the case
+-- where nothing about the issue was fetched, which is the severe one.
+--
+-- The race window is measured from FIRST sighting, not last. The census scans a
+-- project after the issue stream inside one sync, so an issue's latest sighting
+-- is always younger than the scan and a guard written against it would never
+-- fire. An issue first censused more than the race window before the scan has
+-- had at least one whole sync in which to be fetched.
 
 WITH issue_scan AS (
     -- Per (tenant, source): each source instance scans on its own clock, so a
@@ -23,6 +51,27 @@ WITH issue_scan AS (
         max(_airbyte_extracted_at) AS scanned_at
     FROM bronze_jira.jira_issue
     GROUP BY tenant_id, source_id
+),
+
+recent_floor AS (
+    SELECT
+        tenant_id,
+        source_id,
+        min(toUInt64OrZero(jira_id)) AS floor_id
+    FROM bronze_jira.jira_issue FINAL
+    WHERE parseDateTime64BestEffortOrNull(created, 3) >= now() - INTERVAL 30 DAY
+    GROUP BY tenant_id, source_id
+),
+
+first_seen AS (
+    SELECT
+        tenant_id,
+        source_id,
+        entity_id AS jira_id,
+        min(updated_at) AS censused_at
+    FROM staging.jira__issue_availability_history
+    WHERE field_name = 'availability'
+    GROUP BY tenant_id, source_id, entity_id
 )
 
 SELECT
@@ -30,16 +79,20 @@ SELECT
     av.source_id,
     av.jira_id
 FROM staging.jira__issue_availability_state AS av FINAL
-INNER JOIN bronze_jira.jira_issue_keys AS ik FINAL
-    ON ik.tenant_id = av.tenant_id
-    AND ik.source_id = av.source_id
-    AND ik.jira_id = av.jira_id
+INNER JOIN recent_floor AS f
+    ON f.tenant_id = av.tenant_id
+    AND f.source_id = av.source_id
+INNER JOIN issue_scan AS scan
+    ON scan.tenant_id = av.tenant_id
+    AND scan.source_id = av.source_id
+INNER JOIN first_seen AS fs
+    ON fs.tenant_id = av.tenant_id
+    AND fs.source_id = av.source_id
+    AND fs.jira_id = av.jira_id
 LEFT ANTI JOIN bronze_jira.jira_issue AS i FINAL
     ON i.tenant_id = av.tenant_id
     AND i.source_id = av.source_id
     AND i.jira_id = av.jira_id
-INNER JOIN issue_scan AS scan
-    ON scan.tenant_id = av.tenant_id
-    AND scan.source_id = av.source_id
 WHERE av.availability = 'present'
-  AND parseDateTime64BestEffortOrNull(ik.updated, 3) < scan.scanned_at - INTERVAL 1 HOUR
+  AND toUInt64OrZero(av.jira_id) >= f.floor_id
+  AND fs.censused_at < scan.scanned_at - INTERVAL 1 HOUR

--- a/src/ingestion/dbt/tests/task/assert_worklog_deletion_state_consistent.sql
+++ b/src/ingestion/dbt/tests/task/assert_worklog_deletion_state_consistent.sql
@@ -1,3 +1,15 @@
+{{ config(
+    tags=['connector_quality', 'jira'],
+    store_failures=true,
+    meta={
+        'title': 'A tombstoned worklog is flagged deleted in the class contract',
+        'domain': 'task-tracking',
+        'category': 'consistency',
+        'tier': 'error',
+        'remediation': 'Jira reported the worklog as deleted and the class contract still counts it as live, so time-logged metrics include hours the source no longer has. Check the deletion signals in the worklog lifecycle staging models against bronze_jira.jira_worklog_deleted.'
+    }
+) }}
+
 -- API-to-Bronze completeness (#2419): a worklog with an authoritative
 -- /worklog/deleted tombstone must be flagged is_deleted in the class contract.
 -- A violation means the staging model's deletion signals regressed and gold


### PR DESCRIPTION
**Why.** A cluster runs `dbt test` through two tag selectors only, and three task-tracking completeness checks carry no tags, so neither selector matches and none has ever run outside CI. The census one was also blind to the case it exists for.

**What changed.** All three take `connector_quality` plus the connector tag, with `store_failures` and the `meta` block the finding emitter reads. The census check drops its `jira_issue_keys` requirement — that stream filters on the same mutating cursor as `jira_issue`, so the two fail together and requiring it hid the case where nothing about an issue was fetched — and bounds its demand by issue id instead: ids are assigned in creation order, so the smallest id created inside the recent window is a floor above which a censused issue must have a full record.

**No creation date on the census row, deliberately.** That stream asks for `id` alone, which is what lets Jira serve it in 5000-row pages; a second field would cost that across every issue in an instance.

**The race guard moves to first sighting.** The census scans a project after the issue stream inside one sync, so an issue's latest sighting is always younger than the scan and a guard written against it could never fire.

Seeded scenario, seven censused issues, one fetched by neither stream:

| Censused issue | Situation | Before | After |
|---|---|---|---|
| `EX-1`, `EX-2`, `EX-5` | full record present | — | — |
| `EX-3` | fetched by neither stream | not reported | **reported** |
| `EX-4` | first censused inside the race window | — | — |
| `EX-0` | id below the recent-window floor | — | — |
| `EX-6` | censused as deleted | — | — |

**Out of scope.** The collection defect these checks detect is not fixed here. No committed fixture covers the three checks; the scenario above was run by hand.

**Verified.** The table above, on a throwaway ClickHouse of the pinned version with bronze created from the connectors-ddl snapshot and synthetic rows. `dbt parse` reports the same errors with and without the change and names none of the three files. `dbt ls` cannot enumerate tags on the pinned dbt build, so tag selection is left to CI.
