### PR TITLE
feat(jira): carry the issue's immutable id on its changelog, comments and worklogs

### DIFF
--- a/src/ingestion/connectors/task-tracking/jira/README.md
+++ b/src/ingestion/connectors/task-tracking/jira/README.md
@@ -90,6 +90,7 @@ The `jira_boards` stream (`GET /rest/agile/1.0/board`) is the substream parent f
 ### Identity Key
 
 - `jira_user.email_address` — primary identity key
+- `jira_issue_history.jira_id`, `jira_comments.jira_id`, `jira_worklogs.jira_id` — the parent issue's immutable numeric id, taken from the parent slice (`id_readable` is the key at fetch time and changes when an issue moves between projects).
 - `jira_issue.reporter_id`, `jira_issue_history.author_account_id`, `jira_comments.author_account_id`, `jira_worklogs.author_account_id` — Atlassian `accountId` resolved to `email` downstream via `jira_user` JOIN in Silver.
 
 ## Silver Targets

--- a/src/ingestion/connectors/task-tracking/jira/connector.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/connector.yaml
@@ -1246,6 +1246,10 @@ streams:
               $ref: "#/streams/13"
             parent_key: id_readable
             partition_field: id_readable
+            # INVARIANT: the parent's immutable id travels with every child row; the
+            # key is what Jira showed at fetch time and changes on a project move.
+            extra_fields:
+              - [id]
             incremental_dependency: true
     incremental_sync:
       type: DatetimeBasedCursor
@@ -1285,6 +1289,10 @@ streams:
             path:
               - id_readable
             value: "{{ stream_partition.id_readable }}"
+          - type: AddedFieldDefinition
+            path:
+              - jira_id
+            value: "{{ stream_slice.extra_fields['id'] }}"
           - type: AddedFieldDefinition
             path:
               - author_account_id
@@ -1399,6 +1407,10 @@ streams:
             type:
               - string
               - "null"
+          jira_id:
+            type:
+              - string
+              - "null"
           author_account_id:
             type:
               - string
@@ -1449,6 +1461,10 @@ streams:
               $ref: "#/streams/13"
             parent_key: id_readable
             partition_field: id_readable
+            # INVARIANT: the parent's immutable id travels with every child row; the
+            # key is what Jira showed at fetch time and changes on a project move.
+            extra_fields:
+              - [id]
             incremental_dependency: true
     incremental_sync:
       type: DatetimeBasedCursor
@@ -1492,6 +1508,10 @@ streams:
             path:
               - id_readable
             value: "{{ stream_partition.id_readable }}"
+          - type: AddedFieldDefinition
+            path:
+              - jira_id
+            value: "{{ stream_slice.extra_fields['id'] }}"
           - type: AddedFieldDefinition
             path:
               - author_account_id
@@ -1668,6 +1688,10 @@ streams:
             type:
               - string
               - "null"
+          jira_id:
+            type:
+              - string
+              - "null"
           author_account_id:
             type:
               - string
@@ -1721,6 +1745,10 @@ streams:
               $ref: "#/streams/13"
             parent_key: id_readable
             partition_field: id_readable
+            # INVARIANT: the parent's immutable id travels with every child row; the
+            # key is what Jira showed at fetch time and changes on a project move.
+            extra_fields:
+              - [id]
             incremental_dependency: true
     incremental_sync:
       type: DatetimeBasedCursor
@@ -1764,6 +1792,10 @@ streams:
             path:
               - id_readable
             value: "{{ stream_partition.id_readable }}"
+          - type: AddedFieldDefinition
+            path:
+              - jira_id
+            value: "{{ stream_slice.extra_fields['id'] }}"
           - type: AddedFieldDefinition
             path:
               - author_account_id
@@ -1946,6 +1978,10 @@ streams:
               - number
               - "null"
           id_readable:
+            type:
+              - string
+              - "null"
+          jira_id:
             type:
               - string
               - "null"

--- a/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
@@ -41,18 +41,27 @@ name: jira
 # one stayed behind with a stale payload, leaving the issue present twice
 # downstream, once with its real history and once as a ghost.
 #
