### PR TITLE
ci(e2e): warm the backend cargo cache from main so queue entries stop cold-compiling

### DIFF
--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -40,6 +40,16 @@ on:
   # that never ran would leave the check pending forever.
   pull_request:
     branches: [main]
+  # Cache-warm runs only: merge-queue refs cannot restore caches saved by
+  # earlier queue entries, so main is the only warm source build-backend has.
+  # Only `changes` + `build-backend` run on push; every other job skips.
+  push:
+    branches: [main]
+    paths:
+      - "src/backend/**"
+      - "docker-compose.yml"
+      - "dev-compose.sh"
+      - ".github/workflows/e2e-bronze-to-api.yml"
   workflow_dispatch:
 
 # A new push obsoletes any run still in flight for the same ref — cancel it so a
@@ -106,6 +116,14 @@ jobs:
           HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
+          # A push run exists only to warm the backend build cache; the paths:
+          # filter already scoped it, so compile unconditionally and skip the diff.
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            echo "push to main — cache-warm run"
+            exit 0
+          fi
           # No base to diff against (a merge_group without one, or a manual
           # dispatch): assume relevant rather than skipping a required gate on
           # a guess.
@@ -174,10 +192,45 @@ jobs:
         with:
           persist-credentials: false
 
+      # The compile runs inside the compose build-rust container, so the key
+      # tracks that image's toolchain, not the runner's.
+      - name: Read the builder toolchain for the cache key
+        id: toolchain
+        run: |
+          set -euo pipefail
+          image="$(grep -m1 -oE 'image: rust:[^ ]+' docker-compose.yml | cut -d' ' -f2 | tr ':' '-')"
+          [ -n "$image" ] || { echo "::error::no rust builder image found in docker-compose.yml"; exit 1; }
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+      # Plain actions/cache, not Swatinem/rust-cache: rust-cache keys and
+      # prunes against the RUNNER's rustc/cargo, and the compile happens in a
+      # container with its own toolchain and paths. Trade-off: no pruning, so
+      # the target dir grows under the prefix restore-key until Cargo.lock
+      # rotates the exact key and a fresh save resets it.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            .ci-cargo/target
+            .ci-cargo/registry
+          key: e2e-backend-${{ steps.toolchain.outputs.image }}-${{ hashFiles('src/backend/Cargo.lock') }}
+          restore-keys: |
+            e2e-backend-${{ steps.toolchain.outputs.image }}-
+
       - name: Compile the Rust services
-        run: ./dev-compose.sh build rust
+        env:
+          RUST_TARGET_SOURCE: ${{ github.workspace }}/.ci-cargo/target
+          CARGO_REGISTRY_SOURCE: ${{ github.workspace }}/.ci-cargo/registry
+        run: |
+          mkdir -p .ci-cargo/target .ci-cargo/registry
+          ./dev-compose.sh build rust
+
+      # The build container runs as root; the post-job cache tar runs as the
+      # runner user and must be able to read (and later restore over) it all.
+      - name: Reclaim cache dir ownership from the build container
+        run: sudo chown -R "$(id -u):$(id -g)" .ci-cargo
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: github.event_name != 'push'
         with:
           name: backend-binaries
           path: deploy/compose/build/
@@ -190,7 +243,7 @@ jobs:
     # `!cancelled()` so a skipped build-backend (backend untouched → pinned
     # images) does not skip the shards along with it; the result check keeps a
     # FAILED build from letting them run against stale binaries.
