### PR TITLE
fix(e2e): stop pinned test-stand runs from compiling insight-v3-core from source

### DIFF
--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -304,7 +304,8 @@ jobs:
             --image "insight-analytics:${ANALYTICS_POLICY}" \
             --image "insight-authenticator:${AUTHENTICATOR_POLICY}" \
             --image "insight-identity-resolution:${IDENTITY_POLICY}" \
-            --image "insight-gateway:${GATEWAY_POLICY}"
+            --image "insight-gateway:${GATEWAY_POLICY}" \
+            --image "insight-v3-core:unchanged" # build-images exports no insight-v3-core artifact — always the published image
 
       # Restore-only warm start for the --build-backend fallback: the cache is
       # saved by e2e-bronze-to-api.yml's push-to-main run; nothing here saves.
@@ -348,6 +349,7 @@ jobs:
           AUTHENTICATOR_IMAGE: ${{ needs.changes.outputs.backend_artifacts == 'true' && 'insight-authenticator:e2e-prebuilt' || '' }}
           IDENTITY_RESOLUTION_IMAGE: ${{ needs.changes.outputs.backend_artifacts == 'true' && 'insight-identity-resolution:e2e-prebuilt' || '' }}
           GATEWAY_IMAGE: ${{ needs.changes.outputs.backend_artifacts == 'true' && 'insight-gateway:e2e-prebuilt' || '' }}
+          INSIGHT_V3_CORE_IMAGE: ${{ needs.changes.outputs.backend_artifacts == 'true' && 'insight-v3-core:e2e-prebuilt' || '' }}
         run: |
           set -euo pipefail
           # `if` blocks, not `[ … ] && flags+=(…)`: under set -e a false test as

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1602,16 +1602,16 @@ for dbt-built gold data rather than for containers to report healthy.
           block until EVERY gold observation table the seed populates proves
           dbt rebuilt it for this run and left a positive observation in it.
 
-          The four backend services (analytics, authenticator,
-          identity-resolution, gateway) and the frontend are PULLED, each
-          pinned to its own chart's appVersion — never :latest.
+          The backend services (analytics, authenticator,
+          identity-resolution, gateway, insight-v3-core) and the frontend are
+          PULLED, each pinned to its own chart's appVersion — never :latest.
 
           An appVersion names what main released, so pass the flag for whatever
           tree this checkout changes, or the stand will not run it:
 
           --build-backend    Compile the Rust services from this tree. Adds
                              ~28 min (measured across CI's build-path runs).
-          --prebuilt-backend Use backend images already loaded under the four
+          --prebuilt-backend Use backend images already loaded under the
                              *_IMAGE environment variables. Never builds or
                              pulls a fallback image.
           --build-frontend   Build the SPA from this tree with pnpm, served by
@@ -1620,8 +1620,9 @@ for dbt-built gold data rather than for containers to report healthy.
           --skip-build       With --build-backend: mount binaries already in
                              deploy/compose/build/ instead of compiling, over
                              runtime images taken from the chart pins (the
-                             gateway image still builds from this tree). The
-                             caller owns the binaries' freshness.
+                             gateway and insight-v3-core images still build
+                             from this tree). The caller owns the binaries'
+                             freshness.
 
           `up` refuses to pin a tree that differs from origin/main and names
           the flag to pass — but only when origin/main is in the checkout. A
