### PR TITLE
test(metrics): pin the day, the blind size and the own default name behind default-branch code lines

### DIFF
--- a/tests/datapath/metrics/git/git_branch_scope.test.yaml
+++ b/tests/datapath/metrics/git/git_branch_scope.test.yaml
@@ -10,14 +10,28 @@ description: >-
   Her second request merges into a release branch and must NOT promote its
   commit.
 
+  Dave works in a second repository whose default branch is `master`, and
+  which also has a `main` that is NOT its default. Both his commits are
+  flagged outside the default branch; the request merged into `master` lands
+  its commit, the request merged into `main` must not. The comparison is
+  against the repository's OWN default branch name, and only a repository that
+  does not follow the convention can tell — every other commit-side fixture
+  calls its default `main`, so a rule that hardcoded the name passed them all.
+  He sits in a department of his own, so the peer pool of three above is
+  untouched.
+
 bronze:
   bronze_bamboohr.employees:
     - $ref: ../templates/people.yaml#/templates/alice
     - $ref: ../templates/people.yaml#/templates/bob
     - $ref: ../templates/people.yaml#/templates/carol
+    - {$ref: ../templates/people.yaml#/templates/dave, department: "Legacy Platform"}
   bronze_github.branches:
     - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: br-main, repository: "https://github.com/constructor/insight.git", name: main, head_sha: head-main, is_default: true}
     - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: br-release, repository: "https://github.com/constructor/insight.git", name: release/1.x, head_sha: head-release, is_default: false}
+    # Dave's repository: `master` is the default, and `main` exists but is not.
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: br-legacy-master, repository: "https://github.com/constructor/legacy.git", name: master, head_sha: head-legacy-master, is_default: true}
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: br-legacy-main, repository: "https://github.com/constructor/legacy.git", name: main, head_sha: head-legacy-main, is_default: false}
   bronze_github.commits:
     # One landed commit and one still in flight per person. Same numbers each
     # time; only carol's landed one is flagged as outside the default branch.
@@ -27,6 +41,9 @@ bronze:
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-bob-n, sha: sha-bob-n, author_name: bob, author_email: bob@example.com, committer_name: bob, committer_email: bob@example.com, additions: 20, deletions: 2, is_in_default_branch: false}
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-carol-d, sha: sha-carol-d, author_name: carol, author_email: carol@example.com, committer_name: carol, committer_email: carol@example.com, additions: 10, deletions: 1, is_in_default_branch: false}
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-carol-n, sha: sha-carol-n, author_name: carol, author_email: carol@example.com, committer_name: carol, committer_email: carol@example.com, additions: 20, deletions: 2, is_in_default_branch: false}
+    # Dave, both flagged outside the default branch; the requests below decide.
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-dave-master, repository: "https://github.com/constructor/legacy.git", sha: sha-dave-master, author_name: dave, author_email: dave@example.com, committer_name: dave, committer_email: dave@example.com, additions: 10, deletions: 1, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-dave-main, repository: "https://github.com/constructor/legacy.git", sha: sha-dave-main, author_name: dave, author_email: dave@example.com, committer_name: dave, committer_email: dave@example.com, additions: 20, deletions: 2, is_in_default_branch: false}
   bronze_github.file_changes:
     # `.rs` under src/ classifies as code, so the category and code-lines
     # assertions read off the same rows.
@@ -36,6 +53,8 @@ bronze:
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-bob-n, sha: sha-bob-n, filename: src/bob_n.rs, additions: 20, deletions: 2}
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-carol-d, sha: sha-carol-d, filename: src/carol_d.rs, additions: 10, deletions: 1}
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-carol-n, sha: sha-carol-n, filename: src/carol_n.rs, additions: 20, deletions: 2}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-dave-master, repository: "https://github.com/constructor/legacy.git", sha: sha-dave-master, filename: src/dave_master.rs, additions: 10, deletions: 1}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-dave-main, repository: "https://github.com/constructor/legacy.git", sha: sha-dave-main, filename: src/dave_main.rs, additions: 20, deletions: 2}
   bronze_github.pull_requests:
     # One request into the default branch and one into a release branch per
     # person, both merged.
