### PR TITLE
fix(gold): classify a missing issue-type as unknown under either join_use_nulls regime

### DIFF
--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -910,6 +910,16 @@ models:
         description: "Source issue identifier; unique per insight_source_id"
         tests:
           - not_null
+      - name: issue_kind
+        description: >
+          Reconciled issue kind from the issue-type dimension. An issue whose
+          type id has no dimension row is 'unknown' — never an empty string,
+          whichever join_use_nulls regime built the table.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['bug', 'other', 'unknown']
 
   - name: task_status_spans
     description: >

--- a/src/ingestion/gold/task_issue_state.sql
+++ b/src/ingestion/gold/task_issue_state.sql
@@ -161,9 +161,13 @@ SELECT
     p.title                                                                  AS title,
     cur.status_category                                                      AS status_category,
     p.issue_type                                                             AS issue_type,
-    ifNull(it.issue_kind, 'unknown')                                         AS issue_kind,
-    coalesce(it.untranslated_name, it.issue_type_name, nullIf(p.issue_type, '')) AS issue_type_key,
-    coalesce(it.issue_type_name, nullIf(p.issue_type, ''))                   AS issue_type_name,
+    -- A missing dimension row reads as '' under join_use_nulls=0 (the
+    -- non-Nullable String default) and NULL under =1 — nullIf folds both
+    -- into the fallback, matching the null-proofing of `role` above.
+    coalesce(nullIf(it.issue_kind, ''), 'unknown')                           AS issue_kind,
+    coalesce(it.untranslated_name, nullIf(it.issue_type_name, ''),
+             nullIf(p.issue_type, ''))                                       AS issue_type_key,
+    coalesce(nullIf(it.issue_type_name, ''), nullIf(p.issue_type, ''))       AS issue_type_name,
     if(p.due_date_str IS NOT NULL AND p.due_date_str != '',
        toDate(parseDateTimeBestEffortOrNull(p.due_date_str)),
        CAST(NULL AS Nullable(Date)))                                         AS due_date,

--- a/tests/datapath/metrics/tasks/tasks_closed.test.yaml
+++ b/tests/datapath/metrics/tasks/tasks_closed.test.yaml
@@ -11,14 +11,19 @@ description: >
   (value = the requested member's OWN sum; median/p25/p75/range = the department
   (org_unit_id) distribution).
 
-  Department: 5 Engineering members alice..erin of rank r in 1..5, each closing r
-  issues on the same close date (2026-12-25). The custom window 2026-12-20..12-31
-  captures them all -> per-person sums {1,2,3,4,5}; the IC case requests erin (5).
-  Erin's five are 3 Task + 1 Bug + 1 Incident, so her total splits into three
-  type groups that add back up to 5 — and Incident, a name neither configured
-  list covers, stays its own group instead of joining the non-bug work: 1 bug +
-  3 non-bug is one short of the 5 closed, and the missing one is the Incident.
-  Empty window 2026-06 -> no items.
+  Department: 5 Engineering members alice..erin, alice..dave closing rank r
+  issues each and erin 6, on the same close date (2026-12-25). The custom window
+  2026-12-20..12-31 captures them all -> per-person sums {1,2,3,4,6}; the IC
+  case requests erin (6). Erin's six are 3 Task + 1 Bug + 1 Incident + 1 issue
+  with no issuetype field at all, so her total splits into four type groups
+  that add back up to 6 — Incident, a catalogued name neither configured list
+  covers, stays its own group instead of joining the non-bug work, and the
+  type-less issue reports no type id, so the issue-type dimension lookup
+  misses entirely: it counts as closed under the unknown kind, in neither
+  bugs_fixed nor closed_non_bug, and falls in the reserved unknown-type
+  breakdown group. 1 bug + 3 non-bug is two short of the 6 closed; the missing
+  two are the Incident and the type-less issue. Empty window 2026-06 -> no
+  items.
 
 bronze:
   bronze_bamboohr.employees:
@@ -162,6 +167,15 @@ bronze:
       id_readable: TEW5
       created: "2026-01-05T09:00:00"
       custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10099","name":"Incident"},"assignee":{"accountId":"erin-jira-acct","displayName":"Erin Epsilon"}}'
+    # No issuetype field at all: the history pivot yields no type id, so the
+    # issue-type dimension lookup misses instead of resolving a kind.
+    - $ref: ../templates/jira_task.yaml#/templates/jira_issue
+      id: TEW-6
+      jira_id: TEW-6
+      unique_key: jira-test-TEW-6
+      id_readable: TEW6
+      created: "2026-01-05T09:00:00"
+      custom_fields_json: '{"status":{"id":"6","name":"Closed"},"assignee":{"accountId":"erin-jira-acct","displayName":"Erin Epsilon"}}'
 
   bronze_jira.jira_issue_history:
     # ── Alice Alpha (rank 1) ──
@@ -271,6 +285,13 @@ bronze:
       id_readable: TEW5
       changelog_id: "50014"
       unique_key: jira-test-TEW5-50014