@@ -1692,14 +1693,16 @@ test_stand_frontend_image() {
 # The backend services the stand runs from published images rather than from
 # source, as "<compose env var>|<chart path>|<image name>".
 #
-# Building these four compiles the Rust workspace twice — once on the host for
-# the bind-mounted binaries, then again inside each service image — which is
-# where the stand's wall-clock went.
+# Building these compiles the Rust workspace inside each service image (and
+# once more on the host for the bind-mounted binaries) — which is where the
+# stand's wall-clock went. test_stand_assert_no_source_bakes catches a backend
+# service missing from this list before `up` starts compiling it.
 TEST_STAND_PINNED_BACKENDS=(
   "ANALYTICS_IMAGE|src/backend/services/analytics/helm/Chart.yaml|analytics"
   "AUTHENTICATOR_IMAGE|src/backend/services/authenticator/helm/Chart.yaml|authenticator"
   "IDENTITY_RESOLUTION_IMAGE|src/backend/services/identity-resolution/helm/Chart.yaml|identity-resolution"
   "GATEWAY_IMAGE|src/backend/services/gateway/helm/Chart.yaml|gateway"
+  "INSIGHT_V3_CORE_IMAGE|src/backend/services/insight-v3-core/helm/Chart.yaml|v3-core"
 )
 
 # Pin and pull every backend image, or fail.
@@ -1726,14 +1729,15 @@ test_stand_pull_backends() {
 # With --skip-build the caller supplies the binaries, and compose must not
 # bake the dev images just to produce a compiled-in binary the bind-mount
 # shadows. Tag the chart-pinned images under the compose default names so
-# `up` finds them and skips the build. The gateway stays out: routegen bakes
-# routes.yaml into nginx.conf at image-build time, so a routing change is
-# only exercised by an image built from this tree.
+# `up` finds them and skips the build. Gateway and insight-v3-core stay out:
+# routegen bakes routes.yaml into the gateway's nginx.conf at image-build time,
+# and insight-v3-core runs from its image rather than a bind-mounted binary —
+# a source change to either is only exercised by an image built from this tree.
 test_stand_prime_dev_images() {
   local entry var chart name image local_tag
   for entry in "${TEST_STAND_PINNED_BACKENDS[@]}"; do
     IFS='|' read -r var chart name <<<"$entry"
-    [[ "$name" == "gateway" ]] && continue
+    case "$name" in gateway|v3-core) continue ;; esac
     local_tag="insight-${name}:dev"
     docker image inspect "$local_tag" >/dev/null 2>&1 && continue
     image="$(test_stand_pinned_image "$chart" "$name")" || return 1
@@ -1762,6 +1766,40 @@ test_stand_use_prebuilt_backends() {
     update_env_var "$TEST_STAND_ENV_FILE" "$var" "$image"
   done
   echo "=== the backend uses pre-built images from this ref ==="
+}
+
+# When no source build was asked for, no service `up` raises may be about to
+# be built from source. Asks compose itself — every service in the up set that
+# still carries a build: section must resolve to an image that already exists
+# locally, so a backend service missing from TEST_STAND_PINNED_BACKENDS (the
+# way a newly added compose service lands) fails loudly here instead of
+# silently compiling the Rust workspace inside `docker compose up`.
+test_stand_assert_no_source_bakes() {
+  local buildable offenders="" svc image
+  buildable="$(docker compose --env-file "$TEST_STAND_ENV_FILE" -f docker-compose.yml config --format json |
+    python3 -c '
+import json, sys
+services = json.load(sys.stdin)["services"]
+for name, svc in sorted(services.items()):
+    if "build" in svc:
+        print(name, svc.get("image", "<no-image-tag>"))
+')" || { echo "ERROR: cannot resolve the compose up set to check for source builds." >&2; return 1; }
+
+  while read -r svc image; do
+    [[ -n "$svc" ]] || continue
+    docker image inspect "$image" >/dev/null 2>&1 && continue
+    offenders+="         ${svc} -> ${image}"$'\n'
+  done <<<"$buildable"
+  [[ -z "$offenders" ]] && return 0
+
+  echo "ERROR: \`up\` would compile these services from source, in a run that did" >&2
+  echo "       not ask for a source build:" >&2
+  printf '%s' "$offenders" >&2
+  echo "       Every backend service must run a published image here. Add the" >&2
+  echo "       service's \"<VAR>|<chart path>|<name>\" entry to" >&2
+  echo "       TEST_STAND_PINNED_BACKENDS, or pass --build to build from source" >&2
+  echo "       deliberately." >&2
+  return 1
 }
 
 # Refuse to pin when the working tree differs from what a chart describes.
@@ -2204,6 +2242,9 @@ cmd_test_stand() {
           test_stand_pull_backends || return 1
           ;;
       esac
+      if [[ "$backend_mode" != "source" ]]; then
+        test_stand_assert_no_source_bakes || return 1
+      fi
 
       local up_args=(--env-file "$TEST_STAND_ENV_FILE"
                      --authenticator-redirect "$(test_stand_origin)/auth/callback")
@@ -2273,6 +2314,9 @@ cmd_test_stand() {
         pinned)   test_stand_backend_matches_charts || return 1
                   test_stand_pull_backends || return 1 ;;
       esac
+      if [[ "$mbackend_mode" != "source" ]]; then
+        test_stand_assert_no_source_bakes || return 1
+      fi
 
       local mup_args=(--env-file "$TEST_STAND_ENV_FILE" --seed-target identity
                       --authenticator-redirect "$(test_stand_origin)/auth/callback")


### PR DESCRIPTION
Part of #3368.

**Why.** Every `test-stand` bring-up without `--build` compiled insight-v3-core from source — the service is missing from the pinned-backend list, so each of the five data-path shards of every merge-queue entry paid a full release-workspace image build.

**What changed.** insight-v3-core joins `TEST_STAND_PINNED_BACKENDS`, so pinned runs pull `ghcr.io/constructorfabric/insight-v3-core:<appVersion>` like the other four; e2e-stand's merge-group prebuilt path loads it through prebuilt_images.py's existing `unchanged` policy.

**A mechanical guard now fails bring-up before compose builds anything.** After pinning, every service in the compose up set that still carries a `build:` section must resolve to a locally present image — so the next backend service added to docker-compose.yml without a pin entry trips loudly instead of compiling silently. Skipped when `--build`/`--build-backend` asks for a source build.

**Skip-build priming deliberately excludes insight-v3-core.** Like the gateway, its code runs from the image rather than a bind-mounted binary, so under `--build-backend` only an image built from this tree exercises a source change.

**Out of scope.** build-images exports no insight-v3-core e2e-prebuilt artifact, so a merge-group entry touching insight-v3-core alongside a prebuilt service runs the published image, not the PR's, and `--build-backend --skip-build` shards still bake it per shard; both want that export as a follow-up.

**Verified.** `bash -n` and shellcheck (no new findings); pulled the chart-pinned tag from GHCR; `docker compose config` resolves `INSIGHT_V3_CORE_IMAGE`; guard exercised both ways — all five pins pass, removing the v3-core pin trips:

```
ERROR: `up` would compile these services from source, in a run that did
       not ask for a source build:
         insight-v3-core -> insight-v3-core:dev
         insight-v3-core-migrate -> insight-v3-core:dev
       Every backend service must run a published image here. Add the
       service's "<VAR>|<chart path>|<name>" entry to
       TEST_STAND_PINNED_BACKENDS, or pass --build to build from source
       deliberately.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test-environment startup by ensuring the Insight V3 Core service uses the correct prebuilt or locally built image.
  - Added validation to prevent services from unexpectedly compiling from source when required images are unavailable.

- **Chores**
  - Updated test-stand setup, image preparation, and help text to consistently support the expanded backend service set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->