-# Rows written before this keep their old key: `unique_key` is the table's sort
-# key and ClickHouse refuses to UPDATE one, so there is no migration to rewrite
-# them in place, and rebuilding a table this size to change a column nothing
-# reads afterwards would not earn its cost. The readers stop depending on it
-# instead — every dedup over jira_issue now picks its winner by
-# (source_id, jira_id) — so the stale row is simply never chosen.
+# Rows written before this are rebuilt by `heal_jira_issue_key` in
+# apply-ch-migrations.sh: `unique_key` is the sort key and cannot be updated in
+# place, so the table is copied with the new key, one row per issue, and
+# swapped in atomically. Readers dedup by (source_id, jira_id) regardless — the
+# issue's stable key within a source, which is what joins use; `unique_key`
+# exists for ReplacingMergeTree alone. `id_readable` keeps the mutable key as
+# an attribute — the rename is a fact about the issue.
 #
 # MAJOR because the key an existing row is stored under changes, which is what
 # a major means here; the full refresh it dispatches also clears anything
-# derived while the two copies were both visible. `id_readable` keeps the
-# mutable key — the rename is a fact about the issue.
-version: "6.0.0"
+# derived while the two copies were both visible.
+# 6.1.0 (minor): jira_issue_history, jira_comments and jira_worklogs carry
+# `jira_id`, the parent issue's immutable numeric id, taken from the parent
+# slice. Each of these substreams is partitioned by the issue KEY and stamped
+# only `id_readable`, the key at fetch time — so after an issue moved between
+# projects nothing in its changelog, comments or worklogs named the issue by
+# anything stable, and every reader had to recover the id by joining on a key
+# that no longer matched. MINOR: a new column, nothing re-derived; rows written
+# before this are filled by `heal_jira_substream_issue_id` from the two issue
+# streams.
+version: "6.1.0"
 schedule: "0 3 * * *"
 workflow: sync
 # CI build metadata + runtime image refs (ADR-0016). The `images:` block is

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_comments.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_comments.py
@@ -96,6 +96,9 @@ def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
     assert rec["source_id"] == config["insight_source_id"]
     assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-701")
     assert rec["id_readable"] == "PROJ1-1"
+    # The parent issue's immutable id, carried by the slice alongside the key;
+    # an int here for the same reason as in test_jira_issue_keys.
+    assert rec["jira_id"] == 20000
     assert rec["author_account_id"] == "acc-1"
     assert rec["updated"] == "2026-06-15T11:00:00.000+0000"
     # Raw ADF body rides along as JSON; plaintext extraction is deferred to dbt.

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue_history.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue_history.py
@@ -89,6 +89,9 @@ def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
     assert rec["source_id"] == config["insight_source_id"]
     assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-501")
     assert rec["id_readable"] == "PROJ1-1"
+    # The parent issue's immutable id, carried by the slice alongside the key;
+    # an int here for the same reason as in test_jira_issue_keys.
+    assert rec["jira_id"] == 20000
     assert rec["author_account_id"] == "acc-1"
     assert rec["created_at"] == "2026-06-15T10:00:00.000+0000"
     # items[] rides along as JSON for the dbt changelog explode.

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_worklogs.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_worklogs.py
@@ -94,6 +94,9 @@ def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
     assert rec["source_id"] == config["insight_source_id"]
     assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-801")
     assert rec["id_readable"] == "PROJ1-1"
+    # The parent issue's immutable id, carried by the slice alongside the key;
+    # an int here for the same reason as in test_jira_issue_keys.
+    assert rec["jira_id"] == 20000
     assert rec["author_account_id"] == "acc-1"
     assert rec["started"] == "2026-06-15T09:00:00.000+0000"
     assert rec["time_spent_seconds"] == 3600

--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -122,6 +122,161 @@ SQL
 heal_github_project_day_keys project_fields
 heal_github_project_day_keys project_items
 