@@ -45,6 +64,10 @@ bronze:
     - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: pr-bob-rel, id: 22, number: 22, author_login: bob, base_ref: release/1.x, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: merge-bob-rel}
     - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: pr-carol-main, id: 31, number: 31, author_login: carol, base_ref: main, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: merge-carol-main}
     - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: pr-carol-rel, id: 32, number: 32, author_login: carol, base_ref: release/1.x, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: merge-carol-rel}
+    # Dave: one request into his repository's default, `master`, and one into
+    # its `main`, which is not.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: pr-dave-master, repo_full_name: constructor/legacy, id: 41, number: 41, author_login: dave, base_ref: master, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: merge-dave-master}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: pr-dave-main, repo_full_name: constructor/legacy, id: 42, number: 42, author_login: dave, base_ref: main, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: merge-dave-main}
   bronze_github.pull_request_diff_stats:
     # GitHub staging reads a request's author_email from here and nowhere else
     # — bronze `pull_requests` carries only the login. Without a row per
@@ -56,9 +79,14 @@ bronze:
     - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-bob-rel, pull_number: 22, additions: 20, deletions: 2, author_email: bob@example.com}
     - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-carol-main, pull_number: 31, additions: 10, deletions: 1, author_email: carol@example.com}
     - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-carol-rel, pull_number: 32, additions: 20, deletions: 2, author_email: carol@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-dave-master, repo_full_name: constructor/legacy, pull_number: 41, additions: 10, deletions: 1, author_email: dave@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-dave-main, repo_full_name: constructor/legacy, pull_number: 42, additions: 20, deletions: 2, author_email: dave@example.com}
   bronze_github.pull_request_commits:
     # Carol only. Her default-branch request carries the commit whose flag says
     # non-default — that link is the heal. Her release request carries the
     # other one, and must leave it alone.
     - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: lnk-carol-d, sha: sha-carol-d, pull_number: 31, repo_full_name: constructor/insight, author_email: carol@example.com, is_merge: false}
     - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: lnk-carol-n, sha: sha-carol-n, pull_number: 32, repo_full_name: constructor/insight, author_email: carol@example.com, is_merge: false}
+    # Dave: each request carries one commit. Only the `master` link may heal.
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: lnk-dave-master, sha: sha-dave-master, pull_number: 41, repo_full_name: constructor/legacy, author_email: dave@example.com, is_merge: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: lnk-dave-main, sha: sha-dave-main, pull_number: 42, repo_full_name: constructor/legacy, author_email: dave@example.com, is_merge: false}

--- a/tests/datapath/metrics/git/git_default_branch_code_lines.test.yaml
+++ b/tests/datapath/metrics/git/git_default_branch_code_lines.test.yaml
@@ -24,7 +24,8 @@ description: >
   code total that bound it; a landed test file, which raises the unclassified
   default total and not this one; the change-type split, which is also the
   oracle for which of two carriers of one content survived; the extension
-  split; and an empty window.
+  split; the day a commit is filed under, which is the day its work was
+  WRITTEN and not the day it was committed; and an empty window.
 
   The API rejects a metric that requests the same view twice, so each split
   needs its own case.
@@ -53,9 +54,20 @@ description: >
   can. `added: 9` is therefore the assertion that the earliest carrier won,
   and a dedup that preferred the later one reads `modified: 21` instead.
 