+      created_at: "2026-12-25T14:00:00.000+0000"
+      author_account_id: erin-jira-acct
+      items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'
+    - $ref: ../templates/jira_task.yaml#/templates/jira_history
+      id_readable: TEW6
+      changelog_id: "50015"
+      unique_key: jira-test-TEW6-50015
       created_at: "2026-12-25T14:00:00.000+0000"
       author_account_id: erin-jira-acct
       items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'

--- a/tests/datapath/metrics/tasks/test_tasks_closed.py
+++ b/tests/datapath/metrics/tasks/test_tasks_closed.py
@@ -4,7 +4,9 @@ person over a custom window with the department-of-5 distribution.
 Bronze: closed issues, the Status -> Closed history event that dates the close, the
 users and the issue types. Gold counts every closed issue regardless of type and
 carries the type as a breakdown dimension; a type neither configured list covers
-stays its own group. An empty window serves null.
+stays its own group, and an issue reporting no type at all — so the issue-type
+dimension lookup misses — still counts as closed without joining either
+configured-list metric. An empty window serves null.
 """
 
 from __future__ import annotations
@@ -21,8 +23,9 @@ ERIN = "erin@example.com"
 
 
 def test_tasks_closed(spec: SpecRun) -> None:
-    """Dec 20 .. Dec 31 takes all five ranks; erin's 5 closed split 3 Task + 1 Bug +
-    1 Incident, and only the Bug and the Tasks land in the configured-list metrics."""
+    """Dec 20 .. Dec 31 takes all five people; erin's 6 closed split 3 Task + 1 Bug +
+    1 Incident + 1 issue with no type at all (the dimension lookup misses), and only
+    the Bug and the Tasks land in the configured-list metrics."""
     r = spec.call(
         {
             "url": "/v1/metric-results",
@@ -48,12 +51,12 @@ def test_tasks_closed(spec: SpecRun) -> None:
     )
     assert r.status == 200
 
-    r.row("tasks.closed", "period", entity_id=ERIN).equals(value=5)
+    r.row("tasks.closed", "period", entity_id=ERIN).equals(value=6)
     r.row("tasks.closed", "peer", entity_id=ERIN).equals(
-        target_value=5, p25=2, median=3, p75=4, min=1, max=5, n=5
+        target_value=6, p25=2, median=3, p75=4, min=1, max=6, n=5
     )
     closed = one(r.series("tasks.closed"), entity_id=ERIN)["points"]
-    assert float(one(closed, bucket_start="2026-12-25")["value"]) == approx(5.0)
+    assert float(one(closed, bucket_start="2026-12-25")["value"]) == approx(6.0)
     by_type = r.breakdown("tasks.closed")
     assert (
         float(one(by_type, entity_id=ERIN, dimensions={"key": "type", "value": "Task"})["value"])
@@ -69,7 +72,15 @@ def test_tasks_closed(spec: SpecRun) -> None:
         )
         == 1.0
     )
-    assert len(some(by_type, entity_id=ERIN)) == 3
+    assert (
+        float(
+            one(by_type, entity_id=ERIN, dimensions={"key": "type", "value": "__unknown__"})[
+                "value"
+            ]
+        )
+        == 1.0
+    )
+    assert len(some(by_type, entity_id=ERIN)) == 4
 
     r.row("tasks.bugs_fixed", "period", entity_id=ERIN).equals(value=1)
     r.row("tasks.closed_non_bug", "period", entity_id=ERIN).equals(value=3)


### PR DESCRIPTION
Closes #3383.

**Why.** An issue with no issuetype event yet resolves its type to an empty string; under `join_use_nulls = 0` the dimension-join miss yields `''`, the `ifNull` fallback never fires, and the row carries an undeclared `issue_kind = ''`. The compose stand runs `join_use_nulls = 1`, so the bug never reproduced locally.

**What changed.** `task_issue_state` now falls back through `coalesce(nullIf(…, ''), 'unknown')` for `issue_kind`, and the `issue_type_key`/`issue_type_name` chains get the same `nullIf` guard so a joined `''` no longer swallows the snapshot fallback. **`join_use_nulls` is deliberately not pinned in query_settings** — that would change the materialized table's column Nullability; the expression-level fix is regime-independent.

**Verified.** `task_issue_state.issue_kind` now declares `not_null` + `accepted_values [bug, other, unknown]` (the datapath rig runs `dbt build`, so a regression fails the build); a new datapath case seeds an issue whose fields snapshot carries no issuetype and asserts it counts in `tasks.closed`, joins neither bug subset, and lands in the reserved unknown breakdown group — spec green on a local datapath stand (2 passed); `dbt parse` and pre-commit green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added issue-type classification to task issue data, including Bug, Other, and Unknown categories.
  - Issues without a recognized type now appear under an explicit Unknown category instead of being omitted or shown blank.
  - Issue type names and keys now retain useful fallback values when dimension data is unavailable.

- **Bug Fixes**
  - Improved closed-task metrics to correctly include issues without an issue type while excluding them from Bug and non-Bug subtype counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->