+echo "=== Healing Jira bronze issue identity ==="
+# Two heals, in this order, both guarded on the rows they would change so a
+# converged warehouse pays one SELECT per table and nothing else.
+#
+# 1. jira_issue_history / jira_comments / jira_worklogs carry `jira_id` since
+#    connector 6.1.0; rows written before it name their issue only by
+#    `id_readable`, the key at fetch time. The id is recovered from the two
+#    issue streams, read WITHOUT FINAL and before the rebuild below: a moved
+#    issue holds one bronze row per key it ever had, and those old-key rows
+#    are the only thing that maps a pre-move key to its id. A mutation cannot
+#    join a subquery, so the pairs go through a Join-engine table and joinGet,
+#    keyed by (tenant_id, source_id, id_readable) because one bronze holds
+#    every connector instance. Worklogs prefer Jira's own `issueId`.
+#
+# 2. jira_issue / jira_issue_keys were keyed by the issue KEY before descriptor
+#    6.0.0, so a moved issue exists once per key and ReplacingMergeTree can
+#    collapse neither. The table is rebuilt with `unique_key` on the immutable
+#    id — one row per issue, the latest extraction — and swapped in atomically.
+#    INVARIANT: nothing may write to the table between the copy and the
+#    EXCHANGE; only the Argo pipeline writes bronze, so a deploy carrying this
+#    heal must not overlap a Jira sync.
+_jira_issue_id_lookup='staging._jira_issue_id_by_key'
+
+# Counts only the rows the lookup can actually fill: a key no issue stream ever
+# delivered stays NULL forever, and counting it would re-run the mutation on
+# every deploy. Worklogs carry Jira's own issueId and count whenever it is set.
+_jira_rows_needing_issue_id() {
+  local table="$1" own=""
+  [[ "${table}" == "jira_worklogs" ]] && own="OR issueId IS NOT NULL"
+  printf "SELECT count() FROM bronze_jira.%s
+          WHERE jira_id IS NULL AND id_readable IS NOT NULL AND tenant_id IS NOT NULL AND source_id IS NOT NULL
+            AND ((assumeNotNull(tenant_id), assumeNotNull(source_id), assumeNotNull(id_readable)) IN (
+                   SELECT assumeNotNull(tenant_id), assumeNotNull(source_id), assumeNotNull(id_readable)
+                   FROM bronze_jira.jira_issue
+                   WHERE tenant_id IS NOT NULL AND source_id IS NOT NULL AND id_readable IS NOT NULL AND jira_id IS NOT NULL
+                   UNION ALL
+                   SELECT assumeNotNull(tenant_id), assumeNotNull(source_id), assumeNotNull(id_readable)
+                   FROM bronze_jira.jira_issue_keys
+                   WHERE tenant_id IS NOT NULL AND source_id IS NOT NULL AND id_readable IS NOT NULL AND jira_id IS NOT NULL)
+                 %s)" "${table}" "${own}" |
+    _ch_http_query | tr -d '[:space:]'
+}
+
+_jira_rows_keyed_by_issue_key() {
+  local table="$1"
+  printf "SELECT count() FROM bronze_jira.%s WHERE coalesce(unique_key, '') != concat(coalesce(tenant_id, ''), '-', coalesce(source_id, ''), '-', coalesce(jira_id, ''))" "${table}" |
+    _ch_http_query | tr -d '[:space:]'
+}
+
+heal_jira_substream_issue_id() {
+  local pending=() table n
+  for table in jira_issue_history jira_comments jira_worklogs; do
+    ch_table_exists bronze_jira "${table}" || continue
+    n="$(_jira_rows_needing_issue_id "${table}")"
+    [[ "${n}" =~ ^[0-9]+$ && "${n}" -gt 0 ]] || continue
+    echo "  bronze_jira.${table}: ${n} row(s) without jira_id — filling from the issue streams"
+    pending+=("${table}")
+  done
+  [[ "${#pending[@]}" -gt 0 ]] || return 0
+
+  run_ch <<SQL
+DROP TABLE IF EXISTS ${_jira_issue_id_lookup};
+CREATE TABLE ${_jira_issue_id_lookup}
+(
+    tenant_id String,
+    source_id String,
+    id_readable String,
+    jira_id String
+)
+ENGINE = Join(ANY, LEFT, tenant_id, source_id, id_readable);
+INSERT INTO ${_jira_issue_id_lookup}
+SELECT tenant_id, source_id, id_readable, jira_id
+FROM
+(
+    SELECT assumeNotNull(tenant_id) AS tenant_id, assumeNotNull(source_id) AS source_id,
+           assumeNotNull(id_readable) AS id_readable, assumeNotNull(jira_id) AS jira_id
+    FROM bronze_jira.jira_issue
+    WHERE tenant_id IS NOT NULL AND source_id IS NOT NULL AND id_readable IS NOT NULL AND jira_id IS NOT NULL
+    UNION ALL
+    SELECT assumeNotNull(tenant_id) AS tenant_id, assumeNotNull(source_id) AS source_id,
+           assumeNotNull(id_readable) AS id_readable, assumeNotNull(jira_id) AS jira_id
+    FROM bronze_jira.jira_issue_keys
+    WHERE tenant_id IS NOT NULL AND source_id IS NOT NULL AND id_readable IS NOT NULL AND jira_id IS NOT NULL
+)
+GROUP BY tenant_id, source_id, id_readable, jira_id;
+SQL
+
+  local lookup="nullIf(joinGet('${_jira_issue_id_lookup}', 'jira_id', assumeNotNull(tenant_id), assumeNotNull(source_id), assumeNotNull(id_readable)), '')"
+  for table in "${pending[@]}"; do
+    local value="${lookup}"
+    [[ "${table}" == "jira_worklogs" ]] && value="COALESCE(issueId, ${lookup})"
+    run_ch <<SQL
+ALTER TABLE bronze_jira.${table}
+    UPDATE jira_id = ${value}
+    WHERE jira_id IS NULL AND id_readable IS NOT NULL AND tenant_id IS NOT NULL AND source_id IS NOT NULL
+    SETTINGS mutations_sync = 1;
+SQL
+  done
+
+  run_ch <<SQL
+DROP TABLE IF EXISTS ${_jira_issue_id_lookup};
+SQL
+}
+
+_jira_rows_without_identity() {
+  local table="$1"
+  printf "SELECT count() FROM bronze_jira.%s WHERE tenant_id IS NULL OR source_id IS NULL OR jira_id IS NULL" "${table}" |
+    _ch_http_query | tr -d '[:space:]'
+}
+
+heal_jira_issue_key() {
+  local table="$1" n orphans copy_start_ms
+  ch_table_exists bronze_jira "${table}" || return 0
+  n="$(_jira_rows_keyed_by_issue_key "${table}")"
+  [[ "${n}" =~ ^[0-9]+$ && "${n}" -gt 0 ]] || return 0
+
+  # A row without tenant, source or issue id has no key under the new formula.
+  # None can exist — the connector stamps all three on every record — so one
+  # is a corrupted table, and the deploy stops here rather than dropping it.
+  orphans="$(_jira_rows_without_identity "${table}")"
+  if [[ ! "${orphans}" =~ ^[0-9]+$ || "${orphans}" -gt 0 ]]; then
+    echo "  bronze_jira.${table}: ${orphans:-?} row(s) without tenant_id, source_id or jira_id — refusing to rebuild" >&2
+    return 1
+  fi
+
+  echo "  bronze_jira.${table}: ${n} row(s) keyed by the issue key — rebuilding on the issue id"
+  copy_start_ms="$(printf "SELECT toUnixTimestamp64Milli(now64(3))" | _ch_http_query | tr -d '[:space:]')"
+  [[ "${copy_start_ms}" =~ ^[0-9]+$ ]] || { echo "  bronze_jira.${table}: could not read the server clock — refusing to rebuild" >&2; return 1; }
+  run_ch <<SQL
+DROP TABLE IF EXISTS bronze_jira.${table}__rekey;
+CREATE TABLE bronze_jira.${table}__rekey AS bronze_jira.${table};
+INSERT INTO bronze_jira.${table}__rekey
+SELECT * REPLACE (concat(tenant_id, '-', source_id, '-', jira_id) AS unique_key)
+FROM bronze_jira.${table}
+ORDER BY _airbyte_extracted_at DESC
+LIMIT 1 BY tenant_id, source_id, jira_id;
+EXCHANGE TABLES bronze_jira.${table} AND bronze_jira.${table}__rekey;
+SQL
+  # From the EXCHANGE on, writers land in the rebuilt table by name. Rows a sync
+  # committed into the old table while the copy ran are carried over before it
+  # is dropped; the hour of slack covers an extraction stamp older than the
+  # write, and a row copied twice collapses on its key.
+  run_ch <<SQL
+INSERT INTO bronze_jira.${table}
+SELECT * REPLACE (concat(tenant_id, '-', source_id, '-', jira_id) AS unique_key)
+FROM bronze_jira.${table}__rekey
+WHERE _airbyte_extracted_at >= fromUnixTimestamp64Milli(${copy_start_ms}) - INTERVAL 1 HOUR;
+DROP TABLE IF EXISTS bronze_jira.${table}__rekey;
+SQL
+}
+
+heal_jira_substream_issue_id || exit 1
+heal_jira_issue_key jira_issue || exit 1
+heal_jira_issue_key jira_issue_keys || exit 1
+
 echo "=== Healing AI staging contract schemas ==="
 # Physical column order must equal the model's SELECT order (positional
 # incremental inserts, positional union). Labels left the contract (they

