### PR TITLE
feat(jira): honor operator issue-type mappings from config.task_value_map

### DIFF
--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_issuetypes.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_issuetypes.sql
@@ -10,9 +10,33 @@
 -- via `union_by_tag`. Classification reads `untranslatedName`, the type's
 -- language-independent name; `name` is the display label.
 --
+-- `issue_kind` prefers the operator's binding and falls back to the shared
+-- name lists; a name neither knows stays `unknown` and surfaces as its own
+-- bucket. Unlike GitHub, the map key is the NAME, not the type id: Jira mints
+-- a distinct type id per project, so one decision about a name must reach
+-- every project that uses it. A `task_value_map` row for Jira types therefore
+-- carries value_id = lower(trimBoth(<classified name>)) — the same normalized
+-- form `task_issue_kind` matches on.
+--
 -- View, not table: bronze `jira_issuetypes` is MergeTree (full_refresh +
 -- overwrite), so the current state of bronze is the current state of staging.
 
+WITH authored AS (
+    SELECT
+        tenant_id,
+        insight_source_id,
+        value_id,
+        canonical_value
+    FROM {{ source('config', 'task_value_map') }} FINAL
+    WHERE data_source = 'jira'
+      AND field_id = 'type'
+      AND is_deleted = 0
+      AND valid_from <= now64(3)
+      -- Only kinds the silver contract accepts; anything else falls back.
+      AND canonical_value IN ('bug', 'other', 'unknown')
+    ORDER BY valid_from DESC, recorded_at DESC
+    LIMIT 1 BY tenant_id, insight_source_id, value_id
+)
 
 SELECT
     s.unique_key                                                AS unique_key,
@@ -21,12 +45,22 @@ SELECT
     toString(s.id)                                              AS issue_type_id,
     s.name                                                      AS issue_type_name,
     nullIf(toString(s.untranslatedName), '')                    AS untranslated_name,
-    {{ task_issue_kind("coalesce(nullIf(toString(s.untranslatedName), ''), toString(s.name))") }}
-                                                                AS issue_kind,
+    -- Under join_use_nulls=0 an unmatched row reads '' from the map, so the
+    -- nullIf keeps a miss falling through to the name lists, never ''.
+    -- CAST off LowCardinality: `union_by_tag` unions this with the other
+    -- sources' branches, and one differing type fails the shared class.
+    CAST(COALESCE(
+        nullIf(toString(a.canonical_value), ''),
+        {{ task_issue_kind("coalesce(nullIf(toString(s.untranslatedName), ''), toString(s.name))") }}
+    ) AS String)                                                AS issue_kind,
     toDateTime64(s._airbyte_extracted_at, 3)                    AS collected_at,
-    -- Refreshed per run, not per sync: the kind comes from configured name
-    -- lists, so a classification change must reach silver's incremental filter
-    -- without waiting for the connector to re-sync bronze.
+    -- Refreshed per run, not per sync: the kind comes from operator config and
+    -- name lists, so a classification change must reach silver's incremental
+    -- filter without waiting for the connector to re-sync bronze.
     toUnixTimestamp64Milli(now64(3))                            AS _version
 FROM {{ source('bronze_jira', 'jira_issuetypes') }} s
 -- `jira_issuetypes` bronze = MergeTree (full_refresh + overwrite), FINAL not supported.
+LEFT JOIN authored AS a
+    ON a.tenant_id = s.tenant_id
+    AND a.insight_source_id = s.source_id
+    AND a.value_id = lower(trimBoth(coalesce(nullIf(toString(s.untranslatedName), ''), toString(s.name))))

--- a/src/ingestion/dbt/macros/create_task_config_tables.sql
+++ b/src/ingestion/dbt/macros/create_task_config_tables.sql
@@ -9,6 +9,12 @@
   a vendor's literal. `task_value_map` binds a vendor value identifier to the
   canonical value a class dimension carries — a status category, an issue kind.
 
+  What `value_id` is depends on how the vendor keys values. GitHub issue types
+  are org-scoped, so it is the type id. Jira mints a distinct type id per
+  project while the name is what recurs, so for Jira `field_id='type'` rows it
+  is the normalized name: lower(trimBoth(coalesce(nullIf(untranslatedName, ''), name))) —
+  the form `jira__task_issuetypes` joins on.
+
   Bitemporal by design. `valid_from` says which events a mapping applies to: the
   process genuinely changed on a date. `recorded_at` says when the decision was
   made: the mapping was wrong and history is being corrected. One axis cannot