+  Dave carries the dating case alone, so erin's arithmetic above never moves.
+  Every commit of hers has one date; his has two, three days apart — the gap a
+  rebase, a cherry-pick or a late push leaves:
+    * dbcl-late, flag says landed, written on the 2nd, committed on the 5th
+        src/f.rs        +11 added     counts on the 2nd, and not on the 5th
+
+  Nothing else pins this for the branch-scoped line measures: the neighbour
+  that owns the author-date rule asserts active days and the unscoped code
+  lines, and a build that dated commits by the committer left this spec green.
+
 bronze:
   bronze_bamboohr.employees:
     - $ref: ../templates/people.yaml#/templates/erin
+    - $ref: ../templates/people.yaml#/templates/dave
 
   bronze_github.branches:
     - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: dbcl-br-main, repository: "https://github.com/acme/dbcl.git", name: main, head_sha: head-main, is_default: true}
@@ -68,6 +80,8 @@ bronze:
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: dbcl-pr, repository: "https://github.com/acme/dbcl.git", sha: dbcl-pr, authored_date: "2026-10-01T09:20:00Z", committed_date: "2026-10-01T09:20:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 5, changed_files: 1, is_in_default_branch: false}
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: dbcl-branch, repository: "https://github.com/acme/dbcl.git", sha: dbcl-branch, authored_date: "2026-10-01T09:30:00Z", committed_date: "2026-10-01T09:30:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 9, changed_files: 1, is_in_default_branch: false}
     - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: dbcl-squash, repository: "https://github.com/acme/dbcl.git", sha: dbcl-squash, authored_date: "2026-10-01T11:30:00Z", committed_date: "2026-10-01T11:30:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 9, changed_files: 1, is_in_default_branch: true}
+    # Written on the 2nd, committed on the 5th: the metric day is the AUTHOR date.
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: dbcl-late, repository: "https://github.com/acme/dbcl.git", sha: dbcl-late, authored_date: "2026-10-02T09:00:00Z", committed_date: "2026-10-05T14:00:00Z", author_name: dave, author_email: dave@example.com, committer_name: dave, committer_email: dave@example.com, additions: 11, changed_files: 1, is_in_default_branch: true}
 
   bronze_github.file_changes:
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: dbcl-f-a, repository: "https://github.com/acme/dbcl.git", sha: dbcl-landed, filename: src/a.rs, status: modified, additions: 12, deletions: 0, pre_image_oid: dbc10000000000000000000000000000000000a1, post_image_oid: dbc10000000000000000000000000000000000a2}
@@ -78,6 +92,7 @@ bronze:
     # is the only signal telling which row the dedup kept.
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: dbcl-f-d-branch, repository: "https://github.com/acme/dbcl.git", sha: dbcl-branch, filename: src/d.rs, status: added, additions: 9, deletions: 0, post_image_oid: dbc10000000000000000000000000000000000e1}
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: dbcl-f-d-squash, repository: "https://github.com/acme/dbcl.git", sha: dbcl-squash, filename: src/d.rs, status: modified, additions: 9, deletions: 0, post_image_oid: dbc10000000000000000000000000000000000e1}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: dbcl-f-f, repository: "https://github.com/acme/dbcl.git", sha: dbcl-late, filename: src/f.rs, status: added, additions: 11, deletions: 0, post_image_oid: dbc10000000000000000000000000000000000f1}
 
   bronze_github.pull_requests:
     - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: dbcl-pr-1, repo_full_name: acme/dbcl, id: 71, number: 71, author_login: erin, base_ref: main, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: dbcl-merge}

--- a/tests/datapath/metrics/git/git_default_branch_lines_added.test.yaml
+++ b/tests/datapath/metrics/git/git_default_branch_lines_added.test.yaml
@@ -28,8 +28,9 @@ description: >
   and the rig registers none. The row count is what stands in.
 
   Cases: the two paths summing into one figure and one category split; the
-  repository split, where both paths must answer with a single row; and an
-  empty window.
+  repository split, where both paths must answer with a single row; the
+  code-lines twin, which the fallback must NOT reach — a size with no file
+  grain is lines, never code lines; and an empty window.
 
   The API rejects a metric that requests the same view twice, so each split
   needs its own case.