--- a/src/ingestion/scripts/connectors-ddl/jira.sql
+++ b/src/ingestion/scripts/connectors-ddl/jira.sql
@@ -72,6 +72,7 @@ CREATE TABLE IF NOT EXISTS bronze_jira.jira_comments
     `unique_key` Nullable(String),
     `comment_id` Nullable(Decimal(38, 9)),
     `id_readable` Nullable(String),
+    `jira_id` Nullable(String),
     `author_account_id` Nullable(String),
     `collected_at` Nullable(String)
 )
@@ -179,6 +180,7 @@ CREATE TABLE IF NOT EXISTS bronze_jira.jira_issue_history
     `source_id` Nullable(String),
     `unique_key` Nullable(String),
     `id_readable` Nullable(String),
+    `jira_id` Nullable(String),
     `author_account_id` Nullable(String),
     `changelog_id` Nullable(Decimal(38, 9)),
     `created_at` Nullable(String),
@@ -481,6 +483,7 @@ CREATE TABLE IF NOT EXISTS bronze_jira.jira_worklogs
     `unique_key` Nullable(String),
     `worklog_id` Nullable(Decimal(38, 9)),
     `id_readable` Nullable(String),
+    `jira_id` Nullable(String),
     `author_account_id` Nullable(String),
     `time_spent_seconds` Nullable(Decimal(38, 9)),
     `comment` Nullable(String),