--- a/tests/datapath/metrics/tasks/jira_tasks_bugs_value_map_precedence.test.yaml
+++ b/tests/datapath/metrics/tasks/jira_tasks_bugs_value_map_precedence.test.yaml
@@ -1,0 +1,109 @@
+spec_version: 1
+description: >
+  Task Delivery - `tasks.bugs_fixed` for JIRA, and the exact conditions under
+  which an operator's value-map row is allowed to beat the shared name lists.
+
+  Bronze issue types flow through the Jira type dimension into
+  `silver.class_task_issuetypes`, where `issue_kind` prefers the operator's
+  live map row and only then falls back to the name lists; gold counts a
+  closure as a fixed bug when that kind says `bug`. Unlike GitHub, the map
+  keys on the NORMALIZED TYPE NAME (lower/trim of the untranslated name),
+  because Jira mints a distinct type id per project while the name is what
+  recurs. The map row wins only while it is alive: `is_deleted = 0` and
+  `valid_from` not in the future.
+
+  Carol closes five issues, one per branch of that matrix. `Bug` carries a
+  live map row saying `other`, so the map overrules the name list and the
+  issue counts as a non-bug. `Mapped Custom` is a name no list knows, but a
+  live row says `bug`, so it counts as a bug. `Regression` has a row saying
+  `other`, but the row is deleted, so the name-list fallback claims it as a
+  bug. `Future Custom` has a row saying `bug` that starts in 2030, so it is
+  ignored and no list knows the name — the issue stays `unknown`. `Unmapped
+  Custom` has no row and no list knows it — `unknown` too, the safety net for
+  a new type, so both count in tasks.closed only.
+
+  Two bugs and one non-bug out of five closures is the only total all five
+  branches produce together, and each wrong branch moves it in a distinct
+  direction: a name list beating the live row makes bugs three, a lost custom
+  mapping makes it one, a dead row honoured makes it one (and non-bug two),
+  a future row honoured makes it three.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: ../templates/people.yaml#/templates/alice
+    - $ref: ../templates/people.yaml#/templates/bob
+    - $ref: ../templates/people.yaml#/templates/carol
+
+  bronze_jira.jira_user:
+    - $ref: ../templates/jira_task.yaml#/templates/carol_user
+
+  bronze_jira.jira_statuses:
+    - $ref: ../templates/jira_task.yaml#/templates/status_open
+    - $ref: ../templates/jira_task.yaml#/templates/status_in_progress
+    - $ref: ../templates/jira_task.yaml#/templates/status_closed
+
+  bronze_jira.jira_fields:
+    - $ref: ../templates/jira_task.yaml#/templates/field_status
+    - $ref: ../templates/jira_task.yaml#/templates/field_assignee
+    - $ref: ../templates/jira_task.yaml#/templates/field_issuetype
+
+  config.task_value_map:
+    # Live row overruling the bug-name list.
+    - { $ref: ../templates/jira_task.yaml#/templates/jira_value_type, value_id: bug, unique_key: jira-value-type-bug, canonical_value: other, value_display: Bug }
+    # Live row claiming a name no list knows.
+    - { $ref: ../templates/jira_task.yaml#/templates/jira_value_type, value_id: mapped custom, unique_key: jira-value-type-mapped, canonical_value: bug, value_display: Mapped Custom }
+    # Deleted row: says `other`, must be ignored in favour of the name list.
+    - { $ref: ../templates/jira_task.yaml#/templates/jira_value_type, value_id: regression, unique_key: jira-value-type-regression, canonical_value: other, value_display: Regression, is_deleted: 1 }
+    # Future row: says `bug`, must be ignored; no list knows `Future Custom`.
+    - { $ref: ../templates/jira_task.yaml#/templates/jira_value_type, value_id: future custom, unique_key: jira-value-type-future, canonical_value: bug, value_display: Future Custom, valid_from: "2099-01-01 00:00:00.000" }
+
+  bronze_jira.jira_issuetypes:
+    - $ref: ../templates/jira_task.yaml#/templates/issuetype_bug
+    - $ref: ../templates/jira_task.yaml#/templates/issuetype_regression
+    - { $ref: ../templates/jira_task.yaml#/templates/jira_issuetype, unique_key: jira-test-issuetype-10011, id: "10011", name: Mapped Custom, untranslatedName: Mapped Custom }
+    - { $ref: ../templates/jira_task.yaml#/templates/jira_issuetype, unique_key: jira-test-issuetype-10012, id: "10012", name: Unmapped Custom, untranslatedName: Unmapped Custom }
+    - { $ref: ../templates/jira_task.yaml#/templates/jira_issuetype, unique_key: jira-test-issuetype-10013, id: "10013", name: Future Custom, untranslatedName: Future Custom }
+
+  bronze_jira.jira_issue:
+    - $ref: ../templates/jira_task.yaml#/templates/jira_issue
+      id: JVM-1
+      jira_id: JVM-1
+      unique_key: jira-test-JVM-1
+      id_readable: JVM1
+      created: "2026-03-01T09:00:00"
+      custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10000","name":"Bug"},"assignee":{"accountId":"carol-jira-acct","displayName":"Carol Gamma"}}'
+    - $ref: ../templates/jira_task.yaml#/templates/jira_issue
+      id: JVM-2
+      jira_id: JVM-2
+      unique_key: jira-test-JVM-2
+      id_readable: JVM2
+      created: "2026-03-01T09:00:00"
+      custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10011","name":"Mapped Custom"},"assignee":{"accountId":"carol-jira-acct","displayName":"Carol Gamma"}}'
+    - $ref: ../templates/jira_task.yaml#/templates/jira_issue
+      id: JVM-3
+      jira_id: JVM-3
+      unique_key: jira-test-JVM-3
+      id_readable: JVM3
+      created: "2026-03-01T09:00:00"
+      custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10003","name":"Regression"},"assignee":{"accountId":"carol-jira-acct","displayName":"Carol Gamma"}}'
+    - $ref: ../templates/jira_task.yaml#/templates/jira_issue
+      id: JVM-4
+      jira_id: JVM-4
+      unique_key: jira-test-JVM-4
+      id_readable: JVM4
+      created: "2026-03-01T09:00:00"
+      custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10012","name":"Unmapped Custom"},"assignee":{"accountId":"carol-jira-acct","displayName":"Carol Gamma"}}'
+    - $ref: ../templates/jira_task.yaml#/templates/jira_issue
+      id: JVM-5
+      jira_id: JVM-5
+      unique_key: jira-test-JVM-5
+      id_readable: JVM5
+      created: "2026-03-01T09:00:00"
+      custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10013","name":"Future Custom"},"assignee":{"accountId":"carol-jira-acct","displayName":"Carol Gamma"}}'
+
+  bronze_jira.jira_issue_history:
+    - { $ref: ../templates/jira_task.yaml#/templates/closed_hist, id_readable: JVM1, changelog_id: "51000", unique_key: jira-test-JVM1-51000, created_at: "2026-03-25T14:00:00.000+0000", author_account_id: carol-jira-acct }
+    - { $ref: ../templates/jira_task.yaml#/templates/closed_hist, id_readable: JVM2, changelog_id: "51001", unique_key: jira-test-JVM2-51001, created_at: "2026-03-25T14:00:00.000+0000", author_account_id: carol-jira-acct }
+    - { $ref: ../templates/jira_task.yaml#/templates/closed_hist, id_readable: JVM3, changelog_id: "51002", unique_key: jira-test-JVM3-51002, created_at: "2026-03-25T14:00:00.000+0000", author_account_id: carol-jira-acct }
+    - { $ref: ../templates/jira_task.yaml#/templates/closed_hist, id_readable: JVM4, changelog_id: "51003", unique_key: jira-test-JVM4-51003, created_at: "2026-03-25T14:00:00.000+0000", author_account_id: carol-jira-acct }
+    - { $ref: ../templates/jira_task.yaml#/templates/closed_hist, id_readable: JVM5, changelog_id: "51004", unique_key: jira-test-JVM5-51004, created_at: "2026-03-25T14:00:00.000+0000", author_account_id: carol-jira-acct }

--- a/tests/datapath/metrics/tasks/test_jira_tasks_bugs_value_map_precedence.py
+++ b/tests/datapath/metrics/tasks/test_jira_tasks_bugs_value_map_precedence.py
@@ -1,0 +1,47 @@
+"""Value-map precedence over the shared name lists for Jira's bug split.
+
+An operator's map row beats the name lists only while it is alive, and for Jira it
+keys on the normalized type NAME, not the per-project type id. Carol closes a Bug
+whose live row says `other` (map wins, non-bug), a Mapped Custom whose live row says
+`bug` (map claims a name no list knows), a Regression whose row is deleted (name-list
+fallback, bug), an Unmapped Custom with no row (`unknown`) and a Future Custom whose
+row starts in 2030 (ignored, `unknown` too). Two bugs, one non-bug, five closures —
+and each wrong branch moves the bug count off two in its own direction.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_datapath.spec_runner import SpecRun
+
+pytestmark = pytest.mark.fixture
+
+SPEC = "jira_tasks_bugs_value_map_precedence"
+
+CAROL = "carol@example.com"
+
+
+def test_live_map_rows_win_by_name_and_dead_or_future_rows_fall_back(spec: SpecRun) -> None:
+    """A live row beats the bug-name list and claims an unlisted name; a deleted or
+    future row is ignored in favour of the fallback; an unmapped unlisted name stays
+    `unknown` and counts in tasks.closed only."""
+    r = spec.call(
+        {
+            "url": "/v1/metric-results",
+            "method": "POST",
+            "body": {
+                "entity": {"type": "person", "ids": [CAROL]},
+                "period": {"from": "2026-03-20", "to": "2026-03-31"},
+                "metrics": [
+                    {"metric_key": "tasks.closed", "views": [{"view": "period"}]},
+                    {"metric_key": "tasks.bugs_fixed", "views": [{"view": "period"}]},
+                    {"metric_key": "tasks.closed_non_bug", "views": [{"view": "period"}]},
+                ],
+            },
+        }
+    )
+    assert r.status == 200
+
+    r.row("tasks.closed", "period", entity_id=CAROL).equals(value=5)
+    r.row("tasks.bugs_fixed", "period", entity_id=CAROL).equals(value=2)
+    r.row("tasks.closed_non_bug", "period", entity_id=CAROL).equals(value=1)

--- a/tests/datapath/metrics/templates/jira_task.yaml
+++ b/tests/datapath/metrics/templates/jira_task.yaml
@@ -304,7 +304,7 @@ templates:
   jira_issuetype:
     unique_key: null
     source_id: jira-test
-    tenant_id: "00000000-0000-0000-0000-000000000000"
+    tenant_id: "{{ tenant }}"
     id: null
     name: null
     untranslatedName: null
@@ -369,6 +369,26 @@ templates:
     id: "10005"
     name: "Ошибка"
     untranslatedName: Bug
+
+  # ── Operator value map (config.task_value_map) ───────────────────────────
+  # Binds a type NAME to a canonical issue kind. Jira mints a distinct type id
+  # per project, so the map keys on the normalized name — lower/trim of
+  # lower(trimBoth(coalesce(nullIf(untranslatedName, ''), name))) — the form jira__task_issuetypes joins on.
+  jira_value_type:
+    tenant_id: "{{ tenant }}"
+    insight_source_id: jira-test
+    data_source: jira
+    field_id: type
+    value_id: null
+    valid_from: "1970-01-01 00:00:00.000"
+    recorded_at: "2026-01-01 00:00:00.000"
+    unique_key: null
+    canonical_value: null
+    value_display: ""
+    is_deleted: 0
+    note: ""
+    recorded_by: fixture
+    _version: "2026-01-01 00:00:00.000"
 
   # ── Deletion / visibility censuses (specs/DELETION-AND-VISIBILITY.md) ────
   # jira_census: one row per issue observed alive by the id-only sweep. An

--- a/tests/lib/insight_datapath/dbt_runner.py
+++ b/tests/lib/insight_datapath/dbt_runner.py
@@ -164,7 +164,12 @@ class DbtRunner:
         }
         existing_tables = set(
             ch.query(
-                self.cfg, "SELECT database, name FROM system.tables WHERE database LIKE 'bronze_%'"
+                # config tables are created by dbt's own on-run-start hook, so a
+                # staging model reading one must stay selected even when the spec
+                # seeds no config rows.
+                self.cfg,
+                "SELECT database, name FROM system.tables"
+                " WHERE database LIKE 'bronze_%' OR database = 'config'",
             )
         )
         available_sources = {


### PR DESCRIPTION
**Why.** Jira issue-type classification only knows the global name lists; installs with custom type names see those closures fall to `unknown`, undercounting both `bugs_fixed` and `closed_non_bug` with no way to correct it per deployment.

**What changed.** `jira__task_issuetypes` now reads `config.task_value_map` (data_source `jira`, field_id `type`) with precedence over the name lists, mirroring the GitHub connector; unmapped and unlisted names still classify `unknown`, so a new type surfaces there instead of disappearing. **Jira map rows key on the normalized type name, not the type id** — Jira mints an id per project while the name recurs, so one row covers every project; documented in the model header and config DDL. A typoed `canonical_value` outside bug/other/unknown falls back to the lists instead of violating the silver contract.

Also: the datapath rig's source probe now counts `config.*` tables as available (they exist via the on-run-start hook), so specs without config rows keep selecting the jira type models.

**Verified.** New spec `jira_tasks_bugs_value_map_precedence` (map beats a bug-shaped name, maps a custom name to bug, ignores `is_deleted` and future `valid_from`, unmapped stays unknown) green on a local datapath stand; full tasks tree 52 passed, meta 77 passed; `dbt parse` and pre-commit green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Jira issue types can now be classified using operator-configured mappings.
  - Configured classifications take precedence over shared issue-type rules, with valid-date and deletion handling.
  - Issue types are matched consistently using normalized names across projects.
  - Unmapped or unrecognized issue types are reported as unknown.
  - Jira bug and non-bug metrics now reflect configured classifications more accurately.

- **Documentation**
  - Added guidance describing how issue-type mapping values are identified for different vendors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->