### PR TITLE
ci(e2e): build the gateway and insight-v3-core images once, not once per shard

### DIFF
--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -21,7 +21,8 @@ name: E2E bronze to API
 # MINIMAL compose stand of its own (`dev-compose.sh test-stand minimal` —
 # identity and the realm seeded, the warehouse empty), pulls the chart-pinned
 # backend images or, when the diff touched the backend, mounts the binaries
-# `build-backend` compiled once for every shard, runs its
+# and loads the gateway/insight-v3-core images `build-backend` produced once
+# for every shard, runs its
 # directories of the suite host-side with uv, and the metric legs upload that
 # session's `.artifacts/` for `metric-coverage-gate`, a pure-Python check over
 # two JSON files: the builtin metric catalogue the run read from analytics, and
@@ -60,6 +61,8 @@ concurrency:
 
 env:
   CI: "true"
+  # Same cache image and tag scheme build-images.yml writes; read-only here.
+  BUILDCACHE: ghcr.io/constructorfabric/insight-buildcache
 
 permissions:
   contents: read
@@ -177,16 +180,20 @@ jobs:
           fi
 
   # ─── Build the backend once, shared by every shard ────────────────────────
-  # One `cargo build` for all three binaries; the shards mount them via
-  # `--prebuilt` semantics (`--build-backend --skip-build`) instead of each
-  # compiling the same workspace. Five identical compiles per queue entry is
-  # what pushed backend-touching entries past the merge queue's check timeout.
+  # One `cargo build` for all three bind-mounted binaries, plus one image build
+  # each for gateway and insight-v3-core — the two services that run from
+  # images; the shards mount/load them (`--build-backend --skip-build`) instead
+  # of each compiling the same workspace and baking the same two images.
   build-backend:
     name: Build backend
     needs: changes
     if: ${{ needs.changes.outputs.relevant == 'true' && needs.changes.outputs.backend == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      # ghcr login for the read-only registry build cache.
+      packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -234,6 +241,54 @@ jobs:
         with:
           name: backend-binaries
           path: deploy/compose/build/
+          retention-days: 1
+          if-no-files-found: error
+
+      # Gateway and insight-v3-core run from images, not bind-mounted binaries,
+      # so the queue entry's code only runs in images built from this tree —
+      # built once here instead of once per shard. cache-from reuses the layer
+      # cache build-images.yml maintains; no cache-to — queue refs are transient
+      # and main's push to build-images owns the cache writes.
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        if: github.event_name != 'push'
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        if: github.event_name != 'push'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare the image export directory
+        if: github.event_name != 'push'
+        run: mkdir -p /tmp/e2e-images
+      - name: Build the gateway image for the shards
+        if: github.event_name != 'push'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: src/backend
+          file: src/backend/services/gateway/Dockerfile
+          # The shards run on ubuntu-latest amd64; nothing else loads these tars.
+          platforms: linux/amd64
+          tags: insight-gateway:e2e-prebuilt
+          outputs: type=docker,dest=/tmp/e2e-images/insight-gateway.tar
+          cache-from: type=registry,ref=${{ env.BUILDCACHE }}:gateway-amd64
+      - name: Build the insight-v3-core image for the shards
+        if: github.event_name != 'push'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: src/backend
+          file: src/backend/Dockerfile
+          target: insight-v3-core
+          platforms: linux/amd64
+          tags: insight-v3-core:e2e-prebuilt
+          outputs: type=docker,dest=/tmp/e2e-images/insight-v3-core.tar
+          cache-from: |
+            type=registry,ref=${{ env.BUILDCACHE }}:insight-v3-core-amd64
+            type=registry,ref=${{ env.BUILDCACHE }}:backend-deps-amd64
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: github.event_name != 'push'
+        with:
+          name: backend-images
+          path: /tmp/e2e-images/
           retention-days: 1
           if-no-files-found: error
 
@@ -297,6 +352,18 @@ jobs:
         if: ${{ needs.changes.outputs.backend == 'true' }}
         run: find deploy/compose/build -type f -exec chmod 0755 {} +
 
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        with:
+          name: backend-images
+          path: /tmp/e2e-images
+
+      - name: Load the pre-built gateway and insight-v3-core images
+        if: ${{ needs.changes.outputs.backend == 'true' }}
+        run: |
+          set -euo pipefail
+          for tar in /tmp/e2e-images/*.tar; do docker load --input "$tar"; done
+
       # `minimal` seeds identity and the realm and leaves the warehouse empty:
       # the suite writes its own bronze and clears it between specs, and the
       # guard at its door refuses an instance whose seed shares those tables.
@@ -307,7 +374,13 @@ jobs:
         run: |
           set -euo pipefail
           flags=()
-          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build-backend --skip-build); fi
+          if [ "$BUILD_BACKEND" = "true" ]; then
+            flags+=(--build-backend --skip-build)
+            # The two image-run services take the images build-backend built
+            # from this tree instead of baking them here, once per shard.
+            export GATEWAY_IMAGE=insight-gateway:e2e-prebuilt
+            export INSIGHT_V3_CORE_IMAGE=insight-v3-core:e2e-prebuilt
+          fi
           ./dev-compose.sh test-stand minimal "${flags[@]}"
 
       # A reused workspace could carry a previous run's ledger; the gate must

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1619,10 +1619,11 @@ for dbt-built gold data rather than for containers to report healthy.
           --build            Both.
           --skip-build       With --build-backend: mount binaries already in
                              deploy/compose/build/ instead of compiling, over
-                             runtime images taken from the chart pins (the
-                             gateway and insight-v3-core images still build
-                             from this tree). The caller owns the binaries'
-                             freshness.
+                             runtime images taken from the chart pins. The
+                             gateway and insight-v3-core run a locally loaded
+                             image named by GATEWAY_IMAGE / INSIGHT_V3_CORE_IMAGE,
+                             or bake from this tree when those are unset. The
+                             caller owns the binaries' and images' freshness.
 
           `up` refuses to pin a tree that differs from origin/main and names
           the flag to pass — but only when origin/main is in the checkout. A
@@ -1729,15 +1730,30 @@ test_stand_pull_backends() {
 # With --skip-build the caller supplies the binaries, and compose must not
 # bake the dev images just to produce a compiled-in binary the bind-mount
 # shadows. Tag the chart-pinned images under the compose default names so
-# `up` finds them and skips the build. Gateway and insight-v3-core stay out:
-# routegen bakes routes.yaml into the gateway's nginx.conf at image-build time,
-# and insight-v3-core runs from its image rather than a bind-mounted binary —
-# a source change to either is only exercised by an image built from this tree.
+# `up` finds them and skips the build. Gateway and insight-v3-core run from
+# their images rather than bind-mounted binaries, so a source change to either
+# is only exercised by an image built from this tree: they take a caller-loaded
+# image named by GATEWAY_IMAGE / INSIGHT_V3_CORE_IMAGE, or bake from source.
 test_stand_prime_dev_images() {
   local entry var chart name image local_tag
   for entry in "${TEST_STAND_PINNED_BACKENDS[@]}"; do
     IFS='|' read -r var chart name <<<"$entry"
-    case "$name" in gateway|v3-core) continue ;; esac
+    case "$name" in
+      gateway|v3-core)
+        # INVARIANT: cmd_up sources the env file over the process env, so a
+        # caller-supplied image only reaches compose written into the file.
+        image="${!var:-}"
+        [[ -n "$image" ]] || continue
+        docker image inspect "$image" >/dev/null 2>&1 || {
+          echo "ERROR: $var=$image is not loaded locally." >&2
+          echo "       Load it (docker load), or unset $var to bake ${name} from source." >&2
+          return 1
+        }
+        echo "    ${name}: ${image} (pre-built from this tree)"
+        update_env_var "$TEST_STAND_ENV_FILE" "$var" "$image"
+        continue
+        ;;
+    esac
     local_tag="insight-${name}:dev"
     docker image inspect "$local_tag" >/dev/null 2>&1 && continue
     image="$(test_stand_pinned_image "$chart" "$name")" || return 1


### PR DESCRIPTION
Refs #3368 (R2).

**Why.** Gateway and insight-v3-core run from images, not bind-mounted binaries, so under `--build-backend --skip-build` each of the five data-path shards baked both images from source, uncached — up to ten image builds per backend-touching queue entry.

**What changed.** `build-backend` now builds `insight-gateway:e2e-prebuilt` and `insight-v3-core:e2e-prebuilt` once from the queue tree and ships them as a docker-save artifact; the shards load the tars and pass `GATEWAY_IMAGE` / `INSIGHT_V3_CORE_IMAGE` into stand-up, where `test_stand_prime_dev_images` now persists a caller-supplied image for those two services into the stand env file (`cmd_up` sources that file over the process env, so the file is the only channel that reaches compose).

**Built from the queue tree, not pinned.** A pinned image runs main's code; only an image built from this tree exercises the queue entry's gateway/v3-core changes.

**Read-only cache (`cache-from` only).** Queue refs are transient; `build-images.yml` owns the cache writes from main. Cold cache costs minutes inside the existing 45-min budget.

**amd64 only.** The shards run on ubuntu-latest amd64; nothing else loads these tars.

**Out of scope.** R8 (the gateway Dockerfile still does `COPY . .` before the routegen build, so any backend change re-runs that stage) and e2e-stand's R3 fallback — both stay in #3368.

**Verified.** Both buildx commands run locally against the real registry cache (gateway 13 s, v3-core 98 s warm; 64 MB + 52 MB tars), `docker save`/`load` round-trip, then the real `test-stand minimal --build-backend --skip-build` executed to just before `compose up`: compose config resolves both services (and the `-migrate` twin) to the loaded tags and every buildable service in the up set has a local image — zero source bakes. Negative path (var set, image missing) fails loudly; unset vars keep today's bake-from-source. `bash -n`, `shellcheck` (no new findings), `actionlint` (pre-existing SC2001 only). pull_request stays a no-op; the push cache-warm lane skips every new step; workflow_dispatch keeps the pinned path.