--- a/src/ingestion/scripts/migrations/20260911000000_jira-substreams-issue-id.sql
+++ b/src/ingestion/scripts/migrations/20260911000000_jira-substreams-issue-id.sql
@@ -1,0 +1,15 @@
+-- Give the three issue-scoped Jira substreams a column for the issue's
+-- immutable id. Connector 6.1.0 fills it on new rows; the rows already stored
+-- are filled by `heal_jira_substream_issue_id` in apply-ch-migrations.sh, which
+-- runs after this file and only while rows still lack the value.
+--
+-- Idempotent: IF NOT EXISTS, and `jira_id` is not part of the sorting key.
+
+ALTER TABLE bronze_jira.jira_issue_history
+    ADD COLUMN IF NOT EXISTS jira_id Nullable(String) AFTER id_readable;
+
+ALTER TABLE bronze_jira.jira_comments
+    ADD COLUMN IF NOT EXISTS jira_id Nullable(String) AFTER id_readable;
+
+ALTER TABLE bronze_jira.jira_worklogs
+    ADD COLUMN IF NOT EXISTS jira_id Nullable(String) AFTER id_readable;

--- a/tests/datapath/metrics/schemas/bronze_jira.jira_issue_history.yaml
+++ b/tests/datapath/metrics/schemas/bronze_jira.jira_issue_history.yaml
@@ -11,6 +11,7 @@ schemas:
       source_id: {type: string}
       tenant_id: {type: string}
       id_readable: {type: string}