@@ -46,6 +47,11 @@ description: >
 
   So the metric reads 11 + 20 + 30 = 61, its category split is code 11, docs
   20 and unknown 30, and the repository holding all of it is one repository.
+  `git.default_branch_code_lines` reads 11 alone: the blind commit's thirty
+  lines have no path to classify, so nothing may call them code. The other
+  scope's half of that rule lives in `git_uncollected_file_changes`; this is
+  the default side, which a build emitting the fallback into the code measure
+  left green everywhere.
 
 bronze:
   bronze_bamboohr.employees:

--- a/tests/datapath/metrics/git/test_git_branch_scope.py
+++ b/tests/datapath/metrics/git/test_git_branch_scope.py
@@ -5,7 +5,9 @@ disclosure threshold, each reach their default-branch total a different way: ali
 bob by the connector's flag, carol by a merged pull request into the default branch
 while her flag still says otherwise. The merged-request heal is what makes the split
 mean "did this work land"; her second request merges into a release branch and must
-not promote its commit.
+not promote its commit. Dave's repository calls `master` its default and keeps a `main`
+that is not: the heal compares a request's destination with the repository's OWN
+default branch name, never with a conventional one.
 """
 
 from __future__ import annotations
@@ -19,6 +21,7 @@ SPEC = "git_branch_scope"
 
 ALICE = "alice@example.com"
 CAROL = "carol@example.com"
+DAVE = "dave@example.com"
 
 
 def test_branch_scope_splits_partition_their_totals(spec: SpecRun) -> None:
@@ -394,3 +397,36 @@ def test_a_merged_request_into_the_default_branch_promotes_its_commit(spec: Spec
     r.row("git.non_default_branch_commits", "period", entity_id=CAROL).equals(value=1)
     r.row("git.default_branch_lines_added", "period", entity_id=CAROL).equals(value=10)
     r.row("git.non_default_branch_lines_added", "period", entity_id=CAROL).equals(value=20)
+
+
+def test_a_request_lands_only_when_its_destination_is_its_own_repositorys_default(
+    spec: SpecRun,
+) -> None:
+    """Dave's repository calls `master` its default and keeps a `main` that is not. Both
+    his commits are flagged outside the default branch; the request merged into `master`
+    lands its ten lines, the request merged into `main` leaves its twenty where they are.
+    A comparison against a conventional name reads the two the other way round."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [DAVE]},
+                "period": {"from": "2026-10-01", "to": "2026-10-02"},
+                "metrics": [
+                    {"metric_key": "git.default_branch_commits", "views": [{"view": "period"}]},
+                    {"metric_key": "git.non_default_branch_commits", "views": [{"view": "period"}]},
+                    {"metric_key": "git.default_branch_code_lines", "views": [{"view": "period"}]},
+                    {
+                        "metric_key": "git.non_default_branch_code_lines",
+                        "views": [{"view": "period"}],
+                    },
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+    r.row("git.default_branch_commits", "period", entity_id=DAVE).equals(value=1)
+    r.row("git.non_default_branch_commits", "period", entity_id=DAVE).equals(value=1)
+    r.row("git.default_branch_code_lines", "period", entity_id=DAVE).equals(value=10)
+    r.row("git.non_default_branch_code_lines", "period", entity_id=DAVE).equals(value=20)

--- a/tests/datapath/metrics/git/test_git_default_branch_code_lines.py
+++ b/tests/datapath/metrics/git/test_git_default_branch_code_lines.py
@@ -18,6 +18,7 @@ pytestmark = pytest.mark.fixture
 SPEC = "git_default_branch_code_lines"
 
 ERIN = "erin@example.com"
+DAVE = "dave@example.com"
 
 
 def test_a_line_counts_only_if_it_is_code_and_its_commit_landed(spec: SpecRun) -> None:
@@ -142,6 +143,34 @@ def test_an_extension_counts_only_the_landed_lines_of_the_code_files_sharing_it(
         r.breakdown("git.default_branch_code_lines"),
         dimensions={"key": "file_extension", "value": "__unknown__"},
     ), "every landed row has its extension"
+
+
+def test_a_commit_counts_on_the_day_its_work_was_written_not_the_day_it_was_committed(
+    spec: SpecRun,
+) -> None:
+    """dbcl-late was written on the 2nd and committed on the 5th. Its eleven lines belong
+    to the window holding the 2nd, and the window holding the 5th has nothing — a build
+    dating commits by the committer reads the two the other way round."""
+    for window, lines in ((("2026-10-01", "2026-10-02"), 11), (("2026-10-05", "2026-10-06"), None)):
+        r = spec.call(
+            {
+                "url": "/v1/metric-results",
+                "method": "POST",
+                "body": {
+                    "entity": {"type": "person", "ids": [DAVE]},
+                    "period": {"from": window[0], "to": window[1]},
+                    "metrics": [
+                        {
+                            "metric_key": "git.default_branch_code_lines",
+                            "views": [{"view": "period"}],
+                        }
+                    ],
+                },
+            }
+        )
+        assert r.status == 200
+
+        r.row("git.default_branch_code_lines", "period", entity_id=DAVE).equals(value=lines)
 
 
 def test_an_empty_window_is_null_not_zero(spec: SpecRun) -> None:

--- a/tests/datapath/metrics/git/test_git_default_branch_lines_added.py
+++ b/tests/datapath/metrics/git/test_git_default_branch_lines_added.py
@@ -106,6 +106,36 @@ def test_one_repository_answers_with_one_row_whichever_path_its_lines_came_from(
     ).equals(value=61)
 
 
+def test_an_uncollected_size_on_the_default_branch_reaches_the_lines_but_not_the_code_lines(
+    spec: SpecRun,
+) -> None:
+    """dbla-blind's thirty lines are inside the lines measure above and must be absent
+    here: with no file rows there is no path to classify, so the code-lines measure is
+    src/a.rs alone. The other scope's half of this rule lives in
+    git_uncollected_file_changes; a fallback emitted into this measure reads 41."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [ERIN]},
+                "period": {"from": "2026-10-01", "to": "2026-10-02"},
+                "metrics": [
+                    {"metric_key": "git.default_branch_code_lines", "views": [{"view": "period"}]},
+                    {
+                        "metric_key": "git.non_default_branch_code_lines",
+                        "views": [{"view": "period"}],
+                    },
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("git.default_branch_code_lines", "period", entity_id=ERIN).equals(value=11)
+    r.row("git.non_default_branch_code_lines", "period", entity_id=ERIN).equals(value=7)
+
+
 def test_an_empty_window_is_null_not_zero(spec: SpecRun) -> None:
     r = spec.call(
         {


### PR DESCRIPTION
Part of #3046.

**Why.** Three rules `git.default_branch_code_lines` rests on had no test that would notice their loss: mutating each one on a local stand left every git spec green.

**What changed.** One case per rule, in the spec that owns it: the metric day is the author date, not the committer's; a landed commit whose diff was never collected keeps its reported size out of the code lines (the default side of the rule #3355 pinned for the other scope); a merged request lands its commit only against its repository's own default branch name, pinned by a repository whose default is `master` and which also has a non-default `main`.

**Verified.** The three specs on a local `minimal` instance: 6, 4 and 3 passed. Under each mutation exactly the new case fails and every pre-existing case stays green.

```bash
./dev-compose.sh test-stand test --tree=tests/datapath/metrics/git --instance=<name> -q \
  -k "default_branch_code_lines or default_branch_lines_added or branch_scope"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded Git metrics coverage for repositories using different default branch names, ensuring only merges into the actual default branch are classified accordingly.
  - Added validation that code-line metrics use the authoring date rather than the commit date.
  - Added coverage confirming unclassified lines contribute to total line counts but not code-line counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->