-    if: ${{ !cancelled() && needs.changes.outputs.relevant == 'true' && (needs.build-backend.result == 'success' || needs.build-backend.result == 'skipped') }}
+    if: ${{ !cancelled() && github.event_name != 'push' && needs.changes.outputs.relevant == 'true' && (needs.build-backend.result == 'success' || needs.build-backend.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -392,7 +445,7 @@ jobs:
       - build-backend
       - e2e-datapath
       - metric-coverage-gate
-    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.event_name != 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -306,6 +306,27 @@ jobs:
             --image "insight-identity-resolution:${IDENTITY_POLICY}" \
             --image "insight-gateway:${GATEWAY_POLICY}"
 
+      # Restore-only warm start for the --build-backend fallback: the cache is
+      # saved by e2e-bronze-to-api.yml's push-to-main run; nothing here saves.
+      - name: Read the builder toolchain for the cache key
+        id: toolchain
+        if: needs.changes.outputs.backend == 'true' && needs.changes.outputs.backend_artifacts != 'true'
+        run: |
+          set -euo pipefail
+          image="$(grep -m1 -oE 'image: rust:[^ ]+' docker-compose.yml | cut -d' ' -f2 | tr ':' '-')"
+          [ -n "$image" ] || { echo "::error::no rust builder image found in docker-compose.yml"; exit 1; }
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: needs.changes.outputs.backend == 'true' && needs.changes.outputs.backend_artifacts != 'true'
+        with:
+          path: |
+            .ci-cargo/target
+            .ci-cargo/registry
+          key: e2e-backend-${{ steps.toolchain.outputs.image }}-${{ hashFiles('src/backend/Cargo.lock') }}
+          restore-keys: |
+            e2e-backend-${{ steps.toolchain.outputs.image }}-
+
       # `up` writes .env.compose.test-stand, forces the pinned frontend and
       # Keycloak, seeds, and then blocks until EVERY gold observation table the
       # seed populates proves dbt rebuilt it for THIS run and left a positive
@@ -336,6 +357,9 @@ jobs:
             flags+=(--prebuilt-backend)
           elif [ "$BUILD_BACKEND" = "true" ]; then
             flags+=(--build-backend)
+            mkdir -p .ci-cargo/target .ci-cargo/registry
+            export RUST_TARGET_SOURCE="$PWD/.ci-cargo/target"
+            export CARGO_REGISTRY_SOURCE="$PWD/.ci-cargo/registry"
           fi
           if [ "$BUILD_FRONTEND" = "true" ]; then flags+=(--build-frontend); fi
           ./dev-compose.sh test-stand up "${flags[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -613,3 +613,7 @@ screenshots-and-etc/
 # change, not a description of the system: the specs under docs/domain say what
 # it is, and the commit says why it changed.
 docs/superpowers/
+
+# CI-side cargo cache dirs bind-mounted into the build-rust container when
+# RUST_TARGET_SOURCE / CARGO_REGISTRY_SOURCE are set.
+.ci-cargo/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -772,7 +772,10 @@ services:
       CARGO_TARGET_DIR: /target
     volumes:
       - ./src/backend:/workspace
-      - rust-target:/target
+      # Sources are env-overridable so CI can bind-mount actions/cache-backed
+      # host dirs; the named-volume defaults keep local rebuilds incremental.
+      - ${RUST_TARGET_SOURCE:-rust-target}:/target
+      - ${CARGO_REGISTRY_SOURCE:-rust-cargo-registry}:/usr/local/cargo/registry
       - ./deploy/compose/build:/out
     # The script overrides this command to pick a specific bin. Default
     # builds both Rust services.


### PR DESCRIPTION
Audit item R1 in #3368 (leaves the issue open).

**Why.** Every merge-queue entry that touches the backend cold-compiles the whole workspace in `build-backend`: the compose builder keeps its target dir in a named volume and the crate registry inside the container, so a fresh runner starts with both empty.

**What changed.** The `build-rust` mount sources are now env-overridable (`RUST_TARGET_SOURCE`, `CARGO_REGISTRY_SOURCE`); `build-backend` binds them to `.ci-cargo/` and wraps them in `actions/cache` keyed `e2e-backend-<builder image tag>-<hash of src/backend/Cargo.lock>` with a prefix restore-key.

**The warm source is a new push-to-main trigger, not the queue runs.** Caches saved on `gh-readonly-queue/*` refs are not restorable by later queue entries, so only a cache saved on `main` warms them. On push only `changes` + `build-backend` run; the shard, gate and umbrella jobs skip (`github.event_name != 'push'` guards), and PR/merge_group semantics are unchanged.

**Plain `actions/cache`, not Swatinem/rust-cache.** rust-cache keys and prunes against the runner's toolchain; the compile happens inside `rust:1.95-bookworm` with container paths. Trade-off: no pruning — the target dir grows under the prefix key until `Cargo.lock` rotates it.

**The registry got a named-volume default (`rust-cargo-registry`) locally** — the same volume watch mode already uses — so local rebuilds stop re-downloading crates too.

**Root ownership.** The builder writes as root; a `sudo chown -R` step hands `.ci-cargo/` back to the runner user before the post-job cache tar.

`e2e-stand.yml`'s `stand-runner` gets a restore-only copy for its `--build-backend` fallback.

**Out of scope.** R2 (baking the gateway image) and sccache — tracked in #3368.

**Verified.** `docker compose config` clean with and without the overrides; a local `build-rust` run with the bind overrides shows both mounts landing (writes appear host-side); `bash -n dev-compose.sh`; `actionlint` (one pre-existing SC2001 style note on main remains).