+      jira_id: {type: [string, "null"]}
       # changelog id is a JSON number → Decimal(38,9) in the real bronze; accept
       # number|string|null so the string-valued fixture matches via coercion.
       changelog_id: {type: [number, string, "null"]}

--- a/tests/datapath/metrics/schemas/bronze_jira.jira_worklogs.yaml
+++ b/tests/datapath/metrics/schemas/bronze_jira.jira_worklogs.yaml
@@ -14,6 +14,7 @@ schemas:
       # number|string|null to match the real column via the seeder's coercion.
       worklog_id: {type: [number, string, "null"]}
       id_readable: {type: string}
+      jira_id: {type: [string, "null"]}
       author_account_id: {type: string}
       started: {type: string}
       time_spent_seconds: {type: [number, string, "null"]}


### PR DESCRIPTION
**Why.** `jira_issue_history`, `jira_comments` and `jira_worklogs` name their issue only by `id_readable`, the key at fetch time. After an issue moves between projects that key matches nothing, so every reader that needs the issue's id from these rows loses the pre-move part of its history. `jira_issue_keys` rows written before 6.0.0 are still stored under the issue key too, so a moved issue exists once per key and ReplacingMergeTree collapses neither.

**What changed.** Descriptor 6.1.0 carries the parent issue's immutable `jira_id` into each of the three substreams through the slice's `extra_fields`. Two guarded heals in `apply-ch-migrations.sh` fix the rows already stored: the first fills `jira_id` from the two issue streams, the second rebuilds `jira_issue` and `jira_issue_keys` with `unique_key` on the issue id — one row per issue — and swaps the table in atomically.

**Both heals are guarded on the rows they would change.** Migrations replay on every deploy, so an unconditional copy would rebuild the tables each time. The fill counts only rows the issue streams can resolve; a key no stream ever delivered stays `NULL`. The rebuild counts rows whose key differs from the current formula. A converged warehouse pays one `SELECT` per table.

**The fill runs before the rebuild, and the mapping is read without `FINAL`.** The old-key rows of a moved issue are the only thing that maps its pre-move key to an id; the rebuild removes them. Keyed by `(tenant_id, source_id, id_readable)` because one bronze holds every connector instance.

**A write that lands in the old table during the copy is carried over after the swap.** From the `EXCHANGE` on, writers reach the rebuilt table by name; rows committed into the old one while the copy ran are copied across before it is dropped. The window left is the instant between that catch-up and the drop, so a deploy carrying this heal still should not overlap a Jira sync.

**A row without tenant, source or issue id stops the deploy.** It has no key under the new formula and cannot exist — the connector stamps all three — so the rebuild refuses rather than dropping it.

**Out of scope.** Reading the new column and re-keying the field-history journal on `issue_id`: [#3372](https://github.com/constructorfabric/insight/pull/3372), stacked on this one.

**Verified.** Jira mock-server suite, 55 passed. Both heals run against a local ClickHouse holding a synthetic three-table bronze: first pass fills and rebuilds, second pass is a no-op, helper and swap tables gone; a row inserted into the old table survives the swap under the new key; a planted row without an id makes the rebuild exit non-zero; on empty tables both are no-ops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Jira issue history, comments, and worklogs now include a stable issue identifier that remains consistent when issues move between projects.
  * Existing records are backfilled with the stable identifier during migration.
  * The readable issue key remains available for reference.

* **Documentation**
  * Updated Jira connector documentation to explain stable and readable issue identifiers.

* **Tests**
  * Added coverage confirming stable identifiers are emitted for Jira substream records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
