### PR TITLE
fix(gold): a commit lands if any repository copy of it did

### DIFF
--- a/src/ingestion/dbt/macros/git_on_default_branch.sql
+++ b/src/ingestion/dbt/macros/git_on_default_branch.sql
@@ -1,0 +1,6 @@
+{# Whether a repository's copy of a commit sits on that repository's default
+   branch at sync time. An unreported flag reads as not landed, and the result
+   is never NULL, so callers can sort and OR on it. #}
+{% macro git_on_default_branch(flag) -%}
+coalesce({{ flag }}, 0) = 1
+{%- endmacro %}

--- a/src/ingestion/dbt/tests/gold/assert_git_authored_commits_unique.sql
+++ b/src/ingestion/dbt/tests/gold/assert_git_authored_commits_unique.sql
@@ -1,0 +1,12 @@
+-- Build-integrity check (untagged → error severity under `dbt build`).
+-- One row per (tenant_id, data_source, commit_hash): the collapse's `LIMIT 1 BY`
+-- makes that true by construction, so a second row means a commit counts twice
+-- in every commit and line measure that attaches through this set.
+SELECT
+    tenant_id,
+    data_source,
+    commit_hash,
+    count() AS copy_count
+FROM {{ ref('git_authored_commits') }}
+GROUP BY tenant_id, data_source, commit_hash
+HAVING count() > 1

--- a/src/ingestion/gold/git_authored_commits.sql
+++ b/src/ingestion/gold/git_authored_commits.sql
@@ -12,6 +12,11 @@
 -- carries. Materialized so the FINAL read of the commit class and the hash
 -- collapse run once per build in their own query budget, and so the file
 -- change models attach to the surviving commit row without repeating it.
+--
+-- The same hash can sit in more than one connected repository (a fork and its
+-- upstream), each copy with its own `is_default_branch`. Branch scope belongs
+-- to the commit: it landed if any copy did, by flag or by membership, and the
+-- default branch of any connected repository counts. #3354
 
 SELECT
     tenant_id,
@@ -33,11 +38,13 @@ SELECT
     lines_removed,
     -- A semi-join by tuple rather than a LEFT JOIN: the answer is
     -- membership, and a nullable joined column would need guarding under
-    -- either join_use_nulls setting.
+    -- either join_use_nulls setting. Keyed by hash, not by repository copy:
+    -- the copy a merged request lists and the copy that was collected may
+    -- sit in different repositories.
     if(
-        is_default_branch = 1
-            OR (tenant_id, source_id, project_key, repo_slug, commit_hash) IN (
-                SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
+        {{ git_on_default_branch('is_default_branch') }}
+            OR (tenant_id, data_source, commit_hash) IN (
+                SELECT tenant_id, data_source, commit_hash
                 FROM {{ ref('git_default_branch_commits') }}
             ),
         'default',
@@ -73,5 +80,22 @@ WHERE trimBoth(author_email) != ''
       SELECT tenant_id, data_source, commit_hash
       FROM {{ ref('git_derived_commits') }}
   )
-ORDER BY tenant_id, data_source, commit_hash, source_id, project_key, repo_slug
+-- INVARIANT: a copy whose own repository shows the landing (its flag, or a
+-- request or content match there) outranks the other copies, so the
+-- repository dimension names where the work went whenever a copy can say;
+-- repository coordinates only break the remaining ties.
+ORDER BY
+    tenant_id,
+    data_source,
+    commit_hash,
+    (
+        {{ git_on_default_branch('is_default_branch') }}
+            OR (tenant_id, source_id, project_key, repo_slug, commit_hash) IN (
+                SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
+                FROM {{ ref('git_default_branch_commits') }}
+            )
+    ) DESC,
+    source_id,
+    project_key,
+    repo_slug
 LIMIT 1 BY tenant_id, data_source, commit_hash

--- a/src/ingestion/gold/git_default_branch_commits.sql
+++ b/src/ingestion/gold/git_default_branch_commits.sql
@@ -93,7 +93,7 @@ landed_content AS (
         AND carrier.project_key = landed_change.project_key
         AND carrier.repo_slug = landed_change.repo_slug
         AND carrier.commit_hash = landed_change.commit_hash
-    WHERE carrier.is_default_branch = 1
+    WHERE {{ git_on_default_branch('carrier.is_default_branch') }}
       AND NOT (
           coalesce(landed_change.pre_image_oid, '') = ''
               AND coalesce(landed_change.post_image_oid, '') = ''
@@ -121,7 +121,7 @@ unlanded_commits AS (
         commit_hash,
         coalesce(committer_date, date) AS made_at
     FROM {{ ref('class_git_commits') }} FINAL
-    WHERE coalesce(is_default_branch, 0) != 1
+    WHERE NOT ({{ git_on_default_branch('is_default_branch') }})
       AND is_merge_commit = 0
 )
 SELECT DISTINCT
@@ -129,14 +129,16 @@ SELECT DISTINCT
     source_id,
     project_key,
     repo_slug,
-    commit_hash
+    commit_hash,
+    data_source
 FROM (
     SELECT
         links.tenant_id AS tenant_id,
         links.source_id AS source_id,
         links.project_key AS project_key,
         links.repo_slug AS repo_slug,
-        links.commit_hash AS commit_hash
+        links.commit_hash AS commit_hash,
+        links.data_source AS data_source
     FROM {{ ref('class_git_pull_requests_commits') }} AS links FINAL
     INNER JOIN {{ ref('class_git_pull_requests') }} AS prs FINAL
         ON prs.tenant_id = links.tenant_id
@@ -159,7 +161,8 @@ FROM (
         branch_change.source_id AS source_id,
         branch_change.project_key AS project_key,
         branch_change.repo_slug AS repo_slug,
-        branch_change.commit_hash AS commit_hash
+        branch_change.commit_hash AS commit_hash,
+        branch_change.data_source AS data_source
     FROM {{ ref('class_git_file_changes') }} AS branch_change FINAL
     INNER JOIN unlanded_commits AS candidate
         ON candidate.tenant_id IS NOT DISTINCT FROM branch_change.tenant_id

--- a/src/ingestion/gold/git_derived_commits.sql
+++ b/src/ingestion/gold/git_derived_commits.sql
@@ -62,17 +62,20 @@ pull_request_links AS (
         source_id,
         project_key,
         repo_slug,
+        data_source,
         pr_id,
         groupUniqArray(commit_hash) AS linked_hashes,
+        -- Collected in any repository of the connector family: a fork's copy
+        -- of a branch commit is the same commit, and its rows carry the work.
         uniqExactIf(
             commit_hash,
-            (tenant_id, source_id, project_key, repo_slug, commit_hash) IN (
-                SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
+            (tenant_id, data_source, commit_hash) IN (
+                SELECT tenant_id, data_source, commit_hash
                 FROM collected_branch_commits
             )
         ) AS collected_branch_commit_count
     FROM {{ ref('class_git_pull_requests_commits') }} FINAL
-    GROUP BY tenant_id, source_id, project_key, repo_slug, pr_id
+    GROUP BY tenant_id, source_id, project_key, repo_slug, data_source, pr_id
 ),
 -- The requests that produced a result commit at all. Narrowed before the
 -- resolution below, whose prefix test is a residual predicate: the join's only

--- a/src/ingestion/gold/git_file_change_coverage.sql
+++ b/src/ingestion/gold/git_file_change_coverage.sql
@@ -19,8 +19,9 @@
 -- Measured on the CLASS relations, not the gold commit set, and grouped per
 -- source_id: collection is a property of a connector instance, and by the time
 -- a commit reaches git_authored_commits the same hash from a fork and its
--- upstream is deliberately collapsed to one row carrying whichever source
--- sorted first. A healthy instance would hide a broken one.
+-- upstream is deliberately collapsed to one row carrying the copy that
+-- landed, else whichever source sorted first. A healthy instance would hide
+-- a broken one.
 --
 -- Three size classes, because "no file change" is not one condition:
 --   * requires — the source reported a non-zero size, so a diff must exist.

--- a/src/ingestion/gold/git_superseded_file_changes.sql
+++ b/src/ingestion/gold/git_superseded_file_changes.sql
@@ -47,17 +47,20 @@ pull_request_links AS (
         source_id,
         project_key,
         repo_slug,
+        data_source,
         pr_id,
         groupUniqArray(commit_hash) AS linked_hashes,
+        -- Collected in any repository of the connector family: a fork's copy
+        -- of a branch commit is the same commit, and its rows carry the work.
         uniqExactIf(
             commit_hash,
-            (tenant_id, source_id, project_key, repo_slug, commit_hash) IN (
-                SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
+            (tenant_id, data_source, commit_hash) IN (
+                SELECT tenant_id, data_source, commit_hash
                 FROM collected_branch_commits
             )
         ) AS collected_branch_commit_count
     FROM {{ ref('class_git_pull_requests_commits') }} FINAL
-    GROUP BY tenant_id, source_id, project_key, repo_slug, pr_id
+    GROUP BY tenant_id, source_id, project_key, repo_slug, data_source, pr_id
 ),
 -- The requests that produced a result commit at all. Narrowed before the
 -- resolution below, whose prefix test is a residual predicate: the join's only

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -94,8 +94,11 @@ models:
     description: >
       One row per authored commit that reaches a git measure: the surviving row
       of the commit-hash collapse, with branch scope, repository, project and
-      source dimensions already resolved. Materialized so the commit class read
-      and the collapse run once per build in their own query budget.
+      source dimensions already resolved. Branch scope belongs to the commit,
+      not to the copy: a hash held by several repositories lands if any copy
+      did, and a copy whose own repository shows the landing is the one that
+      survives. Materialized so the commit class read and the collapse run
+      once per build in their own query budget.
     columns:
       - name: commit_hash
         description: "Commit identifier; one row per tenant, data source and hash"
@@ -162,11 +165,15 @@ models:
       content when the commit was written: one row per
       tenant/source/project/repo/commit.
       Materialized so the membership joins run once per build in their own
-      query budget; the git evidence build reads it as a semi-join set
-      alongside the sync-time is_default_branch flag.
+      query budget; the commit collapse reads it by tenant, data source and
+      hash alongside the sync-time is_default_branch flag.
     columns:
       - name: commit_hash
         description: "Commit identifier within the repository"
+        tests:
+          - not_null
+      - name: data_source
+        description: "Git source discriminator (insight_github, insight_gitlab, ...)"
         tests:
           - not_null
 

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -335,7 +335,8 @@ CREATE TABLE IF NOT EXISTS insight.git_default_branch_commits
     `source_id` Nullable(String),
     `project_key` String,
     `repo_slug` String,
-    `commit_hash` String
+    `commit_hash` String,
+    `data_source` String
 )
 ENGINE = MergeTree
 ORDER BY (tenant_id, source_id, project_key, repo_slug, commit_hash)

--- a/tests/datapath/metrics/git/git_branch_scope_shared_hash.test.yaml
+++ b/tests/datapath/metrics/git/git_branch_scope_shared_hash.test.yaml
@@ -1,0 +1,74 @@
+spec_version: 1
+description: >-
+  Metric: git.default_branch_commits and its branch-scope siblings — the scope
+  of a commit whose hash sits in two connected repositories, #3354.
+  How it's computed (bronze → silver → gold):
+    • bronze: each repository reports its own copy of a commit with its own
+      default-branch flag; a request lists the hashes it merged.
+    • silver: one commit row per repository copy.
+    • gold:   copies of one hash collapse to one commit. It lands if ANY copy
+      sits on its repository's default branch, or a merged request into a
+      default branch lists the hash, whichever repository holds the copy.
+      The copy whose own repository shows the landing survives and names the
+      repository; repository coordinates only break ties. The squash result
+      a merged request produced is derived even when its branch commits were
+      collected in another repository.
+  A fork (alpha-fork/payments) and its upstream (constructor/payments); the
+  fork's owner sorts first, so a collapse that read scope off the first copy
+  kept the fork's, and a membership test keyed by repository coordinates
+  missed a request filed under the upstream.
+  Cases: dave — flag on the later-sorting copy only, lands under the upstream,
+  a fork-only commit stays in flight; bob — both copies unflagged, a request
+  merged upstream lists the hash, lands under the upstream; erin — collected
+  in the fork only, listed by a request merged upstream whose squash result
+  was collected on the upstream's default branch: the original lands once,
+  the squash is derived, an unlisted commit stays in flight.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: ../templates/people.yaml#/templates/dave
+    - $ref: ../templates/people.yaml#/templates/bob
+    - $ref: ../templates/people.yaml#/templates/erin
+  bronze_github.branches:
+    # Both repositories call their default branch main, as forks do.
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: br-fork-main, repository: "https://github.com/alpha-fork/payments.git", name: main, head_sha: head-fork-main, is_default: true}
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: br-upstream-main, repository: "https://github.com/constructor/payments.git", name: main, head_sha: head-upstream-main, is_default: true}
+  bronze_github.commits:
+    # dave: the same hash in both repositories; only the upstream copy is on
+    # its default branch. `alpha-fork` sorts before `constructor`.
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-dave-fork, repository: "https://github.com/alpha-fork/payments.git", sha: sha-dave-shared, author_name: dave, author_email: dave@example.com, committer_name: dave, committer_email: dave@example.com, additions: 12, deletions: 3, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-dave-upstream, repository: "https://github.com/constructor/payments.git", sha: sha-dave-shared, author_name: dave, author_email: dave@example.com, committer_name: dave, committer_email: dave@example.com, additions: 12, deletions: 3, is_in_default_branch: true}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-dave-inflight, repository: "https://github.com/alpha-fork/payments.git", sha: sha-dave-inflight, author_name: dave, author_email: dave@example.com, committer_name: dave, committer_email: dave@example.com, additions: 5, deletions: 0, is_in_default_branch: false}
+    # bob: the same hash in both repositories, neither copy flagged (the
+    # upstream copy was first seen on the request's branch); the upstream's
+    # merged request is the only evidence, and it names the upstream.
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-bob-fork, repository: "https://github.com/alpha-fork/payments.git", sha: sha-bob-shared, author_name: bob, author_email: bob@example.com, committer_name: bob, committer_email: bob@example.com, additions: 9, deletions: 2, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-bob-upstream, repository: "https://github.com/constructor/payments.git", sha: sha-bob-shared, author_name: bob, author_email: bob@example.com, committer_name: bob, committer_email: bob@example.com, additions: 9, deletions: 2, is_in_default_branch: false}
+    # erin: collected in the fork only; the upstream's merged request lists
+    # it, and the squash it produced sits on the upstream's default branch.
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-erin-fork, repository: "https://github.com/alpha-fork/payments.git", sha: sha-erin-shared, author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 7, deletions: 0, is_in_default_branch: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-erin-squash, repository: "https://github.com/constructor/payments.git", sha: sha-erin-squash, author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, authored_date: "2026-10-01T12:00:00Z", committed_date: "2026-10-01T12:00:00Z", additions: 7, deletions: 0, is_in_default_branch: true}
+    - {$ref: ../templates/git_activity.yaml#/templates/commit, unique_key: c-erin-inflight, repository: "https://github.com/alpha-fork/payments.git", sha: sha-erin-inflight, author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 3, deletions: 0, is_in_default_branch: false}
+  bronze_github.file_changes:
+    # `.rs` under src/ classifies as code. Two copies of one commit report the
+    # same diff, as two clones of one commit do.
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-dave-fork, repository: "https://github.com/alpha-fork/payments.git", sha: sha-dave-shared, filename: src/pay.rs, additions: 12, deletions: 3, pre_image_oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0, post_image_oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-dave-upstream, repository: "https://github.com/constructor/payments.git", sha: sha-dave-shared, filename: src/pay.rs, additions: 12, deletions: 3, pre_image_oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0, post_image_oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-dave-inflight, repository: "https://github.com/alpha-fork/payments.git", sha: sha-dave-inflight, filename: src/wip.rs, status: added, additions: 5, deletions: 0, pre_image_oid: null, post_image_oid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb1}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-bob-fork, repository: "https://github.com/alpha-fork/payments.git", sha: sha-bob-shared, filename: src/bob.rs, additions: 9, deletions: 2, pre_image_oid: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee0, post_image_oid: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee1}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-bob-upstream, repository: "https://github.com/constructor/payments.git", sha: sha-bob-shared, filename: src/bob.rs, additions: 9, deletions: 2, pre_image_oid: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee0, post_image_oid: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee1}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-erin-fork, repository: "https://github.com/alpha-fork/payments.git", sha: sha-erin-shared, filename: src/erin.rs, status: added, additions: 7, deletions: 0, pre_image_oid: null, post_image_oid: ccccccccccccccccccccccccccccccccccccccc1}
+    # The squash carries the branch's content to the upstream's default branch.
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-erin-squash, repository: "https://github.com/constructor/payments.git", sha: sha-erin-squash, filename: src/erin.rs, status: added, additions: 7, deletions: 0, pre_image_oid: null, post_image_oid: ccccccccccccccccccccccccccccccccccccccc1}
+    - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: f-erin-inflight, repository: "https://github.com/alpha-fork/payments.git", sha: sha-erin-inflight, filename: src/erin_wip.rs, status: added, additions: 3, deletions: 0, pre_image_oid: null, post_image_oid: ddddddddddddddddddddddddddddddddddddddd1}
+  bronze_github.pull_requests:
+    # Both requests live in the upstream and merged into its default branch.
+    # bob's result commit was never collected; erin's is the squash above.
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: pr-bob-upstream, repo_full_name: constructor/payments, id: 61, number: 61, author_login: bob, base_ref: main, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: sha-bob-merge}
+    - {$ref: ../templates/git_activity.yaml#/templates/pull_request, unique_key: pr-erin-upstream, repo_full_name: constructor/payments, id: 51, number: 51, author_login: erin, base_ref: main, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: sha-erin-squash}
+  bronze_github.pull_request_diff_stats:
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-bob-upstream, repo_full_name: constructor/payments, pull_number: 61, additions: 9, deletions: 2, author_email: bob@example.com}
+    - {$ref: ../templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-erin-upstream, repo_full_name: constructor/payments, pull_number: 51, additions: 7, deletions: 0, author_email: erin@example.com}
+  bronze_github.pull_request_commits:
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: lnk-bob-upstream, sha: sha-bob-shared, pull_number: 61, repo_full_name: constructor/payments, author_email: bob@example.com, is_merge: false}
+    - {$ref: ../templates/git_activity.yaml#/templates/base, unique_key: lnk-erin-upstream, sha: sha-erin-shared, pull_number: 51, repo_full_name: constructor/payments, author_email: erin@example.com, is_merge: false}

--- a/tests/datapath/metrics/git/git_commit_work_identity.test.yaml
+++ b/tests/datapath/metrics/git/git_commit_work_identity.test.yaml
@@ -31,9 +31,10 @@ description: >
     * indep-a / indep-b: the same patch id on commits in two unrelated
       repositories — two independent authored changes, both count. Patch
       identity folds within a repository only.
-    * xr-fork / xr-upstream: one hash in two repositories, file rows recorded
-      only under the repository that loses the commit collapse. The lines
-      count once, under the surviving repository.
+    * xr-fork / xr-upstream: one hash in two repositories, neither copy
+      flagged or listed by a merged request, file rows recorded only under
+      the repository that loses the commit collapse to repository order. The
+      lines count once, under the surviving repository.
 
   Commit size reads the same commit set: the squash pool is {10, 10, 6}
   (median 10), the surviving patch copy is 7, the partial-branch pair is
@@ -93,7 +94,7 @@ bronze:
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-ia, repository: "https://github.com/constructor/indep-a.git", sha: wi-ia-1, filename: src/a.rs, status: modified, additions: 2, deletions: 0, pre_image_oid: 88888888888888888888888888888888888888b0, post_image_oid: 88888888888888888888888888888888888888b1}
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-ib, repository: "https://github.com/constructor/indep-b.git", sha: wi-ib-1, filename: src/b.rs, status: modified, additions: 2, deletions: 0, pre_image_oid: 99999999999999999999999999999999999999c0, post_image_oid: 99999999999999999999999999999999999999c1}
     # xr: rows recorded ONLY under xr-upstream, which loses the commit
-    # collapse to xr-fork (lexicographic repo order).
+    # collapse to xr-fork: neither copy landed, so repository order decides.
     - {$ref: ../templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-xr, repository: "https://github.com/constructor/xr-upstream.git", sha: wi-xr-1, filename: src/x.rs, status: added, additions: 4, deletions: 0, pre_image_oid: null, post_image_oid: 66666666666666666666666666666666666666f1}
 
   bronze_github.pull_requests:

--- a/tests/datapath/metrics/git/test_git_branch_scope_shared_hash.py
+++ b/tests/datapath/metrics/git/test_git_branch_scope_shared_hash.py
@@ -1,0 +1,130 @@
+"""Branch scope of a commit whose hash sits in two connected repositories (#3354).
+
+A fork and its upstream hold the same commit, each copy with its own default-branch
+flag. The scope served belongs to the commit and it lands if any copy did: by the flag
+on whichever copy sits on its repository's default branch, or by a merged request into
+a default branch that lists the hash, even when the only collected copy is the fork's.
+The copy whose own repository shows the landing survives the collapse and names the
+repository. Before, the fork's owner sorted first and its copy answered for the hash,
+and a request filed under the upstream was matched by repository coordinates and missed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_datapath.metric_expect import MetricResponse, Row
+from insight_datapath.spec_runner import SpecRun
+
+pytestmark = pytest.mark.fixture
+
+SPEC = "git_branch_scope_shared_hash"
+
+DAVE = "dave@example.com"
+BOB = "bob@example.com"
+ERIN = "erin@example.com"
+
+FORK = "git-test:alpha-fork/payments"
+UPSTREAM = "git-test:constructor/payments"
+
+BY_REPOSITORY = {"view": "breakdown", "dimensions": ["repository"]}
+
+
+def _scope_request(person: str) -> dict[str, object]:
+    return {
+        "url": "/v1/metric-results",
+        "method": "POST",
+        "body": {
+            "entity": {"type": "person", "ids": [person]},
+            "period": {"from": "2026-10-01", "to": "2026-10-02"},
+            "metrics": [
+                {
+                    "metric_key": "git.default_branch_commits",
+                    "views": [{"view": "period"}, BY_REPOSITORY],
+                },
+                {
+                    "metric_key": "git.non_default_branch_commits",
+                    "views": [{"view": "period"}, BY_REPOSITORY],
+                },
+                {
+                    "metric_key": "git.default_branch_code_lines",
+                    "views": [{"view": "period"}, BY_REPOSITORY],
+                },
+                {"metric_key": "git.non_default_branch_code_lines", "views": [{"view": "period"}]},
+                {"metric_key": "git.default_branch_lines_removed", "views": [{"view": "period"}]},
+                {"metric_key": "git.commits", "views": [{"view": "period"}]},
+            ],
+        },
+    }
+
+
+def _by_repository(r: MetricResponse, metric_key: str, person: str, repository: str) -> Row:
+    return r.row(
+        metric_key,
+        "breakdown",
+        entity_id=person,
+        dimensions={"key": "repository", "value": repository},
+    )
+
+
+def test_a_commit_lands_when_any_of_its_repository_copies_is_on_a_default_branch(
+    spec: SpecRun,
+) -> None:
+    """Dave's shared hash is flagged only in the upstream, which sorts after the fork: it
+    lands with its lines under the upstream, and still counts once."""
+    r = spec.call(_scope_request(DAVE))
+    assert r.status == 200
+
+    r.row("git.default_branch_commits", "period", entity_id=DAVE).equals(value=1)
+    r.row("git.non_default_branch_commits", "period", entity_id=DAVE).equals(value=1)
+    r.row("git.commits", "period", entity_id=DAVE).equals(value=2)
+
+    r.row("git.default_branch_code_lines", "period", entity_id=DAVE).equals(value=12)
+    r.row("git.default_branch_lines_removed", "period", entity_id=DAVE).equals(value=3)
+    r.row("git.non_default_branch_code_lines", "period", entity_id=DAVE).equals(value=5)
+
+    _by_repository(r, "git.default_branch_commits", DAVE, UPSTREAM).equals(value=1)
+    _by_repository(r, "git.default_branch_code_lines", DAVE, UPSTREAM).equals(value=12)
+    _by_repository(r, "git.non_default_branch_commits", DAVE, FORK).equals(value=1)
+
+
+def test_a_merged_request_upstream_lands_a_hash_no_copy_flags_and_names_its_repository(
+    spec: SpecRun,
+) -> None:
+    """Neither copy of bob's hash is flagged; the upstream's merged request lists it, so it
+    lands, and the upstream copy survives because that is where the request lives."""
+    r = spec.call(_scope_request(BOB))
+    assert r.status == 200
+
+    r.row("git.default_branch_commits", "period", entity_id=BOB).equals(value=1)
+    r.row("git.non_default_branch_commits", "period", entity_id=BOB).equals(value=None)
+    r.row("git.commits", "period", entity_id=BOB).equals(value=1)
+
+    r.row("git.default_branch_code_lines", "period", entity_id=BOB).equals(value=9)
+    r.row("git.default_branch_lines_removed", "period", entity_id=BOB).equals(value=2)
+    r.row("git.non_default_branch_code_lines", "period", entity_id=BOB).equals(value=None)
+
+    _by_repository(r, "git.default_branch_commits", BOB, UPSTREAM).equals(value=1)
+    _by_repository(r, "git.default_branch_code_lines", BOB, UPSTREAM).equals(value=9)
+
+
+def test_a_request_merged_upstream_lands_a_commit_collected_only_in_the_fork_once(
+    spec: SpecRun,
+) -> None:
+    """Erin's commit was collected in the fork alone; the upstream's merged request into
+    main lists its hash, so it lands, filed under the fork where it was collected. The
+    squash that request produced is derived, so the work counts once; her unlisted
+    commit stays in flight."""
+    r = spec.call(_scope_request(ERIN))
+    assert r.status == 200
+
+    r.row("git.default_branch_commits", "period", entity_id=ERIN).equals(value=1)
+    r.row("git.non_default_branch_commits", "period", entity_id=ERIN).equals(value=1)
+    r.row("git.commits", "period", entity_id=ERIN).equals(value=2)
+
+    r.row("git.default_branch_code_lines", "period", entity_id=ERIN).equals(value=7)
+    r.row("git.non_default_branch_code_lines", "period", entity_id=ERIN).equals(value=3)
+    r.row("git.default_branch_lines_removed", "period", entity_id=ERIN).equals(value=0)
+
+    _by_repository(r, "git.default_branch_commits", ERIN, FORK).equals(value=1)
+    _by_repository(r, "git.default_branch_code_lines", ERIN, FORK).equals(value=7)
+    _by_repository(r, "git.non_default_branch_commits", ERIN, FORK).equals(value=1)


### PR DESCRIPTION
Closes #3354.

**Why.** A commit whose hash sits in two connected repositories, a fork and its upstream, took its branch scope from whichever copy sorted first by repository name. Renaming a repository could move the commit and its lines across the default/non-default split.

**What changed.** `git_authored_commits` decides scope per commit: it lands if any copy is flagged on its repository's default branch, or a merged request into a default branch lists the hash in any repository. The copy whose own repository shows the landing survives the collapse, so the repository breakdown names where the work went.

**Any connected repository's default branch counts, forks included.** The product owner chose the simpler rule; no source's fork flag reaches silver yet, and a commit held only by a fork already counted that way. Preferring non-fork copies stays available as a follow-up.

**Merged-request coverage is counted by hash too.** Otherwise a squash collected upstream of a fork-collected branch would count beside its originals on the default side; `git_derived_commits` and `git_superseded_file_changes` now find a linked commit in any repository of the connector family.

**Out of scope.** The content dedup still partitions by the survivor's repository, and the catalog wording still says "the repository's default branch"; both need a follow-up issue.

**Verified.** New datapath spec `git_branch_scope_shared_hash` (3 cases) green on a local stand and red under each of three mutations: all gold models reverted, landing rank dropped, coverage by repository coordinates. Full git datapath tree green on the same stand; `dbt parse` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Git commit and file-change attribution when the same commit exists across forks and upstream repositories.
  - More accurately identifies commits landed on default branches, including commits linked through merged pull requests.
  - Improved repository selection for shared commit hashes and derived squash metrics.
  - Prevented duplicate authored commits from affecting Git metrics.

- **Data Improvements**
  - Git default-branch commit records now include their data source for more reliable cross-repository tracking.

- **Tests**
  - Added coverage for shared commit hashes across connected repositories and related branch-scope scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->